### PR TITLE
feat: VCMS consolidation — tags-only taxonomy, enterprise context from notes

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -7,7 +7,6 @@ on:
       - main
     paths:
       - 'docs/process/**/*.md'
-      - 'docs/enterprise/**/*.md'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -29,12 +28,12 @@ jobs:
         run: |
           # Get list of changed markdown files in docs/process/
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger: sync all docs
-            echo "Manual trigger - syncing all docs in docs/process/ and docs/enterprise/"
-            CHANGED_FILES=$(find docs/process docs/enterprise -name "*.md" -type f 2>/dev/null)
+            # Manual trigger: sync all process docs
+            echo "Manual trigger - syncing all docs in docs/process/"
+            CHANGED_FILES=$(find docs/process -name "*.md" -type f 2>/dev/null)
           else
             # Automatic trigger: only sync changed docs
-            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|enterprise)/.*\.md$" || true)
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/process/.*\.md$" || true)
           fi
 
           if [ -z "$CHANGED_FILES" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,41 +71,47 @@ infisical secrets --path /vc --env dev
 
 See `docs/infra/secrets-management.md` for full documentation.
 
-## Enterprise Knowledge Store
+## Enterprise Knowledge Store (VCMS)
 
-The agent dialog is the hub of the enterprise. All enterprise knowledge
-flows through CLI conversations and is stored in D1, accessible from any
-machine (including Blink Shell on phone).
+The Venture Crane Management System stores agent-relevant enterprise context
+in D1, accessible from any machine. VCMS is for content that makes agents
+smarter — not general note-taking.
 
 **MCP tools:**
 
-- `crane_note` — Store knowledge (create or update)
-- `crane_notes` — Search/retrieve knowledge
+- `crane_note` — Store or update enterprise context
+- `crane_notes` — Search/retrieve by tag, venture, or text
 
-**Trigger phrases** (use `crane_note` when the Captain says these):
+**What belongs in VCMS:**
 
-- "log:" / "captain's log:" → category: `log`
-- "remember:" / "save:" → category: `reference`
-- "save contact:" → category: `contact`
-- "note:" / "idea:" → category: `idea`
-- "governance:" → category: `governance`
+Use `crane_note` when the Captain explicitly asks to store agent-relevant
+context. Tag appropriately using the vocabulary below.
 
-**Retrieval** (use `crane_notes` when the Captain asks):
+| Tag                 | Purpose                                       |
+| ------------------- | --------------------------------------------- |
+| `executive-summary` | Venture overviews, mission, stage, tech stack |
+| `prd`               | Product requirements documents                |
+| `design`            | Design briefs                                 |
+| `strategy`          | Strategic assessments, founder reflections    |
+| `methodology`       | Frameworks, processes (e.g., Crane Way)       |
+| `market-research`   | Competitors, market analysis                  |
+| `bio`               | Founder/team bios                             |
+| `marketing`         | Service descriptions, positioning             |
+| `governance`        | Legal, tax, compliance                        |
 
-- "what's our..." / "what was..." → search by query
-- "show recent log entries" → filter by category
-- "KE contacts" → filter by venture + category
+New tags can be added without code changes.
 
-**Never auto-save.** Only store notes when the Captain explicitly uses a
-trigger phrase or asks to save something. If in doubt, ask before saving.
+**Never auto-save.** Only store notes when the Captain explicitly asks
+to save something. If in doubt, ask before saving.
 
-**Never store in notes:**
+**Never store in VCMS:**
 
 - Code, terminal output, implementation details (ephemeral)
 - Session handoffs (→ `/eod`)
 - Architecture decisions (→ `docs/adr/`)
 - Process docs (→ `docs/process/`)
 - Actual secrets/API keys (→ Infisical)
+- Personal content (→ Apple Notes)
 
 ### Apple Notes (personal only)
 
@@ -115,23 +121,21 @@ Apple Notes MCP is available on macOS machines for personal content only
 
 ### Enterprise Context (Executive Summaries)
 
-Each venture has an executive summary in git, synced to D1 for cross-venture
-agent access. These are the canonical source of enterprise context.
+Executive summaries are stored in VCMS notes tagged `executive-summary`.
+Agents receive them automatically via the `/sod` flow.
 
-**Source of truth:** `docs/enterprise/ventures/`
+**Source of truth:** VCMS notes with tag `executive-summary`
 
-- `smd-enterprise-summary.md` — portfolio overview (scope: global)
-- `vc-executive-summary.md` — shared infrastructure (scope: vc)
-- `ke-executive-summary.md` — co-parent expense tracking (scope: ke)
-- `sc-executive-summary.md` — validation-as-a-service (scope: sc)
-- `dfg-executive-summary.md` — auction intelligence (scope: dfg)
-- `dc-executive-summary.md` — early-stage venture (scope: dc)
+- SMD Enterprise Summary (scope: global)
+- VC Executive Summary (scope: vc)
+- KE Executive Summary (scope: ke)
+- SC Executive Summary (scope: sc)
+- DFG Executive Summary (scope: dfg)
+- DC Executive Summary (scope: dc)
 
-**Distribution:** Git → `upload-doc-to-context-worker.sh` → D1 → `/sod` API → agents
-
-Agents receive enterprise summaries automatically via the existing `/sod` flow.
-To update a summary, edit the markdown file and push to main. The GitHub Actions
-workflow syncs changes to D1 automatically.
+To update a summary, use `crane_note` with action `update` and the note ID.
+Git files in `docs/enterprise/ventures/` are kept for history but are
+no longer the canonical source.
 
 ## Development Workflow
 

--- a/docs/enterprise/ventures/DEPRECATED.md
+++ b/docs/enterprise/ventures/DEPRECATED.md
@@ -1,0 +1,16 @@
+# Deprecated — Executive Summaries Moved to VCMS Notes
+
+The markdown files in this directory are **kept for git history only**.
+
+The canonical source for executive summaries is now the VCMS notes table
+(D1), tagged with `executive-summary`. Agents receive them automatically
+via the `/sod` flow.
+
+To view or update an executive summary:
+
+```
+crane_notes(tag: "executive-summary")           # list all
+crane_note(action: "update", id: "...", ...)    # update one
+```
+
+Migrated: 2026-02-11

--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -146,8 +146,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'crane_note',
         description:
-          'Create or update a note in the enterprise knowledge store. ' +
-          'Use when the Captain says: "log:", "remember:", "save contact:", "note:", "idea:", "governance:", or "update note".',
+          'Create or update a note in the enterprise knowledge store (VCMS). ' +
+          'Use to store agent-relevant context: exec summaries, PRDs, strategy, methodology, bios. Tag appropriately.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -160,11 +160,6 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'Note ID (required for update, ignored for create)',
             },
