### PR TITLE
fix: remove 24h cutoff from SOD handoff retrieval

### DIFF
--- a/packages/crane-mcp/src/tools/sod.test.ts
+++ b/packages/crane-mcp/src/tools/sod.test.ts
@@ -471,7 +471,7 @@ describe('sod tool', () => {
 
     expect(result.status).toBe('valid')
     expect(result.message).toContain('## Continuity')
-    expect(result.message).toContain('2 handoff(s) in the last 24h')
+    expect(result.message).toContain('2 recent handoff(s)')
     expect(result.message).toContain('Fixed the handoff system')
     expect(result.message).toContain('Design work in progress')
     expect(result.recent_handoffs).toHaveLength(2)
@@ -511,7 +511,7 @@ describe('sod tool', () => {
     expect(result.recent_handoffs).toBeUndefined()
   })
 
-  it('filters handoffs older than 24h from recent display', async () => {
+  it('shows older handoffs without 24h cutoff filter', async () => {
     const { executeSod } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
     const { getP0Issues } = await import('../lib/github.js')
@@ -554,9 +554,9 @@ describe('sod tool', () => {
     const result = await executeSod({})
 
     expect(result.status).toBe('valid')
-    // Old handoffs filtered out, should fall back to last_handoff
-    expect(result.message).toContain('Last handoff from claude')
-    expect(result.message).not.toContain('Old handoff')
+    // No 24h cutoff - older handoffs should appear in recent list
+    expect(result.message).toContain('1 recent handoff(s)')
+    expect(result.message).toContain('Old handoff')
   })
 
   it('stores session state after successful start', async () => {

--- a/packages/crane-mcp/src/tools/sod.ts
+++ b/packages/crane-mcp/src/tools/sod.ts
@@ -188,13 +188,9 @@ export async function executeSod(input: SodInput): Promise<SodResult> {
             venture: venture.code,
             repo: fullRepo,
             track: 1,
-            limit: 10,
+            limit: 5,
           })
-          // Filter to last 24 hours
-          const cutoff = Date.now() - 24 * 60 * 60 * 1000
-          recentHandoffs = handoffResult.handoffs.filter(
-            (h) => new Date(h.created_at).getTime() > cutoff
-          )
+          recentHandoffs = handoffResult.handoffs
         } catch {
           // Fall back to single last_handoff from SOD response
         }
@@ -477,7 +473,7 @@ export function buildSodMessage(params: BuildSodMessageParams): string {
     const MAX_HANDOFFS = 3
     if (recentHandoffs.length > 0) {
       const shown = recentHandoffs.slice(0, MAX_HANDOFFS)
-      message += `${recentHandoffs.length} handoff(s) in the last 24h:\n`
+      message += `${recentHandoffs.length} recent handoff(s):\n`
       for (const h of shown) {
         const time = new Date(h.created_at).toLocaleTimeString('en-US', {
           hour: '2-digit',


### PR DESCRIPTION
## Summary
- Removed the 24h client-side filter on handoff retrieval in SOD briefings
- After gaps longer than 24h (weekends, vacation), agents now retain context from recent sessions instead of falling back to a single last_handoff with limited detail
- Reduced API query limit from 10 to 5 since we no longer over-fetch to filter; display logic already caps at 3

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 253 tests)
- [ ] Run `/sod` after a gap > 24h - should show last handoffs instead of falling back

🤖 Generated with [Claude Code](https://claude.com/claude-code)