### PR TITLE
fix: add docs/wireframes/ to setup script dry-run display

### DIFF
--- a/scripts/setup-new-venture.sh
+++ b/scripts/setup-new-venture.sh
@@ -179,6 +179,7 @@ if [ "$DRY_RUN" = "true" ]; then
   echo "  docs/adr/"
   echo "  docs/pm/"
   echo "  docs/process/"
+  echo "  docs/wireframes/"
   echo "  scripts/"
 else
   # Clone the new repo temporarily


### PR DESCRIPTION
## Summary

- The dry-run branch of `setup-new-venture.sh` Step 2 had a hardcoded directory list missing `docs/wireframes/`, added in #283

## Test plan

- [x] `DRY_RUN=true ./scripts/setup-new-venture.sh` shows `docs/wireframes/` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)