### PR TITLE
docs: refresh stale content — KE, DC, financial dashboard

### DIFF
--- a/docs/company/financial-dashboard.md
+++ b/docs/company/financial-dashboard.md
@@ -4,10 +4,11 @@
 
 | Venture            | Revenue (MTD) | Expenses (MTD) | Net | Status      |
 | ------------------ | ------------- | -------------- | --- | ----------- |
-| Durgan Field Guide | -             | ~$500          | -   | Active      |
-| Silicon Crane      | $0            | Minimal        | -   | Pre-revenue |
-| Kid Expenses       | $0            | $0             | -   | Pre-revenue |
-| Draft Crane        | $0            | $0             | -   | Pre-revenue |
+| Venture Crane      | —             | ~$200          | —   | Operating   |
+| Durgan Field Guide | —             | ~$500          | —   | Active      |
+| Silicon Crane      | $0            | Minimal        | —   | Pre-revenue |
+| Kid Expenses       | $0            | Minimal        | —   | Pre-revenue |
+| Draft Crane        | $0            | Minimal        | —   | Pre-revenue |
 
 ## Revenue Streams
 
@@ -21,19 +22,20 @@
 
 ## Expense Categories
 
-| Category       | Examples                    | Typical Monthly |
-| -------------- | --------------------------- | --------------- |
-| Infrastructure | Cloudflare, Vercel, domains | <$100           |
-| AI/APIs        | Claude API, OpenAI          | $100-300        |
-| Software       | GitHub, tools               | <$50            |
-| Marketing      | Ads, content                | TBD             |
-| Professional   | Legal, accounting           | Variable        |
+| Category       | Examples                        | Typical Monthly |
+| -------------- | ------------------------------- | --------------- |
+| Infrastructure | Cloudflare, Vercel, Tailscale   | $0 (free tiers) |
+| AI/APIs        | Claude API, Gemini, OpenAI      | $100–300        |
+| Software       | GitHub, Infisical               | $0 (free tiers) |
+| Domains        | venturecrane.com, venture sites | ~$10 amortized  |
+| Professional   | Legal, accounting               | Variable        |
 
 ## Banking & Accounts
 
-| Function           | Tool   | Notes        |
-| ------------------ | ------ | ------------ |
-| Primary Bank       | TBD    |              |
-| Credit Card        | TBD    |              |
-| Payment Processing | Stripe | All ventures |
-| Accounting         | TBD    |              |
+| Function           | Tool       | Notes                           |
+| ------------------ | ---------- | ------------------------------- |
+| Payment Processing | Stripe     | All ventures                    |
+| Secrets Management | Infisical  | Free tier                       |
+| CI/CD              | GitHub     | Free org                        |
+| Hosting            | Vercel     | Hobby tier                      |
+| Workers/DB         | Cloudflare | Free tier (Workers, D1, R2, KV) |

--- a/docs/ventures/dc/metrics.md
+++ b/docs/ventures/dc/metrics.md
@@ -2,16 +2,29 @@
 
 ## North Star Metric
 
-TBD
+Chapters completed and exported by real authors.
 
 ## Leading Indicators
 
-| Metric | Current | Target | Trend |
-| ------ | ------- | ------ | ----- |
-| TBD    | -       | -      | -     |
+| Metric                     | Current | Target | Notes                              |
+| -------------------------- | ------- | ------ | ---------------------------------- |
+| Authors onboarded          | —       | —      | Pre-launch                         |
+| Chapters drafted           | —       | —      | Core writing loop validation       |
+| AI rewrite acceptance rate | —       | —      | Editor zone usefulness             |
+| Session duration           | —       | —      | Engagement depth (writing is slow) |
 
-## Financial
+## Financial Metrics
 
 | Metric | Current | Target |
 | ------ | ------- | ------ |
-| MRR    | $0      | TBD    |
+| MRR    | $0      | —      |
+| CAC    | —       | —      |
+| LTV    | —       | —      |
+
+## Technical Health
+
+| Metric              | Current     | Notes                                   |
+| ------------------- | ----------- | --------------------------------------- |
+| Open issues         | 15          | 3 high-severity dependency upgrades     |
+| Design token system | 400+ vars   | Enterprise-grade, semantic palette      |
+| Accessibility       | In progress | WCAG 2.1 AA target, ARIA work completed |

