### PR TITLE
feat: staging/production environment split (Phase 1)

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -1,5 +1,8 @@
 name: Sync Docs to Context Worker
 
+# Uploads docs to the PRODUCTION crane-context worker only.
+# Staging does not receive doc syncs (it uses its own empty DB).
+
 # Trigger on push to main when docs change
 on:
   push:

--- a/docs/infra/secrets-management.md
+++ b/docs/infra/secrets-management.md
@@ -24,12 +24,13 @@ All ventures share one Infisical project (`venture-crane`) with folder-based org
 ```
 venture-crane (project)
 └── dev (environment)
-    ├── /vc   - Venture Crane (shared infra + VC-specific)
-    ├── /ke   - Kid Expenses
-    ├── /sc   - Silicon Crane
-    ├── /dfg  - Durgan Field Guide
-    ├── /smd  - SMD Ventures
-    └── /dc   - Draft Crane
+    ├── /vc          - Venture Crane (shared infra + VC-specific)
+    │   └── /staging - Staging-specific infrastructure keys
+    ├── /ke          - Kid Expenses
+    ├── /sc          - Silicon Crane
+    ├── /dfg         - Durgan Field Guide
+    ├── /smd         - SMD Ventures
+    └── /dc          - Draft Crane
 ```
 
 ## Common Secrets by Venture
@@ -47,6 +48,18 @@ venture-crane (project)
 | GH_WEBHOOK_SECRET_CLASSIFIER | Webhook secret for crane-classifier  |
 
 > **Note:** GITHUB_TOKEN was removed from /vc. GitHub API access now uses `gh` CLI keyring auth (via `gh auth login`). This is preferred because keyring auth is managed per-machine and doesn't require Infisical secret rotation.
+
+### /vc/staging (Staging Infrastructure)
+
+Staging workers use distinct infrastructure keys but share external service credentials with production.
+
+| Secret             | Purpose                                         |
+| ------------------ | ----------------------------------------------- |
+| CRANE_CONTEXT_KEY  | Staging access to crane-context-staging         |
+| CRANE_ADMIN_KEY    | Staging admin access to crane-context-staging   |
+| GEMINI_API_KEY     | AI classification (shared with production)      |
+| GH_PRIVATE_KEY_PEM | GitHub App private key (shared with production) |
+| GH_WEBHOOK_SECRET  | Webhook secret (shared with production)         |
 
 ### /ke (Kid Expenses)
 

--- a/workers/crane-classifier/CLAUDE.md
+++ b/workers/crane-classifier/CLAUDE.md
@@ -10,7 +10,8 @@ Crane Classifier is a single-purpose VC infrastructure service that:
 - Calls Gemini Flash to grade issues (qa:0/1/2/3)
 - Applies labels automatically
 
-**Service URL:** https://crane-classifier.automation-ab6.workers.dev
+**Production URL:** https://crane-classifier.automation-ab6.workers.dev
+**Staging URL:** https://crane-classifier-staging.automation-ab6.workers.dev
 
 ## Build Commands
 
@@ -18,7 +19,8 @@ Crane Classifier is a single-purpose VC infrastructure service that:
 # From workers/crane-classifier/
 npm install             # Install dependencies
 npx wrangler dev        # Local dev server
-npx wrangler deploy     # Deploy to Cloudflare
+npx wrangler deploy     # Deploy to staging
+npx wrangler deploy --env production  # Deploy to production
 npx tsc --noEmit        # TypeScript validation
 ```
 
@@ -74,10 +76,15 @@ GitHub App webhook receiver. Expects:
 ```bash
 cd workers/crane-classifier
 
-# Required secrets (copy from crane-relay)
+# Staging secrets (default, no --env flag)
 wrangler secret put GEMINI_API_KEY
 wrangler secret put GH_PRIVATE_KEY_PEM
 wrangler secret put GH_WEBHOOK_SECRET
+
+# Production secrets
+wrangler secret put GEMINI_API_KEY --env production
+wrangler secret put GH_PRIVATE_KEY_PEM --env production
+wrangler secret put GH_WEBHOOK_SECRET --env production
 ```
 
 ## Database Setup
@@ -95,11 +102,17 @@ wrangler d1 migrations apply crane-classifier-db --remote
 ## Deployment
 
 ```bash
-# Deploy
+# Deploy to staging (default)
 npx wrangler deploy
 
-# Check logs
+# Deploy to production
+npx wrangler deploy --env production
+
+# Check logs (staging)
 npx wrangler tail --format pretty
