### PR TITLE
docs: minor refreshes — team-workflow, golden-path, runbooks, machine-inventory

### DIFF
--- a/docs/infra/machine-inventory.md
+++ b/docs/infra/machine-inventory.md
@@ -238,13 +238,13 @@ The sync is additive - enterprise commands are copied/overwritten, venture-speci
 
 **Details:** Dev machines have Tailscale keys that expire periodically. Keys should be set to never expire to prevent disruptions - especially for laptops which are more likely to be offline when expiry occurs.
 
-| Machine | Key Expiry                     |
-| ------- | ------------------------------ |
-| mac23   | 2026-07-20                     |
-| mini    | 2026-07-19                     |
-| mbp27   | 2026-07-25                     |
-| think   | 2026-07-27                     |
-| m16     | TBD (disable in admin console) |
+| Machine | Key Expiry |
+| ------- | ---------- |
+| mac23   | 2026-07-20 |
+| mini    | 2026-07-19 |
+| mbp27   | 2026-07-25 |
+| think   | 2026-07-27 |
+| m16     | Disabled   |
 
 **Fix:**
 
@@ -254,4 +254,4 @@ The sync is additive - enterprise commands are copied/overwritten, venture-speci
 
 ## Last Updated
 
-2026-02-13
+2026-03-23

--- a/docs/process/team-workflow.md
+++ b/docs/process/team-workflow.md
@@ -72,7 +72,7 @@ Before closing ANY issue:
 
 ## Related Documentation
 
-- `AGENT_PERSONA_BRIEFS.md` - Role definitions, quality bars, handoff protocols
+- `agent-persona-briefs.md` - Role definitions, quality bars, handoff protocols
 - `DEV_DIRECTIVE_PR_WORKFLOW.md` - PR-based development requirements
 - `DEV_DIRECTIVE_QA_GRADING.md` - QA grade assignment and routing **(v1.8)**
 - `EOD_SOD_PROCESS.md` - End of day / start of day discipline and handoffs
@@ -84,13 +84,13 @@ Before closing ANY issue:
 
 ## Team Structure
 
-| Team         | Tool                  | Primary Responsibility                                                                                    |
-| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------- |
-| Dev Team     | Claude Code (Desktop) | Implementation, PRs, technical decisions                                                                  |
-| PM Team      | Claude Desktop        | Requirements, prioritization, **verification**, **merges on Captain directive**, GitHub updates via relay |
-| Auxiliary PM | ChatGPT Desktop       | Strategic input, second opinions                                                                          |
-| Advisor      | Gemini Web            | Operator perspective, risk assessment                                                                     |
-| Captain      | Human                 | Routing directives between teams, approvals, final decisions                                              |
+| Team         | Tool            | Primary Responsibility                                                                                    |
+| ------------ | --------------- | --------------------------------------------------------------------------------------------------------- |
+| Dev Team     | Claude Code CLI | Implementation, PRs, technical decisions                                                                  |
+| PM Team      | Claude Code CLI | Requirements, prioritization, **verification**, **merges on Captain directive**, GitHub updates via relay |
+| Auxiliary PM | ChatGPT Desktop | Strategic input, second opinions                                                                          |
+| Advisor      | Gemini Web      | Operator perspective, risk assessment                                                                     |
+| Captain      | Human           | Routing directives between teams, approvals, final decisions                                              |
 
 ### Key Principle (v1.5+)
 
@@ -248,7 +248,7 @@ Since PM writes ACs and tests them:
 **Does this story change what a user sees in a browser or app?** If yes, wireframe. If no (API, background job, config, pure backend logic), skip to Phase 2.
 
 0. PM loads venture design spec via `crane_doc('{venture_code}', 'design-spec.md')` for visual context
-1. PM feeds PRD + acceptance criteria + design spec context to Claude (any agent - Claude Code, Claude Desktop, etc.)
+1. PM feeds PRD + acceptance criteria + design spec context to Claude Code CLI
 2. Claude generates interactive HTML/CSS prototype using venture design tokens
 3. PM iterates via prompt refinement until wireframe matches intent
 4. PM verifies wireframe renders correctly (open in browser, test mobile viewport, confirm interactive states work)

--- a/docs/runbooks/new-box-onboarding.md
+++ b/docs/runbooks/new-box-onboarding.md
@@ -68,6 +68,24 @@ Add the new machine to the `MACHINES` array in `scripts/setup-ssh-mesh.sh`, then
 
 This establishes bidirectional SSH between the new machine and all existing fleet machines.
 
