### PR TITLE
feat: add pre-flight CI check, overlap detection, faster stuck detection

### DIFF
--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -80,6 +80,37 @@ Same wave planning logic as `/sprint`:
 
 For fleet orchestration, MAX_CONCURRENT per wave is the sum of available machine slots (see Step 3).
 
+#### Step 2b: Pre-flight CI Check
+
+Before dispatching any tasks, verify CI passes on `origin/main`. SSH to one healthy fleet machine and run the verify command in a temporary worktree:
+
+```bash
+ssh {machine} "cd ~/dev/{REPO_NAME} && git fetch origin main 2>&1 && git worktree add /tmp/preflight-$$ origin/main 2>/dev/null && cd /tmp/preflight-$$ && npm ci --prefer-offline > /dev/null 2>&1 && {VERIFY_COMMAND}; EXIT=$?; cd ~/dev/{REPO_NAME} && git worktree remove --force /tmp/preflight-$$ 2>/dev/null; exit $EXIT"
+```
+
+If the verify command fails, display the failures and ask the Captain using AskUserQuestion:
+
+**"CI is broken on main. Fix first, or override and dispatch anyway?"**
+
+Options: "Fix first (abort)" / "Override and dispatch"
+
+- **Fix first**: Stop orchestration. Display: `CI broken on main. Fix before dispatching.`
+- **Override**: Continue with a warning: `Warning: Dispatching despite CI failures on main. Agents may encounter pre-existing failures.`
+
+#### Step 2c: Shared-File Overlap Detection
+
+After fetching issues, scan issue bodies for file path references (patterns like `src/...`, `*.css`, `*.ts` paths). Also check if issue titles/bodies mention the same component names.
+
+If 2+ issues in the same wave reference the same file, display a warning:
+
+```
+Warning: Potential merge conflict risk
+  - {filename} referenced by #{A}, #{B}
+Consider: Merge in order of fewest shared-file touches first, or split into separate waves.
+```
+
+This is advisory - it does not block dispatch.
+
 #### Step 3: Fleet Health Check and Machine Assignment
 
 **Available machines** (orchestrator host mac23 excluded from worker pool by default):
@@ -208,7 +239,7 @@ Track status transitions:
 - `crashed` (PID dead, no result.json) -> task failed
 - `not_found` -> warn, continue checking
 
-**Stuck detection**: If a task has been running for >20 minutes with no result.json, flag it:
+**Stuck detection**: If a task has been running for >10 minutes with no result.json, flag it:
 
 ```
 Warning: Task {task_id} on {machine} for issue #{N} has been running for {minutes}min. Potentially stuck.

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -205,6 +205,27 @@ Options: "Execute" / "Abort"
 
 If Abort, stop: "Sprint aborted. Re-run with adjusted arguments."
 
+### Step 4b: Pre-flight CI Check
+
+Before creating worktrees, verify CI passes on `origin/main`. Create a temporary worktree, run verify, and clean up:
+
+```bash
+cd {REPO_ROOT} && git fetch origin main 2>&1
+git worktree add {REPO_ROOT}/.worktrees/_preflight origin/main 2>/dev/null
+cd {REPO_ROOT}/.worktrees/_preflight && npm ci --prefer-offline > /dev/null 2>&1 && {VERIFY_COMMAND}
+# Clean up regardless of result
+cd {REPO_ROOT} && git worktree remove --force {REPO_ROOT}/.worktrees/_preflight 2>/dev/null
+```
+
+If the verify command fails, display the failures and ask the Captain using AskUserQuestion:
+
+**"CI is broken on main. Fix first, or override and dispatch anyway?"**
+
+Options: "Fix first (abort)" / "Override and dispatch"
+
+- **Fix first**: Stop sprint. Display: `CI broken on main. Fix before dispatching.`
+- **Override**: Continue with a warning: `Warning: Dispatching despite CI failures on main. Agents may encounter pre-existing failures.`
+
 ### Step 5: Set Up Worktrees
 
 **Check for active sprint:**


### PR DESCRIPTION
## Summary
- Reduce stuck detection threshold from 20 to 10 minutes in orchestrate.md
- Add pre-flight CI check against origin/main before dispatching tasks (both /orchestrate and /sprint)
- Add shared-file overlap detection to warn about merge conflict risk when multiple issues reference the same files

## Changes
- `.claude/commands/orchestrate.md` - stuck threshold 20->10min, new Step 2b (pre-flight CI), new Step 2c (overlap detection)
- `.claude/commands/sprint.md` - new Step 4b (pre-flight CI check in temporary worktree)

## Test Plan
- [x] All 252 tests pass
- [x] Verify protocol instructions are clear and unambiguous
- [ ] Run /orchestrate or /sprint and observe pre-flight CI behavior

Closes #272
Closes #273
Closes #274

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>