### PR TITLE
docs: add 7 undocumented core processes + process coverage check

### DIFF
--- a/.agents/skills/docs-refresh/SKILL.md
+++ b/.agents/skills/docs-refresh/SKILL.md
@@ -128,6 +128,30 @@ After approval:
 
 After the PR merges to main, Vercel automatically rebuilds the site at `crane-console.vercel.app` with the updated content. Template variables (`{{portfolio:table}}`, `{{venture:CODE:FIELD}}`) in markdown files are replaced at build time from `config/ventures.json`. No manual rebuild needed.
 
+## Process Coverage Check
+
+As part of the audit (Step 1), also check for undocumented processes:
+
+1. List all skills from `.agents/skills/*/SKILL.md`
+2. List all scripts from `scripts/*.sh`
+3. List all GitHub Actions from `.github/workflows/*.yml`
+4. Compare against files in `docs/process/`, `docs/instructions/`, `docs/runbooks/`
+5. Flag any process (skill, script, or workflow) that has no corresponding documentation
+
+```
+PROCESS COVERAGE
+  COVERED  /sod → docs/process/eod-sod-process.md
+  COVERED  /sprint → docs/process/fleet-orchestration.md
+  MISSING  scripts/deploy-to-fleet.sh → no doc
+  MISSING  .github/workflows/deploy.yml → no doc
+  ...
+  TOTAL: {N} covered, {N} missing
+```
+
+Not every script needs a standalone doc — one-time setup scripts and simple wrappers are fine without docs. Flag only scripts/workflows that represent repeatable operational processes (deployment, sync, health checks, audits).
+
+Include coverage results in the GitHub issue if auto-creating one.
+
 ## Quality Bar
 
 Updated pages must:

--- a/docs/process/crane-cli-launcher.md
+++ b/docs/process/crane-cli-launcher.md
@@ -1,0 +1,157 @@
+# Crane CLI Launcher
+
+The `crane` CLI is the primary entry point for launching AI agent sessions within the Venture Crane ecosystem. It resolves a venture, fetches secrets from Infisical, injects environment variables, configures MCP server registration, and spawns the selected agent binary in the correct working directory.
+
+**Source files:**
+
+- `packages/crane-mcp/src/cli/launch.ts` -- thin entry point, calls `main()`
+- `packages/crane-mcp/src/cli/launch-lib.ts` -- all launcher logic
+- `packages/crane-mcp/src/cli/ssh-auth.ts` -- SSH session authentication
+- `config/ventures.json` -- venture registry
+
+## Usage
+
+```
+crane              # Interactive menu
+crane vc           # Direct launch into Venture Crane
+crane ke --gemini  # Launch Kid Expenses with Gemini
+crane vc -p "fix the typo"  # Headless mode (args pass through to agent)
+crane --list       # Show ventures without launching
+crane --help       # Full help
+```
+
+## What Happens When You Run `crane vc`
+
+1. **Fresh build detection** -- compares `.ts` source mtimes against `.js` dist mtimes in `packages/crane-mcp/`. If source is newer, rebuilds and re-execs with the fresh binary. Prevents stale code after `git pull` on fleet machines.
+2. **Agent resolution** -- determines which agent binary to launch (default: `claude`).
+3. **Venture resolution** -- looks up `vc` in the venture registry fetched from the crane-context API (`/ventures` endpoint). Matches the venture to a local repo clone under `~/dev/`.
+4. **SSH session handling** -- if running over SSH, uses Infisical Universal Auth and unlocks the macOS keychain.
+5. **Secret injection** -- fetches secrets from Infisical via `infisical export --format=json`, parses them, validates that `CRANE_CONTEXT_KEY` is present.
+6. **MCP setup** -- ensures `crane-mcp` binary is on PATH and registers it with the target agent's MCP configuration.
+7. **Agent launch** -- spawns the agent binary with secrets and identity variables injected into the child process environment.
+
+## Venture Resolution
+
+The launcher fetches the venture list from the production crane-context API (always production, even when `CRANE_ENV=dev`, because the staging DB may be empty). Each venture in `config/ventures.json` has:
+
+| Field          | Example                       | Purpose                             |
+| -------------- | ----------------------------- | ----------------------------------- |
+| `code`         | `vc`, `ke`, `dfg`, `sc`       | Short code used on the command line |
+| `name`         | `Venture Crane`               | Human-readable name                 |
+| `org`          | `venturecrane`                | GitHub organization                 |
+| `repos`        | `["crane-console", "vc-web"]` | Known repos in the org              |
+| `capabilities` | `["has_api", "has_database"]` | Feature flags                       |
+| `portfolio`    | `{status, bvmStage, ...}`     | Portfolio metadata                  |
+
+Local repo matching uses the convention `{code}-console` (e.g., `ke` matches `ke-console`), with a special case: `vc` matches `crane-console`. The launcher scans `~/dev/` for Git repos with remotes matching the venture's org.
+
+If a venture's repo is not cloned locally, the launcher offers to clone it via `gh repo clone`.
+
+## Secret Injection
+
+Secrets come from Infisical, fetched once at launch time and frozen for the session duration. The flow:
+
+1. **Ensure `.infisical.json`** exists in the target repo (auto-copies from `crane-console` if missing). This file contains the Infisical workspace ID.
+2. **Run `infisical export --format=json`** with the venture-specific path.
+3. **Parse the JSON** array of `{key, value}` pairs into a flat `Record<string, string>`.
+4. **Validate** that the result is non-empty and that `CRANE_CONTEXT_KEY` is present.
+5. **Inject** the secrets into the child process environment alongside identity variables.
+
+### Infisical Paths
+
+Each venture has a dedicated Infisical path. Only secrets at the exact path are fetched -- sub-paths (e.g., `/vc/vault`) are excluded to keep the injected set minimal.
+
+| Venture | Path   |
+| ------- | ------ |
+| vc      | `/vc`  |
+| ke      | `/ke`  |
+| sc      | `/sc`  |
+| dfg     | `/dfg` |
+| smd     | `/smd` |
+| dc      | `/dc`  |
+
+### Shared Secrets
+
+`config/ventures.json` defines shared secrets that should exist in every venture's Infisical path (sourced from `/vc`):
+
+- `CRANE_CONTEXT_KEY` -- API key for crane-context
+- `CRANE_ADMIN_KEY` -- admin API key
+- `GH_TOKEN` -- GitHub PAT
+- `VERCEL_TOKEN` -- Vercel CLI access
+- `CLOUDFLARE_API_TOKEN` -- Cloudflare API access
+
+The `scripts/sync-shared-secrets.sh` script (invoked via `crane --secrets-audit`) audits and optionally fixes missing shared secrets across ventures.
+
+## Environment Variables Injected
+
+The child agent process receives all fetched secrets plus these identity variables:
+
+| Variable               | Source                  | Example              |
+| ---------------------- | ----------------------- | -------------------- |
+| `CRANE_ENV`            | `--env` flag or default | `prod`               |
+| `CRANE_VENTURE_CODE`   | Resolved venture        | `vc`                 |
+| `CRANE_VENTURE_NAME`   | Resolved venture        | `Venture Crane`      |
+| `CRANE_REPO`           | Repo directory basename | `crane-console`      |
+| `CRANE_CONTEXT_KEY`    | Infisical secret        | (API key value)      |
+| `GH_TOKEN`             | Infisical secret        | (GitHub PAT value)   |
+| `VERCEL_TOKEN`         | Infisical secret        | (Vercel token value) |
+| `CLOUDFLARE_API_TOKEN` | Infisical secret        | (CF API token value) |
+
+## SSH Session Handling
+
+When the launcher detects an SSH session (via `SSH_CLIENT`, `SSH_TTY`, or `SSH_CONNECTION` environment variables), it performs extra authentication steps:
+
+1. **Infisical Universal Auth** -- reads machine identity credentials from `~/.infisical-ua` (a `key=value` file containing `INFISICAL_UA_CLIENT_ID` and `INFISICAL_UA_CLIENT_SECRET`). Logs in via `infisical login --method=universal-auth` and passes the resulting `INFISICAL_TOKEN` to the secret fetch step. This bypasses the interactive browser-based login that normal Infisical auth requires.
+2. **macOS Keychain unlock** -- Claude Code stores OAuth tokens in the macOS keychain, which is locked during SSH sessions. The launcher prompts for the macOS login password via `security unlock-keychain` and verifies the Claude Code credential is readable afterward.
+
+If either step fails, the launcher aborts with an error message pointing to the bootstrap script (`scripts/bootstrap-infisical-ua.sh`).
+
+## Agent Binary Resolution
+
+The launcher supports multiple agent CLIs:
+
+| Flag       | Binary   | Install Command                            |
+| ---------- | -------- | ------------------------------------------ |
+| `--claude` | `claude` | `npm install -g @anthropic-ai/claude-code` |
+| `--gemini` | `gemini` | `npm install -g @google/gemini-cli`        |
+| `--codex`  | `codex`  | `npm install -g @openai/codex`             |
+| `--hermes` | `hermes` | `pip install hermes-agent`                 |
+
+Resolution priority:
+
+1. Explicit flag (`--claude`, `--gemini`, `--codex`, `--hermes`)
+2. `--agent <name>` flag
+3. `CRANE_DEFAULT_AGENT` environment variable
+4. Default: `claude`
+
+The launcher validates the binary is on PATH before proceeding. Passthrough args (anything not recognized as a crane flag) are forwarded to the agent binary, enabling headless mode (e.g., `-p "prompt"` for Claude).
+
+## MCP Server Registration
+
+The launcher ensures `crane-mcp` is installed and registered with the target agent:
+
+- **Claude** -- copies `.mcp.json` from crane-console to the target repo if missing. The MCP config points to `crane-mcp` as a stdio server.
+- **Gemini** -- writes/updates `.gemini/settings.json` in the target repo with `mcpServers.crane` config. Also configures `security.environmentVariableRedaction.allowed` to bypass Gemini CLI's env sanitization that strips variables matching `TOKEN`, `KEY`, `SECRET`.
+- **Codex** -- writes/updates `~/.codex/config.toml` with `[mcp_servers.crane]`, `env_vars` whitelist, `[shell_environment_policy] ignore_default_excludes = true`, and `[sandbox_workspace_write] network_access = true`.
+- **Hermes** -- verifies `crane_tools.py` exists in `~/.hermes/hermes-agent/tools/` and patches `model_tools.py` if the crane tools discovery entry is missing.
+
+## The `--env dev` Flag
+
+Setting `CRANE_ENV=dev` (or using the `--env dev` flag) switches the launcher to staging mode:
+
+- Secrets are fetched from the Infisical `dev` environment instead of `prod`.
+- For ventures with staging-specific Infisical paths, the path is remapped (via `getStagingInfisicalPath()`).
+- If staging secrets are unavailable for a venture, the launcher falls back to production with a warning.
+- The `CRANE_ENV` variable propagated to the child process tells the MCP server to target the staging crane-context worker URL.
+
+## Fresh Build Detection
+
+At startup, the launcher compares the newest `.ts` file mtime in `packages/crane-mcp/src/` against the newest `.js` file mtime in `packages/crane-mcp/dist/`. If source is newer:
+
+1. Runs `npm run build` in the crane-mcp package directory.
+2. Re-executes itself with `CRANE_FRESH_BUILD=1` to pick up the new code.
+3. The `CRANE_FRESH_BUILD` guard prevents infinite re-exec loops.
+
+This solves the fleet deployment gap: after `git pull`, the next `crane` invocation automatically rebuilds without requiring manual `npm run build` on every machine.
+
+If the build fails, the launcher continues with the existing (stale) build and prints a warning.