+
+# Check logs (production)
+npx wrangler tail --format pretty --env production
 ```
 
 ## GitHub App Webhook Configuration

--- a/workers/crane-classifier/package.json
+++ b/workers/crane-classifier/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy",
+    "deploy:prod": "wrangler deploy --env production",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/workers/crane-classifier/wrangler.toml
+++ b/workers/crane-classifier/wrangler.toml
@@ -1,8 +1,9 @@
-name = "crane-classifier"
+name = "crane-classifier-staging"
 main = "src/index.ts"
 compatibility_date = "2025-12-15"
 compatibility_flags = ["nodejs_compat"]
 
+# Default = staging
 [vars]
 GH_APP_ID = "2619905"
 GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482"}'
@@ -15,5 +16,18 @@ GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482"}'
 
 [[d1_databases]]
 binding = "DB"
+database_name = "crane-classifier-db-staging"
+database_id = "ca5df161-4773-4942-b706-b8b956308369"
+
+# Production — preserves existing worker name and URL
+[env.production]
+name = "crane-classifier"
+
+[[env.production.d1_databases]]
+binding = "DB"
 database_name = "crane-classifier-db"
 database_id = "e01fe064-daf5-4ee9-89e1-6bcaa756b4c0"
+
+[env.production.vars]
+GH_APP_ID = "2619905"
+GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482"}'

--- a/workers/crane-context/package.json
+++ b/workers/crane-context/package.json
@@ -5,10 +5,13 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy",
+    "deploy:prod": "wrangler deploy --env production",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
-    "db:migrate": "wrangler d1 execute crane-context-db-prod --remote --file=./migrations/schema.sql",
-    "db:migrate:local": "wrangler d1 execute crane-context-db-prod --local --file=./migrations/schema.sql"
+    "db:migrate": "wrangler d1 execute crane-context-db-staging --remote --file=./migrations/schema.sql",
+    "db:migrate:prod": "wrangler d1 execute crane-context-db-prod --remote --file=./migrations/schema.sql --env production",
+    "db:migrate:local": "wrangler d1 execute crane-context-db-staging --local --file=./migrations/schema.sql"
   },
   "dependencies": {
     "ajv": "^8.12.0",

--- a/workers/crane-context/wrangler.toml
+++ b/workers/crane-context/wrangler.toml
@@ -1,11 +1,12 @@
-name = "crane-context"
+name = "crane-context-staging"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
+# Default = staging
 [[d1_databases]]
 binding = "DB"
-database_name = "crane-context-db-prod"
-database_id = "afa6ecea-25f6-4ed6-9f4d-f81fd0409e2e"
+database_name = "crane-context-db-staging"
+database_id = "b2182c5b-6f83-47e8-87ee-3dc62511c24e"
 preview_database_id = "0d8f52b3-a06c-4b20-b226-bcb76a6b18d4"
 
 [vars]
@@ -16,3 +17,18 @@ HEARTBEAT_JITTER_SECONDS = "120"
 
 # Secrets (set via: wrangler secret put <NAME>)
 # CONTEXT_RELAY_KEY = "<same-as-relay-key>"
+
+# Production — preserves existing worker name and URL
+[env.production]
+name = "crane-context"
+
+[[env.production.d1_databases]]
+binding = "DB"
+database_name = "crane-context-db-prod"
+database_id = "afa6ecea-25f6-4ed6-9f4d-f81fd0409e2e"
+
+[env.production.vars]
+CONTEXT_SESSION_STALE_MINUTES = "45"
+IDEMPOTENCY_TTL_SECONDS = "3600"
+HEARTBEAT_INTERVAL_SECONDS = "600"
+HEARTBEAT_JITTER_SECONDS = "120"


### PR DESCRIPTION
## Summary

- Add `[env.production]` blocks to crane-context and crane-classifier wrangler.toml files — default deploy targets staging, `--env production` preserves existing worker names and URLs
- Create staging D1 databases, run migrations, set up Infisical `/vc/staging` path with distinct infrastructure keys
- Add `deploy:staging`, `deploy:prod`, `db:migrate:prod` npm scripts to both workers
- Update ADR 026 status to Accepted, remove crane-relay references, document Phase 1 completion

## Test plan

- [x] Production health endpoints return 200 (no regression)
- [x] Staging health endpoints return 200
- [x] `wrangler secret list --env production` shows expected secrets for both workers
- [x] `npm run verify` passes locally (151 tests, 0 lint errors)
- [x] `wrangler dev` still works for local development
- [ ] Production `/sod` still works end-to-end

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)