### PR TITLE
fix: make /active endpoint params optional for unfiltered queries

### DIFF
--- a/workers/crane-context/src/endpoints/queries.ts
+++ b/workers/crane-context/src/endpoints/queries.ts
@@ -41,34 +41,12 @@ export async function handleGetActiveSessions(request: Request, env: Env): Promi
   }
 
   try {
-    // 2. Parse query parameters
+    // 2. Parse query parameters (all optional for unfiltered queries)
     const url = new URL(request.url)
-    const agent = url.searchParams.get('agent')
-    const venture = url.searchParams.get('venture')
-    const repo = url.searchParams.get('repo')
+    const agent = url.searchParams.get('agent') || null
+    const venture = url.searchParams.get('venture') || null
+    const repo = url.searchParams.get('repo') || null
     const trackParam = url.searchParams.get('track')
-
-    // Validate required parameters
-    if (!agent) {
-      return validationErrorResponse(
-        [{ field: 'agent', message: 'Required query parameter' }],
-        context.correlationId
-      )
-    }
-
-    if (!venture) {
-      return validationErrorResponse(
-        [{ field: 'venture', message: 'Required query parameter' }],
-        context.correlationId
-      )
-    }
-
-    if (!repo) {
-      return validationErrorResponse(
-        [{ field: 'repo', message: 'Required query parameter' }],
-        context.correlationId
-      )
-    }
 
     // Parse optional track parameter
     let track: number | null = null

--- a/workers/crane-context/src/sessions.ts
+++ b/workers/crane-context/src/sessions.ts
@@ -31,18 +31,19 @@ import {
  */
 export async function findActiveSessions(
   db: D1Database,
-  agent: string,
-  venture: string,
-  repo: string,
+  agent: string | null,
+  venture: string | null,
+  repo: string | null,
   track: number | null
 ): Promise<SessionRecord[]> {
-  // When track is null, match ALL sessions (ignore track filter)
-  // When track is provided, match only that specific track
+  // All filters are optional. When null, that filter is skipped.
+  // This allows both targeted queries (conflict detection) and
+  // unfiltered queries (remote MCP "show all active sessions").
   const query = `
     SELECT * FROM sessions
-    WHERE agent = ?
-      AND venture = ?
-      AND repo = ?
+    WHERE (? IS NULL OR agent = ?)
+      AND (? IS NULL OR venture = ?)
+      AND (? IS NULL OR repo = ?)
       AND (? IS NULL OR track = ?)
       AND status = 'active'
     ORDER BY last_heartbeat_at DESC
@@ -50,7 +51,7 @@ export async function findActiveSessions(
 
   const result = await db
     .prepare(query)
-    .bind(agent, venture, repo, track, track)
+    .bind(agent, agent, venture, venture, repo, repo, track, track)
     .all<SessionRecord>()
 
   return result.results || []


### PR DESCRIPTION
## Summary

- Makes `agent`, `venture`, and `repo` query params optional on `GET /active`
- When omitted, returns all active sessions (unfiltered)
- Fixes crane_active_sessions tool error in crane-mcp-remote

The remote MCP needs to show all active sessions across all ventures without knowing specific agent/venture/repo values. Previously these were required params, causing a 400 error.

Uses the same `(? IS NULL OR col = ?)` pattern already used for the `track` param.

## Test plan

- [x] `npm run verify` passes
- [x] Existing callers (crane_sod) still pass all params - behavior unchanged
- [ ] Deploy crane-context staging, verify `GET /active` returns all sessions
- [ ] Verify crane_active_sessions works in claude.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)