### PR TITLE
feat: platform alignment + fleet orchestrator

### DIFF
--- a/.claude/agents/sprint-worker.md
+++ b/.claude/agents/sprint-worker.md
@@ -1,0 +1,135 @@
+---
+model: sonnet
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Sprint Worker
+
+You are a coding agent implementing a single GitHub issue in an isolated git worktree.
+
+## Working Directory Discipline
+
+**CRITICAL**: You are operating in a shared git repository via worktrees. Other agents may be running simultaneously in sibling worktrees.
+
+- Your worktree path is provided in your assignment. ALL file operations MUST be within this path.
+- The Bash tool resets your working directory between every call. You MUST prefix every bash command with `cd {WORKTREE_PATH} &&` or use absolute paths prefixed with your worktree path.
+- NEVER run commands outside your worktree.
+- NEVER modify files that are not relevant to your issue.
+- NEVER push to main or merge any PR.
+
+Before your first code change, verify your branch:
+
+```bash
+cd {WORKTREE_PATH} && git branch --show-current
+```
+
+If you are not on the expected branch, STOP and report an error.
+
+## Workflow
+
+1. **Understand the codebase.** Read `{WORKTREE_PATH}/CLAUDE.md` for project conventions and build commands. Explore the relevant code. Read nearby files to understand patterns before making changes.
+
+2. **Implement the change.** Make minimal, focused changes. Do not refactor unrelated code. Do not add features beyond what the issue requests.
+
+3. **Verify.** Run the verification command provided in your assignment:
+
+   ```bash
+   cd {WORKTREE_PATH} && {VERIFY_COMMAND}
+   ```
+
+   Fix failures and re-run. If you cannot pass after 3 attempts, STOP and report the failure. Do NOT open a PR with failing verification.
+
+4. **Commit.** Stage specific changed files (not `git add -A`). Write a conventional commit message referencing the issue number.
+
+5. **Push.**
+
+   ```bash
+   cd {WORKTREE_PATH} && git push -u origin {BRANCH_NAME}
+   ```
+
+6. **Open PR.**
+
+   ```bash
+   cd {WORKTREE_PATH} && gh pr create --repo {REPO} --base main \
+     --head {BRANCH_NAME} --title "{type}: {description}" \
+     --body "$(cat <<'PREOF'
+   ## Summary
+   {1-2 sentence summary}
+
+   ## Changes
+   - {change 1}
+   - {change 2}
+
+   ## Test Plan
+   - [ ] {test step 1}
+   - [ ] {test step 2}
+
+   Closes #{NUMBER}
+
+   Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+   PREOF
+   )"
+   ```
+
+7. **Write result.** After completing (success or failure), write a `result.json` file to the worktree root:
+
+   **On success:**
+
+   ```bash
+   cd {WORKTREE_PATH} && cat > result.json <<'EOF'
+   {
+     "status": "success",
+     "pr_url": "https://github.com/{REPO}/pull/{N}",
+     "verify_attempts": {N},
+     "files_changed": ["{file1}", "{file2}"]
+   }
+   EOF
+   ```
+
+   **On failure:**
+
+   ```bash
+   cd {WORKTREE_PATH} && cat > result.json <<'EOF'
+   {
+     "status": "failed",
+     "error": "{description of what failed}",
+     "verify_attempts": {N},
+     "files_changed": ["{file1}", "{file2}"]
+   }
+   EOF
+   ```
+
+## Time Awareness
+
+- Small issues (single file, clear fix): aim for under 10 minutes.
+- Medium issues (multi-file feature): aim for under 20 minutes.
+- Large issues (cross-cutting change): aim for under 30 minutes.
+
+If you have been working significantly longer than expected, STOP, write a failed result.json with your progress, and let the orchestrator decide.
+
+## Report
+
+Your final message MUST include exactly one of these lines:
+
+- `PR_URL: https://github.com/{repo}/pull/{N}`
+- `FAILED: {reason}`
+
+Also include:
+
+- `FILES_CHANGED: {comma-separated list}`
+- `VERIFY_STATUS: pass OR fail`
+- `DECISIONS: {any ambiguity resolutions, or "none"}`
+
+## Constraints
+
+- NEVER run commands outside your worktree
+- NEVER push to main or merge the PR
+- NEVER modify files that are not relevant to your issue
+- NEVER use `git add -A` or `git add .` - stage specific files only
+- If blocked, stop and report immediately with FAILED

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -1,0 +1,400 @@
+# /orchestrate - Fleet Sprint Orchestrator
+
+Dispatches coding tasks across fleet machines using `crane` headless mode, monitors progress, and collects results. Extends `/sprint` (single-machine, local worktrees) to multi-machine fleet execution.
+
+## Arguments
+
+```
+/orchestrate <issue numbers> --repo <org/repo> [--venture <code>] [--dry-run] [--resume <sprint_id>]
+```
+
+- Issue numbers: space or comma-separated, `#` prefix optional
+- `--repo <org/repo>`: target repository (required)
+- `--venture <code>`: venture code (default: detect from repo name)
+- `--dry-run`: show dispatch plan only, do not execute
+- `--resume <sprint_id>`: resume a previous orchestration
+
+Parse `$ARGUMENTS`:
+
+1. Split on whitespace and commas
+2. Strip `#` prefix from any token
+3. Extract `--repo <value>` (required)
+4. Extract `--venture <value>` (optional)
+5. Extract `--dry-run` flag if present
+6. Extract `--resume <sprint_id>` if present
+7. Remaining tokens are issue numbers (must be positive integers)
+
+If `--resume` is provided, skip to the Resume Logic section.
+
+If no issue numbers remain after parsing (and no `--resume`), display usage and stop:
+
+```
+Usage: /orchestrate <issue numbers> --repo <org/repo> [--venture <code>] [--dry-run] [--resume <sprint_id>]
+
+Examples:
+  /orchestrate 42 45 51 --repo venturecrane/dc-console
+  /orchestrate 42 45 --repo venturecrane/dc-console --dry-run
+  /orchestrate --resume sprint_01ABC123
+```
+
+Store: `ISSUE_NUMBERS` (array), `REPO` (string), `VENTURE` (string), `DRY_RUN` (bool), `RESUME_ID` (string or null).
+
+## Execution
+
+### DISPATCH Phase
+
+#### Step 1: Fetch and Analyze Issues
+
+For each issue number, fetch via:
+
+```bash
+gh issue view {N} --repo {REPO} --json number,title,body,labels,state
+```
+
+**CRITICAL**: Make all `gh issue view` calls in parallel.
+
+For each issue, extract from labels:
+
+- **Priority**: `prio:*` label (P0/P1/P2/P3)
+- **QA grade**: `qa-grade:*` label
+- **Component**: `component:*` label
+
+Also extract dependencies from body (same logic as `/sprint`):
+
+- `depends on #N`, `blocked by #N`, `after #N`, `requires #N`
+
+**Validation:**
+
+- If any issue does not exist, stop: `Issue #{N} not found in {REPO}. Aborting.`
+- If any issue has `state: closed`, stop: `Issue #{N} is closed. Remove it and re-run.`
+
+Display issue summary table.
+
+#### Step 2: Build Wave Plan
+
+Same wave planning logic as `/sprint`:
+
+- Extract explicit dependencies
+- Schedule waves respecting dependencies and MAX_CONCURRENT per machine
+- Detect cycles
+
+For fleet orchestration, MAX_CONCURRENT per wave is the sum of available machine slots (see Step 3).
+
+#### Step 3: Fleet Health Check and Machine Assignment
+
+**Available machines** (orchestrator host mac23 excluded from worker pool by default):
+
+| Hostname | Max Concurrent |
+| -------- | -------------- |
+| m16      | 3              |
+| mini     | 2              |
+| mbp27    | 2              |
+| think    | 1              |
+
+For each machine, run a health check via `crane_fleet_dispatch` dry-run equivalent:
+
+```bash
+ssh -o ConnectTimeout=5 -o BatchMode=yes {machine} "echo ok && df -BG / | awk 'NR==2{print \$4}'"
+```
+
+Exclude unhealthy machines. If no machines are healthy, stop:
+
+```
+No healthy fleet machines available. Fix connectivity and retry.
+```
+
+**Assign issues to machines:**
+
+Round-robin across healthy machines, respecting per-machine concurrency limits. Priority order: P0 first, then P1, P2, P3.
+
+Display the assignment plan:
+
+```
+Fleet Dispatch Plan:
+
+Wave 1:
+  #{45} [P0] Fix balance calc -> m16
+  #{42} [P1] Add expense filter -> mini
+  #{47} [P2] Update docs -> mbp27
+
+Wave 2 (after Wave 1 merges):
+  #{48} [P1] Refactor auth -> m16
+
+Machines: 3 healthy (m16: 1/3, mini: 1/2, mbp27: 1/2)
+```
+
+#### Step 4: Write Sprint Cache
+
+Generate a sprint ID: `sprint_{ULID-style}` (use `crypto.randomUUID()` to generate).
+
+Write to `~/.crane/sprints/{id}.json`:
+
+```json
+{
+  "id": "sprint_abc123",
+  "venture": "dc",
+  "repo": "venturecrane/dc-console",
+  "current_wave": 1,
+  "wave_plan": [[42, 45, 47], [48]],
+  "dispatched": {},
+  "created_at": "2026-02-20T10:00:00Z",
+  "updated_at": "2026-02-20T10:00:00Z"
+}
+```
+
+#### Step 5: Captain Approval
+
+If `DRY_RUN` is true, stop: `Dry run complete. Re-run without --dry-run to execute.`
+
+Ask the user using AskUserQuestion:
+
+**"Execute Wave {N}? ({count} tasks across {machine_count} machines)"**
+
+Options: "Execute" / "Abort"
+
+If Abort, stop: `Orchestration aborted.`
+
+#### Step 6: Dispatch
+
+For each issue in the current wave, call `crane_fleet_dispatch`:
+
+```
+crane_fleet_dispatch({
+  machine: "{assigned_machine}",
+  venture: "{VENTURE}",
+  repo: "{REPO}",
+  issue_number: {N},
+  branch_name: "{issue-number}-{slugified-title}"
+})
+```
+
+Branch naming follows the same convention as `/sprint`: `{issue-number}-{slugified-title}`, truncated to 50 chars.
+
+**CRITICAL**: Make all `crane_fleet_dispatch` calls in parallel (one message).
+
+Update the sprint cache with dispatch metadata:
+
+```json
+{
+  "dispatched": {
+    "42": { "machine": "m16", "task_id": "task_abc123" },
+    "45": { "machine": "mini", "task_id": "task_def456" }
+  }
+}
+```
+
+Display: `Wave {N} dispatched. Entering monitor loop.`
+
+### MONITOR Phase
+
+Poll loop with exponential backoff: start at 30s, max 5 min, back off when no status changes detected.
+
+For each dispatched task in the current wave:
+
+```
+crane_fleet_status({
+  machine: "{machine}",
+  task_id: "{task_id}"
+})
+```
+
+**CRITICAL**: Make all `crane_fleet_status` calls in parallel.
+
+Track status transitions:
+
+- `running` -> continue monitoring
+- `success` (result.json has `status: success`) -> task complete
+- `failed` (result.json has `status: failed`) -> task failed
+- `crashed` (PID dead, no result.json) -> task failed
+- `not_found` -> warn, continue checking
+
+**Stuck detection**: If a task has been running for >20 minutes with no result.json, flag it:
+
+```
+Warning: Task {task_id} on {machine} for issue #{N} has been running for {minutes}min. Potentially stuck.
+```
+
+Display progress on each poll:
+
+```
+Monitor [2min elapsed]:
+  #{42} on m16: running (5min)
+  #{45} on mini: success - PR #260
+  #{47} on mbp27: running (3min)
+```
+
+Loop until all tasks are terminal (success, failed, or crashed) or Captain intervenes.
+
+### COLLECT Phase
+
+#### Step 1: PR Status Check
+
+For successful tasks, get PR and CI status:
+
+```
+crane_fleet_status({
+  repo: "{REPO}",
+  issue_numbers: [{successful_issue_numbers}]
+})
+```
+
+Display PR summary:
+
+```
+Results:
+
+| #   | Title              | Status  | PR    | CI      |
+| --- | ------------------ | ------- | ----- | ------- |
+| 42  | Fix balance calc   | SUCCESS | #260  | passing |
+| 45  | Add expense filter | SUCCESS | #261  | pending |
+| 47  | Update docs        | FAILED  | -     | -       |
+```
+
+#### Step 2: Handle Failures
+
+For each failed task, ask the user using AskUserQuestion:
+
+**"Issue #{N} failed: {reason}. Retry or skip?"**
+
+Options: "Retry" / "Skip"
+
+- **Retry**: Call `crane_fleet_dispatch` again for this issue on the same machine (or a different one if the original is unhealthy). Max 1 retry per issue. Update sprint cache.
+- **Skip**: Mark as skipped, continue.
+
+If retrying, loop back to MONITOR for just the retried tasks.
+
+#### Step 3: Captain Merge Approval
+
+Once all PRs have passing CI (or Captain decides to proceed), ask:
+
+**"Merge {N} PRs? (squash merge in dependency order)"**
+
+Options: "Merge all" / "Select which to merge" / "Skip merge"
+
+- **Merge all**: For each successful PR in dependency order:
+
+  ```bash
+  gh pr merge {PR_NUMBER} --repo {REPO} --squash
+  ```
+
+  If a merge fails (conflict), stop and escalate:
+
+  ```
+  Merge conflict on PR #{N}. Resolve manually and re-run with --resume {sprint_id}.
+  ```
+
+- **Select**: Ask which PRs to merge, then merge those in order.
+- **Skip**: Leave PRs open for manual review.
+
+#### Step 4: Update Labels and Cleanup
+
+For each successfully merged PR:
+
+```bash
+gh issue edit {N} --repo {REPO} --remove-label "status:ready" --add-label "status:done"
+```
+
+For each successful but unmerged PR:
+
+```bash
+gh issue edit {N} --repo {REPO} --remove-label "status:ready" --add-label "status:review"
+```
+
+Clean up worktrees on target machines (best-effort):
+
+```bash
+ssh {machine} "cd {repo_path} && git worktree remove --force ~/.crane/tasks/{task_id}/worktree 2>/dev/null; rm -rf ~/.crane/tasks/{task_id}"
+```
+
+#### Step 5: Advance to Next Wave
+
+If more waves remain in the wave plan:
+
+1. Update sprint cache: `current_wave += 1`
+2. Display: `Wave {N} complete. Advancing to Wave {N+1}.`
+3. Loop back to DISPATCH Step 3 (fleet health check) with the next wave's issues.
+
+If all waves complete:
+
+```
+Orchestration complete.
+
+Sprint: {sprint_id}
+Waves: {total}
+Issues: {succeeded}/{total} succeeded
+PRs merged: {merged_count}
+```
+
+Remove sprint cache file.
+
+## Resume Logic (`--resume`)
+
+When `--resume <sprint_id>` is provided:
+
+1. **Read sprint cache**: Load `~/.crane/sprints/{sprint_id}.json` for dispatch metadata.
+
+   If file not found, stop: `Sprint {sprint_id} not found. Check ~/.crane/sprints/`
+
+2. **Query GitHub for actual state**: For all issues in the sprint's wave plan:
+
+   ```
+   crane_fleet_status({
+     repo: "{repo}",
+     issue_numbers: [{all_issue_numbers}]
+   })
+   ```
+
+3. **Query fleet for task state**: For all dispatched tasks:
+
+   ```
+   crane_fleet_status({
+     machine: "{machine}",
+     task_id: "{task_id}"
+   })
+   ```
+
+4. **Reconcile state** (GitHub wins over cache):
+   - PR merged -> issue is done, regardless of cache
+   - PR open -> task succeeded, resume at COLLECT
+   - Task running (PID alive) -> resume at MONITOR
+   - Task crashed (PID dead, no result.json) -> treat as failed
+   - No PR and no task running -> treat as failed
+
+5. **Determine resume point**:
+   - If all current wave PRs are merged -> advance to next wave DISPATCH
+   - If PRs are open but not merged -> resume at COLLECT
+   - If tasks are still running -> resume at MONITOR
+   - If all current wave tasks failed -> offer retry or skip, then advance
+
+6. Display reconciled state and resume point. Ask Captain for confirmation before continuing.
+
+## Sprint Cache Schema
+
+```json
+{
+  "id": "sprint_abc123",
+  "venture": "dc",
+  "repo": "venturecrane/dc-console",
+  "current_wave": 1,
+  "wave_plan": [[42, 45], [51]],
+  "dispatched": {
+    "42": { "machine": "m16", "task_id": "task_abc" },
+    "45": { "machine": "mbp27", "task_id": "task_def" }
+  },
+  "created_at": "2026-02-20T10:00:00Z",
+  "updated_at": "2026-02-20T10:05:00Z"
+}
+```
+
+This is a **local performance cache**, NOT source of truth. GitHub is authoritative. The cache stores dispatch metadata (machine assignments, task IDs) that GitHub doesn't know about - this is its only purpose. No duplicated PR state or CI status.
+
+## Notes
+
+- **mac23 excluded from worker pool**: The orchestrator host doesn't run workers by default to avoid resource contention.
+- **Fleet health checks before every wave**: Machines can go offline mid-sprint. Re-check before dispatching each wave.
+- **Exponential backoff**: Monitor polling starts at 30s intervals, backs off to 5min max when no changes detected. Resets to 30s when a status change is observed.
+- **GitHub as source of truth**: Resume reconstructs state from observable reality (GitHub PRs + fleet task status), not from the cache file. The cache accelerates resume but is never trusted over live state.
+- **Structured results**: Sprint workers write `result.json` to their worktree on completion. The fleet status tool reads this for structured status - no log scraping.
+- **Defense in depth**: Shell arguments are escaped in fleet-exec.sh and fleet-dispatch.ts. Issue bodies are passed via `gh issue view`, not inline.
+- **Single retry**: Failed tasks get at most one retry. Second failure is final.
+- **Merge order**: PRs are merged in dependency order (Wave 1 before Wave 2, within a wave: by issue number).

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -237,6 +237,14 @@ Check if `.worktrees/` or `.worktrees` appears in `{REPO_ROOT}/.gitignore`. If n
 echo '.worktrees/' >> {REPO_ROOT}/.gitignore
 ```
 
+**Sync gate - fetch remote main:**
+
+Before creating any worktrees, fetch the latest remote main. Worktrees branch directly from `origin/main` to eliminate stale-base bugs and race conditions.
+
+```bash
+cd {REPO_ROOT} && git fetch origin main
+```
+
 **Create worktrees** for each Wave 1 issue:
 
 Branch naming: `{issue-number}-{slugified-title}` where slugified-title is the issue title lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 chars, trailing hyphens stripped.
@@ -244,8 +252,10 @@ Branch naming: `{issue-number}-{slugified-title}` where slugified-title is the i
 For each issue:
 
 ```bash
