### PR TITLE
fix: harden fleet dispatch against stderr false-failures and stale worktrees

### DIFF
--- a/packages/crane-mcp/src/lib/ssh.ts
+++ b/packages/crane-mcp/src/lib/ssh.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared SSH execution utility for fleet tools.
+ *
+ * Extracted from fleet-dispatch.ts and fleet-status.ts to avoid duplication.
+ */
+
+import { spawnSync } from 'node:child_process'
+
+const DEFAULT_TIMEOUT_MS = 60_000
+
+/**
+ * Run a command on a remote machine via SSH.
+ * Returns { stdout, stderr, exitCode, ok }.
+ */
+export function sshExec(
+  machine: string,
+  command: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS
+): { stdout: string; stderr: string; exitCode: number | null; ok: boolean } {
+  const result = spawnSync(
+    'ssh',
+    [
+      '-o',
+      'ConnectTimeout=5',
+      '-o',
+      'StrictHostKeyChecking=accept-new',
+      '-o',
+      'BatchMode=yes',
+      machine,
+      command,
+    ],
+    {
+      timeout: timeoutMs,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  )
+
+  return {
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? '',
+    exitCode: result.status,
+    ok: result.status === 0,
+  }
+}

--- a/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
@@ -3,12 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { spawnSync } from 'child_process'
 
-vi.mock('child_process', () => ({
-  spawnSync: vi.fn(),
-  execSync: vi.fn(),
-  spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
+vi.mock('../lib/ssh.js', () => ({
+  sshExec: vi.fn(),
 }))
 
 const getModule = async () => {
@@ -16,9 +13,19 @@ const getModule = async () => {
   return import('./fleet-dispatch.js')
 }
 
+const getSshMock = async () => {
+  vi.resetModules()
+  const mod = await import('../lib/ssh.js')
+  return vi.mocked(mod.sshExec)
+}
+
 describe('fleet-dispatch tool', () => {
-  beforeEach(() => {
+  let sshExecMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
     vi.clearAllMocks()
+    const mod = await import('../lib/ssh.js')
+    sshExecMock = vi.mocked(mod.sshExec)
   })
 
   afterEach(() => {
@@ -37,32 +44,16 @@ describe('fleet-dispatch tool', () => {
     const { executeFleetDispatch } = await getModule()
 
     // Health check: SSH ping succeeds
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: 'ok',
-        stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
-      })
+    sshExecMock
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
       // Health check: disk space OK
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: '50G',
-        stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
-      })
+      .mockReturnValueOnce({ stdout: '50G', stderr: '', exitCode: 0, ok: true })
       // SSH dispatch: fleet-exec.sh succeeds
       .mockReturnValueOnce({
-        status: 0,
         stdout: 'Dispatched task task_abc123 (PID 1234) for issue #42',
         stderr: '',
-        pid: 3,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
 
     const result = await executeFleetDispatch(baseInput)
@@ -78,13 +69,11 @@ describe('fleet-dispatch tool', () => {
   it('fails when SSH is unreachable', async () => {
     const { executeFleetDispatch } = await getModule()
 
-    vi.mocked(spawnSync).mockReturnValueOnce({
-      status: 255,
+    sshExecMock.mockReturnValueOnce({
       stdout: '',
       stderr: 'ssh: connect to host m16 port 22: Connection refused',
-      pid: 1,
-      output: [],
-      signal: null,
+      exitCode: 255,
+      ok: false,
     })
 
     const result = await executeFleetDispatch(baseInput)
@@ -98,24 +87,10 @@ describe('fleet-dispatch tool', () => {
     const { executeFleetDispatch } = await getModule()
 
     // SSH ping succeeds
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: 'ok',
-        stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
-      })
+    sshExecMock
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
       // Disk space: only 1GB free
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: '1G',
-        stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
-      })
+      .mockReturnValueOnce({ stdout: '1G', stderr: '', exitCode: 0, ok: true })
 
     const result = await executeFleetDispatch(baseInput)
 
@@ -128,31 +103,15 @@ describe('fleet-dispatch tool', () => {
     const { executeFleetDispatch } = await getModule()
 
     // Health checks pass
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: 'ok',
-        stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: '50G',
-        stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
-      })
+    sshExecMock
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
+      .mockReturnValueOnce({ stdout: '50G', stderr: '', exitCode: 0, ok: true })
       // fleet-exec.sh fails
       .mockReturnValueOnce({
-        status: 1,
         stdout: '',
         stderr: 'Error: /home/user/dev/crane-console is not a git repo',
-        pid: 3,
-        output: [],
-        signal: null,
+        exitCode: 1,
+        ok: false,
       })
 
     const result = await executeFleetDispatch(baseInput)
@@ -162,35 +121,33 @@ describe('fleet-dispatch tool', () => {
     expect(result.message).toContain('not a git repo')
   })
 
+  it('includes exit code in failure message', async () => {
+    const { executeFleetDispatch } = await getModule()
+
+    sshExecMock
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
+      .mockReturnValueOnce({ stdout: '50G', stderr: '', exitCode: 0, ok: true })
+      .mockReturnValueOnce({
+        stdout: '',
+        stderr: 'timeout',
+        exitCode: 124,
+        ok: false,
+      })
+
+    const result = await executeFleetDispatch(baseInput)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('exit code 124')
+  })
+
   it('uses structured SSH args for defense against injection', async () => {
     const { executeFleetDispatch } = await getModule()
 
-    // Health checks pass
-    vi.mocked(spawnSync)
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: 'ok',
-        stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: '50G',
-        stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
-      })
-      .mockReturnValueOnce({
-        status: 0,
-        stdout: 'ok',
-        stderr: '',
-        pid: 3,
-        output: [],
-        signal: null,
-      })
+    // Health checks pass + dispatch succeeds
+    sshExecMock
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
+      .mockReturnValueOnce({ stdout: '50G', stderr: '', exitCode: 0, ok: true })
+      .mockReturnValueOnce({ stdout: 'ok', stderr: '', exitCode: 0, ok: true })
 
     await executeFleetDispatch({
       ...baseInput,
@@ -198,9 +155,8 @@ describe('fleet-dispatch tool', () => {
     })
 
     // The SSH dispatch call (3rd call) should have shell-escaped args
-    const dispatchCall = vi.mocked(spawnSync).mock.calls[2]
-    expect(dispatchCall[0]).toBe('ssh')
-    const sshCommand = dispatchCall[1]![dispatchCall[1]!.length - 1]
+    const dispatchCall = sshExecMock.mock.calls[2]
+    const sshCommand = dispatchCall[1] as string
     // Branch name should be quoted
     expect(sshCommand).toContain("'42-fix'\\''")
   })

--- a/packages/crane-mcp/src/tools/fleet-dispatch.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.ts
@@ -7,8 +7,8 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { spawnSync } from 'node:child_process'
 import { z } from 'zod'
+import { sshExec } from '../lib/ssh.js'
 
 export const fleetDispatchInputSchema = z.object({
   machine: z.string().describe('Target machine hostname (Tailscale or SSH name)'),
@@ -25,43 +25,8 @@ export interface FleetDispatchResult {
   message: string
 }
 
-const SSH_TIMEOUT_MS = 15_000
+const SSH_TIMEOUT_MS = 60_000
 const HEALTH_CHECK_TIMEOUT_MS = 10_000
-
-/**
- * Run a command on a remote machine via SSH.
- * Returns { stdout, stderr, ok }.
- */
-function sshExec(
-  machine: string,
-  command: string,
-  timeoutMs: number = SSH_TIMEOUT_MS
-): { stdout: string; stderr: string; ok: boolean } {
-  const result = spawnSync(
-    'ssh',
-    [
-      '-o',
-      'ConnectTimeout=5',
-      '-o',
-      'StrictHostKeyChecking=accept-new',
-      '-o',
-      'BatchMode=yes',
-      machine,
-      command,
-    ],
-    {
-      timeout: timeoutMs,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }
-  )
-
-  return {
-    stdout: result.stdout?.trim() ?? '',
-    stderr: result.stderr?.trim() ?? '',
-    ok: result.status === 0,
-  }
-}
 
 /**
  * Pre-dispatch health check: SSH ping + disk space.
@@ -118,13 +83,13 @@ export async function executeFleetDispatch(
     shellescape(branch_name),
   ].join(' ')
 
-  const result = sshExec(machine, sshCommand)
+  const result = sshExec(machine, sshCommand, SSH_TIMEOUT_MS)
 
   if (!result.ok) {
     return {
       success: false,
       message:
-        `Fleet dispatch failed on ${machine}.\n` +
+        `Fleet dispatch failed on ${machine} (exit code ${result.exitCode}).\n` +
         `Task ID: ${taskId}\n` +
         `Error: ${result.stderr || 'unknown error'}\n` +
         `Command output: ${result.stdout || '(none)'}`,

--- a/packages/crane-mcp/src/tools/fleet-status.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { spawnSync, execSync } from 'child_process'
+import { execSync } from 'child_process'
+
+vi.mock('../lib/ssh.js', () => ({
+  sshExec: vi.fn(),
+}))
 
 vi.mock('child_process', () => ({
   spawnSync: vi.fn(),
@@ -17,8 +21,12 @@ const getModule = async () => {
 }
 
 describe('fleet-status tool - task mode', () => {
-  beforeEach(() => {
+  let sshExecMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
     vi.clearAllMocks()
+    const mod = await import('../lib/ssh.js')
+    sshExecMock = vi.mocked(mod.sshExec)
   })
 
   afterEach(() => {
@@ -29,9 +37,8 @@ describe('fleet-status tool - task mode', () => {
     const { executeFleetStatus } = await getModule()
 
     // Read status.json
-    vi.mocked(spawnSync)
+    sshExecMock
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({
           status: 'running',
           task_id: 'task_abc',
@@ -39,13 +46,11 @@ describe('fleet-status tool - task mode', () => {
           started_at: '2026-02-20T10:00:00Z',
         }),
         stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       // Read result.json
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({
           status: 'success',
           pr_url: 'https://github.com/venturecrane/crane-console/pull/260',
@@ -53,9 +58,8 @@ describe('fleet-status tool - task mode', () => {
           files_changed: ['src/index.ts'],
         }),
         stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
 
     const result = await executeFleetStatus({
@@ -71,26 +75,22 @@ describe('fleet-status tool - task mode', () => {
   it('returns failed status with error from result.json', async () => {
     const { executeFleetStatus } = await getModule()
 
-    vi.mocked(spawnSync)
+    sshExecMock
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({ status: 'running', task_id: 'task_def' }),
         stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({
           status: 'failed',
           error: 'Tests failed after 3 attempts',
           verify_attempts: 3,
         }),
         stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
 
     const result = await executeFleetStatus({
@@ -106,46 +106,38 @@ describe('fleet-status tool - task mode', () => {
   it('returns running status when PID is alive but no result.json', async () => {
     const { executeFleetStatus } = await getModule()
 
-    vi.mocked(spawnSync)
+    sshExecMock
       // status.json
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({
           status: 'running',
           task_id: 'task_ghi',
           started_at: new Date(Date.now() - 300_000).toISOString(),
         }),
         stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       // result.json - not found
       .mockReturnValueOnce({
-        status: 1,
         stdout: '',
         stderr: 'No such file',
-        pid: 2,
-        output: [],
-        signal: null,
+        exitCode: 1,
+        ok: false,
       })
       // PID file
       .mockReturnValueOnce({
-        status: 0,
         stdout: '12345',
         stderr: '',
-        pid: 3,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       // kill -0 check - alive
       .mockReturnValueOnce({
-        status: 0,
         stdout: '',
         stderr: '',
-        pid: 4,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
 
     const result = await executeFleetStatus({
@@ -161,41 +153,33 @@ describe('fleet-status tool - task mode', () => {
   it('returns crashed status when PID is dead and no result.json', async () => {
     const { executeFleetStatus } = await getModule()
 
-    vi.mocked(spawnSync)
+    sshExecMock
       .mockReturnValueOnce({
-        status: 0,
         stdout: JSON.stringify({ status: 'running', task_id: 'task_jkl' }),
         stderr: '',
-        pid: 1,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       // result.json - not found
       .mockReturnValueOnce({
-        status: 1,
         stdout: '',
         stderr: '',
-        pid: 2,
-        output: [],
-        signal: null,
+        exitCode: 1,
+        ok: false,
       })
       // PID file
       .mockReturnValueOnce({
-        status: 0,
         stdout: '99999',
         stderr: '',
-        pid: 3,
-        output: [],
-        signal: null,
+        exitCode: 0,
+        ok: true,
       })
       // kill -0 check - dead
       .mockReturnValueOnce({
-        status: 1,
         stdout: '',
         stderr: 'No such process',
-        pid: 4,
-        output: [],
-        signal: null,
+        exitCode: 1,
+        ok: false,
       })
 
     const result = await executeFleetStatus({
@@ -211,13 +195,11 @@ describe('fleet-status tool - task mode', () => {
   it('returns not_found when no status.json exists', async () => {
     const { executeFleetStatus } = await getModule()
 
-    vi.mocked(spawnSync).mockReturnValueOnce({
-      status: 1,
+    sshExecMock.mockReturnValueOnce({
       stdout: '',
       stderr: 'No such file or directory',
-      pid: 1,
-      output: [],
-      signal: null,
+      exitCode: 1,
+      ok: false,
     })
 
     const result = await executeFleetStatus({

--- a/packages/crane-mcp/src/tools/fleet-status.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.ts
@@ -6,8 +6,9 @@
  *   PR mode: gh pr list + checks, match PRs to issues via "Closes #N".
  */
 
-import { spawnSync, execSync } from 'node:child_process'
+import { execSync } from 'node:child_process'
 import { z } from 'zod'
+import { sshExec } from '../lib/ssh.js'
 
 export const fleetStatusInputSchema = z
   .object({
@@ -43,47 +44,13 @@ export interface FleetStatusResult {
 const SSH_TIMEOUT_MS = 15_000
 
 /**
- * Run a command on a remote machine via SSH.
- */
-function sshExec(
-  machine: string,
-  command: string,
-  timeoutMs: number = SSH_TIMEOUT_MS
-): { stdout: string; stderr: string; ok: boolean } {
-  const result = spawnSync(
-    'ssh',
-    [
-      '-o',
-      'ConnectTimeout=5',
-      '-o',
-      'StrictHostKeyChecking=accept-new',
-      '-o',
-      'BatchMode=yes',
-      machine,
-      command,
-    ],
-    {
-      timeout: timeoutMs,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }
-  )
-
-  return {
-    stdout: result.stdout?.trim() ?? '',
-    stderr: result.stderr?.trim() ?? '',
-    ok: result.status === 0,
-  }
-}
-
-/**
  * Task mode: SSH to target, read status.json + result.json, check PID.
  */
 function checkTaskStatus(machine: string, taskId: string): string {
   const taskDir = `$HOME/.crane/tasks/${taskId}`
 
   // Read status.json
-  const statusResult = sshExec(machine, `cat ${taskDir}/status.json 2>/dev/null`)
+  const statusResult = sshExec(machine, `cat ${taskDir}/status.json 2>/dev/null`, SSH_TIMEOUT_MS)
   if (!statusResult.ok) {
     return `Task ${taskId} on ${machine}: not_found\n(No status.json at ${taskDir})`
   }
@@ -96,7 +63,11 @@ function checkTaskStatus(machine: string, taskId: string): string {
   }
 
   // Read result.json (written by the agent on completion)
-  const resultResult = sshExec(machine, `cat ${taskDir}/worktree/result.json 2>/dev/null`)
+  const resultResult = sshExec(
+    machine,
+    `cat ${taskDir}/worktree/result.json 2>/dev/null`,
+    SSH_TIMEOUT_MS
+  )
   let agentResult: Record<string, unknown> | null = null
   if (resultResult.ok && resultResult.stdout) {
     try {
@@ -121,10 +92,10 @@ function checkTaskStatus(machine: string, taskId: string): string {
   }
 
   // No result.json yet - check if PID is still alive
-  const pidResult = sshExec(machine, `cat ${taskDir}/pid 2>/dev/null`)
+  const pidResult = sshExec(machine, `cat ${taskDir}/pid 2>/dev/null`, SSH_TIMEOUT_MS)
   if (pidResult.ok && pidResult.stdout) {
     const pid = pidResult.stdout.trim()
-    const alive = sshExec(machine, `kill -0 ${pid} 2>/dev/null`)
+    const alive = sshExec(machine, `kill -0 ${pid} 2>/dev/null`, SSH_TIMEOUT_MS)
 
     if (alive.ok) {
       // Calculate age

--- a/scripts/fleet-exec.sh
+++ b/scripts/fleet-exec.sh
@@ -25,7 +25,29 @@ if [ ! -d "$REPO_PATH/.git" ]; then
   exit 1
 fi
 
-# Create task directory
+# Clean up stale worktree/branch if they exist from a previous crashed dispatch
+WORKTREE_PATH="$TASK_DIR/worktree"
+
+cd "$REPO_PATH"
+
+if git worktree list --porcelain | grep -q "^worktree.*$WORKTREE_PATH"; then
+  git worktree remove --force "$WORKTREE_PATH" 2>/dev/null || true
+fi
+
+# Safe branch cleanup: prefer safe delete, protect unpushed work
+if git branch --list "$BRANCH_NAME" | grep -q .; then
+  if git branch -d "$BRANCH_NAME" 2>/dev/null; then
+    : # safely deleted (merged or no commits ahead)
+  elif git log "origin/$BRANCH_NAME..$BRANCH_NAME" --oneline 2>/dev/null | grep -q .; then
+    echo "Warning: branch $BRANCH_NAME has unpushed commits. Refusing to delete." >&2
+    exit 1
+  else
+    git branch -D "$BRANCH_NAME" 2>/dev/null || true
+  fi
+fi
+
+# Clean up task dir and recreate
+rm -rf "$TASK_DIR" 2>/dev/null || true
 mkdir -p "$TASK_DIR"
 
 # Write initial status
@@ -33,10 +55,8 @@ cat > "$TASK_DIR/status.json" <<EOF
 {"status":"setting_up","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 EOF
 
-# Create worktree from origin/main (no local main dependency)
-cd "$REPO_PATH"
-git fetch origin main
-WORKTREE_PATH="$TASK_DIR/worktree"
+# Fetch origin/main - redirect stderr to avoid false-failure from git progress output
+git fetch origin main 2>&1
 
 if git worktree add "$WORKTREE_PATH" -b "$BRANCH_NAME" origin/main 2>/dev/null; then
   : # success
@@ -59,10 +79,10 @@ fi
 ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body,title -q '.title + "\n\n" + .body')
 ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title -q '.title')
 
-# Detect verify command from CLAUDE.md
+# Detect verify command from CLAUDE.md (POSIX-compatible grep)
 VERIFY_CMD="npm run verify"
 if [ -f "$WORKTREE_PATH/CLAUDE.md" ]; then
-  DETECTED=$(grep -oP '(?<=`)(npm run verify|npm run test|npm test)(?=`)' "$WORKTREE_PATH/CLAUDE.md" | head -1) || true
+  DETECTED=$(grep -Eo '`(npm run verify|npm run test|npm test)`' "$WORKTREE_PATH/CLAUDE.md" | head -1 | tr -d '`') || true
   if [ -n "${DETECTED:-}" ]; then
     VERIFY_CMD="$DETECTED"
   fi


### PR DESCRIPTION
## Summary
- Extract shared `sshExec` into `packages/crane-mcp/src/lib/ssh.ts` to eliminate duplication between fleet-dispatch and fleet-status
- Increase SSH dispatch timeout from 15s to 60s to accommodate git fetch + npm ci
- Redirect git fetch stderr to stdout in `fleet-exec.sh` to prevent false-failure classification
- Replace BSD-incompatible `grep -oP` with POSIX `grep -Eo` for verify command detection
- Add stale worktree and branch cleanup before dispatch with safe-delete semantics (protects unpushed work)

## Changes
- `packages/crane-mcp/src/lib/ssh.ts` (new) - shared SSH execution utility with configurable timeout and exit code in return type
- `packages/crane-mcp/src/tools/fleet-dispatch.ts` - import shared sshExec, increase timeout, include exit code in failure messages
- `packages/crane-mcp/src/tools/fleet-status.ts` - import shared sshExec (no behavior change)
- `packages/crane-mcp/src/tools/fleet-dispatch.test.ts` - updated mocks for new module structure, added exit code test
- `packages/crane-mcp/src/tools/fleet-status.test.ts` - updated mocks for new module structure
- `scripts/fleet-exec.sh` - stderr redirect, grep fix, stale worktree/branch cleanup

## Test Plan
- [x] All 253 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint and Prettier pass
- [ ] Dispatch to a fleet machine and verify no false-failure from git stderr

Closes #269
Closes #270

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>