### PR TITLE
chore: make wireframe docs tool-agnostic, add issue 286 wireframe

### DIFF
--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -15,9 +15,9 @@ Bug fixes skip wireframes unless the fix changes layout.
 
 An interactive HTML/CSS prototype - a single self-contained HTML file with inline CSS and JS. No external dependencies.
 
-### Prompt Template for Claude Desktop
+### Prompt Template
 
-Feed Claude Desktop the acceptance criteria and this prompt pattern:
+Feed Claude the acceptance criteria and this prompt pattern (works in Claude Code, Claude Desktop, or any Claude agent):
 
 > Generate an interactive HTML wireframe for this feature:
 >

--- a/docs/process/agent-persona-briefs.md
+++ b/docs/process/agent-persona-briefs.md
@@ -91,7 +91,7 @@ Incomplete handoffs will be rejected. Verbal "it's deployed" or "it's done" with
 - Answering `needs:pm` questions promptly
 - Making scope decisions when ambiguity arises
 - All GitHub updates via Crane Relay
-- Generating wireframes for UI-facing stories using Claude Desktop
+- Generating wireframes for UI-facing stories using Claude (any agent)
 - Iterating wireframes until they match PRD intent
 - Verifying wireframe renders correctly before committing
 - Committing wireframe artifacts to `/docs/wireframes/{issue-number}/`

--- a/docs/process/team-workflow.md
+++ b/docs/process/team-workflow.md
@@ -247,8 +247,8 @@ Since PM writes ACs and tests them:
 
 **Does this story change what a user sees in a browser or app?** If yes, wireframe. If no (API, background job, config, pure backend logic), skip to Phase 2.
 
-1. PM feeds PRD + acceptance criteria to Claude Desktop
-2. Claude Desktop generates interactive HTML/CSS prototype
+1. PM feeds PRD + acceptance criteria to Claude (any agent - Claude Code, Claude Desktop, etc.)
+2. Claude generates interactive HTML/CSS prototype
 3. PM iterates via prompt refinement until wireframe matches intent
 4. PM verifies wireframe renders correctly (open in browser, test mobile viewport, confirm interactive states work)
 5. PM commits wireframe to `/docs/wireframes/{issue-number}/`