+### Verify MCP Server Setup
+
+The bootstrap script builds and links crane-mcp. Verify it's working:
+
+```bash
+ssh <hostname>
+crane-mcp --help          # Should show usage
+crane vc                  # Launch Claude with full MCP toolchain
+```
+
+If `crane` or `crane-mcp` are not found, rebuild from the cloned repo:
+
+```bash
+cd ~/dev/crane-console
+npm install && npm run build
+npm link packages/crane-cli packages/crane-mcp
+```
+
 ### Connect
 
 Connect via Tailscale hostname (works from anywhere):
@@ -159,6 +177,7 @@ Current machines on Tailscale:
 - mini (Linux)
 - mbp27 (Linux)
 - think (Linux) - added 2026-01-28
+- m16 (Mac) - added 2026-02-09
 
 Check fleet status:
 
@@ -168,4 +187,4 @@ tailscale status
 
 ---
 
-**Last Updated:** 2026-02-04
+**Last Updated:** 2026-03-23

--- a/docs/runbooks/new-mac-setup.md
+++ b/docs/runbooks/new-mac-setup.md
@@ -4,11 +4,12 @@ Add a new macOS machine to the Crane dev fleet in ~30 minutes.
 
 ## Prerequisites (on the new Mac)
 
-These 3 steps require physical access to the new Mac:
+These 4 steps require physical access to the new Mac:
 
 1. **Enable Remote Login:** System Settings > General > Sharing > Remote Login > ON
 2. **Install Tailscale:** App Store > Tailscale > Install > Sign in to tailnet
-3. **Enable passwordless sudo:**
+3. **Install Infisical CLI:** `brew install infisical/get-cli/infisical && infisical login`
+4. **Enable passwordless sudo:**
    ```bash
    echo "$USER ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$USER
    ```
@@ -39,17 +40,24 @@ infisical run --path /vc -- ./scripts/bootstrap-new-mac.sh 100.119.24.42 scottdu
 SSH into the new machine and complete:
 
 ```bash
-# 1. Login to Infisical
+# 1. Login to Infisical (if not done in prerequisites)
 infisical login
 
 # 2. Login to Claude
 claude login
 
-# 3. Update SSH mesh on all machines (from any fleet machine)
+# 3. Configure MCP servers
+#    The bootstrap script installs crane-mcp. Verify it's available:
+crane-mcp --help
+#    Then add the MCP server config to Claude Code settings:
+#    ~/.claude/settings.json should include the crane-context MCP server.
+#    See crane-console/packages/crane-mcp/README.md for config details.
+
+# 4. Update SSH mesh on all machines (from any fleet machine)
 ./scripts/setup-ssh-mesh.sh
 
-# 4. Start a session
-infisical run --path /vc -- crane vc
+# 5. Start a session
+crane vc
 ```
 
 ## Resume After Failure

--- a/docs/standards/golden-path.md
+++ b/docs/standards/golden-path.md
@@ -51,14 +51,15 @@ Products move through stages. Requirements scale with proven value.
 **When:** Preparing for acquisition, major scale, or external investment
 **Trigger:** Active exit discussions or significant growth
 
-| Requirement          | Details                                             |
-| -------------------- | --------------------------------------------------- |
-| Everything in Tier 2 | Plus...                                             |
-| Security Audit       | Third-party or thorough internal review             |
-| Performance Baseline | Load testing, documented benchmarks                 |
-| Full Documentation   | Architecture docs, ADRs, operational runbooks       |
-| Compliance           | GDPR/privacy review if applicable                   |
-| Code Quality         | Technical debt addressed, test coverage targets met |
+| Requirement          | Details                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| Everything in Tier 2 | Plus...                                                                |
+| Security Audit       | Third-party or thorough internal review                                |
+| Performance Baseline | Load testing, documented benchmarks                                    |
+| Full Documentation   | Architecture docs, ADRs, operational runbooks                          |
+| MCP Architecture     | crane-context MCP server integrated, MCP tools documented in CLAUDE.md |
+| Compliance           | GDPR/privacy review if applicable                                      |
+| Code Quality         | Technical debt addressed, test coverage targets met                    |
 
 ---
 


### PR DESCRIPTION
Closes #326

- Remove "Claude Desktop" references from team-workflow, replace with "Claude Code CLI"
- Fix agent-persona-briefs cross-reference (AGENT_PERSONA_BRIEFS.md → agent-persona-briefs.md)
- Add MCP Architecture to golden-path Tier 3 requirements
- Add Infisical CLI as prerequisite in new-mac-setup runbook
- Add MCP server setup steps to both mac and box onboarding runbooks
- Add m16 to new-box-onboarding fleet status list
- Update machine-inventory m16 Tailscale key expiry from "TBD" to "Disabled"
- Update Last Updated dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)