--- a/docs/ventures/dc/product-overview.md
+++ b/docs/ventures/dc/product-overview.md
@@ -4,18 +4,39 @@
 
 ## What It Is
 
-Draft Crane is a structured writing environment for consultants, coaches, and subject-matter experts who want to turn their expertise into a publishable nonfiction book. AI-assisted outlining, drafting, and revision with a workflow designed around how nonfiction gets written - not how chatbots generate text.
+Draft Crane is a structured writing environment for consultants, coaches, and subject-matter experts who want to turn their expertise into a publishable nonfiction book. AI-assisted outlining, drafting, and revision with a workflow designed around how nonfiction gets written — not how chatbots generate text.
+
+## Target Market
+
+**Primary:** Subject-matter experts and professionals writing nonfiction books
+**Secondary:** Consultants and coaches turning frameworks into published content
+
+## Value Proposition
+
+Replace scattered docs and half-finished drafts with a focused writing environment:
+
+- Dual-zone interaction model: Author zone for content creation, Editor zone for AI-powered review
+- Chapter-based structure that matches how nonfiction books are organized
+- AI assistance that supports the writing process, not replaces it
+- iPad-first design for writing anywhere
 
 ## Tech Stack
 
-Astro, Cloudflare Workers, D1
-
-## Current Stage
-
-**Prototype**
+Next.js (App Router), Tailwind v4, TipTap (ProseMirror), Clerk, Vercel
 
 ## Revenue Model
 
 | Stream        | Type      | Status  |
 | ------------- | --------- | ------- |
 | Subscriptions | Recurring | Planned |
+
+## Current Stage
+
+**Prototype**
+
+## Key Principles
+
+1. Writing is thinking — the tool supports the author's process, not shortcuts it
+2. Structure before prose — chapter outlines and instruction sets guide the work
+3. iPad-first — professional writers work on tablets, not just desktops
+4. Author/Editor metaphor — clear separation between creation and AI-assisted review

--- a/docs/ventures/dc/roadmap.md
+++ b/docs/ventures/dc/roadmap.md
@@ -1,10 +1,41 @@
 # Roadmap
 
 **Current Stage:** Prototype
-**Next Milestone:** TBD
+**Next Milestone:** InstructionList integration + dependency security sweep
 
-## Milestones
+## Current Focus
 