--- a/docs/wireframes/286/index.html
+++ b/docs/wireframes/286/index.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wireframe: Latest Build Log Section - Issue #286</title>
+    <style>
+      /* ============================================
+       Design tokens matching vc-web design system
+       ============================================ */
+      :root {
+        --vc-chrome: #1a1a2e;
+        --vc-surface: #242438;
+        --vc-raised: #2a2a42;
+        --vc-border: #3a3a55;
+        --vc-text: #e0e0e0;
+        --vc-text-muted: #9ca3af;
+        --vc-accent: #818cf8;
+        --vc-accent-hover: #6366f1;
+        --vc-gold: #dbb05c;
+        --vc-radius: 8px;
+        --vc-content-width: 1200px;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: var(--vc-chrome);
+        color: var(--vc-text);
+        line-height: 1.6;
+      }
+
+      /* ============================================
+       Page context (simulating homepage above/below)
+       ============================================ */
+      .page-context {
+        max-width: var(--vc-content-width);
+        margin: 0 auto;
+        padding: 2rem 1.5rem;
+      }
+
+      .context-placeholder {
+        background: var(--vc-surface);
+        border: 2px dashed var(--vc-border);
+        border-radius: var(--vc-radius);
+        padding: 3rem 2rem;
+        text-align: center;
+        color: var(--vc-text-muted);
+        font-size: 0.875rem;
+      }
+
+      /* ============================================
+       BUILD LOG SECTION - the actual wireframe
+       ============================================ */
+      .build-log-section {
+        max-width: var(--vc-content-width);
+        margin: 0 auto;
+        padding: 4rem 1.5rem;
+      }
+
+      .section-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 2rem;
+      }
+
+      .section-title {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--vc-text);
+        letter-spacing: -0.02em;
+      }
+
+      .section-link {
+        font-size: 0.875rem;
+        color: var(--vc-accent);
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
+
+      .section-link:hover {
+        color: var(--vc-accent-hover);
+      }
+
+      .section-link::after {
+        content: '\2192';
+      }
+
+      /* Card grid */
+      .log-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+      }
+
+      @media (min-width: 640px) {
+        .log-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+
+      @media (min-width: 1024px) {
+        .log-grid {
+          grid-template-columns: repeat(3, 1fr);
+        }
+      }
+
+      /* Individual card */
+      .log-card {
+        background: var(--vc-surface);
+        border: 1px solid var(--vc-border);
+        border-radius: var(--vc-radius);
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        transition:
+          border-color 0.15s ease,
+          transform 0.15s ease;
+        text-decoration: none;
+        color: inherit;
+        cursor: pointer;
+      }
+
+      .log-card:hover {
+        border-color: var(--vc-accent);
+        transform: translateY(-2px);
+      }
+
+      .log-date {
+        font-size: 0.75rem;
+        color: var(--vc-gold);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .log-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--vc-text);
+        line-height: 1.4;
+      }
+
+      .log-excerpt {
+        font-size: 0.875rem;
+        color: var(--vc-text-muted);
+        line-height: 1.6;
+        flex-grow: 1;
+      }
+
+      .log-read-more {
+        font-size: 0.8125rem;
+        color: var(--vc-accent);
+        font-weight: 500;
+      }
+
+      /* ============================================
+       EMPTY STATE
+       ============================================ */
+      .empty-state {
+        text-align: center;
+        padding: 3rem 2rem;
+        color: var(--vc-text-muted);
+      }
+
+      .empty-state p {
+        font-size: 0.875rem;
+      }
+
+      /* ============================================
+       State switcher (wireframe-only UI)
+       ============================================ */
+      .wireframe-controls {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        background: var(--vc-raised);
+        border: 1px solid var(--vc-border);
+        border-radius: var(--vc-radius);
+        padding: 1rem;
+        z-index: 100;
+        font-size: 0.8125rem;
+      }
+
+      .wireframe-controls h4 {
+        font-size: 0.75rem;
+        color: var(--vc-gold);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.5rem;
+      }
+
+      .wireframe-controls button {
+        display: block;
+        width: 100%;
+        padding: 0.375rem 0.75rem;
+        margin-bottom: 0.25rem;
+        background: var(--vc-surface);
+        border: 1px solid var(--vc-border);
+        border-radius: 4px;
+        color: var(--vc-text);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .wireframe-controls button:hover {
+        border-color: var(--vc-accent);
+      }
+
+      .wireframe-controls button.active {
+        border-color: var(--vc-accent);
+        background: rgba(129, 140, 248, 0.1);
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Context: existing homepage content above -->
+    <div class="page-context">
+      <div class="context-placeholder">
+        Existing homepage content above (hero, featured articles, portfolio cards)
+      </div>
+    </div>
+
+    <!-- =============================================
+       THE WIREFRAME: Latest Build Log Section
+       ============================================= -->
+    <section class="build-log-section" aria-label="Latest from the Build Log" id="section-default">
+      <div class="section-header">
+        <h2 class="section-title">Latest from the Build Log</h2>
+        <a href="/log/" class="section-link">View all</a>
+      </div>
+
+      <div class="log-grid">
+        <a href="/log/remote-mcp-browser-advisor/" class="log-card">
+          <span class="log-date">Feb 28, 2026</span>
+          <h3 class="log-title">Remote MCP Browser Advisor</h3>
+          <p class="log-excerpt">
+            Shipped crane-mcp-remote - a Cloudflare Worker that proxies crane-context tools to
+            claude.ai via OAuth. Fleet agents and browser sessions now share the same context.
+          </p>
+          <span class="log-read-more">Read entry</span>
+        </a>
+
+        <a href="/log/offline-field-development/" class="log-card">
+          <span class="log-date">Feb 25, 2026</span>
+          <h3 class="log-title">Offline Field Development with Local LLMs</h3>
+          <p class="log-excerpt">
+            Tested Ollama + Codex CLI for disconnected development on fleet machines. Local models
+            handle mechanical tasks; complex reasoning still needs cloud.
+          </p>
+          <span class="log-read-more">Read entry</span>
+        </a>
+
+        <a href="/log/fleet-sprint-orchestrator/" class="log-card">
+          <span class="log-date">Feb 22, 2026</span>
+          <h3 class="log-title">Fleet Sprint Orchestrator</h3>
+          <p class="log-excerpt">
+            Built the /orchestrate command - coordinates parallel sprints across fleet machines with
+            automatic task distribution and progress tracking.
+          </p>
+          <span class="log-read-more">Read entry</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- EMPTY STATE variant (hidden by default) -->
+    <section class="build-log-section" id="section-empty" style="display: none">
+      <div class="section-header">
+        <h2 class="section-title">Latest from the Build Log</h2>
+      </div>
+      <div class="empty-state">
+        <p>No build log entries yet. Check back soon.</p>
+      </div>
+    </section>
+
+    <!-- SINGLE ENTRY variant (hidden by default) -->
+    <section class="build-log-section" id="section-single" style="display: none">
+      <div class="section-header">
+        <h2 class="section-title">Latest from the Build Log</h2>
+        <a href="/log/" class="section-link">View all</a>
+      </div>
+      <div class="log-grid">
+        <a href="/log/remote-mcp-browser-advisor/" class="log-card">
+          <span class="log-date">Feb 28, 2026</span>
+          <h3 class="log-title">Remote MCP Browser Advisor</h3>
+          <p class="log-excerpt">
+            Shipped crane-mcp-remote - a Cloudflare Worker that proxies crane-context tools to
+            claude.ai via OAuth.
+          </p>
+          <span class="log-read-more">Read entry</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- Context: existing homepage content below -->
+    <div class="page-context">
+      <div class="context-placeholder">Existing homepage content below (footer)</div>
+    </div>
+
+    <!-- Wireframe-only: state switcher -->
+    <div class="wireframe-controls">
+      <h4>Wireframe States</h4>
+      <button class="active" onclick="showState('default')">3 entries (default)</button>
+      <button onclick="showState('single')">1 entry</button>
+      <button onclick="showState('empty')">0 entries (empty)</button>
+    </div>
+
+    <script>
+      function showState(state) {
+        document.getElementById('section-default').style.display = 'none'
+        document.getElementById('section-empty').style.display = 'none'
+        document.getElementById('section-single').style.display = 'none'
+        document.getElementById('section-' + state).style.display = 'block'
+
+        document.querySelectorAll('.wireframe-controls button').forEach(function (btn) {
+          btn.classList.remove('active')
+        })
+        event.target.classList.add('active')
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Updated wireframe workflow docs to say "Claude (any agent)" instead of "Claude Desktop" - the workflow works in Claude Code, Claude Desktop, or any Claude agent
- Added wireframe prototype for issue #286 (build log homepage section) - first real wireframe produced through the new workflow

## Test plan

- [x] `npm run verify` passes
- [x] Wireframe renders correctly in browser (3 entries, 1 entry, empty states)
- [x] Issue #286 Agent Brief links to wireframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)