### PR TITLE
feat: track per-machine reliability scores across fleet sprints

### DIFF
--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -103,9 +103,13 @@ Exclude unhealthy machines. If no machines are healthy, stop:
 No healthy fleet machines available. Fix connectivity and retry.
 ```
 
+**Check reliability scores:**
+
+Read `~/.crane/fleet-reliability.json` (if it exists) and compute each machine's success rate: `successes / dispatches * 100`. Machines below 70% success rate are deprioritized - assign them work only when higher-reliability machines are full. Display scores alongside health status.
+
 **Assign issues to machines:**
 
-Round-robin across healthy machines, respecting per-machine concurrency limits. Priority order: P0 first, then P1, P2, P3.
+Round-robin across healthy machines, respecting per-machine concurrency limits and reliability scores. Priority order: P0 first, then P1, P2, P3. Prefer machines with higher reliability scores.
 
 Display the assignment plan:
 
@@ -249,6 +253,16 @@ Results:
 | 45  | Add expense filter | SUCCESS | #261  | pending |
 | 47  | Update docs        | FAILED  | -     | -       |
 ```
+
+#### Step 1b: Record Reliability Outcomes
+
+For each task in the wave, record its outcome for machine reliability tracking. Update `~/.crane/fleet-reliability.json` by reading the file, incrementing the appropriate counter for the machine, and writing it back:
+
+- Task succeeded (has result.json with `status: success`) -> increment `successes`
+- Task failed (has result.json with `status: failed`) -> increment `failures`
+- Task crashed (PID dead, no result.json) -> increment `crashes`
+
+This data feeds back into Step 3 of the DISPATCH phase for future sprints.
 
 #### Step 2: Handle Failures
 

--- a/packages/crane-mcp/src/lib/fleet-reliability.ts
+++ b/packages/crane-mcp/src/lib/fleet-reliability.ts
@@ -1,0 +1,92 @@
+/**
+ * Fleet machine reliability scoring.
+ *
+ * Tracks dispatch counts and outcomes per machine in ~/.crane/fleet-reliability.json.
+ * Used by fleet-dispatch to record dispatches and by the orchestrate protocol
+ * to record outcomes and deprioritize unreliable machines.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface MachineStats {
+  dispatches: number
+  successes: number
+  failures: number
+  crashes: number
+}
+
+export type ReliabilityData = Record<string, MachineStats>
+
+const RELIABILITY_PATH = join(homedir(), '.crane', 'fleet-reliability.json')
+
+function ensureDir(): void {
+  mkdirSync(join(homedir(), '.crane'), { recursive: true })
+}
+
+function readData(): ReliabilityData {
+  try {
+    return JSON.parse(readFileSync(RELIABILITY_PATH, 'utf-8'))
+  } catch {
+    return {}
+  }
+}
+
+function writeData(data: ReliabilityData): void {
+  ensureDir()
+  writeFileSync(RELIABILITY_PATH, JSON.stringify(data, null, 2) + '\n')
+}
+
+function getOrCreate(data: ReliabilityData, machine: string): MachineStats {
+  if (!data[machine]) {
+    data[machine] = { dispatches: 0, successes: 0, failures: 0, crashes: 0 }
+  }
+  return data[machine]
+}
+
+/**
+ * Record a dispatch to a machine (called at dispatch time).
+ */
+export function recordDispatch(machine: string): void {
+  const data = readData()
+  const stats = getOrCreate(data, machine)
+  stats.dispatches++
+  writeData(data)
+}
+
+/**
+ * Record the outcome of a dispatched task (called by orchestrator after collection).
+ */
+export function recordOutcome(machine: string, outcome: 'success' | 'failure' | 'crash'): void {
+  const data = readData()
+  const stats = getOrCreate(data, machine)
+  if (outcome === 'success') stats.successes++
+  else if (outcome === 'failure') stats.failures++
+  else if (outcome === 'crash') stats.crashes++
+  writeData(data)
+}
+
+/**
+ * Get reliability scores for all machines.
+ * Returns machine name -> success rate (0-100).
+ */
+export function getScores(): Record<string, number> {
+  const data = readData()
+  const scores: Record<string, number> = {}
+  for (const [machine, stats] of Object.entries(data)) {
+    if (stats.dispatches === 0) {
+      scores[machine] = 100
+    } else {
+      scores[machine] = Math.round((stats.successes / stats.dispatches) * 100)
+    }
+  }
+  return scores
+}
+
+/**
+ * Get raw reliability data for all machines.
+ */
+export function getReliabilityData(): ReliabilityData {
+  return readData()
+}

--- a/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.test.ts
@@ -8,6 +8,10 @@ vi.mock('../lib/ssh.js', () => ({
   sshExec: vi.fn(),
 }))
 
+vi.mock('../lib/fleet-reliability.js', () => ({
+  recordDispatch: vi.fn(),
+}))
+
 const getModule = async () => {
   vi.resetModules()
   return import('./fleet-dispatch.js')

--- a/packages/crane-mcp/src/tools/fleet-dispatch.ts
+++ b/packages/crane-mcp/src/tools/fleet-dispatch.ts
@@ -9,6 +9,7 @@
 import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 import { sshExec } from '../lib/ssh.js'
+import { recordDispatch } from '../lib/fleet-reliability.js'
 
 export const fleetDispatchInputSchema = z.object({
   machine: z.string().describe('Target machine hostname (Tailscale or SSH name)'),
@@ -82,6 +83,9 @@ export async function executeFleetDispatch(
     String(issue_number),
     shellescape(branch_name),
   ].join(' ')
+
+  // Record dispatch for reliability tracking
+  recordDispatch(machine)
 
   const result = sshExec(machine, sshCommand, SSH_TIMEOUT_MS)
 


### PR DESCRIPTION
## Summary
- Add `fleet-reliability.ts` utility tracking dispatch counts, successes, failures, and crashes per machine
- fleet-dispatch automatically records each dispatch for reliability tracking
- orchestrate.md protocol updated to record outcomes in COLLECT phase and deprioritize machines below 70% success rate

## Changes
- `packages/crane-mcp/src/lib/fleet-reliability.ts` (new) - reliability tracking with `recordDispatch()`, `recordOutcome()`, `getScores()`
- `packages/crane-mcp/src/tools/fleet-dispatch.ts` - calls `recordDispatch()` on successful health check
- `packages/crane-mcp/src/tools/fleet-dispatch.test.ts` - added fleet-reliability mock
- `.claude/commands/orchestrate.md` - reliability score check in Step 3, outcome recording in COLLECT Step 1b

## Test Plan
- [x] All 253 tests pass
- [x] TypeScript compiles cleanly
- [ ] Run fleet dispatch and verify `~/.crane/fleet-reliability.json` is written

**Note:** Base branch is `269-fix-fleet-dispatch-infra` (PR #277). Merge that first.

Closes #271

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>