-| Milestone | Target Date | Status  | Notes |
-| --------- | ----------- | ------- | ----- |
-| TBD       | TBD         | Planned |       |
+- InstructionList integration into Chapter Editor panel (#408) and Desk tab (#407)
+- Update SourcesContext for three instruction types (#409)
+- Retire legacy InstructionSetPicker and InstructionPicker (#410)
+- High-severity dependency upgrades: Hono (#445), flatted (#446), vitest-pool-workers (#447)
+
+## Near-Term
+
+- Add instruction list design tokens to globals.css (#412)
+- Instruction speed validation on iPad (#413)
+- Accessibility audit for InstructionList (#414)
+- Voice & tone audit for seed instruction labels (#415)
+- CI deployment step for workers on main merge (#430)
+- Replace console.log with structured logging (#429)
+- Add test coverage for drive route handlers (#428)
+
+## Future
+
+- Google Drive import/export integration
+- Collaborative editing
+- Export to manuscript formats (EPUB, PDF)
+
+## Completed (Recent)
+
+- Design system polish batch (2026-02-25): layout/motion tokens, toolbar keyboard shortcuts, ARIA live regions, panel animations, component extraction
+- Editor panel empty state and streaming response headers (2026-02-25)
+- Landing page copy updated with Author/Editor metaphor (2026-02-25)
+
+## Dependencies
+
+| Item                | Blocks            | Notes                             |
+| ------------------- | ----------------- | --------------------------------- |
+| Dependency upgrades | Production deploy | 3 HIGH CVE chains in Hono/flatted |
+| Clerk auth          | Multi-user        | Currently single-author scope     |
+| TipTap/ProseMirror  | Core editing      | Rich text editor foundation       |

--- a/docs/ventures/ke/metrics.md
+++ b/docs/ventures/ke/metrics.md
@@ -2,16 +2,29 @@
 
 ## North Star Metric
 
-TBD
+Active co-parent pairs splitting expenses monthly.
 
 ## Leading Indicators
 
-| Metric | Current | Target | Trend |
-| ------ | ------- | ------ | ----- |
-| TBD    | -       | -      | -     |
+| Metric                 | Current | Target | Notes                          |
+| ---------------------- | ------- | ------ | ------------------------------ |
+| Families onboarded     | —       | —      | Pre-launch                     |
+| Expenses logged        | —       | —      | Core feature validation metric |
+| Dispute resolution     | —       | —      | Question → Resolved cycle time |
+| Invite acceptance rate | —       | —      | Co-parent pair formation       |
 
-## Financial
+## Financial Metrics
 
 | Metric | Current | Target |
 | ------ | ------- | ------ |
-| MRR    | $0      | TBD    |
+| MRR    | $0      | —      |
+| CAC    | —       | —      |
+| LTV    | —       | —      |
+
+## Technical Health
+
+| Metric        | Current     | Notes                                |
+| ------------- | ----------- | ------------------------------------ |
+| Open bugs     | 5           | P0: 1 (privacy policy), P1: 4        |
+| Test coverage | Added       | Integration tests shipped 2026-02    |
+| Accessibility | In progress | WCAG 2.1 AA target, 3 a11y bugs open |

--- a/docs/ventures/ke/roadmap.md
+++ b/docs/ventures/ke/roadmap.md
@@ -1,10 +1,38 @@
 # Roadmap
 
 **Current Stage:** Prototype
-**Next Milestone:** TBD
+**Next Milestone:** Privacy policy + accessibility fixes (P0/P1 sweep)
 
-## Milestones
+## Current Focus
 
-| Milestone | Target Date | Status  | Notes |
-| --------- | ----------- | ------- | ----- |
-| TBD       | TBD         | Planned |       |
+- Privacy policy and terms of service (#123, P0)
+- Accessibility: pinch-zoom (#115), input labels (#116), aria attributes (#118)
+- Security: CSPRNG for invite codes (#113), amount constraint (#114)
+
+## Near-Term
+
+- Rate limiting middleware (#121)
+- Consolidate dual API clients (#119)
+- Move dispute timeouts to background job (#117)
+- Expense filtering: category, status, date, child (#106)
+- Balance audit trail / period breakdown (#107)
+
+## Future
+
+- Leave family flow (#108)
+- User profile settings (#109)
+- Voice-to-expense entry via Workers AI (#124)
+- Multi-family support architecture (#145)
+
+## Completed (Recent)
+
+- PWA support: manifest, service worker, iOS meta (2026-02-18)
+- Code review sweep: CORS hardening, API path fixes, ESLint, integration tests (2026-02-17)
+- Classifier integration after org consolidation (2026-02-11)
+
+## Dependencies
+
+| Item           | Blocks       | Notes                                |
+| -------------- | ------------ | ------------------------------------ |
+| Privacy policy | Beta launch  | P0 — required for user-facing app    |
+| Clerk auth     | Multi-family | Current auth scoped to single family |


### PR DESCRIPTION
## Summary

- Enriches all 5 pages flagged by the build staleness report (0 stale pages remaining)
- **KE metrics**: North star metric, leading indicators, technical health with bug counts
- **KE roadmap**: P0/P1 sweep focus, near-term features from GitHub issues, recent completions
- **DC metrics**: North star metric, writing-loop indicators, design system health
- **DC roadmap**: InstructionList integration focus, dependency security sweep, recent design batch
- **DC product overview**: Fixed stale tech stack (Astro→Next.js/TipTap/Clerk), added target market and key principles
- **Financial dashboard**: Added VC to portfolio, replaced TBD banking with actual tooling, updated expense categories

## Test plan

- [x] `cd site && npm run build` succeeds with 0 staleness warnings
- [x] `npm run verify` passes (260 tests, typecheck, lint, format)
- [ ] Verify updated pages render correctly on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)