-git worktree add {REPO_ROOT}/.worktrees/{issue-number} -b {branch-name}
+git worktree add {REPO_ROOT}/.worktrees/{issue-number} -b {branch-name} origin/main
 ```
+
+This creates the worktree branching directly from the remote tracking ref - no dependency on local main being up to date.
 
 If the branch already exists, ask the user: reuse the existing branch or create with a `-2` suffix.
 
@@ -265,95 +275,26 @@ Display: `Worktrees ready. Dependencies installed.`
 
 ### Step 6: Execute Wave 1
 
-**Spawn all agents in ONE message** using the Task tool (`subagent_type: general-purpose`).
+**Spawn all agents in ONE message** using the Task tool (`subagent_type: sprint-worker`).
 
 **CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
 
-Each agent receives the prompt below, filled with its specific values. Store `ISSUE_BODY` from the earlier fetch.
+Each agent receives only dynamic context. Static behavioral instructions (working directory discipline, verification workflow, result.json format, constraints) are defined in the `sprint-worker` agent definition at `.claude/agents/sprint-worker.md`.
 
 ---
 
-**Coding Agent Prompt:**
+**Coding Agent Prompt (dynamic context only):**
 
 ```
-You are a coding agent implementing a single GitHub issue.
-
 ## Assignment
 - Issue: #{NUMBER} - {TITLE}
 - Worktree: {WORKTREE_PATH}
 - Branch: {BRANCH_NAME} (already checked out)
 - Repo: {REPO}
