### PR TITLE
fix: replace as-any casts with typed interfaces in crane-context

### DIFF
--- a/workers/crane-context/src/docs.ts
+++ b/workers/crane-context/src/docs.ts
@@ -27,6 +27,14 @@ export interface DocsResponse {
   content_hash_combined: string // Combined hash of all docs for cache validation
 }
 
+export interface DocMetadataRow {
+  scope: string
+  doc_name: string
+  content_hash: string
+  title: string | null
+  version: number
+}
+
 // ============================================================================
 // Documentation Fetching
 // ============================================================================
@@ -106,7 +114,7 @@ export async function fetchDocsMetadata(
       .all()
 
     return {
-      docs: result.results as any,
+      docs: result.results as unknown as DocMetadataRow[],
       count: result.results.length,
     }
   } catch (error) {

--- a/workers/crane-context/src/endpoints/admin.ts
+++ b/workers/crane-context/src/endpoints/admin.ts
@@ -292,7 +292,7 @@ export async function handleListDocs(request: Request, env: Env): Promise<Respon
 
     const response: ListDocsResponse = {
       success: true,
-      docs: result.results as any,
+      docs: result.results as ListDocsResponse['docs'],
       count: result.results.length,
     }
 

--- a/workers/crane-context/src/endpoints/machines.ts
+++ b/workers/crane-context/src/endpoints/machines.ts
@@ -4,7 +4,7 @@
  * Handlers for machine registration, listing, heartbeat, and SSH mesh config.
  */
 
-import type { Env } from '../types'
+import type { Env, RegisterMachineRequest } from '../types'
 import {
   registerMachine,
   listMachines,
@@ -26,7 +26,7 @@ export async function handleRegisterMachine(request: Request, env: Env): Promise
   }
 
   try {
-    const body = (await request.json()) as any
+    const body = (await request.json()) as RegisterMachineRequest
 
     // Validate required fields
     const required = ['hostname', 'tailscale_ip', 'user', 'os', 'arch'] as const

--- a/workers/crane-context/src/endpoints/notes.ts
+++ b/workers/crane-context/src/endpoints/notes.ts
@@ -12,6 +12,24 @@ import { jsonResponse, errorResponse, validationErrorResponse } from '../utils'
 import { HTTP_STATUS } from '../constants'
 
 // ============================================================================
+// Request Body Types
+// ============================================================================
+
+interface CreateNoteBody {
+  title?: string
+  content: string
+  tags?: string[]
+  venture?: string
+}
+
+interface UpdateNoteBody {
+  title?: string
+  content?: string
+  tags?: string[]
+  venture?: string
+}
+
+// ============================================================================
 // POST /notes - Create a Note
 // ============================================================================
 
@@ -22,7 +40,7 @@ export async function handleCreateNote(request: Request, env: Env): Promise<Resp
   }
 
   try {
-    const body = (await request.json()) as any
+    const body = (await request.json()) as CreateNoteBody
 
     // Validate required fields
     if (!body.content || typeof body.content !== 'string') {
@@ -153,7 +171,7 @@ export async function handleUpdateNote(
   }
 
   try {
-    const body = (await request.json()) as any
+    const body = (await request.json()) as UpdateNoteBody
 
     const note = await updateNote(env.DB, noteId, {
       title: body.title,

--- a/workers/crane-context/src/endpoints/sessions.ts
+++ b/workers/crane-context/src/endpoints/sessions.ts
@@ -34,6 +34,61 @@ import type { DocAuditResult } from '../audit'
 import { touchMachineByHostname } from '../machines'
 
 // ============================================================================
+// Request Body Types
+// ============================================================================
+
+interface StartOfDayBody {
+  agent: string
+  client?: string
+  client_version?: string
+  host?: string
+  venture: string
+  repo: string
+  track?: number
+  issue_number?: number
+  branch?: string
+  commit_sha?: string
+  session_group_id?: string
+  meta?: Record<string, unknown>
+  include_docs?: boolean
+  docs_format?: 'full' | 'index'
+  include_scripts?: boolean
+  scripts_format?: 'full' | 'index'
+  update_id?: string
+}
+
+interface EndOfDayBody {
+  session_id: string
+  to_agent?: string
+  status_label?: string
+  summary: string
+  payload?: Record<string, unknown>
+  end_reason?: string
+  update_id?: string
+}
+
+interface UpdateBody {
+  session_id: string
+  update_id?: string
+  branch?: string
+  commit_sha?: string
+  meta?: Record<string, unknown>
+}
+
+interface HeartbeatBody {
+  session_id: string
+}
+
+interface CheckpointBody {
+  session_id: string
+  summary: string
+  work_completed?: string[]
+  blockers?: string[]
+  next_actions?: string[]
+  notes?: string
+}
+
+// ============================================================================
 // POST /sod - Start of Day (Resume or Create Session)
 // ============================================================================
 
@@ -80,7 +135,7 @@ export async function handleStartOfDay(request: Request, env: Env): Promise<Resp
       })
     }
 
-    const body = (await request.json()) as any
+    const body = (await request.json()) as StartOfDayBody
 
     // Basic validation
     if (!body.agent || typeof body.agent !== 'string') {
@@ -351,7 +406,7 @@ export async function handleEndOfDay(request: Request, env: Env): Promise<Respon
       })
     }
 
-    const body = (await request.json()) as any
+    const body = (await request.json()) as EndOfDayBody
 
     // Basic validation
     if (!body.session_id || typeof body.session_id !== 'string') {
@@ -499,7 +554,7 @@ export async function handleUpdate(request: Request, env: Env): Promise<Response
 
   try {
     // 2. Parse and validate request body
-    const body = (await request.json()) as any
+    const body = (await request.json()) as UpdateBody
 
     // Basic validation
     if (!body.session_id || typeof body.session_id !== 'string') {
@@ -606,7 +661,7 @@ export async function handleHeartbeat(request: Request, env: Env): Promise<Respo
 
   try {
     // 2. Parse and validate request body
-    const body = (await request.json()) as any
+    const body = (await request.json()) as HeartbeatBody
 
     // Basic validation
     if (!body.session_id || typeof body.session_id !== 'string') {
@@ -692,7 +747,7 @@ export async function handleCheckpoint(request: Request, env: Env): Promise<Resp
 
   try {
     // 2. Parse and validate request body
-    const body = (await request.json()) as any
+    const body = (await request.json()) as CheckpointBody
 
     // Basic validation
     if (!body.session_id || typeof body.session_id !== 'string') {

--- a/workers/crane-context/src/scripts.ts
+++ b/workers/crane-context/src/scripts.ts
@@ -28,6 +28,14 @@ export interface ScriptsResponse {
   content_hash_combined: string // Combined hash of all scripts for cache validation
 }
 
+export interface ScriptMetadataRow {
+  scope: string
+  script_name: string
+  content_hash: string
+  executable: boolean
+  version: number
+}
+
 // ============================================================================
 // Script Fetching
 // ============================================================================
@@ -110,7 +118,7 @@ export async function fetchScriptsMetadata(
       .all()
 
     return {
-      scripts: result.results as any,
+      scripts: result.results as unknown as ScriptMetadataRow[],
       count: result.results.length,
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Define typed interfaces for request bodies in endpoint handlers (sessions.ts, notes.ts, machines.ts)
- Define row types for D1 query results (docs.ts, scripts.ts, admin.ts)
- Replace all 11 `as any` casts with proper type assertions, eliminating untyped casts from the crane-context worker source

## Changes
- **sessions.ts**: Add `StartOfDayBody`, `EndOfDayBody`, `UpdateBody`, `HeartbeatBody`, `CheckpointBody` interfaces; replace 5 `as any` casts
- **notes.ts**: Add `CreateNoteBody`, `UpdateNoteBody` interfaces; replace 2 `as any` casts
- **machines.ts**: Import existing `RegisterMachineRequest` from types.ts; replace 1 `as any` cast
- **admin.ts**: Cast D1 results to `ListDocsResponse['docs']` instead of `any`; replace 1 `as any` cast
- **docs.ts**: Add `DocMetadataRow` interface; replace 1 `as any` cast
- **scripts.ts**: Add `ScriptMetadataRow` interface; replace 1 `as any` cast

## Test plan
- [x] `npm run verify` passes (typecheck + format + lint + test)
- [x] No behavioral changes - types are compile-time only
- [x] Zero `as any` remaining in `workers/crane-context/src/` (confirmed via grep)

Closes #216

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>