### PR TITLE
fix: use timing-safe comparison for secret key auth

### DIFF
--- a/workers/crane-context/src/auth.ts
+++ b/workers/crane-context/src/auth.ts
@@ -6,7 +6,12 @@
  */
 
 import type { Env, AuthContext, RequestContext } from './types'
-import { deriveActorKeyId, generateCorrelationId, unauthorizedResponse } from './utils'
+import {
+  deriveActorKeyId,
+  generateCorrelationId,
+  timingSafeEqual,
+  unauthorizedResponse,
+} from './utils'
 
 // ============================================================================
 // Auth Validation
@@ -26,7 +31,7 @@ export async function validateRelayKey(request: Request, env: Env): Promise<stri
     return null
   }
 
-  if (key !== env.CONTEXT_RELAY_KEY) {
+  if (!(await timingSafeEqual(key, env.CONTEXT_RELAY_KEY))) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- Replace direct string `===` comparison with `crypto.subtle.timingSafeEqual` for relay key auth in `auth.ts`
- Replace SHA-256 hash + string `===` comparison with `crypto.subtle.timingSafeEqual` for admin key auth in `admin.ts`
- Add shared `timingSafeEqual` helper in `utils.ts` that handles differing-length strings by hashing to fixed-size buffers before comparison, avoiding length-based timing leaks

## Test Plan
- [ ] Verify relay key auth still works (valid key accepted, invalid key rejected)
- [ ] Verify admin key auth still works (valid key accepted, invalid key rejected)
- [ ] `npm run verify` passes (typecheck, format, lint, tests, build)

Closes #213

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>