### PR TITLE
fix: resolve moderate npm audit vulnerabilities in worker toolchains

### DIFF
--- a/workers/crane-context/package-lock.json
+++ b/workers/crane-context/package-lock.json
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Summary
Fix the lodash prototype pollution vulnerability (GHSA-xxjr-mmjv-4gpg) in crane-context by updating from 4.17.21 to 4.17.23. The remaining moderate vulnerabilities (esbuild, undici, miniflare) are locked in the wrangler v3 transitive dependency chain and require a wrangler v4 major upgrade to resolve.

## Changes
- Updated lodash from 4.17.21 to 4.17.23 in crane-context (fixes prototype pollution in `_.unset` and `_.omit`)
- Confirmed both workers are already on latest wrangler v3 (3.114.17) - no further non-breaking updates available
- crane-context: reduced from 8 to 7 moderate vulnerabilities
- crane-classifier: 7 moderate vulnerabilities remain (all require wrangler v4, out of scope)

## Audit Summary

| Worker | Before | After | Fixed | Remaining (wrangler v4 required) |
|--------|--------|-------|-------|----------------------------------|
| crane-context | 8 moderate | 7 moderate | lodash prototype pollution | esbuild, undici, miniflare, vite chain |
| crane-classifier | 7 moderate | 7 moderate | none (no non-breaking fixes) | esbuild, undici, miniflare, vite chain |

## Test Plan
- [x] `npm run verify` passes (typecheck + format + lint + tests)
- [x] `npm audit` in crane-context confirms lodash vulnerability resolved
- [x] No breaking changes - only lockfile updated
- [ ] Wrangler v4 upgrade tracked separately for remaining vulnerabilities

Closes #220

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>