-            category: {
-              type: 'string',
-              enum: ['log', 'reference', 'contact', 'idea', 'governance'],
-              description: 'Note category (required for create)',
-            },
             title: {
               type: 'string',
               description: 'Optional title/subject',
@@ -176,7 +171,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             tags: {
               type: 'array',
               items: { type: 'string' },
-              description: 'Optional tags for categorization',
+              description:
+                'Tags for categorization (e.g., executive-summary, prd, strategy, methodology, bio, governance)',
             },
             venture: {
               type: 'string',
@@ -189,23 +185,19 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'crane_notes',
         description:
-          'Search and list notes from the enterprise knowledge store. ' +
-          'Use when the Captain asks: "what\'s our...", "show recent...", "find the note about...".',
+          'Search and list notes from the enterprise knowledge store (VCMS). ' +
+          'Use when asked: "what\'s our...", "show recent...", "find the note about...".',
         inputSchema: {
           type: 'object',
           properties: {
-            category: {
-              type: 'string',
-              enum: ['log', 'reference', 'contact', 'idea', 'governance'],
-              description: 'Filter by category',
-            },
             venture: {
               type: 'string',
               description: 'Filter by venture code',
             },
             tag: {
               type: 'string',
-              description: 'Filter by tag',
+              description:
+                'Filter by tag (e.g., executive-summary, prd, strategy, methodology, bio)',
             },
             q: {
               type: 'string',

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -89,6 +89,10 @@ export interface SodResponse {
     count: number
     content_hash?: string
   }
+  enterprise_context?: {
+    notes: Note[]
+    count: number
+  }
 }
 
 export interface UploadDocRequest {
@@ -164,7 +168,6 @@ export interface SshMeshConfigResponse {
 
 export interface Note {
   id: string
-  category: string
   title: string | null
   content: string
   tags: string | null
@@ -177,7 +180,6 @@ export interface Note {
 }
 
 export interface CreateNoteRequest {
-  category: string
   title?: string
   content: string
   tags?: string[]
@@ -189,7 +191,6 @@ export interface CreateNoteResponse {
 }
 
 export interface ListNotesParams {
-  category?: string
   venture?: string
   tag?: string
   q?: string
@@ -210,7 +211,6 @@ export interface UpdateNoteRequest {
   content?: string
   tags?: string[]
   venture?: string | null
-  category?: string
 }
 
 export interface GetNoteResponse {
@@ -385,7 +385,6 @@ export class CraneApi {
 
   async listNotes(params: ListNotesParams = {}): Promise<ListNotesResponse> {
     const queryParts: string[] = []
-    if (params.category) queryParts.push(`category=${encodeURIComponent(params.category)}`)
     if (params.venture) queryParts.push(`venture=${encodeURIComponent(params.venture)}`)
     if (params.tag) queryParts.push(`tag=${encodeURIComponent(params.tag)}`)
     if (params.q) queryParts.push(`q=${encodeURIComponent(params.q)}`)

--- a/packages/crane-mcp/src/tools/notes.test.ts
+++ b/packages/crane-mcp/src/tools/notes.test.ts
@@ -26,7 +26,7 @@ describe('crane_note tool', () => {
     vi.unstubAllGlobals()
   })
 
-  it('creates a log note', async () => {
+  it('creates a note with tags', async () => {
     const { executeNote } = await getModule()
 
     mockFetch.mockResolvedValueOnce({
@@ -34,10 +34,9 @@ describe('crane_note tool', () => {
       json: async () => ({
         note: {
           id: 'note_01ABC',
-          category: 'log',
           title: null,
           content: 'Decided to push KE beta to March.',
-          tags: null,
+          tags: '["strategy"]',
           venture: 'ke',
           archived: 0,
           created_at: '2026-02-10T00:00:00.000Z',
@@ -50,17 +49,17 @@ describe('crane_note tool', () => {
 
     const result = await executeNote({
       action: 'create',
-      category: 'log',
       content: 'Decided to push KE beta to March.',
+      tags: ['strategy'],
       venture: 'ke',
     })
 
     expect(result.success).toBe(true)
     expect(result.message).toContain('note_01ABC')
-    expect(result.message).toContain('log')
+    expect(result.message).toContain('strategy')
   })
 
-  it('creates a reference note with title and tags', async () => {
+  it('creates a note with title and multiple tags', async () => {
     const { executeNote } = await getModule()
 
     mockFetch.mockResolvedValueOnce({
@@ -68,10 +67,9 @@ describe('crane_note tool', () => {
       json: async () => ({
         note: {
           id: 'note_01DEF',
-          category: 'reference',
           title: 'Cloudflare Account ID',
           content: 'ab6cc9362f7e51ba9a610aec1fc3a833',
-          tags: '["cloudflare","infra"]',
+          tags: '["methodology","governance"]',
           venture: null,
           archived: 0,
           created_at: '2026-02-10T00:00:00.000Z',
@@ -84,10 +82,9 @@ describe('crane_note tool', () => {
 
     const result = await executeNote({
       action: 'create',
-      category: 'reference',
       title: 'Cloudflare Account ID',
       content: 'ab6cc9362f7e51ba9a610aec1fc3a833',
-      tags: ['cloudflare', 'infra'],
+      tags: ['methodology', 'governance'],
     })
 
     expect(result.success).toBe(true)
@@ -102,7 +99,6 @@ describe('crane_note tool', () => {
 
     const result = await executeNote({
       action: 'create',
-      category: 'log',
       content: 'test',
     })
 
@@ -110,24 +106,11 @@ describe('crane_note tool', () => {
     expect(result.message).toContain('CRANE_CONTEXT_KEY not found')
   })
 
-  it('returns error when category missing for create', async () => {
-    const { executeNote } = await getModule()
-
-    const result = await executeNote({
-      action: 'create',
-      content: 'test',
-    })
-
-    expect(result.success).toBe(false)
-    expect(result.message).toContain('Category is required')
-  })
-
   it('returns error when content missing for create', async () => {
     const { executeNote } = await getModule()
 
     const result = await executeNote({
       action: 'create',
-      category: 'log',
     })
 
     expect(result.success).toBe(false)
@@ -142,10 +125,9 @@ describe('crane_note tool', () => {
       json: async () => ({
         note: {
           id: 'note_01ABC',
-          category: 'reference',
           title: 'Cloudflare Account ID',
           content: '123abc',
-          tags: '["cloudflare","infra"]',
+          tags: '["governance"]',
           venture: null,
           archived: 0,
           created_at: '2026-02-10T00:00:00.000Z',
@@ -190,7 +172,6 @@ describe('crane_note tool', () => {
 
     const result = await executeNote({
       action: 'create',
-      category: 'log',
       content: 'test',
     })
 
@@ -225,10 +206,9 @@ describe('crane_notes tool', () => {
         notes: [
           {
             id: 'note_01ABC',
-            category: 'log',
             title: 'KE Beta Decision',
             content: 'Decided to push KE beta to March.',
-            tags: null,
+            tags: '["strategy"]',
             venture: 'ke',
             archived: 0,
             created_at: '2026-02-10T00:00:00.000Z',
@@ -249,7 +229,7 @@ describe('crane_notes tool', () => {
     expect(result.message).toContain('note_01ABC')
   })
 
-  it('filters by category and venture', async () => {
+  it('filters by tag and venture', async () => {
     const { executeNotes } = await getModule()
 
     mockFetch.mockResolvedValueOnce({
@@ -261,18 +241,18 @@ describe('crane_notes tool', () => {
     })
 
     const result = await executeNotes({
-      category: 'log',
+      tag: 'executive-summary',
       venture: 'ke',
     })
 
     expect(result.success).toBe(true)
     expect(result.message).toContain('No notes found')
-    expect(result.message).toContain('category=log')
+    expect(result.message).toContain('tag=executive-summary')
     expect(result.message).toContain('venture=ke')
 
     // Verify query params passed correctly
     const url = mockFetch.mock.calls[0][0] as string
-    expect(url).toContain('category=log')
+    expect(url).toContain('tag=executive-summary')
     expect(url).toContain('venture=ke')
   })
 
@@ -285,10 +265,9 @@ describe('crane_notes tool', () => {
         notes: [
           {
             id: 'note_01DEF',
-            category: 'reference',
             title: 'Cloudflare Account ID',
             content: 'ab6cc9362f7e51ba9a610aec1fc3a833',
-            tags: '["cloudflare"]',
+            tags: '["governance"]',
             venture: null,
             archived: 0,
             created_at: '2026-02-10T00:00:00.000Z',

--- a/packages/crane-mcp/src/tools/sod.ts
+++ b/packages/crane-mcp/src/tools/sod.ts
@@ -245,6 +245,18 @@ export async function executeSod(input: SodInput): Promise<SodResult> {
           message += '\n'
         }
 
+        // Enterprise context from notes
+        const ecNotes = session.enterprise_context?.notes || []
+        if (ecNotes.length > 0) {
+          message += `### Enterprise Context\n`
+          for (const note of ecNotes) {
+            const scope = note.venture || 'global'
+            message += `\n#### ${note.title || '(untitled)'} (${scope})\n\n`
+            message += note.content + '\n'
+          }
+          message += '\n'
+        }
+
         // Doc audit results
         if (healingResults.generated.length > 0) {
           message += `### Documentation (self-healed)\n`

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -53,21 +53,7 @@ GLOBAL_DOCS=(
   "cli-context-integration.md"
   "dev-box-setup.md"
   "CONTEXT-WORKER-SETUP.md"
-  "smd-enterprise-summary.md"
 )
-
-# Enterprise docs: venture-scoped executive summaries
-# Returns scope for a given enterprise doc name, or empty string if not found
-enterprise_scope() {
-  case "$1" in
-    vc-executive-summary.md) echo "vc" ;;
-    ke-executive-summary.md) echo "ke" ;;
-    sc-executive-summary.md) echo "sc" ;;
-    dfg-executive-summary.md) echo "dfg" ;;
-    dc-executive-summary.md) echo "dc" ;;
-    *) echo "" ;;
-  esac
-}
 
 # Validate arguments
 if [ -z "$1" ]; then
@@ -112,9 +98,6 @@ else
   if [ "$IS_GLOBAL" = true ]; then
     SCOPE="global"
     echo -e "${BLUE}Scope: global (whitelisted doc)${NC}"
-  elif [ -n "$(enterprise_scope "$DOC_NAME")" ]; then
-    SCOPE="$(enterprise_scope "$DOC_NAME")"
-    echo -e "${BLUE}Scope: $SCOPE (enterprise doc)${NC}"
   else
     # Venture-specific: determine from repo
     if [ -n "$GITHUB_REPOSITORY" ]; then

--- a/workers/crane-context/migrations/0011_drop_note_categories.sql
+++ b/workers/crane-context/migrations/0011_drop_note_categories.sql
@@ -1,0 +1,27 @@
+-- Drop category column from notes table
+-- Categories replaced by tags-only taxonomy
+
+CREATE TABLE notes_new (
+  id TEXT PRIMARY KEY,
+  title TEXT,
+  content TEXT NOT NULL,
+  tags TEXT,                            -- JSON array: ["executive-summary", "prd"]
+  venture TEXT,                         -- optional venture scope (null = global)
+  archived INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  actor_key_id TEXT,
+  meta_json TEXT
+);
+
+INSERT INTO notes_new (id, title, content, tags, venture, archived, created_at, updated_at, actor_key_id, meta_json)
+  SELECT id, title, content, tags, venture, archived, created_at, updated_at, actor_key_id, meta_json
+  FROM notes;
+
+DROP TABLE notes;
+ALTER TABLE notes_new RENAME TO notes;
+
+-- Recreate indexes (drop category index, keep the rest)
+CREATE INDEX idx_notes_venture ON notes(venture);
+CREATE INDEX idx_notes_created ON notes(created_at DESC);
+CREATE INDEX idx_notes_tags ON notes(tags) WHERE tags IS NOT NULL;

--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -101,10 +101,20 @@ export const ID_PREFIXES = {
 // ============================================================================
 
 /**
- * Valid note categories
+ * Recommended tags for the enterprise knowledge store (VCMS)
+ * Informational — agents and humans can use any tag
  */
-export const NOTE_CATEGORIES = ['log', 'reference', 'contact', 'idea', 'governance'] as const
-export type NoteCategory = (typeof NOTE_CATEGORIES)[number]
+export const RECOMMENDED_TAGS = [
+  'executive-summary',
+  'prd',
+  'design',
+  'strategy',
+  'methodology',
+  'market-research',
+  'bio',
+  'marketing',
+  'governance',
+] as const
 
 /**
  * Maximum note content size: 500KB
@@ -238,26 +248,6 @@ export const DEFAULT_DOC_REQUIREMENTS = [
     auto_generate: true,
     generation_sources: '["migrations","schema_files","wrangler_toml"]',
     description: 'Database schema — tables, columns, relationships.',
-    staleness_days: 90,
-  },
-  {
-    doc_name_pattern: '{venture}-executive-summary.md',
-    scope_type: 'all_ventures',
-    required: true,
-    condition: null,
-    auto_generate: false,
-    generation_sources: '[]',
-    description: 'Executive summary — venture mission, stage, tech stack, key dependencies.',
-    staleness_days: 90,
-  },
-  {
-    doc_name_pattern: 'smd-enterprise-summary.md',
-    scope_type: 'global',
-    required: true,
-    condition: null,
-    auto_generate: false,
-    generation_sources: '[]',
-    description: 'Enterprise portfolio overview — all ventures, infrastructure model, methodology.',
     staleness_days: 90,
   },
 ] as const

--- a/workers/crane-context/src/endpoints/notes.ts
+++ b/workers/crane-context/src/endpoints/notes.ts
@@ -9,7 +9,7 @@ import type { Env } from '../types'
 import { createNote, listNotes, getNote, updateNote, archiveNote } from '../notes'
 import { buildRequestContext, isResponse } from '../auth'
 import { jsonResponse, errorResponse, validationErrorResponse } from '../utils'
-import { HTTP_STATUS, NOTE_CATEGORIES } from '../constants'
+import { HTTP_STATUS } from '../constants'
 
 // ============================================================================
 // POST /notes - Create a Note
@@ -25,13 +25,6 @@ export async function handleCreateNote(request: Request, env: Env): Promise<Resp
     const body = (await request.json()) as any
 
     // Validate required fields
-    if (!body.category || typeof body.category !== 'string') {
-      return validationErrorResponse(
-        [{ field: 'category', message: `Required. Must be one of: ${NOTE_CATEGORIES.join(', ')}` }],
-        context.correlationId
-      )
-    }
-
     if (!body.content || typeof body.content !== 'string') {
       return validationErrorResponse(
         [{ field: 'content', message: 'Required string field' }],
@@ -40,7 +33,6 @@ export async function handleCreateNote(request: Request, env: Env): Promise<Resp
     }
 
     const note = await createNote(env.DB, {
-      category: body.category,
       title: body.title,
       content: body.content,
       tags: body.tags,
@@ -81,7 +73,6 @@ export async function handleListNotes(request: Request, env: Env): Promise<Respo
     const url = new URL(request.url)
 
     const result = await listNotes(env.DB, {
-      category: url.searchParams.get('category') || undefined,
       venture: url.searchParams.get('venture') || undefined,
       tag: url.searchParams.get('tag') || undefined,
       q: url.searchParams.get('q') || undefined,
@@ -169,7 +160,6 @@ export async function handleUpdateNote(
       content: body.content,
       tags: body.tags,
       venture: body.venture,
-      category: body.category,
       actor_key_id: context.actorKeyId,
     })
 

--- a/workers/crane-context/src/types.ts
+++ b/workers/crane-context/src/types.ts
@@ -5,10 +5,10 @@
  * Matches ADR 025 specification.
  */
 
-import type { Venture, SessionStatus, EndReason, NoteCategory } from './constants'
+import type { Venture, SessionStatus, EndReason } from './constants'
 
 // Re-export for convenience
-export type { Venture, SessionStatus, EndReason, NoteCategory }
+export type { Venture, SessionStatus, EndReason }
 
 // ============================================================================
 // Environment Bindings
@@ -209,7 +209,6 @@ export interface MachineRecord {
 
 export interface NoteRecord {
   id: string
-  category: NoteCategory
   title: string | null
   content: string
   tags: string | null // JSON array


### PR DESCRIPTION
## Summary

- Drop `category` column from notes table, replace with tags-only taxonomy using a controlled vocabulary (executive-summary, prd, strategy, methodology, bio, etc.)
- Add `fetchEnterpriseContext()` to serve executive summaries from notes via `/sod`
- Remove executive summary requirements from doc audit (now lives in notes, not context_docs)
- Clean up GitHub Actions and upload script to stop syncing enterprise docs from git
- Update CLAUDE.md with VCMS scope, tag vocabulary, and new guidance

## Post-merge deploy steps

1. D1 migration: `cd workers/crane-context && npx wrangler d1 migrations apply crane-context-db-prod --remote`
2. Deploy worker: `cd workers/crane-context && npm run deploy`
3. Migrate 6 exec summaries to notes via curl (POST /notes with tag `executive-summary`)
4. Clean up stale context_docs rows (DELETE WHERE doc_name LIKE `%-executive-summary.md`)
5. Archive non-agent notes via POST /notes/:id/archive
6. Rebuild MCP: `cd packages/crane-mcp && npm run build && npm link`

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + 143 tests)
- [ ] Deploy worker and run D1 migration
- [ ] `crane_note` creates notes without category field
- [ ] `crane_notes` filters by tag and venture (not category)
- [ ] `/sod` renders enterprise context from notes
- [ ] Doc audit no longer flags missing exec summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)