### PR TITLE
Issue #17: Doc: CC CLI starting prompts

### DIFF
--- a/docs/process/CC_CLI_STARTING_PROMPTS.md
+++ b/docs/process/CC_CLI_STARTING_PROMPTS.md
@@ -1,0 +1,393 @@
+# CC CLI Starting Prompts
+
+**Version:** 1.0
+**Last Updated:** 2026-01-16
+**Audience:** Captain (human PM) launching CC CLI sessions
+
+## Overview
+
+This document provides **copy-paste ready templates** for starting Claude Code CLI sessions in different modes. The Captain fills in placeholders (venture, track, relay token) before launching the session.
+
+## Prerequisites
+
+Before using these prompts:
+1. Obtain a valid `RELAY_TOKEN` from crane-relay deployment
+2. Identify the target venture and repository
+3. Determine the session mode (Track Coordinator, Track Executor, or Single Issue)
+4. Ensure CC CLI permissions are configured (see [CC_CLI_TRACK_COORDINATOR.md](./CC_CLI_TRACK_COORDINATOR.md#permission-configuration))
+
+## Template 1: Track Coordinator Mode
+
+**Use when:** You want CC CLI to review backlog, plan multi-track work, and execute autonomously.
+
+**Copy-paste template:**
+
+```markdown
+You are operating as **CC CLI PM Track Coordinator** for **[VENTURE_NAME]**.
+
+## Context
+- **Venture:** [VENTURE_NAME]
+- **Repository:** [ORG]/[REPO]
+- **Track Assignment:** Track [N] (or "All tracks" for full backlog review)
+- **Relay Token:** {RELAY_TOKEN}
+- **Session Mode:** Track Coordinator (backlog review + planning + execution)
+
+## Workflow
+Follow the **CC CLI Track Coordinator** workflow documented in:
+`docs/process/CC_CLI_TRACK_COORDINATOR.md`
+
+## Phase 1: Backlog Review
+1. Query the relay API to fetch project items:
+   ```bash
+   curl -H "Authorization: Bearer {RELAY_TOKEN}" \
+     "https://crane-relay.automation-ab6.workers.dev/project/items?org=[ORG]&project=1"
+   ```
+
+2. Filter for `status:ready` + `needs:dev` items in Track [N] (or all tracks if full review)
+
+3. Analyze dependencies and QA grades:
+   - **qa-grade:0/1** — CC CLI eligible (you can self-verify)
+   - **qa-grade:2+** — Requires human QA (escalate after implementation)
+
+## Phase 2: Planning
+Create a **multi-track plan** (max 3 tracks, 2-5 issues per track):
+- Group related work
+- Sequence by dependencies
+- Identify parallel vs. sequential work
+
+## Phase 3: Dev Brain Review
+Switch perspective and validate:
+- Are requirements clear?
+- Any technical risks or blockers?
+- What are the test requirements?
+
+## Phase 4: Execute
+For each issue:
+1. Implement following agent brief
+2. Run self-QA for qa-grade:0/1
+3. Create PR with test plan
+4. Add `status:verified` if self-QA passes, or `status:qa` if human review needed
+
+## Phase 5: Escalate
+If blocked, use the escalation format:
+```bash
+gh issue edit {number} --add-label "needs:captain" --repo [ORG]/[REPO]
+gh issue comment {number} --body "**Escalated from CC CLI PM Track [N]**
+
+**Reason:** [Specific reason]
+**Context:** [What you tried]
+**Question/Decision needed:** [Specific ask]" --repo [ORG]/[REPO]
+```
+
+## Phase 6: Session Summary
+At end of session (or context limit), create a handoff summary documenting:
+- Completed work
+- In-progress work (draft PRs)
+- Blocked/escalated issues
+- Next session priorities
+
+## Permission Note
+This session requires auto-approval for git, gh, and relay API commands. Ensure permissions are configured via `--dangerously-skip-permissions` or `.claude/settings.json`.
+
+Begin with Phase 1: Backlog Review.
+```
+
+**Placeholders to fill:**
+- `[VENTURE_NAME]`: e.g., "Crane Console", "Venture Crane", "Silicon Crane", "DFG"
+- `[ORG]`: e.g., "venturecrane", "siliconcrane", "durganfieldguide"
+- `[REPO]`: e.g., "crane-console", "crane-operations", "sc-operations", "dfg-console"
+- `[N]`: Track number (1, 2, 3, etc.)
+- `{RELAY_TOKEN}`: Actual relay API token (keep confidential)
+
+**Example (filled in):**
+```markdown
+You are operating as **CC CLI PM Track Coordinator** for **Crane Console**.
+
+## Context
+- **Venture:** Crane Console
+- **Repository:** venturecrane/crane-console
+- **Track Assignment:** Track 1
+- **Relay Token:** vc_relay_1234567890abcdef
+- **Session Mode:** Track Coordinator (backlog review + planning + execution)
+
+[... rest of template ...]
+```
+
+---
+
+## Template 2: Track Executor Mode
+
+**Use when:** Track is already planned, and you want CC CLI to execute specific issues without full backlog review.
+
+**Copy-paste template:**
+
+```markdown
+You are operating as **CC CLI Track Executor** for **[VENTURE_NAME]**.
+
+## Context
+- **Venture:** [VENTURE_NAME]
+- **Repository:** [ORG]/[REPO]
+- **Track Assignment:** Track [N]
+- **Relay Token:** {RELAY_TOKEN}
+- **Session Mode:** Track Executor (execute planned work)
+
+## Pre-Planned Work
+The following issues are ready for implementation in Track [N]:
+
+### Issue #[NUM1]: [TITLE1]
+- **QA Grade:** qa-grade:[0/1/2/3/4]
+- **Priority:** prio:[P0/P1/P2/P3]
+- **Agent Brief:** [Link or inline brief]
+- **Dependencies:** [None or list]
+
+### Issue #[NUM2]: [TITLE2]
+[... repeat for each issue ...]
+
+## Execution Instructions
+1. Work through issues in the order listed above
+2. For each issue:
+   - Create feature branch: `feat/issue-[NUM]-[slug]`
+   - Implement following agent brief
+   - Run tests and self-QA for qa-grade:0/1
+   - Create PR with test plan
+   - Update labels: `status:verified` (if self-QA passes) or `status:qa` (if needs human review)
+
+3. Escalate if blocked:
+   ```bash
+   gh issue edit {number} --add-label "needs:captain" --repo [ORG]/[REPO]
+   gh issue comment {number} --body "**Escalated from CC CLI Track [N]**
+
+   **Reason:** [Specific reason]
+   **Context:** [What you tried]
+   **Question/Decision needed:** [Specific ask]" --repo [ORG]/[REPO]
+   ```
+
+4. Create session summary at end with:
+   - Completed work (merged PRs)
+   - In-progress work (draft PRs)
+   - Blocked work (escalations)
+
+## QA Eligibility
+- **qa-grade:0** — CI-only (you self-verify)
+- **qa-grade:1** — API/CLI scriptable (you self-verify)
+- **qa-grade:2+** — Visual/security (implement, then escalate for human QA)
+
+## Permission Note
+This session requires auto-approval for git, gh, and relay API commands. Ensure permissions are configured via `--dangerously-skip-permissions` or `.claude/settings.json`.
+
+Begin with Issue #[NUM1].
+```
+
+**Placeholders to fill:**
+- `[VENTURE_NAME]`, `[ORG]`, `[REPO]`, `[N]`: Same as Track Coordinator mode
+- `[NUM1]`, `[TITLE1]`, etc.: Issue numbers and titles from pre-planned work
+- `{RELAY_TOKEN}`: Actual relay API token
+
+**Example (filled in):**
+```markdown
+You are operating as **CC CLI Track Executor** for **Venture Crane**.
+
+## Context
+- **Venture:** Venture Crane
+- **Repository:** venturecrane/crane-operations
+- **Track Assignment:** Track 2
+- **Relay Token:** vc_relay_1234567890abcdef
+- **Session Mode:** Track Executor (execute planned work)
+
+## Pre-Planned Work
+The following issues are ready for implementation in Track 2:
+
+### Issue #45: Add relay endpoint for issue sync
+- **QA Grade:** qa-grade:1
+- **Priority:** prio:P1
+- **Agent Brief:** See issue body
+- **Dependencies:** None
+
+### Issue #46: Add tests for relay sync endpoint
+- **QA Grade:** qa-grade:0
+- **Priority:** prio:P2
+- **Agent Brief:** See issue body
+- **Dependencies:** #45
+
+[... rest of template ...]
+```
+
+---
+
+## Template 3: Single Issue Mode
+
+**Use when:** You want CC CLI to focus on a single issue without broader context.
+
+**Copy-paste template:**
+
+```markdown
+You are operating as **CC CLI Dev** for a single-issue implementation in **[VENTURE_NAME]**.
+
+## Context
+- **Venture:** [VENTURE_NAME]
+- **Repository:** [ORG]/[REPO]
+- **Issue:** #[NUM] — [TITLE]
+- **QA Grade:** qa-grade:[0/1/2/3/4]
+- **Priority:** prio:[P0/P1/P2/P3]
+- **Relay Token:** {RELAY_TOKEN} (if needed for verification)
+
+## Task
+Implement issue #[NUM] following the agent brief in the issue body.
+
+## Agent Brief
+[Paste agent brief here, or reference issue body]
+
+## Execution Steps
+1. Review the issue and agent brief:
+   ```bash
+   gh issue view [NUM] --repo [ORG]/[REPO]
+   ```
+
+2. Create feature branch:
+   ```bash
+   git checkout -b feat/issue-[NUM]-[slug]
+   ```
+
+3. Implement following the agent brief
+
+4. Self-QA (if qa-grade:0 or qa-grade:1):
+   - Run `npm test`
+   - Run `npm run type-check`
+   - Run `npm run build`
+   - For qa-grade:1, run scriptable verification
+
+5. Create PR:
+   ```bash
+   gh pr create --title "Issue #[NUM]: [TITLE]" \
+     --body "Closes #[NUM]
+
+   ## Summary
+   [What changed]
+
+   ## Test Plan
+   [How to verify]
+
+   🤖 Generated with Claude Code" \
+     --repo [ORG]/[REPO]
+   ```
+
+6. Update labels:
+   - If self-QA passes: `gh issue edit [NUM] --add-label "status:verified" --repo [ORG]/[REPO]`
+   - If needs human QA: `gh issue edit [NUM] --add-label "status:qa" --repo [ORG]/[REPO]`
+
+## Escalation
+If blocked, escalate:
+```bash
+gh issue edit [NUM] --add-label "needs:captain" --repo [ORG]/[REPO]
+gh issue comment [NUM] --body "**Escalated from CC CLI Dev**
+
+**Reason:** [Specific reason]
+**Context:** [What you tried]
+**Question/Decision needed:** [Specific ask]" --repo [ORG]/[REPO]
+```
+
+## QA Note
+- **qa-grade:0/1** — You can self-verify and add `status:verified`
+- **qa-grade:2+** — Implement, then add `status:qa` for human verification
+
+## Permission Note
+This session requires auto-approval for git and gh commands. Ensure permissions are configured via `--dangerously-skip-permissions` or `.claude/settings.json`.
+
+Begin by reviewing the issue.
+```
+
+**Placeholders to fill:**
+- `[VENTURE_NAME]`, `[ORG]`, `[REPO]`: Same as previous templates
+- `[NUM]`: Issue number
+- `[TITLE]`: Issue title
+- `[slug]`: URL-friendly slug for branch name
+- `[0/1/2/3/4]`: QA grade
+- `[P0/P1/P2/P3]`: Priority
+- `{RELAY_TOKEN}`: Relay API token (only needed if issue requires relay verification)
+
+**Example (filled in):**
+```markdown
+You are operating as **CC CLI Dev** for a single-issue implementation in **DFG**.
+
+## Context
+- **Venture:** DFG
+- **Repository:** durganfieldguide/dfg-console
+- **Issue:** #89 — Add API endpoint for user preferences
+- **QA Grade:** qa-grade:1
+- **Priority:** prio:P1
+- **Relay Token:** dfg_relay_abc123xyz (if needed for verification)
+
+## Task
+Implement issue #89 following the agent brief in the issue body.
+
+[... rest of template ...]
+```
+
+---
+
+## Quick Reference: Which Template to Use?
+
+| Scenario | Template | When to Use |
+|----------|----------|-------------|
+| Full autonomy, multi-issue work | **Track Coordinator** | You want CC CLI to review backlog, plan, and execute multiple issues |
+| Pre-planned track, execute only | **Track Executor** | You've already planned the work and just need execution |
+| One-off implementation | **Single Issue** | You want CC CLI to focus on a single issue without broader context |
+
+## Filling in Placeholders
+
+### Venture Context
+
+| Venture | `[VENTURE_NAME]` | `[ORG]` | `[REPO]` |
+|---------|------------------|---------|----------|
+| Crane Console | Crane Console | venturecrane | crane-console |
+| Venture Crane | Venture Crane | venturecrane | crane-operations |
+| Silicon Crane | Silicon Crane | siliconcrane | sc-operations |
+| DFG | DFG | durganfieldguide | dfg-console |
+
+### Relay Token
+
+**How to get the token:**
+1. Access Cloudflare dashboard
+2. Navigate to Workers > crane-relay
+3. Go to Settings > Variables
+4. Copy the `RELAY_TOKEN` value
+5. **Keep this confidential** — do not commit to repos or share publicly
+
+**Format:** The token is typically a long alphanumeric string starting with the venture abbreviation:
+- `vc_relay_...` (Venture Crane)
+- `sc_relay_...` (Silicon Crane)
+- `dfg_relay_...` (DFG)
+
+### Track Assignment
+
+Check the project board to determine track numbers:
+- Track 1: Usually infrastructure/platform work
+- Track 2: Usually product features
+- Track 3: Usually integrations/extensions
+
+Use relay API to see track assignments:
+```bash
+curl -H "Authorization: Bearer {RELAY_TOKEN}" \
+  "https://crane-relay.automation-ab6.workers.dev/project/items?org=[ORG]&project=1" \
+  | jq '.items[] | select(.track != null) | {number, title, track}'
+```
+
+## Tips for Effective CC CLI Sessions
+
+1. **Start with Track Coordinator for exploratory work** — let CC CLI discover what's ready
+2. **Use Track Executor for focused sprints** — when you've already triaged and planned
+3. **Use Single Issue for quick wins** — one-off fixes or small features
+4. **Always include relay token** — even if not strictly needed, it enables verification
+5. **Review session summary** — CC CLI should provide handoff at end of session
+6. **Monitor context usage** — plan for session boundaries on large multi-track work
+7. **Escalate early** — don't waste context on unclear requirements or blockers
+
+## Related Documentation
+
+- **CC CLI Track Coordinator Workflow:** `docs/process/CC_CLI_TRACK_COORDINATOR.md` — Detailed workflow phases and escalation format
+- **Team Workflow:** `workers/crane-command/CLAUDE.md` — Slash commands and QA grade reference
+- **Relay API Documentation:** See crane-relay worker for endpoint details
+
+## Version History
+
+- **1.0** (2026-01-16): Initial starting prompt templates for Track Coordinator, Track Executor, and Single Issue modes


### PR DESCRIPTION
Closes #17
Depends on: #16

## Summary
- Created `/docs/process/CC_CLI_STARTING_PROMPTS.md` with copy-paste ready templates
- Three modes: Track Coordinator, Track Executor, Single Issue
- Each template includes venture context, relay token placeholder, track assignment, and permission notes
- Quick reference table for selecting the right template
- Placeholder filling guide with venture-specific details
- References CC_CLI_TRACK_COORDINATOR.md for detailed workflow

## Templates Included
1. **Track Coordinator** — Full backlog review + planning + execution
   - Use when: You want CC CLI to autonomously review, plan, and execute multi-issue work
   - Includes: Relay API query, multi-track planning, dev brain review, execution, escalation

2. **Track Executor** — Pre-planned track, execute mode only
   - Use when: Track is already planned, just need execution
   - Includes: Pre-planned issue list, execution instructions, QA guidelines

3. **Single Issue** — Focused single-issue implementation
   - Use when: One-off implementation or quick fix
   - Includes: Issue context, agent brief, execution steps, QA note

## Coverage
- ✅ Track Coordinator template (full backlog review + planning)
- ✅ Track Executor template (assigned track, execute mode)
- ✅ Single Issue template (one issue focus)
- ✅ Venture context placeholders (org, repo, venture name)
- ✅ Relay token placeholder with security note
- ✅ Track assignment guidance
- ✅ Permission notes (reference to settings.json or --dangerously-skip-permissions)
- ✅ Templates are copy-paste ready with clear placeholder markers

## Test Plan
- [x] Documentation follows markdown best practices
- [x] All acceptance criteria met
- [x] Templates reference CC_CLI_TRACK_COORDINATOR.md
- [x] Placeholders clearly marked with [BRACKETS] and {BRACES}
- [x] Quick reference table aids template selection

🤖 Generated with Claude Code