+- Verify command: {VERIFY_COMMAND}
 
 ## Issue Details
 {FULL_ISSUE_BODY}
-
-## CRITICAL: Working Directory
-
-The Bash tool resets your working directory between every call. You MUST
-prefix every bash command with `cd {WORKTREE_PATH} &&` or use absolute
-paths prefixed with {WORKTREE_PATH}/. Running commands in the wrong
-directory will corrupt other agents' work.
-
-Before your first code change, verify your branch:
-  cd {WORKTREE_PATH} && git branch --show-current
-If you are not on {BRANCH_NAME}, STOP and report an error.
-
-## Workflow
-
-1. Read {WORKTREE_PATH}/CLAUDE.md for project conventions and build commands.
-2. Explore the relevant code. Read nearby files to understand patterns.
-3. Implement the change. Make minimal, focused changes. Do not refactor
-   unrelated code.
-4. Run verification:
-     cd {WORKTREE_PATH} && {VERIFY_COMMAND}
-   Fix failures and re-run. If you cannot pass after 3 attempts, STOP
-   and report the failure. Do NOT open a PR with failing verification.
-5. Stage specific changed files (not git add -A), commit with a
-   conventional message referencing the issue number.
-6. Push: cd {WORKTREE_PATH} && git push -u origin {BRANCH_NAME}
-7. Open PR:
-     cd {WORKTREE_PATH} && gh pr create --repo {REPO} --base main \
-       --head {BRANCH_NAME} --title "{type}: {description}" \
-       --body "$(cat <<'PREOF'
-   ## Summary
-   {1-2 sentence summary}
-
-   ## Changes
-   - {change 1}
-   - {change 2}
-
-   ## Test Plan
-   - [ ] {test step 1}
-   - [ ] {test step 2}
-
-   Closes #{NUMBER}
-
-   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
-   PREOF
-   )"
-
-## Time Awareness
-Small issues (single file, clear fix): aim for under 10 minutes.
-Medium issues (multi-file feature): aim for under 20 minutes.
-Large issues (cross-cutting change): aim for under 30 minutes.
-If you have been working significantly longer than expected, STOP, report
-your progress and what is blocking you, and let the orchestrator decide.
-
-## Report
-Your final message MUST include exactly one of these lines:
-- PR_URL: https://github.com/{repo}/pull/{N}
-- FAILED: {reason}
-
-Also include:
-- FILES_CHANGED: {comma-separated list}
-- VERIFY_STATUS: pass OR fail
-- DECISIONS: {any ambiguity resolutions, or "none"}
-
-## Constraints
-- NEVER run commands outside your worktree
-- NEVER push to main or merge the PR
-- NEVER modify files that are not relevant to your issue
-- If blocked, stop and report immediately with FAILED
 ```
 
 ---
@@ -382,7 +323,7 @@ Ask the user per failed issue using AskUserQuestion:
 
 Options: "Retry" / "Skip"
 
-- **Retry**: Remove the worktree (`git worktree remove --force ...`), recreate fresh from main, reinstall dependencies, and spawn one new agent with the same prompt. After retry completes, process its result (update labels on success, report failure on second failure without further retry).
+- **Retry**: Remove the worktree (`git worktree remove --force ...`), fetch origin main, recreate fresh from `origin/main` (`git worktree add ... -b {branch} origin/main`), reinstall dependencies, and spawn one new `sprint-worker` agent with the same dynamic context prompt. After retry completes, process its result (update labels on success, report failure on second failure without further retry).
 - **Skip**: Mark as incomplete, continue.
 
 ### Step 7: Report and Cleanup
@@ -432,10 +373,11 @@ Done.
 
 - **Single-wave execution**: Only Wave 1 is executed per run. User merges those PRs, then re-runs for Wave 2. This eliminates inter-wave state management and the dependency-branching problem.
 - **Worktrees inside repo**: `.worktrees/` lives at the repo root and is gitignored. No external directory management needed.
-- **Branches from main**: Every branch starts from current main. PRs are independently reviewable.
+- **Branches from origin/main**: Every branch starts from `origin/main` (fetched fresh before worktree creation). Eliminates stale-base bugs. PRs are independently reviewable.
 - **Orchestrator owns side effects**: Label updates happen here, not in the coding agents. Agents only push code and open PRs.
-- **Retry semantics**: Failed agents get a fresh worktree from main. One retry max per failed issue. Second failure is final.
+- **Retry semantics**: Failed agents get a fresh worktree from `origin/main`. One retry max per failed issue. Second failure is final.
 - **Lock file**: Prevents concurrent sprint runs from colliding. PID-based with stale detection.
-- **Agent type**: All coding agents use `subagent_type: general-purpose` via the Task tool.
+- **Agent type**: All coding agents use `subagent_type: sprint-worker` via the Task tool. Static behavioral instructions live in `.claude/agents/sprint-worker.md`; only dynamic context (issue, worktree, branch, repo, verify command) is passed in the Task prompt.
+- **Structured results**: Sprint workers write `result.json` to the worktree root on completion (success or failure). The orchestrator can read this for structured status instead of parsing agent messages.
 - **Parallelism**: All Wave 1 agents launch in a single message for true parallel execution.
 - **No complexity estimation**: Issue metadata (AC count, body length) is displayed for human judgment. No S/M/L/XL heuristics.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist/
 dev-log/
 workers/crane-context/manual-test-log.md
 .worktrees/
+
+# Disposable handoff cache (D1 is authoritative, this is for CC's /resume)
+.claude/handoff.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,16 @@ Fetch the relevant module when working in that domain.
 
 Fetch with: `crane_doc('global', '<module>')`
 
+## Claude Code Integration Principles
+
+Crane builds on Claude Code's native capabilities. The custom layer stays thin:
+
+1. **Custom agents for behavioral separation.** Static instructions (working directory discipline, verification workflow, result format) live in agent definitions (`.claude/agents/`). Dynamic context (issue, worktree, branch) goes in the Task prompt.
+2. **Manual worktrees for branch naming control.** CC can't customize branch names, so we manage worktrees directly. Worktrees always branch from `origin/main` (not local main) to avoid stale-base bugs.
+3. **Headless mode for remote execution.** `crane <venture> -p "prompt"` passes `-p` through to the agent binary, enabling fire-and-forget dispatch on fleet machines.
+4. **Thin custom layer.** Crane owns orchestration (what to run, where, monitoring, state). CC owns execution (agent runtime, context, tools, verification). Migrate to native features as CC adds them.
+5. **Dual-write for interop.** D1 is the authoritative handoff store. `.claude/handoff.md` is a disposable cache for CC's native `/resume` - gitignored, overwritten on every handoff.
+
 ## MEMORY.md Governance
 
 Domain instructions live in the modules above. MEMORY.md is for

--- a/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for fleet-dispatch.ts tool
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'child_process'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+  execSync: vi.fn(),
+  spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
+}))
+
+const getModule = async () => {
+  vi.resetModules()
+  return import('./fleet-dispatch.js')
+}
+
+describe('fleet-dispatch tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const baseInput = {
+    machine: 'm16',
+    venture: 'vc',
+    repo: 'venturecrane/crane-console',
+    issue_number: 42,
+    branch_name: '42-fix-login',
+  }
+
+  it('dispatches successfully when machine is healthy', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    // Health check: SSH ping succeeds
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      // Health check: disk space OK
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '50G',
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+      // SSH dispatch: fleet-exec.sh succeeds
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'Dispatched task task_abc123 (PID 1234) for issue #42',
+        stderr: '',
+        pid: 3,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetDispatch(baseInput)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Task dispatched successfully')
+    expect(result.message).toContain('task_')
+    expect(result.message).toContain('m16')
+    expect(result.message).toContain('#42')
+    expect(result.message).toContain('42-fix-login')
+  })
+
+  it('fails when SSH is unreachable', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      status: 255,
+      stdout: '',
+      stderr: 'ssh: connect to host m16 port 22: Connection refused',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+
+    const result = await executeFleetDispatch(baseInput)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('unhealthy')
+    expect(result.message).toContain('SSH unreachable')
+  })
+
+  it('fails when disk space is low', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    // SSH ping succeeds
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      // Disk space: only 1GB free
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '1G',
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetDispatch(baseInput)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('unhealthy')
+    expect(result.message).toContain('Low disk space')
+  })
+
+  it('fails when fleet-exec.sh returns error', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    // Health checks pass
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '50G',
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+      // fleet-exec.sh fails
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: '',
+        stderr: 'Error: /home/user/dev/crane-console is not a git repo',
+        pid: 3,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetDispatch(baseInput)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Fleet dispatch failed')
+    expect(result.message).toContain('not a git repo')
+  })
+
+  it('uses structured SSH args for defense against injection', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    // Health checks pass
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '50G',
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        pid: 3,
+        output: [],
+        signal: null,
+      })
+
+    await executeFleetDispatch({
+      ...baseInput,
+      branch_name: "42-fix'; rm -rf /; echo '",
+    })
+
+    // The SSH dispatch call (3rd call) should have shell-escaped args
+    const dispatchCall = vi.mocked(spawnSync).mock.calls[2]
+    expect(dispatchCall[0]).toBe('ssh')
+    const sshCommand = dispatchCall[1]![dispatchCall[1]!.length - 1]
+    // Branch name should be quoted
+    expect(sshCommand).toContain("'42-fix'\\''")
+  })
+})

--- a/packages/crane-mcp/src/tools/fleet-dispatch.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.ts
@@ -1,0 +1,154 @@
+/**
+ * crane_fleet_dispatch tool - Dispatch a task to a fleet machine via SSH
+ *
+ * Pre-dispatch health check (SSH ping + disk space), then SSH dispatch
+ * fleet-exec.sh on the target machine. Returns a structured task_id for
+ * subsequent status queries.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { z } from 'zod'
+
+export const fleetDispatchInputSchema = z.object({
+  machine: z.string().describe('Target machine hostname (Tailscale or SSH name)'),
+  venture: z.string().describe('Venture code (vc, ke, sc, dfg, etc.)'),
+  repo: z.string().describe('Full repo path (org/repo)'),
+  issue_number: z.number().describe('GitHub issue number to implement'),
+  branch_name: z.string().describe('Git branch name for the worktree'),
+})
+
+export type FleetDispatchInput = z.infer<typeof fleetDispatchInputSchema>
+
+export interface FleetDispatchResult {
+  success: boolean
+  message: string
+}
+
+const SSH_TIMEOUT_MS = 15_000
+const HEALTH_CHECK_TIMEOUT_MS = 10_000
+
+/**
+ * Run a command on a remote machine via SSH.
+ * Returns { stdout, stderr, ok }.
+ */
+function sshExec(
+  machine: string,
+  command: string,
+  timeoutMs: number = SSH_TIMEOUT_MS
+): { stdout: string; stderr: string; ok: boolean } {
+  const result = spawnSync(
+    'ssh',
+    [
+      '-o',
+      'ConnectTimeout=5',
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      '-o',
+      'BatchMode=yes',
+      machine,
+      command,
+    ],
+    {
+      timeout: timeoutMs,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  )
+
+  return {
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? '',
+    ok: result.status === 0,
+  }
+}
+
+/**
+ * Pre-dispatch health check: SSH ping + disk space.
+ */
+function healthCheck(machine: string): { healthy: boolean; reason?: string } {
+  // SSH ping
+  const ping = sshExec(machine, 'echo ok', HEALTH_CHECK_TIMEOUT_MS)
+  if (!ping.ok) {
+    return { healthy: false, reason: `SSH unreachable: ${ping.stderr || 'connection failed'}` }
+  }
+
+  // Disk space check - warn if <2GB free on /
+  const disk = sshExec(machine, "df -BG / | awk 'NR==2{print $4}'", HEALTH_CHECK_TIMEOUT_MS)
+  if (disk.ok) {
+    const freeGB = parseInt(disk.stdout.replace('G', ''), 10)
+    if (!isNaN(freeGB) && freeGB < 2) {
+      return { healthy: false, reason: `Low disk space: ${freeGB}GB free` }
+    }
+  }
+
+  return { healthy: true }
+}
+
+export async function executeFleetDispatch(
+  input: FleetDispatchInput
+): Promise<FleetDispatchResult> {
+  const { machine, venture, repo, issue_number, branch_name } = input
+
+  // Pre-dispatch health check
+  const health = healthCheck(machine)
+  if (!health.healthy) {
+    return {
+      success: false,
+      message:
+        `Fleet dispatch failed: ${machine} is unhealthy.\n` +
+        `Reason: ${health.reason}\n` +
+        `Fix the issue and retry, or choose a different machine.`,
+    }
+  }
+
+  // Generate task ID
+  const taskId = `task_${randomUUID().replace(/-/g, '').slice(0, 16)}`
+
+  // Build the SSH command to run fleet-exec.sh on the target
+  // Arguments are passed positionally to avoid shell injection via content
+  const fleetExecPath = '$HOME/dev/crane-console/scripts/fleet-exec.sh'
+  const sshCommand = [
+    'bash',
+    fleetExecPath,
+    shellescape(taskId),
+    shellescape(venture),
+    shellescape(repo),
+    String(issue_number),
+    shellescape(branch_name),
+  ].join(' ')
+
+  const result = sshExec(machine, sshCommand)
+
+  if (!result.ok) {
+    return {
+      success: false,
+      message:
+        `Fleet dispatch failed on ${machine}.\n` +
+        `Task ID: ${taskId}\n` +
+        `Error: ${result.stderr || 'unknown error'}\n` +
+        `Command output: ${result.stdout || '(none)'}`,
+    }
+  }
+
+  return {
+    success: true,
+    message:
+      `Task dispatched successfully.\n\n` +
+      `Task ID: ${taskId}\n` +
+      `Machine: ${machine}\n` +
+      `Issue: #${issue_number}\n` +
+      `Branch: ${branch_name}\n` +
+      `Venture: ${venture}\n` +
+      `Repo: ${repo}\n\n` +
+      `Use crane_fleet_status to check progress.`,
+  }
+}
+
+/**
+ * Escape a string for safe inclusion in a shell command.
+ * Wraps in single quotes and escapes embedded single quotes.
+ */
+function shellescape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'"
+}

