### PR TITLE
fix: use timing-safe comparison for webhook signature validation

### DIFF
--- a/workers/crane-classifier/src/index.ts
+++ b/workers/crane-classifier/src/index.ts
@@ -239,7 +239,10 @@ async function validateGitHubSignature(
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
 
-  return computedSig === expectedSig
+  // Use timing-safe comparison to prevent side-channel attacks
+  const a = encoder.encode(computedSig)
+  const b = encoder.encode(expectedSig)
+  return a.byteLength === b.byteLength && crypto.subtle.timingSafeEqual(a, b)
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace string `===` comparison with `crypto.subtle.timingSafeEqual` for webhook signature validation in crane-classifier
- Prevents timing side-channel attacks where an attacker could theoretically brute-force the webhook secret byte-by-byte by measuring response times

## Changes
- Updated `validateGitHubSignature` in `workers/crane-classifier/src/index.ts` to encode both hex strings as `Uint8Array` via `TextEncoder` and compare with `crypto.subtle.timingSafeEqual`

## Test Plan
- [x] `npm run verify` passes (typecheck, format, lint, tests, build)
- [ ] Verify webhook signature validation still accepts valid signatures
- [ ] Verify webhook signature validation still rejects invalid signatures

Closes #214

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>