### PR TITLE
feat: surface enterprise rules in CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,15 @@ Full verification runs before push:
 - Fix root cause, not symptoms
 - Run `npm run verify` locally before pushing
 
+## Enterprise Rules
+
+- **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.
+- **Never echo secret values.** Transcripts persist in ~/.claude/ and are sent to API providers. Pipe from Infisical, never inline.
+- **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
+- **Never auto-save to VCMS** without explicit Captain approval.
+- **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
+
 ## Environment Variables
 
 When launched via `crane`, the following environment variables are available:
@@ -97,12 +106,13 @@ When PM creates an issue, they assign a QA grade. This determines verification r
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module               | Key Rule (always applies)                                                    | Fetch for details                          |
-| -------------------- | ---------------------------------------------------------------------------- | ------------------------------------------ |
-| `secrets.md`         | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App     |
-| `content-policy.md`  | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style |
-| `fleet-ops.md`       | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS            |
-| `creating-issues.md` | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                | Templates, labels, target repos            |
+| Module               | Key Rule (always applies)                                                    | Fetch for details                             |
+| -------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
+| `secrets.md`         | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App        |
+| `content-policy.md`  | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style    |
+| `team-workflow.md`   | All changes through PRs; never push to main                                  | Full workflow, QA grades, escalation triggers |
+| `fleet-ops.md`       | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS               |
+| `creating-issues.md` | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                | Templates, labels, target repos               |
 
 Fetch with: `crane_doc('global', '<module>')`
 

--- a/templates/venture/CLAUDE.md
+++ b/templates/venture/CLAUDE.md
@@ -6,6 +6,24 @@ This file provides guidance for Claude Code agents working in this repository.
 
 {Brief description of the product/venture}
 
+## Session Start
+
+Every session must begin with:
+
+1. Call the `crane_preflight` MCP tool (no arguments)
+2. Call the `crane_sod` MCP tool with `venture: "{CODE}"`
+
+This creates a session, loads documentation, and establishes handoff context.
+
+## Enterprise Rules
+
+- **All changes through PRs.** Never push directly to main. Branch, PR, CI, QA, merge.
+- **Never echo secret values.** Transcripts persist in ~/.claude/ and are sent to API providers. Pipe from Infisical, never inline.
+- **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
+- **Never auto-save to VCMS** without explicit Captain approval.
+- **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
+
 ## Build Commands
 
 ```bash
@@ -60,14 +78,19 @@ Full verification runs before push:
 
 {Document key patterns, conventions, and architectural decisions here}
 
-## Session Management
+## Instruction Modules
 
-```bash
-/sod                    # Start of day - load context
-/eod                    # End of day - create handoff
-/update                 # Update session context mid-session
-/heartbeat              # Keep session alive
-```
+Detailed domain instructions stored as on-demand documents.
+Fetch the relevant module when working in that domain.
+
+| Module              | Key Rule (always applies)                                                    | Fetch for details                             |
+| ------------------- | ---------------------------------------------------------------------------- | --------------------------------------------- |
+| `secrets.md`        | Verify secret VALUES, not just key existence                                 | Infisical, vault, API keys, GitHub App        |
+| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                                | VCMS tags, storage rules, editorial, style    |
+| `team-workflow.md`  | All changes through PRs; never push to main                                  | Full workflow, QA grades, escalation triggers |
+| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh | SSH, machines, Tailscale, macOS               |
+
+Fetch with: `crane_doc('global', '<module>')`
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary

- Add Enterprise Rules section to crane-console CLAUDE.md with 6 critical guardrails (PR workflow, secrets handling, VCMS, scope discipline, escalation triggers)
- Add `team-workflow.md` to the Instruction Modules table
- Update venture CLAUDE.md template with standardized session start, enterprise rules, and instruction modules sections

Part of a cross-venture initiative to surface VCMS enterprise rules directly in CLAUDE.md files so agents see them at session start. Companion PRs being created for ke-console, dc-console, dfg-console, sc-console, and vc-web.

## Test plan

- [x] `npm run verify` passes locally
- [ ] Verify Enterprise Rules section visible in CLAUDE.md
- [ ] Verify Instruction Modules table includes `team-workflow.md`
- [ ] Verify template includes all standardized sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)