### PR TITLE
chore: update CI workflows to Node 22

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: workers/${{ matrix.worker }}
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         working-directory: workers/${{ matrix.worker }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install root dependencies


### PR DESCRIPTION
## Summary
- Update Node version from 20 to 22 in verify.yml and security.yml workflows
- Node 20 EOL: April 2026. Node 22 LTS: active support through Oct 2027.

## Test plan
- [ ] CI workflows pass with Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)