--- a/packages/crane-mcp/src/tools/fleet-status.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for fleet-status.ts tool
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { spawnSync, execSync } from 'child_process'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+  execSync: vi.fn(),
+  spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
+}))
+
+const getModule = async () => {
+  vi.resetModules()
+  return import('./fleet-status.js')
+}
+
+describe('fleet-status tool - task mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns success status with PR url from result.json', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    // Read status.json
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({
+          status: 'running',
+          task_id: 'task_abc',
+          issue: '42',
+          started_at: '2026-02-20T10:00:00Z',
+        }),
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      // Read result.json
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({
+          status: 'success',
+          pr_url: 'https://github.com/venturecrane/crane-console/pull/260',
+          verify_attempts: 1,
+          files_changed: ['src/index.ts'],
+        }),
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetStatus({
+      machine: 'm16',
+      task_id: 'task_abc',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('success')
+    expect(result.message).toContain('pull/260')
+  })
+
+  it('returns failed status with error from result.json', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({ status: 'running', task_id: 'task_def' }),
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({
+          status: 'failed',
+          error: 'Tests failed after 3 attempts',
+          verify_attempts: 3,
+        }),
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetStatus({
+      machine: 'm16',
+      task_id: 'task_def',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('failed')
+    expect(result.message).toContain('Tests failed after 3 attempts')
+  })
+
+  it('returns running status when PID is alive but no result.json', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(spawnSync)
+      // status.json
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({
+          status: 'running',
+          task_id: 'task_ghi',
+          started_at: new Date(Date.now() - 300_000).toISOString(),
+        }),
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      // result.json - not found
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: '',
+        stderr: 'No such file',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+      // PID file
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '12345',
+        stderr: '',
+        pid: 3,
+        output: [],
+        signal: null,
+      })
+      // kill -0 check - alive
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '',
+        stderr: '',
+        pid: 4,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetStatus({
+      machine: 'm16',
+      task_id: 'task_ghi',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('running')
+    expect(result.message).toContain('PID: 12345')
+  })
+
+  it('returns crashed status when PID is dead and no result.json', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(spawnSync)
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: JSON.stringify({ status: 'running', task_id: 'task_jkl' }),
+        stderr: '',
+        pid: 1,
+        output: [],
+        signal: null,
+      })
+      // result.json - not found
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: '',
+        stderr: '',
+        pid: 2,
+        output: [],
+        signal: null,
+      })
+      // PID file
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: '99999',
+        stderr: '',
+        pid: 3,
+        output: [],
+        signal: null,
+      })
+      // kill -0 check - dead
+      .mockReturnValueOnce({
+        status: 1,
+        stdout: '',
+        stderr: 'No such process',
+        pid: 4,
+        output: [],
+        signal: null,
+      })
+
+    const result = await executeFleetStatus({
+      machine: 'm16',
+      task_id: 'task_jkl',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('crashed')
+    expect(result.message).toContain('99999')
+  })
+
+  it('returns not_found when no status.json exists', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      status: 1,
+      stdout: '',
+      stderr: 'No such file or directory',
+      pid: 1,
+      output: [],
+      signal: null,
+    })
+
+    const result = await executeFleetStatus({
+      machine: 'm16',
+      task_id: 'task_nonexistent',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('not_found')
+  })
+})
+
+describe('fleet-status tool - PR mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('matches PRs to issues via Closes #N pattern', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    // gh pr list
+    vi.mocked(execSync)
+      .mockReturnValueOnce(
+        JSON.stringify([
+          {
+            number: 260,
+            title: 'fix: resolve login issue',
+            body: 'Fixes the auth flow.\n\nCloses #42',
+            headRefName: '42-fix-login',
+          },
+          {
+            number: 261,
+            title: 'feat: add dashboard',
+            body: 'New feature.\n\nCloses #45',
+            headRefName: '45-add-dashboard',
+          },
+        ])
+      )
+      // gh pr checks for #42's PR
+      .mockReturnValueOnce(
+        JSON.stringify([{ name: 'CI', state: 'COMPLETED', conclusion: 'SUCCESS' }])
+      )
+      // gh pr view state for #42's PR
+      .mockReturnValueOnce('OPEN')
+      // gh pr checks for #45's PR
+      .mockReturnValueOnce(
+        JSON.stringify([{ name: 'CI', state: 'COMPLETED', conclusion: 'SUCCESS' }])
+      )
+      // gh pr view state for #45's PR
+      .mockReturnValueOnce('MERGED')
+
+    const result = await executeFleetStatus({
+      repo: 'venturecrane/crane-console',
+      issue_numbers: [42, 45],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('#42: PR #260')
+    expect(result.message).toContain('open')
+    expect(result.message).toContain('#45: PR #261')
+    expect(result.message).toContain('merged')
+  })
+
+  it('reports no PR found for unmatched issues', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(execSync).mockReturnValueOnce(JSON.stringify([]))
+
+    const result = await executeFleetStatus({
+      repo: 'venturecrane/crane-console',
+      issue_numbers: [99],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('#99: no PR found')
+  })
+
+  it('returns error when gh CLI fails', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(execSync).mockImplementationOnce(() => {
+      throw new Error('gh: not found')
+    })
+
+    const result = await executeFleetStatus({
+      repo: 'venturecrane/crane-console',
+      issue_numbers: [42],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Failed to list PRs')
+  })
+
+  it('matches PRs by branch name when body has no Closes', async () => {
+    const { executeFleetStatus } = await getModule()
+
+    vi.mocked(execSync)
+      .mockReturnValueOnce(
+        JSON.stringify([
+          {
+            number: 262,
+            title: 'fix: something',
+            body: 'No closes reference here',
+            headRefName: '42-fix-something',
+          },
+        ])
+      )
+      .mockReturnValueOnce(JSON.stringify([]))
+      .mockReturnValueOnce('OPEN')
+
+    const result = await executeFleetStatus({
+      repo: 'venturecrane/crane-console',
+      issue_numbers: [42],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('#42: PR #262')
+  })
+})
+
+describe('fleet-status tool - validation', () => {
+  it('requires task mode or PR mode fields', async () => {
+    const { fleetStatusInputSchema } = await getModule()
+
+    expect(() => fleetStatusInputSchema.parse({})).toThrow()
+    expect(() => fleetStatusInputSchema.parse({ machine: 'm16' })).toThrow()
+    expect(() => fleetStatusInputSchema.parse({ repo: 'org/repo' })).toThrow()
+  })
+})

--- a/packages/crane-mcp/src/tools/fleet-status.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.ts
@@ -1,0 +1,258 @@
+/**
+ * crane_fleet_status tool - Check task or PR status on fleet machines
+ *
+ * Dual-mode:
+ *   Task mode: SSH to target, read status.json + result.json, check PID alive.
+ *   PR mode: gh pr list + checks, match PRs to issues via "Closes #N".
+ */
+
+import { spawnSync, execSync } from 'node:child_process'
+import { z } from 'zod'
+
+export const fleetStatusInputSchema = z
+  .object({
+    // Task mode fields
+    machine: z.string().optional().describe('Target machine hostname (task mode)'),
+    task_id: z.string().optional().describe('Task ID to check (task mode)'),
+    // PR mode fields
+    repo: z.string().optional().describe('Full repo path org/repo (PR mode)'),
+    issue_numbers: z
+      .array(z.number())
+      .optional()
+      .describe('Issue numbers to check PRs for (PR mode)'),
+  })
+  .refine(
+    (data) => {
+      const hasTaskMode = data.machine && data.task_id
+      const hasPrMode = data.repo && data.issue_numbers
+      return hasTaskMode || hasPrMode
+    },
+    {
+      message:
+        'Provide either (machine + task_id) for task mode or (repo + issue_numbers) for PR mode',
+    }
+  )
+
+export type FleetStatusInput = z.infer<typeof fleetStatusInputSchema>
+
+export interface FleetStatusResult {
+  success: boolean
+  message: string
+}
+
+const SSH_TIMEOUT_MS = 15_000
+
+/**
+ * Run a command on a remote machine via SSH.
+ */
+function sshExec(
+  machine: string,
+  command: string,
+  timeoutMs: number = SSH_TIMEOUT_MS
+): { stdout: string; stderr: string; ok: boolean } {
+  const result = spawnSync(
+    'ssh',
+    [
+      '-o',
+      'ConnectTimeout=5',
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      '-o',
+      'BatchMode=yes',
+      machine,
+      command,
+    ],
+    {
+      timeout: timeoutMs,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  )
+
+  return {
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? '',
+    ok: result.status === 0,
+  }
+}
+
+/**
+ * Task mode: SSH to target, read status.json + result.json, check PID.
+ */
+function checkTaskStatus(machine: string, taskId: string): string {
+  const taskDir = `$HOME/.crane/tasks/${taskId}`
+
+  // Read status.json
+  const statusResult = sshExec(machine, `cat ${taskDir}/status.json 2>/dev/null`)
+  if (!statusResult.ok) {
+    return `Task ${taskId} on ${machine}: not_found\n(No status.json at ${taskDir})`
+  }
+
+  let status: Record<string, unknown>
+  try {
+    status = JSON.parse(statusResult.stdout)
+  } catch {
+    return `Task ${taskId} on ${machine}: error\n(Malformed status.json)`
+  }
+
+  // Read result.json (written by the agent on completion)
+  const resultResult = sshExec(machine, `cat ${taskDir}/worktree/result.json 2>/dev/null`)
+  let agentResult: Record<string, unknown> | null = null
+  if (resultResult.ok && resultResult.stdout) {
+    try {
+      agentResult = JSON.parse(resultResult.stdout)
+    } catch {
+      // result.json exists but malformed
+    }
+  }
+
+  // If agent wrote result.json, that's the definitive status
+  if (agentResult) {
+    const agentStatus = agentResult.status as string
+    const prUrl = agentResult.pr_url as string | undefined
+    const error = agentResult.error as string | undefined
+    const attempts = agentResult.verify_attempts as number | undefined
+
+    let msg = `Task ${taskId} on ${machine}: ${agentStatus}\n`
+    if (prUrl) msg += `PR: ${prUrl}\n`
+    if (error) msg += `Error: ${error}\n`
+    if (attempts !== undefined) msg += `Verify attempts: ${attempts}\n`
+    return msg.trimEnd()
+  }
+
+  // No result.json yet - check if PID is still alive
+  const pidResult = sshExec(machine, `cat ${taskDir}/pid 2>/dev/null`)
+  if (pidResult.ok && pidResult.stdout) {
+    const pid = pidResult.stdout.trim()
+    const alive = sshExec(machine, `kill -0 ${pid} 2>/dev/null`)
+
+    if (alive.ok) {
+      // Calculate age
+      const startedAt = status.started_at as string | undefined
+      let ageStr = ''
+      if (startedAt) {
+        const ageMs = Date.now() - new Date(startedAt).getTime()
+        const ageMin = Math.round(ageMs / 60_000)
+        ageStr = ` (running ${ageMin}min)`
+      }
+
+      return `Task ${taskId} on ${machine}: running${ageStr}\nPID: ${pid}`
+    } else {
+      // PID is dead but no result.json - crashed
+      return `Task ${taskId} on ${machine}: crashed\nPID ${pid} is dead, no result.json found.`
+    }
+  }
+
+  // No PID file either - just report status.json content
+  return `Task ${taskId} on ${machine}: ${status.status || 'unknown'}`
+}
+
+/**
+ * PR mode: check GitHub PRs matching the given issues.
+ */
+function checkPrStatus(repo: string, issueNumbers: number[]): string {
+  // List open PRs for the repo
+  let prList: Array<{ number: number; title: string; body: string; headRefName: string }>
+  try {
+    const output = execSync(
+      `gh pr list --repo ${repo} --state all --limit 50 --json number,title,body,headRefName`,
+      { encoding: 'utf-8', timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'] }
+    )
+    prList = JSON.parse(output)
+  } catch {
+    return `Failed to list PRs for ${repo}. Check gh CLI auth.`
+  }
+
+  // Match PRs to issues via "Closes #N" in body or branch name starting with issue number
+  const lines: string[] = []
+
+  for (const issueNum of issueNumbers) {
+    const closesPattern = new RegExp(`closes\\s+#${issueNum}\\b`, 'i')
+    const branchPattern = new RegExp(`^${issueNum}-`)
+
+    const matchedPr = prList.find(
+      (pr) => closesPattern.test(pr.body || '') || branchPattern.test(pr.headRefName || '')
+    )
+
+    if (!matchedPr) {
+      lines.push(`#${issueNum}: no PR found`)
+      continue
+    }
+
+    // Check CI status for the matched PR
+    let ciStatus = 'unknown'
+    try {
+      const checksOutput = execSync(
+        `gh pr checks ${matchedPr.number} --repo ${repo} --json name,state,conclusion 2>/dev/null`,
+        { encoding: 'utf-8', timeout: 15_000, stdio: ['pipe', 'pipe', 'pipe'] }
+      )
+      const checks: Array<{ name: string; state: string; conclusion: string }> =
+        JSON.parse(checksOutput)
+
+      if (checks.length === 0) {
+        ciStatus = 'no checks'
+      } else {
+        const failed = checks.filter(
+          (c) => c.conclusion === 'FAILURE' || c.conclusion === 'failure'
+        )
+        const pending = checks.filter(
+          (c) => c.state === 'PENDING' || c.state === 'IN_PROGRESS' || c.state === 'QUEUED'
+        )
+
+        if (failed.length > 0) {
+          ciStatus = `failed (${failed.map((c) => c.name).join(', ')})`
+        } else if (pending.length > 0) {
+          ciStatus = 'pending'
+        } else {
+          ciStatus = 'passing'
+        }
+      }
+    } catch {
+      ciStatus = 'check failed'
+    }
+
+    // Get PR merge state
+    let prState = 'open'
+    try {
+      const stateOutput = execSync(
+        `gh pr view ${matchedPr.number} --repo ${repo} --json state -q .state`,
+        { encoding: 'utf-8', timeout: 10_000, stdio: ['pipe', 'pipe', 'pipe'] }
+      )
+      prState = stateOutput.trim().toLowerCase()
+    } catch {
+      // Use default "open"
+    }
+
+    lines.push(
+      `#${issueNum}: PR #${matchedPr.number} (${prState}) | CI: ${ciStatus} | Branch: ${matchedPr.headRefName}`
+    )
+  }
+
+  return lines.join('\n')
+}
+
+export async function executeFleetStatus(input: FleetStatusInput): Promise<FleetStatusResult> {
+  // Task mode
+  if (input.machine && input.task_id) {
+    const result = checkTaskStatus(input.machine, input.task_id)
+    return {
+      success: true,
+      message: result,
+    }
+  }
+
+  // PR mode
+  if (input.repo && input.issue_numbers) {
+    const result = checkPrStatus(input.repo, input.issue_numbers)
+    return {
+      success: true,
+      message: result,
+    }
+  }
+
+  return {
+    success: false,
+    message:
+      'Provide either (machine + task_id) for task mode or (repo + issue_numbers) for PR mode.',
+  }
+}

--- a/scripts/fleet-exec.sh
+++ b/scripts/fleet-exec.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# fleet-exec.sh - Minimal per-task execution wrapper for fleet machines.
+#
+# Runs on the target machine. The crane launcher handles secrets, env, and
+# agent config. This script only handles worktree setup and fire-and-forget
+# dispatch via crane headless mode.
+#
+# Usage: fleet-exec.sh <task_id> <venture> <repo> <issue_number> <branch_name>
+
+set -euo pipefail
+
+TASK_ID="${1:?task_id required}"
+VENTURE="${2:?venture required}"
+REPO="${3:?repo (org/repo) required}"
+ISSUE_NUMBER="${4:?issue_number required}"
+BRANCH_NAME="${5:?branch_name required}"
+
+TASK_DIR="$HOME/.crane/tasks/$TASK_ID"
+REPO_NAME="${REPO#*/}"
+REPO_PATH="$HOME/dev/$REPO_NAME"
+
+# Validate repo exists locally
+if [ ! -d "$REPO_PATH/.git" ]; then
+  echo "Error: $REPO_PATH is not a git repo" >&2
+  exit 1
+fi
+
+# Create task directory
+mkdir -p "$TASK_DIR"
+
+# Write initial status
+cat > "$TASK_DIR/status.json" <<EOF
+{"status":"setting_up","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+EOF
+
+# Create worktree from origin/main (no local main dependency)
+cd "$REPO_PATH"
+git fetch origin main
+WORKTREE_PATH="$TASK_DIR/worktree"
+
+if git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" origin/main 2>/dev/null; then
+  : # success
+elif git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null; then
+  : # branch already exists, reuse it
+else
+  echo "Error: failed to create worktree for $BRANCH_NAME" >&2
+  cat > "$TASK_DIR/status.json" <<EOF
+{"status":"failed","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","error":"worktree creation failed","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+EOF
+  exit 1
+fi
+
+# Install dependencies if package.json exists
+if [ -f "$WORKTREE_PATH/package.json" ]; then
+  (cd "$WORKTREE_PATH" && npm ci --prefer-offline > /dev/null 2>&1) || true
+fi
+
+# Fetch issue body for prompt
+ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body,title -q '.title + "\n\n" + .body')
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title -q '.title')
+
+# Detect verify command from CLAUDE.md
+VERIFY_CMD="npm run verify"
+if [ -f "$WORKTREE_PATH/CLAUDE.md" ]; then
+  DETECTED=$(grep -oP '(?<=`)(npm run verify|npm run test|npm test)(?=`)' "$WORKTREE_PATH/CLAUDE.md" | head -1) || true
+  if [ -n "${DETECTED:-}" ]; then
+    VERIFY_CMD="$DETECTED"
+  fi
+fi
+
+# Build prompt (dynamic context only - static instructions from sprint-worker agent)
+PROMPT="## Assignment
+- Issue: #$ISSUE_NUMBER - $ISSUE_TITLE
+- Worktree: $WORKTREE_PATH
+- Branch: $BRANCH_NAME (already checked out)
+- Repo: $REPO
+- Verify command: $VERIFY_CMD
+
+## Issue Details
+$ISSUE_BODY"
+
+# Update status to running
+cat > "$TASK_DIR/status.json" <<EOF
+{"status":"running","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","pid":0}
+EOF
+
+# Launch crane in headless mode and record PID
+nohup crane "$VENTURE" -p "$PROMPT" > "$TASK_DIR/output.log" 2>&1 &
+CRANE_PID=$!
+echo "$CRANE_PID" > "$TASK_DIR/pid"
+
+# Update status with actual PID
+cat > "$TASK_DIR/status.json" <<EOF
+{"status":"running","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","pid":$CRANE_PID}
+EOF
+
+echo "Dispatched task $TASK_ID (PID $CRANE_PID) for issue #$ISSUE_NUMBER"


### PR DESCRIPTION
## Summary

- Refactors sprint system onto CC native agent types (`sprint-worker` custom agent)
- Adds headless mode to `crane` launcher (`crane vc -p "prompt"` passthrough)
- Builds fleet orchestrator using `claude -p` instead of tmux sessions
- Adds `/orchestrate` command for multi-machine fleet sprints
- Dual-write handoff to `.claude/handoff.md` for CC `/resume` interop

## Changes

### Phase 1 - Sprint Alignment
- `.claude/agents/sprint-worker.md` - custom agent with static behavioral instructions
- `.claude/commands/sprint.md` - sync gate (worktrees from `origin/main`), `sprint-worker` agent type, slimmed dynamic-only prompts

### Phase 2 - Launcher Headless Mode
- `packages/crane-mcp/src/cli/launch-lib.ts` - `extraArgs` passthrough to agent binary, `extractPassthroughArgs()` utility
- 11 new tests for arg passthrough

### Phase 3 - Fleet Execution (#257)
- `scripts/fleet-exec.sh` - per-task wrapper (worktree + `crane -p` dispatch)
- `crane_fleet_dispatch` MCP tool - SSH dispatch with health check
- `crane_fleet_status` MCP tool - dual-mode task/PR status
- 15 new tests

### Phase 4 - Orchestrator (#258)
- `.claude/commands/orchestrate.md` - 3-phase control loop (DISPATCH/MONITOR/COLLECT) with resume from reality

### Phase 5 - Strategic Bridges
- Handoff dual-write (`.claude/handoff.md` cache, D1 authoritative)
- CC integration principles in `CLAUDE.md`

## Test plan
- [x] `npm run verify` passes (246 tests, 0 errors)
- [x] Pre-push hook passes
- [ ] CI passes
- [ ] Smoke test `/sprint` with sprint-worker agent on a real issue
- [ ] Smoke test `crane vc -p "echo hello"` headless mode
- [ ] Smoke test fleet dispatch to one machine

Closes #257, closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)