### PR TITLE
feat: gate venture names on go-live process

### DIFF
--- a/.claude/commands/go-live.md
+++ b/.claude/commands/go-live.md
@@ -94,12 +94,14 @@ If all pass, ask via AskUserQuestion:
 
 1. Update `config/ventures.json`:
    - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.showInPortfolio` to `true` (this enables venture name usage in published articles and build logs per terminology.md)
    - Set `portfolio.url` if provided by user (ask if not already set)
    - Update `bvmStage` if appropriate
 2. Commit with message: `feat: launch {venture name}`
-3. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+3. Run `/portfolio-review` to sync the venture to vc-web's portfolio page
+4. Create handoff via `crane_handoff` MCP tool with summary of what was launched
 
-Report: "{Venture Name} is live. ventures.json updated, handoff saved."
+Report: "{Venture Name} is live. ventures.json updated, portfolio synced, handoff saved."
 
 ## Important Notes
 

--- a/.claude/commands/new-venture.md
+++ b/.claude/commands/new-venture.md
@@ -63,12 +63,13 @@ The script handles:
 
 After the script completes, walk through remaining manual steps from the checklist:
 
-1. **Venture-specific secrets** (Phase 3.5) - add venture-specific secrets (shared secrets like CRANE_CONTEXT_KEY and CRANE_ADMIN_KEY are synced automatically by the setup script)
-2. **Seed documentation** - upload PRD/project instructions to crane-context
-3. **Verify** - run `crane {venture-code}` and `/sod` in the new repo
-4. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
-5. **Monitoring** (Phase 4.6) - Sentry, uptime checks
-6. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
+1. **Add to `config/ventures.json`** - Add the new venture entry with `portfolio.showInPortfolio: false` (ventures are not public until `/go-live` sets this to `true`)
+2. **Venture-specific secrets** (Phase 3.5) - add venture-specific secrets (shared secrets like CRANE_CONTEXT_KEY and CRANE_ADMIN_KEY are synced automatically by the setup script)
+3. **Seed documentation** - upload PRD/project instructions to crane-context
+4. **Verify** - run `crane {venture-code}` and `/sod` in the new repo
+5. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
+6. **Monitoring** (Phase 4.6) - Sentry, uptime checks
+7. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
 
 ### Step 5: Update CLAUDE.md
 


### PR DESCRIPTION
## Summary
- `/go-live` Step 6 now sets `showInPortfolio: true` and triggers `/portfolio-review` to sync the venture to vc-web's portfolio page
- `/new-venture` Step 4 explicitly defaults `showInPortfolio: false` so new ventures stay stealth until launched
- `config/ventures.json` already had all ventures set to `false` (done in #288)

## Test plan
- [ ] `grep showInPortfolio config/ventures.json` shows all `false`
- [ ] Read go-live.md Step 6 - confirms `showInPortfolio: true` and `/portfolio-review` trigger
- [ ] Read new-venture.md Step 4 - confirms explicit `showInPortfolio: false` default
- [ ] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)