--- a/docs/process/doc-sync-pipeline.md
+++ b/docs/process/doc-sync-pipeline.md
@@ -1,0 +1,187 @@
+# Doc Sync Pipeline
+
+How documentation flows from markdown files in git to agents (via D1) and to the Starlight documentation site.
+
+## Architecture
+
+Two independent sync paths run on every push to `main`:
+
+```
+                                  ┌──> GitHub Action (sync-docs.yml)
+                                  │       │
+docs/**/*.md committed to main ───┤       ▼
+                                  │    upload-doc-to-context-worker.sh
+                                  │       │
+                                  │       ▼
+                                  │    crane-context D1 (context_docs table)
+                                  │       │
+                                  │       ▼
+                                  │    crane_doc MCP tool (agents read docs)
+                                  │
+                                  └──> Vercel build
+                                          │
+                                          ▼
+                                       sync-docs.mjs (prebuild)
+                                          │
+                                          ▼
+                                       Starlight site (site/src/content/docs/)
+```
+
+### Path 1: Git Push to Agent-Readable D1
+
+Agents read documentation via the `crane_doc` MCP tool, which fetches from crane-context's D1 database. The sync from git to D1 is handled by a GitHub Action.
+
+### Path 2: Git Push to Starlight Documentation Site
+
+The Starlight site (hosted on Vercel) runs `sync-docs.mjs` as a prebuild step. This copies markdown files from the repo into the site's content directory with frontmatter injection and template variable replacement.
+
+## Path 1: GitHub Action to D1
+
+### Trigger
+
+The workflow (`.github/workflows/sync-docs.yml`) runs on:
+
+- **Push to `main`** when files change under `docs/company/`, `docs/operations/`, or `docs/ventures/`
+- **Manual dispatch** (`workflow_dispatch`) for bulk re-upload of all docs
+
+### Scope Determination
+
+Every document gets a scope that determines which agents can see it:
+
+| Directory path           | Scope                 | Example                      |
+| ------------------------ | --------------------- | ---------------------------- |
+| `docs/company/*`         | `global`              | Available to all ventures    |
+| `docs/operations/*`      | `global`              | Available to all ventures    |
+| `docs/ventures/{code}/*` | `{code}` (e.g., `ke`) | Only visible to that venture |
+
+The scope is derived from the file path using a simple regex match. Files outside these three directories are ignored.
+
+### Change Detection
+
+On push events, the workflow runs `git diff --name-status HEAD^ HEAD` to detect:
+
+- **Added/Modified** (`A`/`M`) files -- queued for upload
+- **Deleted** (`D`) files -- queued for deletion from D1
+- **Renamed** (`R`) files -- old path deleted, new path uploaded
+
+On manual dispatch, all matching files are treated as additions.
+
+### Upload Process
+
+Each changed file is uploaded by `scripts/upload-doc-to-context-worker.sh`:
+
+1. Reads the markdown content from disk
+2. Extracts the title from the first `# heading`
+3. Builds a JSON payload with `scope`, `doc_name`, `content`, `title`, `source_repo`, `source_path`, and `uploaded_by`
+4. POSTs to `crane-context /admin/docs` with `X-Admin-Key` authentication
+5. crane-context computes a SHA-256 content hash, assigns a version number, and stores the document
+
+The API response includes:
+
+- `version` -- Auto-incremented integer
+- `content_hash` -- SHA-256 of the content
+- `created` -- Boolean indicating first upload vs update
+- `content_size_bytes` -- Size of stored content
+
+### Deletion Process
+
+For deleted files, the workflow sends `DELETE /admin/docs/{scope}/{doc_name}` directly via `curl`.
+
+### Content Hashing and Versioning
+
+crane-context stores each document in the `context_docs` table with:
+
+| Column         | Purpose                         |
+| -------------- | ------------------------------- |
+| `scope`        | `global` or venture code        |
+| `doc_name`     | Filename (e.g., `secrets.md`)   |
+| `content`      | Full markdown content           |
+| `content_hash` | SHA-256 of the content          |
+| `title`        | Extracted from first heading    |
+| `version`      | Auto-incremented on each update |
+
+When an agent fetches docs for a venture, crane-context returns all `global` docs plus docs scoped to that specific venture. A combined content hash (SHA-256 of all individual hashes joined by `|`) enables cache validation.
+
+### How Agents Read Docs
+
+Agents call `crane_doc(scope, doc_name)` via MCP, which hits `GET /docs/{scope}/{doc_name}` on crane-context. The response includes the full content, hash, title, and version.
+
+For listing available docs: `GET /docs?venture={code}` returns metadata (without content) for all global + venture-specific docs.
+
+## Path 2: Starlight Site Sync
+
+### Trigger
+
+The `sync-docs.mjs` script runs as a Vercel prebuild step before `astro build`.
+
+### Directories Synced
+
+The script syncs markdown files from these directories under `docs/`:
+
+```
+company, operations, ventures, infra, process,
+instructions, design-system, adr, runbooks, standards
+```
+
+Additionally, venture design specs from `docs/design/ventures/{code}/` are copied into each venture's content directory.
+
+### Processing Pipeline
+
+For each markdown file:
+
+1. **Template variable replacement** -- Tokens are replaced with data from `config/ventures.json`:
+   - `{{venture:CODE:FIELD}}` -- Replaced with the venture's field value (e.g., `{{venture:ke:name}}` becomes "Kid Expenses")
+   - `{{portfolio:table}}` -- Replaced with a generated markdown table of all ventures with stage, status, and tech stack
+   - `{{skills:table}}` -- Replaced with an auto-generated table of all skills from `.agents/skills/*/SKILL.md`
+2. **Frontmatter injection** -- If the file lacks YAML frontmatter, a `title` is extracted from the first `# heading` and frontmatter is prepended
+3. **Staleness check** -- Files with more than 2 TBD markers or fewer than 20 lines are flagged in a staleness report
+
+### Fail-Fast Guard
+
+If the `docs/` directory does not exist (which happens when Vercel's Root Directory is misconfigured), the script exits immediately with an error message.
+
+## Documentation Audit System
+
+crane-context maintains a `doc_requirements` table that defines which documents each venture should have. The audit system (`GET /docs/audit`) compares requirements against actual documents in the `context_docs` table.
+
+### Default Requirements
+
+| Pattern                             | Condition    | Auto-Generate | Staleness |
+| ----------------------------------- | ------------ | ------------- | --------- |
+| `{venture}-project-instructions.md` | All ventures | Yes           | 90 days   |
+| `{venture}-api.md`                  | Has API      | Yes           | 90 days   |
+| `{venture}-schema.md`               | Has database | Yes           | 90 days   |
+
+The `{venture}` placeholder is replaced with the venture code at audit time. Requirements can specify `condition` fields (`has_api`, `has_database`) and `generation_sources` (what to read when auto-generating the doc).
+
+Agents access the audit via `crane_doc_audit` MCP tool.
+
+## Manual Upload
+
+For one-off uploads outside the GitHub Action:
+
+```bash
+CRANE_ADMIN_KEY=<key> ./scripts/upload-doc-to-context-worker.sh <doc-path> [scope]
+```
+
+The script has a built-in whitelist of global doc names. If the doc name is not whitelisted, scope is determined from the `GITHUB_REPOSITORY` environment variable or must be provided as a second argument.
+
+## Cache Invalidation and Freshness
+
+- **D1 path**: Documents are overwritten on every push. There is no TTL-based expiry; freshness is guaranteed by the git-to-D1 sync running on every merge to `main`.
+- **Agent cache**: The combined content hash returned by `GET /docs?venture={code}` can be used by clients to detect when the doc set has changed.
+- **Staleness detection**: The doc audit system flags documents older than their configured `staleness_days` threshold. The Starlight prebuild script flags pages with excessive TBD markers.
+
+## Key Files
+
+| File                                             | Purpose                                   |
+| ------------------------------------------------ | ----------------------------------------- |
+| `.github/workflows/sync-docs.yml`                | GitHub Action: sync on push to main       |
+| `scripts/upload-doc-to-context-worker.sh`        | Upload script called by the Action        |
+| `site/scripts/sync-docs.mjs`                     | Prebuild sync for Starlight site          |
+| `workers/crane-context/src/docs.ts`              | Doc fetch utilities and combined hash     |
+| `workers/crane-context/src/endpoints/queries.ts` | GET /docs, GET /docs/:scope/:doc_name     |
+| `workers/crane-context/src/endpoints/admin.ts`   | POST /admin/docs, DELETE /admin/docs      |
+| `workers/crane-context/src/audit.ts`             | Documentation audit engine                |
+| `workers/crane-context/src/constants.ts`         | DEFAULT_DOC_REQUIREMENTS definition       |
+| `config/ventures.json`                           | Venture metadata for template replacement |

--- a/docs/process/mcp-server-architecture.md
+++ b/docs/process/mcp-server-architecture.md
@@ -1,0 +1,215 @@
+# MCP Server Architecture
+
+The crane-mcp package is a Model Context Protocol (MCP) server that bridges AI agents to the crane-context REST API. It runs locally as a stdio process and provides agents with tools for session management, documentation access, knowledge store operations, scheduling, fleet orchestration, and notifications.
+
+**Source files:**
+
+- `packages/crane-mcp/src/index.ts` -- server setup and tool registration
+- `packages/crane-mcp/src/tools/*.ts` -- tool implementations
+- `packages/crane-mcp/src/lib/crane-api.ts` -- REST API client
+- `workers/crane-context/src/index.ts` -- API route definitions
+- `workers/crane-mcp-remote/src/index.ts` -- remote HTTP MCP server
+
+## Architecture Overview
+
+```
+Agent (Claude, Gemini, Codex, Hermes)
+    |
+    | stdio (JSON-RPC 2.0 / MCP protocol)
+    v
+crane-mcp (local MCP server)
+    |
+    | HTTPS + X-Relay-Key header
+    v
+crane-context (Cloudflare Worker)
+    |
+    v
+   D1 (SQLite database)
+```
+
+For remote/browser access (claude.ai, Claude Desktop):
+
+```
+claude.ai / Claude Desktop
+    |
+    | Streamable HTTP + GitHub OAuth
+    v
+crane-mcp-remote (Cloudflare Worker + Durable Object)
+    |
+    | HTTPS + X-Relay-Key header
+    v
+crane-context (Cloudflare Worker)
+    |
+    v
+   D1
+```
+
+## How It Connects
+
+### Local (stdio transport)
+
+The primary deployment mode. The `crane` CLI launcher configures the agent to spawn `crane-mcp` as a child process communicating over stdin/stdout using the MCP stdio transport (`StdioServerTransport` from `@modelcontextprotocol/sdk`). The agent sends JSON-RPC 2.0 requests, and crane-mcp responds with tool results.
+
+Configuration varies by agent:
+
+- **Claude** -- `.mcp.json` in the repo root with `{"command": "crane-mcp"}`
+- **Gemini** -- `.gemini/settings.json` with `mcpServers.crane` entry
+- **Codex** -- `~/.codex/config.toml` with `[mcp_servers.crane]` section
+
+### Remote (HTTP transport via crane-mcp-remote)
+
+The `crane-mcp-remote` Cloudflare Worker serves a read-only subset of crane tools over Streamable HTTP for browser-based and remote MCP clients. It uses:
+
+- **OAuthProvider** from `@cloudflare/workers-oauth-provider` for GitHub OAuth authentication
+- **McpAgent** Durable Object from `agents/mcp` for per-session MCP protocol handling
+- **CraneContextClient** to proxy API calls to the crane-context worker
+- **KV** for OAuth storage and read cache fallback
+
+Production URL: `https://crane-mcp-remote.automation-ab6.workers.dev`
+Staging URL: `https://crane-mcp-remote-staging.automation-ab6.workers.dev`
+
+## Authentication
+
+### Local crane-mcp
+
+The local server reads `CRANE_CONTEXT_KEY` from its process environment (injected by the `crane` launcher at startup). All requests to crane-context include this key in the `X-Relay-Key` HTTP header. The crane-context worker validates the key with a timing-safe comparison and derives an actor identity as `SHA-256(key)[0:16]` for audit logging.
+
+### Remote crane-mcp-remote
+
+Uses GitHub OAuth via the venturecrane-github App. Access is restricted to GitHub logins listed in the `ALLOWED_GITHUB_USERS` environment variable. Authenticated requests to crane-context use the worker's own `CRANE_CONTEXT_KEY` secret with an `X-Actor-Identity` header for audit trail.
+
+## Complete Tool Inventory (Local crane-mcp)
+
+The local MCP server registers 16 tools. Each tool validates input with Zod schemas and calls the crane-context REST API via the `CraneApi` client.
+
+### Session Lifecycle
+
+| Tool              | Description                                                                           | API Endpoint                   |
+| ----------------- | ------------------------------------------------------------------------------------- | ------------------------------ |
+| `crane_preflight` | Validates environment: CRANE_CONTEXT_KEY, gh CLI auth, git repo, API connectivity     | `/health` (connectivity check) |
+| `crane_sod`       | Start of Day -- initializes session, returns context, directives, alerts, work status | `POST /sod`                    |
+| `crane_handoff`   | Creates end-of-session handoff summary for agent-to-agent context passing             | `POST /eod`                    |
+| `crane_context`   | Returns current session context: venture, repo, branch, validation status             | (local state)                  |
+
+### Work Management
+
+| Tool           | Description                                                          | API Endpoint        |
+| -------------- | -------------------------------------------------------------------- | ------------------- |
+| `crane_status` | Full GitHub issue breakdown: P0, ready, in-progress, blocked, triage | (GitHub API via gh) |
+| `crane_plan`   | Reads weekly plan from `docs/planning/WEEKLY_PLAN.md`                | (local filesystem)  |
+
+### Venture & Documentation
+
+| Tool              | Description                                                  | API Endpoint                 |
+| ----------------- | ------------------------------------------------------------ | ---------------------------- |
+| `crane_ventures`  | Lists all ventures with repos and installation status        | `GET /ventures`              |
+| `crane_doc`       | Fetches a specific document by scope and name                | `GET /docs/:scope/:doc_name` |
+| `crane_doc_audit` | Runs documentation audit; shows missing, stale, present docs | `GET /docs/audit`            |
+
+### Knowledge Store (VCMS)
+
+| Tool          | Description                                                  | API Endpoint                              |
+| ------------- | ------------------------------------------------------------ | ----------------------------------------- |
+| `crane_note`  | Creates or updates a note in the enterprise knowledge store  | `POST /notes` or `POST /notes/:id/update` |
+| `crane_notes` | Searches and lists notes with venture, tag, and text filters | `GET /notes`                              |
+
+### Scheduling (Cadence Engine)
+
+| Tool             | Description                                                                           | API Endpoint                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `crane_schedule` | Multi-action tool: list briefing, complete items, manage planned events, view history | `GET /schedule/briefing`, `POST /schedule/:name/complete`, `GET/POST /planned-events`, `GET /sessions/history` |
+
+### Fleet Operations
+
+| Tool                   | Description                                                           | API Endpoint          |
+| ---------------------- | --------------------------------------------------------------------- | --------------------- |
+| `crane_fleet_dispatch` | Dispatches coding task to fleet machine via SSH; returns task_id      | (SSH + local scripts) |
+| `crane_fleet_status`   | Checks task status on fleet machines or PR/CI status for given issues | (SSH or GitHub API)   |
+
+### Notifications
+
+| Tool                        | Description                                                          | API Endpoint                     |
+| --------------------------- | -------------------------------------------------------------------- | -------------------------------- |
+| `crane_notifications`       | Lists CI/CD notifications from GitHub Actions and Vercel deployments | `GET /notifications`             |
+| `crane_notification_update` | Updates notification status (acknowledge or resolve)                 | `POST /notifications/:id/status` |
+
+### Observability
+
+| Tool                 | Description                                                   | API Endpoint |
+| -------------------- | ------------------------------------------------------------- | ------------ |
+| `crane_token_report` | Shows estimated token usage by tool, venture, and time period | (local data) |
+
+## Complete Tool Inventory (Remote crane-mcp-remote)
+
+The remote server exposes a read-only subset (plus schedule completion) of 9 tools:
+
+| Tool                    | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `crane_briefing`        | Portfolio dashboard: schedule, active sessions, handoffs, executive summaries |
+| `crane_ventures`        | List all ventures with metadata                                               |
+| `crane_doc`             | Fetch a documentation document by scope and name                              |
+| `crane_doc_audit`       | Run documentation audit for one or all ventures                               |
+| `crane_notes`           | Search and list VCMS notes                                                    |
+| `crane_note_read`       | Read full content of a specific note by ID                                    |
+| `crane_schedule`        | View or complete cadence items (list and complete actions only)               |
+| `crane_handoffs`        | Query handoff history                                                         |
+| `crane_active_sessions` | List currently active agent sessions                                          |
+
+Tools requiring local resources (filesystem, gh CLI, SSH) are excluded from the remote server.
+
+## How Tools Map to crane-context API Endpoints
+
+The `CraneApi` class in `packages/crane-mcp/src/lib/crane-api.ts` provides typed methods for every crane-context endpoint. Key mappings:
+
+| CraneApi Method              | HTTP Method | Endpoint                        |
+| ---------------------------- | ----------- | ------------------------------- |
+| `getVentures()`              | GET         | `/ventures`                     |
+| `startSession()`             | POST        | `/sod`                          |
+| `createHandoff()`            | POST        | `/eod`                          |
+| `getDocAudit()`              | GET         | `/docs/audit`                   |
+| `getDoc()`                   | GET         | `/docs/:scope/:doc_name`        |
+| `uploadDoc()`                | POST        | `/admin/docs`                   |
+| `createNote()`               | POST        | `/notes`                        |
+| `listNotes()`                | GET         | `/notes`                        |
+| `getNote()`                  | GET         | `/notes/:id`                    |
+| `updateNote()`               | POST        | `/notes/:id/update`             |
+| `archiveNote()`              | POST        | `/notes/:id/archive`            |
+| `getScheduleBriefing()`      | GET         | `/schedule/briefing`            |
+| `completeScheduleItem()`     | POST        | `/schedule/:name/complete`      |
+| `getScheduleItems()`         | GET         | `/schedule/items`               |
+| `linkScheduleCalendar()`     | POST        | `/schedule/:name/link-calendar` |
+| `getPlannedEvents()`         | GET         | `/planned-events`               |
+| `createPlannedEvent()`       | POST        | `/planned-events`               |
+| `updatePlannedEvent()`       | PATCH       | `/planned-events/:id`           |
+| `clearPlannedEvents()`       | DELETE      | `/planned-events`               |
+| `getSessionHistory()`        | GET         | `/sessions/history`             |
+| `listMachines()`             | GET         | `/machines`                     |
+| `registerMachine()`          | POST        | `/machines/register`            |
+| `getSshMeshConfig()`         | GET         | `/machines/ssh-mesh-config`     |
+| `listNotifications()`        | GET         | `/notifications`                |
+| `updateNotificationStatus()` | POST        | `/notifications/:id/status`     |
+| `queryHandoffs()`            | GET         | `/handoffs`                     |
+| `upsertWorkDay()`            | POST        | `/work-day`                     |
+
+## Token Usage Tracking
+
+The local crane-mcp server includes lightweight token estimation. After each tool call, `logToolTokens()` estimates input and output token counts based on character length (using a ratio of 3.5 chars/token for structured tools, 4.0 for text-heavy tools). Usage data is stored in memory and surfaced via the `crane_token_report` tool.
+
+## crane-context API Overview
+
+The crane-context Cloudflare Worker (`workers/crane-context/`) is the backend that crane-mcp calls. Key endpoint groups:
+
+- **Session lifecycle** -- `/sod`, `/eod`, `/update`, `/heartbeat`, `/checkpoint`
+- **Queries** -- `/active`, `/handoffs`, `/handoffs/latest`, `/sessions/history`
+- **Documentation** -- `/docs`, `/docs/audit`, `/docs/:scope/:doc_name`
+- **Notes (VCMS)** -- `/notes` CRUD with search, tagging, and archival
+- **Schedule** -- `/schedule/briefing`, `/schedule/items`, `/schedule/:name/complete`
+- **Planned events** -- `/planned-events` CRUD
+- **Machine registry** -- `/machines`, `/machines/register`, `/machines/ssh-mesh-config`
+- **Notifications** -- `/notifications`, `/notifications/ingest`, `/notifications/:id/status`
+- **Admin** -- `/admin/docs`, `/admin/scripts`, `/admin/doc-requirements`
+- **Health** -- `/health` (no auth required)
+- **Config** -- `/ventures` (no auth required)
+- **MCP** -- `/mcp` (JSON-RPC 2.0 over HTTP, rate-limited to 100 req/min per actor)
+
+All endpoints except `/health`, `/ventures`, and `OPTIONS` require authentication via `X-Relay-Key` (standard) or `X-Admin-Key` (admin).

--- a/docs/process/multi-agent-coordination.md
+++ b/docs/process/multi-agent-coordination.md
@@ -1,0 +1,217 @@
+# Multi-Agent Coordination
+
+How multiple agents coordinate work across the same ventures and repositories without stepping on each other.
+
+## Overview
+
+Venture Crane regularly runs multiple agents in parallel -- either on the same machine (local sprint) or across fleet machines (fleet orchestration). Coordination relies on four mechanisms:
+
+1. **Session groups** in crane-context for mutual awareness
+2. **Git worktree isolation** so each agent has its own working directory
+3. **Branch naming conventions** to avoid collisions
+4. **Handoff chains** for context passing between sequential sessions
+
+For the mechanics of dispatching parallel work, see `docs/process/fleet-orchestration.md`.
+
+## Session Groups
+
+When multiple agents work on the same venture or repo simultaneously, they share a `session_group_id`. This is set during `POST /sod` (start of day) and links the sessions in crane-context's D1 database.
+
+### How Grouping Works
+
+Each agent calls `/sod` with its session parameters (agent name, venture, repo, track number). If a `session_group_id` is provided, the session is associated with that group.
+
+Agents can discover their siblings via `GET /siblings?session_group_id={id}`, which returns:
+
+- Session ID, agent name, venture, repo, track number
+- Issue number being worked
+- Branch name
+- Last heartbeat timestamp
+
+This allows an agent to know who else is active, what they are working on, and whether they are still alive.
+
+### SOD Conflict Detection
+
+When an agent calls `/sod`, crane-context checks for existing active sessions matching the same (agent, venture, repo, track) tuple:
+
+1. **No existing session** -- A new session is created.
+2. **One active session, not stale** -- The session is resumed (heartbeat refreshed).
+3. **One active session, stale** (no heartbeat for 45+ minutes) -- The stale session is marked `abandoned`, and a new session is created.
+4. **Multiple active sessions** -- The most recent is kept; all others are marked `superseded`. Then the staleness check runs on the survivor.
+
+This prevents ghost sessions from blocking new work.
+
+### Session Lifecycle Constants
+
+| Constant                     | Value        | Purpose                                  |
+| ---------------------------- | ------------ | ---------------------------------------- |
+| `STALE_AFTER_MINUTES`        | 45 minutes   | Session considered dead if no heartbeat  |
+| `HEARTBEAT_INTERVAL_SECONDS` | 600 (10 min) | Base interval between heartbeats         |
+| `HEARTBEAT_JITTER_SECONDS`   | 120 (2 min)  | Random jitter to prevent thundering herd |
+
+Heartbeat interval with jitter gives a range of 8-12 minutes between beats, with a 45-minute timeout providing a 4.5x safety margin.
+
+## Worktree Isolation
+
+Each agent works in its own git worktree, branched from `origin/main`. This provides complete filesystem isolation -- agents cannot accidentally modify each other's files.
+
+### Local Sprint Worktrees
+
+For `/sprint` (single machine, multiple agents):
+
+- Worktrees are created at `.worktrees/{issue-number}` relative to the repo root
+- Each worktree gets its own `node_modules` via `npm ci`
+- A lock file (`.worktrees/.sprint.lock`) prevents multiple sprints from running simultaneously
+
+### Fleet Worktrees
+
+For `/orchestrate` (multi-machine):
+
+- Each machine creates worktrees under `~/.crane/tasks/{task_id}/worktree`
+- The orchestrator cleans up remote worktrees after collection
+
+### Worktree Rules
+
+Agents in worktrees must follow strict constraints:
+
+- Never operate outside the assigned worktree directory
+- Never push to `main` or merge PRs directly
+- Never modify files unrelated to the assigned issue
+- Prefix every shell command with `cd {WORKTREE_PATH} &&`
+
+## Branch Naming Conventions
+
+Branch names encode enough information to identify the agent, issue, and purpose at a glance.
+
+### Sprint Branches
+
+For sprint-executed issues:
+
+```
+{issue-number}-{slugified-title}
+```
+
+Examples: `45-fix-balance-calc`, `42-add-expense-filter`
+
+The title is lowercased, spaces replaced with hyphens, non-alphanumeric characters removed, truncated to 50 characters, and trailing hyphens stripped.
+
+### Parallel Dev Track Branches
+
+For manual parallel tracks on different machines:
+
+```
+dev/{instance}/{feature}
+```
+
+Examples: `dev/host/fix-relay-timeout`, `dev/crane1/add-lot-filter`
+
+Instance identifiers correspond to physical machines or VMs.
+
+### Collision Avoidance
+
+- Sprint branches use issue numbers as prefixes, which are globally unique within a repo.
+- Dev track branches include the instance identifier.
+- If a branch already exists during sprint execution, the agent asks the user to reuse or create a `-2` suffixed variant.
+
+## Handoff Chains
+
+Handoff documents are the primary mechanism for passing context between sequential agent sessions. When agent A finishes a session (`/eod`), it writes a handoff containing its progress, open questions, and next steps. When agent B starts (`/sod`), it reads the latest handoff for that venture/repo/track.
+
+### Handoff Flow
+
+```
+Agent A: /sod (creates session) -> works -> /eod (writes handoff, ends session)
+                                                    │
+Agent B: /sod (creates session, reads handoff) <────┘
+```
+
+### Handoff Query Modes
+
+Handoffs can be queried by:
+
+- **Issue number** -- Get the latest handoff for a specific issue
+- **Track number** -- Get the latest handoff for a parallel track
+- **Session ID** -- Get the handoff from a specific session
+
+### What Handoffs Contain
+
+Handoff payloads are free-form JSON (up to 800KB) but typically include:
+
+- Summary of work completed
+- Files changed and why
+- Open questions or blockers
+- Suggested next steps
+- Branch name and commit SHA
+
+## Parallel Tracks
+
+Track numbers provide a lightweight coordination mechanism for multi-stream work within the same venture/repo. Each track is an independent stream of work.
+
+### How Tracks Work
+
+- Track numbers are integers assigned when an agent starts a session
+- Sessions with different track numbers are independent and do not conflict
+- Sessions with the same track number are sequential (one replaces the other)
+- The track number appears in session queries and handoff lookups
+
+### When to Use Tracks
+
+- **Single issue work** -- No track needed (default)
+- **Two independent features in the same repo** -- Assign track 1 and track 2
+- **Sprint execution** -- Each issue effectively gets its own track via the sprint framework
+
+## File Overlap Risks and Merge Conflict Prevention
+
+The most common coordination failure is two agents modifying the same file. Prevention happens at multiple levels:
+
+### Pre-Dispatch Detection
+
+The `/orchestrate` command scans issue bodies for file path references before dispatching. If two issues in the same wave reference the same file, a warning is displayed:
+
+```
+Warning: Potential merge conflict risk
+  - src/components/Layout.tsx referenced by #42, #47
+```
+
+This is advisory and does not block dispatch.
+
+### Component Labels
+
+Issues tagged with the same `component:*` label in the same sprint wave trigger a conflict warning. This catches overlap even when issue bodies do not mention specific files.
+
+### Merge Order
+
+PRs are merged in dependency order (Wave 1 before Wave 2, within a wave by issue number). The agent with the fewest shared-file touches should merge first to minimize conflict surface.
+
+### When Conflicts Occur
+
+If a merge conflict happens:
+
+1. The merge operation stops and escalates to the user
+2. The conflicting PR is left open for manual resolution
+3. The sprint can be resumed with `--resume` after the conflict is resolved
+
+## When to Use Parallel Agents vs Sequential Work
+
+| Scenario                                          | Approach            | Reason                                    |
+| ------------------------------------------------- | ------------------- | ----------------------------------------- |
+| 4+ independent issues across different components | Fleet orchestration | Maximum throughput, minimal conflict risk |
+| 1-3 issues, or high file overlap                  | Local sprint        | Simpler coordination, one machine         |
+| Issues with strict dependencies (A before B)      | Sequential work     | Wave planning adds overhead for chains    |
+| Exploratory/research work                         | Single agent        | Unclear scope makes parallelism wasteful  |
+| Cross-cutting refactor touching many files        | Single agent        | High conflict risk with parallel agents   |
+| Emergency fix on production                       | Single agent        | Speed and focus over throughput           |
+
+The decision framework is documented in detail in `docs/process/fleet-decision-framework.md`.
+
+## Key Files
+
+| File                                         | Purpose                                        |
+| -------------------------------------------- | ---------------------------------------------- |
+| `workers/crane-context/src/sessions.ts`      | Session CRUD, resume logic, sibling queries    |
+| `workers/crane-context/src/constants.ts`     | Session timing constants, heartbeat config     |
+| `.agents/skills/sprint/SKILL.md`             | Local sprint skill (sequential on one machine) |
+| `.claude/commands/orchestrate.md`            | Fleet orchestrator command                     |
+| `docs/process/fleet-orchestration.md`        | Fleet orchestration process overview           |
+| `docs/process/parallel-dev-track-runbook.md` | Manual parallel track runbook                  |
+| `docs/process/fleet-decision-framework.md`   | Decision matrix: local vs fleet                |

--- a/docs/process/notifications-pipeline.md
+++ b/docs/process/notifications-pipeline.md
@@ -1,0 +1,201 @@
+# Notifications Pipeline
+
+How CI/CD events flow from GitHub and Vercel webhooks through crane-watch and crane-context to reach agents.
+
+## Architecture
+
+```
+GitHub App webhooks ──┐
+                      ├──> crane-watch ──> crane-context ──> D1 (notifications table)
+Vercel webhooks ──────┘         │                                    │
+                                │                                    ▼
+                          QA classification              crane_notifications MCP tool
+                          (issues.opened only)           (agents query on demand)
+```
+
+Three Cloudflare Workers participate:
+
+| Worker        | Role                                                  | URL                                                 |
+| ------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| crane-watch   | Webhook gateway, signature verification, event router | `https://crane-watch.automation-ab6.workers.dev`    |
+| crane-context | Notification storage, query API, deduplication        | `https://crane-context.automation-ab6.workers.dev`  |
+| crane-mcp     | MCP tool layer agents call (`crane_notifications`)    | Runs locally inside the agent's Claude Code session |
+
+## GitHub Events Handled
+
+crane-watch receives webhooks from the Crane Relay GitHub App (installed across all venture orgs).
+
+### Issue QA Classification (`issues.opened`)
+
+When a new issue is opened in any installed org:
+
+1. **Signature verification** -- `X-Hub-Signature-256` header validated against `GH_WEBHOOK_SECRET` using HMAC-SHA256 with timing-safe comparison.
+2. **Skip checks** -- Classification is skipped if:
+   - Sender is a bot (`sender.type === 'Bot'`)
+   - Issue already has a `qa:*` label
+   - Issue already has an `automation:graded` label
+3. **Acceptance criteria extraction** -- The issue body is scanned for a `## Acceptance Criteria` heading or `AC1`/`AC2` patterns.
+4. **Idempotency** -- A delivery-based idempotency key (`gh:delivery:{delivery_id}`) prevents duplicate processing. A semantic key (SHA-256 of repo, issue number, prompt version, AC text, and relevant labels) catches re-deliveries with identical content.
+5. **Gemini Flash classification** -- The issue title, body, labels, and extracted ACs are sent to `gemini-2.0-flash` with a structured JSON schema. Temperature is set to 0.1 for deterministic output. The model returns:
+   - `grade`: `qa:0` through `qa:3`
+   - `confidence`: 0.0 to 1.0
+   - `rationale`: up to 240 characters
+   - `signals`: lowercase tokens explaining the grade
+   - `test_required`: boolean (optional)
+6. **Test-required detection** -- Gemini's `test_required` flag is supplemented by local regex patterns matching calculation logic, financial terms, and numerical fields.
+7. **Label application** -- A GitHub App installation token is minted for the issue's org, and labels are applied: `{grade}`, `automation:graded`, and optionally `test:required`.
+8. **Audit logging** -- Every classification run (success, skip, or error) is recorded in the `classify_runs` D1 table.
+
+#### QA Grades
+
+| Grade  | Meaning            | Verification method       |
+| ------ | ------------------ | ------------------------- |
+| `qa:0` | Automated only     | CI/tests cover it         |
+| `qa:1` | CLI/API verifiable | `curl`/`gh`/DB queries    |
+| `qa:2` | Light visual       | Single page spot-check    |
+| `qa:3` | Full visual        | Multi-step UI walkthrough |
+
+### CI Event Forwarding (`workflow_run`, `check_suite`, `check_run`)
+
+These three GitHub event types are short-circuited before the classification path. On receipt:
+
+1. Signature is verified (same HMAC-SHA256 flow).
+2. The raw payload is forwarded to crane-context via `POST /notifications/ingest` using `ctx.waitUntil()` (non-blocking).
+3. crane-watch returns `200 OK` immediately.
+
+The forwarding prefers a Cloudflare Service Binding (`CRANE_CONTEXT` fetcher) for Worker-to-Worker calls. If no binding is configured, it falls back to the public `CRANE_CONTEXT_URL`.
+
+## Vercel Events Handled
+
+crane-watch receives Vercel deployment webhooks.
+
+### Signature Verification
+
+Vercel uses HMAC-SHA1 (not SHA-256). The `x-vercel-signature` header is validated against `VERCEL_WEBHOOK_SECRET` with timing-safe comparison.
+
+### Forwarded Events
+
+Only two event types are forwarded to crane-context:
+
+| Event                 | Action                                    |
+| --------------------- | ----------------------------------------- |
+| `deployment.error`    | Forwarded as notification                 |
+| `deployment.canceled` | Forwarded as notification                 |
+| All other events      | Acknowledged with `200 OK`, not forwarded |
+
+The payload is forwarded via the same `forwardToNotifications` function used for GitHub CI events.
+
+## Normalization in crane-context
+
+When crane-context receives a `POST /notifications/ingest` request, it routes the payload to a source-specific normalizer.
+
+### GitHub Normalizers
+
+Each GitHub event type has a dedicated normalizer that extracts structured fields:
+
+- **`workflow_run`** -- Extracts workflow name, run number, conclusion, branch, commit SHA, and HTML URL.
+- **`check_suite`** -- Extracts app name, conclusion, branch, commit SHA, and run count.
+- **`check_run`** -- Only processes completed runs. Extracts check name, conclusion, branch, commit SHA, and HTML URL.
+
+All three normalizers share the same severity logic.
+
+### Vercel Normalizer
+
+Extracts project name, deployment ID, target environment, branch, commit info, and error message. Derives venture code from the project name using a static mapping in `constants.ts`:
+
+```
+crane-console -> vc
+ke-console    -> ke
+sc-console    -> sc
+dfg-console   -> dfg
+dc-console    -> dc
+vc-web        -> vc
+```
+
+## Notification Severity Levels
+
+### GitHub Severity Rules
+
+| Conclusion  | Protected branch (`main`/`master`/`production`) | Other branch |
+| ----------- | ----------------------------------------------- | ------------ |
+| `failure`   | `critical`                                      | `info`       |
+| `timed_out` | `warning`                                       | `warning`    |
+| `cancelled` | `info`                                          | `info`       |
+| `success`   | Ignored (no notification)                       | Ignored      |
+| `neutral`   | Ignored                                         | Ignored      |
+| `skipped`   | Ignored                                         | Ignored      |
+
+### Vercel Severity Rules
+
+| Event                 | Production target | Preview target |
+| --------------------- | ----------------- | -------------- |
+| `deployment.error`    | `critical`        | `warning`      |
+| `deployment.canceled` | `info`            | `info`         |
+
+## Deduplication
+
+Each notification gets a dedupe hash computed from `source | event_type | repo | branch | content_key`. The content key is source-specific:
+
+- GitHub: `{event_type}:{entity_id}:{conclusion}` (e.g., `workflow_run:123456:failure`)
+- Vercel: `vercel:{deployment_id}:{webhook_type}`
+
+The `notifications` table has a `UNIQUE` constraint on `dedupe_hash`. Duplicate inserts are silently ignored via `INSERT OR IGNORE`.
+
+## Notification Lifecycle
+
+Notifications follow a state machine:
+
+```
+new -> acked -> resolved
+new ----------> resolved
+```
+
+Valid transitions are enforced server-side. The `resolved` state is terminal.
+
+### Status Values
+
+| Status     | Meaning                               |
+| ---------- | ------------------------------------- |
+| `new`      | Unacknowledged, just ingested         |
+| `acked`    | Agent has seen it                     |
+| `resolved` | Issue addressed, notification cleared |
+
+## Retention
+
+Notifications are retained for 30 days. The retention is enforced as a filter-on-read: all list queries include a `created_at > (now - 30 days)` condition.
+
+## How Agents Access Notifications
+
+Agents use the `crane_notifications` MCP tool (registered in crane-mcp). The tool calls `GET /notifications` on crane-context with optional filters:
+
+| Filter     | Values                        |
+| ---------- | ----------------------------- |
+| `status`   | `new`, `acked`, `resolved`    |
+| `severity` | `critical`, `warning`, `info` |
+| `venture`  | Any venture code              |
+| `repo`     | `org/repo` format             |
+| `source`   | `github`, `vercel`            |
+| `limit`    | 1-100 (default 20)            |
+
+Results are formatted as a markdown table for display. Agents can update notification status using `crane_notification_update`.
+
+## Webhook Authentication Summary
+
+| Source | Header                | Algorithm   | Secret env var          |
+| ------ | --------------------- | ----------- | ----------------------- |
+| GitHub | `X-Hub-Signature-256` | HMAC-SHA256 | `GH_WEBHOOK_SECRET`     |
+| Vercel | `x-vercel-signature`  | HMAC-SHA1   | `VERCEL_WEBHOOK_SECRET` |
+
+Both validations use timing-safe comparison to prevent side-channel attacks.
+
+## Key Files
+
+| File                                                   | Purpose                                    |
+| ------------------------------------------------------ | ------------------------------------------ |
+| `workers/crane-watch/src/index.ts`                     | Webhook receiver, QA classifier, forwarder |
+| `workers/crane-context/src/endpoints/notifications.ts` | Ingest, list, and status-update endpoints  |
+| `workers/crane-context/src/notifications.ts`           | CRUD, deduplication, venture derivation    |
+| `workers/crane-context/src/notifications-github.ts`    | GitHub event normalizers                   |
+| `workers/crane-context/src/notifications-vercel.ts`    | Vercel event normalizer                    |
+| `workers/crane-context/src/constants.ts`               | Severity levels, sources, retention config |
+| `packages/crane-mcp/src/tools/notifications.ts`        | MCP tool for agent access                  |

--- a/docs/process/session-lifecycle.md
+++ b/docs/process/session-lifecycle.md
@@ -1,0 +1,307 @@
+# Agent Session Lifecycle
+
+This document describes the full lifecycle of an agent session in Crane Context, from creation through heartbeat maintenance to termination. Sessions are the unit of continuity that lets agents resume work, coordinate with siblings, and pass context across time.
+
+## Overview
+
+A session represents a single agent working on a specific venture and repository. Sessions are stored in the `sessions` table in D1, identified by prefixed ULIDs (`sess_<ULID>`). The system is designed so that agents never lose context - sessions either resume cleanly, hand off to the next session, or get marked as abandoned when the agent disappears.
+
+## Session States
+
+Sessions have three possible statuses:
+
+| Status      | Meaning                                           |
+| ----------- | ------------------------------------------------- |
+| `active`    | Agent is currently working (heartbeat is fresh)   |
+| `ended`     | Agent cleanly terminated the session via `/eod`   |
+| `abandoned` | Session went stale (no heartbeat for 45+ minutes) |
+
+### State Transitions
+
+```
+                    ┌─────────────┐
+         /sod       │             │
+     ───────────>   │   active    │
+                    │             │
+                    └──────┬──────┘
+                           │
+               ┌───────────┼───────────┐
+               │           │           │
+               ▼           ▼           ▼
+         ┌──────────┐ ┌──────────┐ ┌──────────┐
+         │  ended   │ │ ended    │ │abandoned │
+         │ (manual) │ │(supersede│ │ (stale)  │
+         └──────────┘ └──────────┘ └──────────┘
+```
+
+End reasons for terminated sessions:
+
+| End Reason   | Trigger                                              |
+| ------------ | ---------------------------------------------------- |
+| `manual`     | Agent called `/eod` to cleanly end the session       |
+| `stale`      | Heartbeat exceeded the 45-minute staleness threshold |
+| `superseded` | A newer `/sod` call found multiple active sessions   |
+| `error`      | Session ended due to an error condition              |
+
+## Session Creation (POST /sod)
+
+Sessions are created (or resumed) via `POST /sod`, typically triggered by the `crane_sod` MCP tool at the start of a work session. The `/sod` endpoint implements resume-or-create logic.
+
+### Resume-or-Create Flow
+
+1. **Find active sessions** matching the tuple: `(agent, venture, repo, track)`.
+2. **Multiple sessions found**: Keep the most recent (by `last_heartbeat_at`), mark all others as `superseded`.
+3. **Single session found, not stale**: Resume it by refreshing the heartbeat. Return `status: "resumed"`.
+4. **Single session found, stale (>45 min)**: Mark it as `abandoned`, then create a new session. Return `status: "created"`.
+5. **No active session found**: Create a new session. Return `status: "created"`.
+
+### What /sod Returns
+
+The `/sod` response is a comprehensive briefing that includes:
+
+- **Session context** - session ID, status (resumed/created), full session record
+- **Heartbeat schedule** - `next_heartbeat_at` with jitter, `heartbeat_interval_seconds`
+- **Documentation index** - available docs for the venture (metadata by default, full content optional)
+- **Scripts index** - available operational scripts
+- **Doc audit** - missing or stale documentation report
+- **Enterprise context** - executive summaries from VCMS notes tagged `executive-summary`
+- **Knowledge base** - venture-relevant VCMS notes (PRDs, design specs, strategy, methodology, market research)
+- **Last handoff** - the most recent handoff for this venture/repo/track
+
+### Session Fields Set at Creation
+
+| Field                     | Description                                         |
+| ------------------------- | --------------------------------------------------- |
+| `id`                      | `sess_<ULID>` - sortable, timestamp-embedded        |
+| `agent`                   | Agent identifier (e.g., `claude-cli-hostname`)      |
+| `client`                  | CLI client type (claude-cli, gemini-cli, codex-cli) |
+| `client_version`          | CLI version string                                  |
+| `host`                    | Hostname of the machine                             |
+| `venture`                 | Venture code (vc, ke, sc, dfg, dc)                  |
+| `repo`                    | Repository in `owner/repo` format                   |
+| `track`                   | Track number for parallel dev (nullable)            |
+| `branch`                  | Git branch at session start                         |
+| `commit_sha`              | Git commit at session start                         |
+| `session_group_id`        | Group ID for multi-agent coordination (nullable)    |
+| `meta_json`               | Freeform JSON metadata                              |
+| `actor_key_id`            | SHA-256 derived key ID for attribution              |
+| `creation_correlation_id` | Correlation ID from the creating request            |
+
+## Heartbeat Protocol
+
+Heartbeats keep sessions alive. Without regular heartbeats, a session will be marked as abandoned.
+
+### Timing Parameters
+
+| Parameter                    | Value        | Purpose                                          |
+| ---------------------------- | ------------ | ------------------------------------------------ |
+| `HEARTBEAT_INTERVAL_SECONDS` | 600 (10 min) | Base interval between heartbeats                 |
+| `HEARTBEAT_JITTER_SECONDS`   | 120 (2 min)  | Random offset applied to prevent thundering herd |
+| `STALE_AFTER_MINUTES`        | 45           | Session considered stale after this duration     |
+
+### How Jitter Works
+
+Each heartbeat response includes a `next_heartbeat_at` timestamp calculated as:
+
+```
+interval = 600 + random(-120, +120)  // 8 to 12 minutes
+next_heartbeat_at = now + interval
+```
+
+This gives a 4.5x safety margin: even at the maximum interval (12 minutes), the agent has nearly four heartbeat opportunities before the 45-minute staleness threshold.
+
+### Implicit Heartbeats
+
+Not every heartbeat requires a dedicated `/heartbeat` call. The following operations all refresh `last_heartbeat_at`:
+
+- `POST /sod` (session resume)
+- `POST /update` (session metadata update)
+- `POST /checkpoint` (mid-session progress save)
+- `POST /heartbeat` (dedicated heartbeat)
+
+An agent actively using `/update` or `/checkpoint` does not need separate heartbeat calls.
+
+### Staleness Detection
+
+A session is stale when:
+
+```
+last_heartbeat_at < (now - STALE_AFTER_MINUTES)
+```
+
+Stale sessions are not proactively cleaned up on a timer. Instead, staleness is evaluated on-demand when `/sod` checks for existing sessions to resume. A stale session found during `/sod` is marked `abandoned` (with `ended_at` set to `last_heartbeat_at`) and a fresh session is created.
+
+## Mid-Session Updates (POST /update)
+
+The `/update` endpoint lets an agent refresh its session metadata without ending the session. This is useful when an agent switches branches, makes significant progress, or starts working on a different issue.
+
+### What Can Be Updated
+
+| Field        | Description                                  |
+| ------------ | -------------------------------------------- |
+| `branch`     | Current git branch                           |
+| `commit_sha` | Current git commit                           |
+| `meta`       | Freeform JSON (issue number, priority, etc.) |
+
+Fields set at creation (`venture`, `repo`, `track`, `agent`) cannot be changed via `/update`. If those need to change, the agent should end the session and start a new one.
+
+### When to Use /update
+
+- Switched to a new branch
+- Started work on a different issue
+- Reached a significant milestone
+- Want to update visibility for other agents ("Agent X is on branch Y working on issue #123")
+
+## Checkpoints (POST /checkpoint)
+
+Checkpoints are mid-session snapshots of work progress. Unlike handoffs (which end the session), checkpoints record incremental progress while keeping the session active.
+
+### Checkpoint Structure
+
+| Field               | Description                                |
+| ------------------- | ------------------------------------------ |
+| `id`                | `cp_<ULID>` - sortable, timestamp-embedded |
+| `session_id`        | Parent session                             |
+| `checkpoint_number` | Auto-incrementing within the session       |
+| `summary`           | Required text summary of progress          |
+| `work_completed`    | Array of completed items                   |
+| `blockers`          | Array of current blockers                  |
+| `next_actions`      | Array of planned next steps                |
+| `notes`             | Freeform additional notes                  |
+
+Checkpoints are auto-numbered within each session (1, 2, 3, ...) and inherit venture/repo/track/branch/commit from the parent session at the time of creation.
+
+### Querying Checkpoints
+
+`GET /checkpoints` supports filtering by:
+
+- `session_id` - checkpoints for a specific session
+- `venture` - all checkpoints for a venture
+- `repo` - combined with venture for finer filtering
+- `track` - for parallel dev track isolation
+
+## Session Groups
+
+Session groups enable multi-agent coordination. When multiple agents work on the same venture and repository simultaneously, they share a `session_group_id` so they can discover each other.
+
+### How Groups Work
+
+1. The first agent starts a session with a `session_group_id` (typically set by the orchestrator).
+2. Subsequent agents on the same venture/repo use the same `session_group_id`.
+3. Any agent can query `GET /siblings?session_group_id=<id>` to discover sibling sessions.
+4. The response excludes the querying agent's own session (via `exclude_session_id`).
+
+### Sibling Session Summaries
+
+The `/siblings` endpoint returns lightweight summaries (not full session records):
+
+- Session ID, agent name, venture, repo, track
+- Issue number and branch (what each agent is working on)
+- Last heartbeat timestamp (how recently each agent was active)
+- Creation timestamp
+
+This enables coordination patterns like "Agent A is on branch feat/auth, Agent B is on branch feat/api" without requiring direct agent-to-agent communication.
+
+## Handoff Creation (POST /eod)
+
+Handoffs are the formal mechanism for passing context from one session to the next. The `/eod` endpoint ends the session and creates a handoff document in a single atomic operation.
+
+### Handoff Structure
+
+| Field          | Description                                |
+| -------------- | ------------------------------------------ |
+| `id`           | `ho_<ULID>` - sortable, timestamp-embedded |
+| `session_id`   | The session that created this handoff      |
+| `from_agent`   | Agent that created the handoff             |
+| `to_agent`     | Optional target agent                      |
+| `status_label` | One of: `in_progress`, `blocked`, `done`   |
+| `summary`      | Required text summary of the session       |
+| `payload`      | Structured JSON (max 800KB) with details   |
+
+### EOD Flow
+
+1. Agent synthesizes session context (conversation history, git log, PRs, issues).
+2. Agent generates a handoff summary with sections: Accomplished, In Progress, Blocked, Next Session.
+3. Agent shows the summary to the user for confirmation (single yes/no).
+4. On confirmation, agent calls `crane_handoff` MCP tool (which calls `POST /eod`).
+5. The endpoint creates the handoff record and sets the session status to `ended`.
+6. The next session's `/sod` call retrieves this handoff as `last_handoff`.
+
+### Handoff Payload Limits
+
+Handoff payloads are capped at 800KB (D1 rows are limited to 1MB, leaving 200KB for metadata columns). Payloads are canonicalized and hashed for content addressing.
+
+## Session Resume Logic
+
+When an agent starts a new session with `/sod`, the system attempts to maintain continuity:
+
+1. **Match criteria**: `agent` + `venture` + `repo` + `track` must all match an existing active session.
+2. **Freshness check**: The matched session's `last_heartbeat_at` must be within the 45-minute threshold.
+3. **Resume behavior**: If both conditions pass, the existing session is resumed (heartbeat refreshed), not replaced.
+4. **Stale handling**: If the session is stale, it is marked `abandoned` and a new session is created.
+
+This means an agent that crashes and restarts within 45 minutes seamlessly picks up its previous session. After 45 minutes, a clean break occurs and continuity passes through the handoff system.
+
+## Status Queries (GET /active, /status)
+
+### Active Sessions Query
+
+`GET /active` returns currently active sessions filtered by:
+
+- `agent` - specific agent
+- `venture` - specific venture
+- `repo` - specific repository
+
+All filters are optional. When called with no filters, it returns all active sessions across the fleet.
+
+### Status Display
+
+The `/status` skill presents a consolidated view:
+
+```
+== Session Status ==
+Session: sess_01HXY...
+Age: 2h 15m
+Venture: Venture Crane (vc)
+
+== Tasks ==
+In Progress: 2
+  - Implement auth module
+Pending: 1
+  - Write tests
+
+== Git ==
+Branch: feat/auth
+Changes: 3 staged, 1 unstaged
+Remote: 2 ahead
+
+== Context ==
+Repo: venturecrane/crane-console
+Dir: ~/dev/crane-console
+Machine: dev-mac-01
+```
+
+## Timing Reference
+
+```
+ 0 min    10 min     20 min     30 min     40 min     45 min
+ │         │          │          │          │          │
+ ├─────────┼──────────┼──────────┼──────────┼──────────┤
+ │  HB 1   │  HB 2    │  HB 3    │  HB 4    │  STALE   │
+ │         │          │          │          │          │
+ ▼         ▼          ▼          ▼          ▼          ▼
+/sod    ~10min     ~20min     ~30min     ~40min    Session
+        ±2min      ±2min      ±2min      ±2min     marked
+                                                  abandoned
+```
+
+At the base 10-minute interval, an agent gets approximately 4 heartbeat opportunities before the 45-minute threshold. The 2-minute jitter spreads heartbeat traffic across the fleet while maintaining a comfortable safety margin.
+
+## Idempotency
+
+All mutating session endpoints (`/sod`, `/eod`, `/update`) support idempotency keys via:
+
+- `Idempotency-Key` HTTP header, or
+- `update_id` field in the request body
+
+Cached responses are stored for 1 hour (`IDEMPOTENCY_TTL_SECONDS = 3600`). Responses under 64KB are stored in full; larger ones store only a hash. Idempotency keys are scoped per endpoint, so the same key used on `/sod` and `/eod` will not conflict.

--- a/docs/process/vcms-conventions.md
+++ b/docs/process/vcms-conventions.md
@@ -1,0 +1,240 @@
+# VCMS Conventions
+
+VCMS (Venture Crane Management System) is the enterprise knowledge store. It holds agent-relevant context in a tagged notes system backed by Cloudflare D1, accessible from any machine via the Crane Context API. This document covers storage conventions, tag taxonomy, MCP tool usage, and boundaries with other storage systems.
+
+## What VCMS Is
+
+VCMS is a `notes` table in the crane-context D1 database. Each note has:
+
+| Field          | Type              | Description                                                      |
+| -------------- | ----------------- | ---------------------------------------------------------------- |
+| `id`           | `note_<ULID>`     | Sortable, timestamp-embedded identifier                          |
+| `title`        | string (nullable) | Optional title/subject line                                      |
+| `content`      | string            | Note body (max 500KB)                                            |
+| `tags`         | JSON string array | Categorization tags (max 20 tags, 50 chars each)                 |
+| `venture`      | string (nullable) | Venture scope (`vc`, `ke`, `sc`, `dfg`, `dc`) or null for global |
+| `archived`     | boolean           | Soft-delete flag (0 = active, 1 = archived)                      |
+| `created_at`   | ISO 8601          | Creation timestamp                                               |
+| `updated_at`   | ISO 8601          | Last modification timestamp                                      |
+| `actor_key_id` | string            | Attribution (derived from API key)                               |
+
+Notes are designed to make agents smarter across sessions. They persist enterprise context that would otherwise be lost between session handoffs.
+
+## When to Use VCMS vs Other Storage
+
+| Content Type                | Storage         | Why                                            |
+| --------------------------- | --------------- | ---------------------------------------------- |
+| Venture overviews, strategy | VCMS            | Agent context that crosses sessions and repos  |
+| Product requirements (PRDs) | VCMS            | Agents need these during development sessions  |
+| Market research, bios       | VCMS            | Enterprise knowledge reused by multiple agents |
+| Design briefs               | VCMS            | Referenced during implementation sessions      |
+| Work items, bugs, features  | GitHub Issues   | Trackable, assignable, closeable               |
+| Architecture decisions      | `docs/adr/`     | Version-controlled, repo-specific              |
+| Process documentation       | `docs/process/` | Version-controlled, repo-specific              |
+| Code                        | Git             | Version-controlled source of truth             |
+| Secrets, API keys           | Infisical       | Encrypted, rotatable, auditable                |
+| Session handoffs            | `/eod` endpoint | Structured session-to-session context passing  |
+| Personal content            | Apple Notes     | Not enterprise knowledge                       |
+
+**Key rule: never auto-save to VCMS.** Only store notes when the Captain (human operator) explicitly asks to save something. If in doubt, ask before saving.
+
+## Tag Taxonomy
+
+Tags are the primary organization mechanism. Notes can have up to 20 tags. New tags can be added freely without code changes, but the following are the established vocabulary:
+
+### Core Tags
+
+| Tag                 | Purpose                                                     | Typical Venture Scope |
+| ------------------- | ----------------------------------------------------------- | --------------------- |
+| `executive-summary` | Venture overviews - mission, stage, tech stack              | Per venture + global  |
+| `prd`               | Product requirements documents                              | Per venture           |
+| `design`            | Design briefs, component specs, visual direction            | Per venture           |
+| `strategy`          | Strategic assessments, founder reflections, market position | Per venture           |
+| `methodology`       | Frameworks, processes (e.g., Crane Way, BVM)                | Global or per venture |
+| `market-research`   | Competitor analysis, market sizing, trends                  | Per venture           |
+| `bio`               | Founder and team bios                                       | Global or per venture |
+| `marketing`         | Service descriptions, positioning, messaging                | Per venture           |
+| `governance`        | Legal, tax, compliance notes                                | Global or per venture |
+| `code-review`       | Codebase review scorecards, enterprise drift assessments    | Per venture           |
+| `content-scan`      | Content pipeline scan results and analysis                  | Per venture           |
+
+### Tags Surfaced in SOD Briefing
+
+The SOD (Start of Day) flow includes a "Venture Knowledge Base" discovery section. This section surfaces notes matching a subset of tags considered venture-critical for development agents:
+
+- `prd`
+- `design`
+- `strategy`
+- `methodology`
+- `market-research`
+
+Notes tagged `executive-summary` are delivered separately as enterprise context. Tags like `bio`, `marketing`, and `governance` are available via search but not included in the automatic SOD briefing.
+
+## CRUD Operations via MCP Tools
+
+### crane_note - Create or Update
+
+The `crane_note` MCP tool handles both creation and updates.
+
+**Create a note:**
+
+```
+crane_note(
+  action: "create",
+  title: "KE Product Requirements",
+  content: "...",
+  tags: ["prd"],
+  venture: "ke"
+)
+```
+
+**Update an existing note:**
+
+```
+crane_note(
+  action: "update",
+  id: "note_01HXY...",
+  title: "KE Product Requirements v2",
+  content: "...",
+  tags: ["prd"]
+)
+```
+
+Parameters:
+
+| Parameter | Create   | Update   | Description                     |
+| --------- | -------- | -------- | ------------------------------- |
+| `action`  | Required | Required | `"create"` or `"update"`        |
+| `id`      | Ignored  | Required | Note ID to update               |
+| `title`   | Optional | Optional | Title/subject line              |
+| `content` | Required | Optional | Note body                       |
+| `tags`    | Optional | Optional | Array of tag strings            |
+| `venture` | Optional | Optional | Venture code or omit for global |
+
+### crane_notes - Search and List
+
+The `crane_notes` MCP tool searches and lists notes.
+
+**Search by tag:**
+
+```
+crane_notes(tag: "executive-summary")
+```
+
+**Search by venture:**
+
+```
+crane_notes(venture: "ke")
+```
+
+**Text search:**
+
+```
+crane_notes(q: "authentication flow")
+```
+
+**Combined filters:**
+
+```
+crane_notes(tag: "prd", venture: "sc", limit: 5)
+```
+
+Parameters:
+
+| Parameter | Description                          | Default |
+| --------- | ------------------------------------ | ------- |
+| `venture` | Filter by venture code               | All     |
+| `tag`     | Filter by single tag                 | All     |
+| `q`       | Text search across title and content | None    |
+| `limit`   | Maximum results to return            | 10      |
+
+Results are returned sorted by creation date (newest first). When more results exist than the limit, a pagination cursor is available.
+
+## Venture Scoping
+
+Notes have an optional `venture` field that determines their visibility scope:
+
+- **Venture-scoped** (`venture: "ke"`) - visible only when querying for that venture
+- **Global** (`venture: null`) - visible to all ventures
+
+When querying with `include_global: true` (used internally by SOD), notes matching the specified venture AND global notes are both returned. This is how the SMD Enterprise Summary (global) and per-venture executive summaries both appear in SOD briefings.
+
+Valid venture codes are loaded from `config/ventures.json` and validated on write. Attempting to save a note with an unrecognized venture code returns an error.
+
+## Search Conventions
+
+### By Tag
+
+Tags are stored as JSON arrays and searched with SQL LIKE patterns. A query for tag `prd` matches any note whose `tags` column contains `"prd"` in the JSON array.
+
+```
+crane_notes(tag: "executive-summary", venture: "vc")
+```
+
+### By Venture
+
+Venture filtering is exact-match. To include global notes alongside venture-specific ones, the internal API uses `include_global: true`.
+
+```
+crane_notes(venture: "dfg")
+```
+
+### Text Search
+
+Text search is case-insensitive substring matching across both `title` and `content` fields.
+
+```
+crane_notes(q: "competitor analysis")
+```
+
+### Common Search Patterns by Skill
+
+| Skill             | Query Pattern                                              |
+| ----------------- | ---------------------------------------------------------- |
+| Portfolio Review  | `crane_notes(tag: "code-review", venture: "{code}")`       |
+| Content Scan      | `crane_notes(tag: "content-scan", limit: 1)`               |
+| Design Brief      | `crane_notes(tag: "executive-summary", venture: "{code}")` |
+| Code Review       | `crane_notes(tag: "code-review", venture: "{code}")`       |
+| Enterprise Review | `crane_notes(tag: "code-review", q: "Enterprise Review")`  |
+| Docs Refresh      | `crane_notes(tag: "executive-summary", venture: "{code}")` |
+| Build Log         | `crane_notes` (broad search for recent handoff context)    |
+
+## Archiving
+
+Notes are soft-deleted via the `archived` flag. Archived notes:
+
+- Are excluded from all queries by default
+- Can be included by setting `include_archived: true` in the API query
+- Retain all data (title, content, tags, venture) for potential restoration
+- Continue to have their `updated_at` and `actor_key_id` updated when archived
+
+Archive a note via the REST API:
+
+```
+POST /notes/:id/archive
+```
+
+There is no MCP tool for archiving - it is done through the direct API endpoint.
+
+## Size Limits
+
+| Constraint        | Limit    | Notes                                     |
+| ----------------- | -------- | ----------------------------------------- |
+| Content size      | 500KB    | D1 rows cap at 1MB; 500KB leaves headroom |
+| Tags per note     | 20       | Each tag max 50 characters                |
+| Tag length        | 50 chars | Per individual tag                        |
+| Results per query | 100 max  | Default page size is 20                   |
+
+## What NOT to Put in VCMS
+
+- **Work items, bugs, feature requests** - Use GitHub Issues. Issues are trackable, assignable, and closeable. VCMS is not a task tracker.
+- **Code, terminal output, implementation details** - These are ephemeral and belong in git or session context, not permanent knowledge.
+- **Session handoffs** - Use `/eod`. Handoffs have their own structured table with session linkage.
+- **Architecture decisions** - Use `docs/adr/` in the relevant repository. ADRs are version-controlled and repo-specific.
+- **Process documentation** - Use `docs/process/` in the relevant repository.
+- **Secrets, API keys, credentials** - Use Infisical. Never store secrets in VCMS.
+- **Personal content** - Use Apple Notes. VCMS is for enterprise knowledge only.
+
+## AI Agent Authorship Note
+
+All VCMS content is produced by AI agents operating under the Crane system. The agents ARE the voice. Content stored in VCMS reflects this - it is not human writing with AI assistance, it is what an organized, structured team of AI agents produces. Never change author attribution to a human name or present content as human-drafted.


### PR DESCRIPTION
## Summary

Adds documentation for the 7 highest-priority gaps identified by systematic gap analysis:

- **Crane CLI launcher** — venture resolution, secret injection, SSH auth, agent launch
- **MCP server architecture** — tool inventory, API mappings, auth model, remote MCP
- **Session lifecycle** — heartbeat, checkpoint, update, session groups, resume logic
- **VCMS conventions** — tag taxonomy, search patterns, decision matrix
- **Notifications pipeline** — webhook → crane-watch → crane-context → agents
- **Doc sync pipeline** — git → D1 → agents, git → Vercel → Starlight site
- **Multi-agent coordination** — session groups, worktree isolation, handoff chains

Also adds **process coverage check** to `/docs-refresh` audit — compares skills/scripts/workflows against docs to flag undocumented processes.

~1,300 new lines of documentation. Site grows from 77 to 85 pages.

## Test plan

- [x] `cd site && npm run build` succeeds (83 files synced, 85 pages built)
- [ ] All 7 new pages render on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)