### PR TITLE
fix: use service binding for crane-watch notification forwarding

### DIFF
--- a/workers/crane-watch/src/index.ts
+++ b/workers/crane-watch/src/index.ts
@@ -20,6 +20,7 @@ interface Env {
   CLASSIFIER_API_KEY?: string
   CONTEXT_RELAY_KEY?: string
   CRANE_CONTEXT_URL?: string
+  CRANE_CONTEXT?: Fetcher
   VERCEL_WEBHOOK_SECRET?: string
 }
 
@@ -1058,18 +1059,26 @@ async function forwardToNotifications(
   deliveryId: string,
   payload: unknown
 ): Promise<void> {
-  const contextUrl = env.CRANE_CONTEXT_URL
   const relayKey = env.CONTEXT_RELAY_KEY
 
-  if (!contextUrl || !relayKey) {
+  if (!relayKey) {
+    console.error('CONTEXT_RELAY_KEY not configured, skipping notification forwarding')
+    return
+  }
+
+  // Prefer Service Binding (direct Worker-to-Worker), fall back to public URL
+  const fetcher = env.CRANE_CONTEXT || null
+  const contextUrl = env.CRANE_CONTEXT_URL
+
+  if (!fetcher && !contextUrl) {
     console.error(
-      'CRANE_CONTEXT_URL or CONTEXT_RELAY_KEY not configured, skipping notification forwarding'
+      'Neither CRANE_CONTEXT service binding nor CRANE_CONTEXT_URL configured, skipping notification forwarding'
     )
     return
   }
 
   try {
-    const response = await fetch(`${contextUrl}/notifications/ingest`, {
+    const requestInit: RequestInit = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -1081,7 +1090,11 @@ async function forwardToNotifications(
         delivery_id: deliveryId,
         payload,
       }),
-    })
+    }
+
+    const response = fetcher
+      ? await fetcher.fetch('https://crane-context/notifications/ingest', requestInit)
+      : await fetch(`${contextUrl}/notifications/ingest`, requestInit)
 
     if (!response.ok) {
       const text = await response.text()

--- a/workers/crane-watch/wrangler.toml
+++ b/workers/crane-watch/wrangler.toml
@@ -22,6 +22,10 @@ binding = "DB"
 database_name = "crane-watch-db-staging"
 database_id = "ca5df161-4773-4942-b706-b8b956308369"
 
+[[services]]
+binding = "CRANE_CONTEXT"
+service = "crane-context-staging"
+
 # Production - preserves existing worker name and URL
 [env.production]
 name = "crane-watch"
@@ -30,6 +34,10 @@ name = "crane-watch"
 binding = "DB"
 database_name = "crane-watch-db"
 database_id = "e01fe064-daf5-4ee9-89e1-6bcaa756b4c0"
+
+[[env.production.services]]
+binding = "CRANE_CONTEXT"
+service = "crane-context"
 
 [env.production.vars]
 GH_APP_ID = "2619905"


### PR DESCRIPTION
## Summary
- Worker-to-Worker `fetch()` via public workers.dev URL returns Cloudflare error 1042
- Adds Service Binding (`CRANE_CONTEXT`) for direct Worker-to-Worker routing
- Falls back to `CRANE_CONTEXT_URL` if binding not configured
- Deployed and verified: real GitHub CI failure notifications now flow end-to-end

## Test plan
- [x] Verified with `wrangler tail` - no forwarding errors after service binding
- [x] Triggered Security Checks workflow - notifications created in crane-context D1
- [x] `npm run verify` passes (260 tests, typecheck, lint, format)

Generated with [Claude Code](https://claude.com/claude-code)