### PR TITLE
feat: accurate session end-time via last_activity_at

### DIFF
--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -156,6 +156,7 @@ export interface HandoffRequest {
   session_id: string
   issue_number?: number
   payload?: Record<string, unknown>
+  last_activity_at?: string
 }
 
 export interface HandoffRecord {
@@ -702,6 +703,7 @@ export class CraneApi {
         summary: handoff.summary,
         status_label: handoff.status,
         issue_number: handoff.issue_number,
+        last_activity_at: handoff.last_activity_at,
         payload: handoff.payload ?? {},
       }),
     })

--- a/packages/crane-mcp/src/lib/session-log.test.ts
+++ b/packages/crane-mcp/src/lib/session-log.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for session-log.ts - Claude Code JSONL session log reader
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir, homedir } from 'node:os'
+
+// We need to mock homedir and process.ppid to control file paths
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return { ...actual, homedir: vi.fn(() => actual.homedir()) }
+})
+
+const getModule = async () => {
+  vi.resetModules()
+  return import('./session-log.js')
+}
+
+describe('session-log', () => {
+  let tempHome: string
+  let originalPpid: number
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), 'session-log-test-'))
+    vi.mocked(homedir).mockReturnValue(tempHome)
+    originalPpid = process.ppid
+  })
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true })
+    Object.defineProperty(process, 'ppid', { value: originalPpid, writable: true })
+    vi.restoreAllMocks()
+  })
+
+  function setupSessionFiles(sessionId: string, journalLines: string[], cwd?: string): void {
+    const pid = process.ppid
+    const effectiveCwd = cwd || process.cwd()
+
+    // Create ~/.claude/sessions/{ppid}.json
+    const sessionsDir = join(tempHome, '.claude', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    writeFileSync(
+      join(sessionsDir, `${pid}.json`),
+      JSON.stringify({ pid, sessionId, cwd: effectiveCwd, startedAt: Date.now() })
+    )
+
+    // Create ~/.claude/projects/{projectDir}/{sessionId}.jsonl
+    const projectDir = `-${effectiveCwd.replace(/\//g, '-').replace(/^-/, '')}`
+    const projectPath = join(tempHome, '.claude', 'projects', projectDir)
+    mkdirSync(projectPath, { recursive: true })
+    writeFileSync(join(projectPath, `${sessionId}.jsonl`), journalLines.join('\n') + '\n')
+  }
+
+  function assistantMsg(timestamp: string, text: string): string {
+    return JSON.stringify({
+      type: 'assistant',
+      timestamp,
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    })
+  }
+
+  function userMsg(timestamp: string, text: string): string {
+    return JSON.stringify({
+      type: 'user',
+      timestamp,
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    })
+  }
+
+  function toolResultMsg(timestamp: string): string {
+    return JSON.stringify({
+      type: 'user',
+      timestamp,
+      message: {
+        role: 'user',
+        content: [{ tool_use_id: 'tool_1', type: 'tool_result', content: 'ok' }],
+      },
+    })
+  }
+
+  it('returns timestamp of last assistant message', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    setupSessionFiles('sess-001', [
+      userMsg('2026-03-23T10:00:00.000Z', 'Fix the bug'),
+      assistantMsg('2026-03-23T10:01:00.000Z', 'Looking at the code...'),
+      toolResultMsg('2026-03-23T10:01:05.000Z'),
+      assistantMsg('2026-03-23T10:02:00.000Z', 'Fixed the bug.'),
+      userMsg('2026-03-23T10:03:00.000Z', 'Thanks'),
+    ])
+
+    const result = await getLastActivityTimestamp()
+    expect(result).toBe('2026-03-23T10:02:00.000Z')
+  })
+
+  it('returns last assistant message before /eod boundary', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    setupSessionFiles('sess-002', [
+      userMsg('2026-03-23T10:00:00.000Z', 'Fix the bug'),
+      assistantMsg('2026-03-23T10:01:00.000Z', 'Done fixing.'),
+      userMsg(
+        '2026-03-23T14:00:00.000Z',
+        '# /eod - End of Day Handoff\n\nAuto-generate handoff...'
+      ),
+      assistantMsg('2026-03-23T14:00:05.000Z', 'Here is your handoff summary...'),
+      assistantMsg('2026-03-23T14:00:10.000Z', 'Handoff saved to D1.'),
+    ])
+
+    const result = await getLastActivityTimestamp()
+    expect(result).toBe('2026-03-23T10:01:00.000Z')
+  })
+
+  it('returns null when session file not found', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    // No files set up
+    const result = await getLastActivityTimestamp()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when JSONL file is empty', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    setupSessionFiles('sess-003', [])
+
+    const result = await getLastActivityTimestamp()
+    expect(result).toBeNull()
+  })
+
+  it('handles malformed JSONL lines gracefully', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    setupSessionFiles('sess-004', [
+      assistantMsg('2026-03-23T10:00:00.000Z', 'Valid message'),
+      'not valid json at all',
+      '{"incomplete": true',
+      assistantMsg('2026-03-23T10:05:00.000Z', 'Another valid message'),
+    ])
+
+    const result = await getLastActivityTimestamp()
+    expect(result).toBe('2026-03-23T10:05:00.000Z')
+  })
+
+  it('returns null when no assistant messages exist', async () => {
+    const { getLastActivityTimestamp } = await getModule()
+
+    setupSessionFiles('sess-005', [
+      userMsg('2026-03-23T10:00:00.000Z', 'Hello'),
+      userMsg('2026-03-23T10:01:00.000Z', 'Anyone there?'),
+    ])
+
+    const result = await getLastActivityTimestamp()
+    expect(result).toBeNull()
+  })
+})

--- a/packages/crane-mcp/src/lib/session-log.ts
+++ b/packages/crane-mcp/src/lib/session-log.ts
@@ -1,0 +1,142 @@
+/**
+ * Claude Code session JSONL reader.
+ * Discovers the active session log and extracts the last activity timestamp.
+ *
+ * Used at EOD to determine when the agent actually stopped working,
+ * which may differ significantly from when /eod is run.
+ */
+
+import { readFileSync, openSync, readSync, closeSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+interface SessionFile {
+  pid: number
+  sessionId: string
+  cwd: string
+  startedAt: number
+}
+
+interface JournalEntry {
+  type?: string
+  timestamp?: string
+  message?: {
+    role?: string
+    content?: unknown
+  }
+}
+
+/**
+ * Get the timestamp of the last real agent activity from the Claude Code session log.
+ *
+ * Discovery: process.ppid → ~/.claude/sessions/{ppid}.json → sessionId → JSONL file.
+ * Then reads the tail of the JSONL to find the last assistant message before /eod.
+ *
+ * @returns ISO 8601 timestamp or null if discovery fails
+ */
+export async function getLastActivityTimestamp(): Promise<string | null> {
+  try {
+    // 1. Find Claude Code session ID via parent PID
+    const ppid = process.ppid
+    if (!ppid) return null
+
+    const sessionFilePath = join(homedir(), '.claude', 'sessions', `${ppid}.json`)
+    const sessionFile: SessionFile = JSON.parse(readFileSync(sessionFilePath, 'utf-8'))
+    const { sessionId } = sessionFile
+
+    // 2. Build JSONL path from cwd
+    const projectDir = `-${process.cwd().replace(/\//g, '-').replace(/^-/, '')}`
+    const jsonlPath = join(homedir(), '.claude', 'projects', projectDir, `${sessionId}.jsonl`)
+
+    // 3. Read tail of JSONL (last 64KB should contain recent messages)
+    const tail = readTail(jsonlPath, 64 * 1024)
+    if (!tail) return null
+
+    // 4. Parse lines backwards, find last assistant message before /eod
+    const lines = tail.split('\n').filter((l) => l.trim())
+
+    // First pass: find the /eod boundary (last user message containing /eod)
+    let eodTimestamp: string | null = null
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const entry = safeParse(lines[i])
+      if (!entry) continue
+
+      if (entry.type === 'user' && entry.timestamp) {
+        const content = extractTextContent(entry.message?.content)
+        if (content && /\/eod\b/i.test(content)) {
+          eodTimestamp = entry.timestamp
+          break
+        }
+      }
+    }
+
+    // Second pass: find the last assistant message before the /eod boundary
+    // If no /eod found, find the last assistant message period
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const entry = safeParse(lines[i])
+      if (!entry) continue
+
+      if (entry.type === 'assistant' && entry.timestamp) {
+        // If we found an /eod boundary, only accept messages before it
+        if (eodTimestamp && entry.timestamp >= eodTimestamp) continue
+        return entry.timestamp
+      }
+    }
+
+    return null
+  } catch {
+    // Best-effort: any failure returns null (caller falls back to current behavior)
+    return null
+  }
+}
+
+/**
+ * Read the last N bytes of a file.
+ */
+function readTail(filePath: string, bytes: number): string | null {
+  try {
+    const stats = statSync(filePath)
+    const fileSize = stats.size
+    const readSize = Math.min(bytes, fileSize)
+    const offset = fileSize - readSize
+
+    const fd = openSync(filePath, 'r')
+    try {
+      const buffer = Buffer.alloc(readSize)
+      readSync(fd, buffer, 0, readSize, offset)
+      return buffer.toString('utf-8')
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Safely parse a JSON line, returning null on failure.
+ */
+function safeParse(line: string): JournalEntry | null {
+  try {
+    return JSON.parse(line)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Extract text content from a message content field.
+ * Handles both string content and array-of-blocks content.
+ */
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (typeof block === 'string') return block
+      if (block && typeof block === 'object' && 'text' in block && typeof block.text === 'string') {
+        return block.text
+      }
+    }
+  }
+  return null
+}

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -8,6 +8,7 @@ import { mockRepoInfo } from '../__fixtures__/repo-fixtures.js'
 
 vi.mock('../lib/repo-scanner.js')
 vi.mock('../lib/session-state.js')
+vi.mock('../lib/session-log.js')
 
 const getModule = async () => {
   vi.resetModules()
@@ -104,6 +105,70 @@ describe('handoff tool', () => {
     expect(body.summary).toBe('Test')
     expect(body.status_label).toBe('done')
     expect(body.payload).toEqual({})
+  })
+
+  it('includes last_activity_at when session log is available', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+    const { getLastActivityTimestamp } = await import('../lib/session-log.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_abc',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+    vi.mocked(getLastActivityTimestamp).mockResolvedValue('2026-03-23T15:30:00.000Z')
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: mockVentures }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    await executeHandoff({ summary: 'Test', status: 'done' })
+
+    const eodCall = mockFetch.mock.calls[1]
+    const body = JSON.parse(eodCall[1].body)
+    expect(body.last_activity_at).toBe('2026-03-23T15:30:00.000Z')
+  })
+
+  it('omits last_activity_at when session log discovery fails', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+    const { getLastActivityTimestamp } = await import('../lib/session-log.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_abc',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+    vi.mocked(getLastActivityTimestamp).mockResolvedValue(null)
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: mockVentures }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    await executeHandoff({ summary: 'Test', status: 'done' })
+
+    const eodCall = mockFetch.mock.calls[1]
+    const body = JSON.parse(eodCall[1].body)
+    expect(body.last_activity_at).toBeUndefined()
   })
 
   it('returns error when no session active', async () => {

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -10,6 +10,7 @@ import { CraneApi } from '../lib/crane-api.js'
 import { getApiBase } from '../lib/config.js'
 import { getCurrentRepoInfo, findVentureByRepo } from '../lib/repo-scanner.js'
 import { getSessionContext } from '../lib/session-state.js'
+import { getLastActivityTimestamp } from '../lib/session-log.js'
 
 export const handoffInputSchema = z.object({
   summary: z.string().describe('Summary of work completed and any in-progress items'),
@@ -90,6 +91,14 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
   }
 
   try {
+    // Best-effort: discover last real activity from Claude Code session log
+    let lastActivityAt: string | undefined
+    try {
+      lastActivityAt = (await getLastActivityTimestamp()) ?? undefined
+    } catch {
+      // Non-fatal: fall back to current behavior (ended_at = now)
+    }
+
     await api.createHandoff({
       venture: venture.code,
       repo: currentRepo,
@@ -98,6 +107,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
       status: input.status,
       session_id: session.sessionId,
       issue_number: input.issue_number,
+      last_activity_at: lastActivityAt,
     })
 
     // Dual-write: also write .claude/handoff.md as a disposable cache for CC's native /resume.

--- a/workers/crane-context/migrations/0018_add_last_activity_at.sql
+++ b/workers/crane-context/migrations/0018_add_last_activity_at.sql
@@ -1,0 +1,5 @@
+-- Migration 0018: Add last_activity_at for accurate session end-time tracking
+-- When /eod runs late, last_activity_at captures when the agent actually stopped working
+-- (derived from Claude Code session JSONL logs at handoff time)
+
+ALTER TABLE sessions ADD COLUMN last_activity_at TEXT;

--- a/workers/crane-context/migrations/schema.sql
+++ b/workers/crane-context/migrations/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE sessions (
   started_at TEXT NOT NULL,              -- Same as created_at (semantic)
   last_heartbeat_at TEXT NOT NULL,       -- Drives staleness detection
   ended_at TEXT,
+  last_activity_at TEXT,                 -- When agent last did real work (from session JSONL)
   end_reason TEXT,                       -- manual, stale, superseded, error
 
   -- Schema versioning (Captain approved)

--- a/workers/crane-context/src/endpoints/queries.ts
+++ b/workers/crane-context/src/endpoints/queries.ts
@@ -625,7 +625,7 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
 
     // Query ended sessions since cutoff with detail fields
     const result = await env.DB.prepare(
-      `SELECT venture, created_at, ended_at, host, repo, branch, issue_number
+      `SELECT venture, created_at, ended_at, last_activity_at, host, repo, branch, issue_number
        FROM sessions
        WHERE status = 'ended'
          AND ended_at IS NOT NULL
@@ -637,6 +637,7 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
         venture: string
         created_at: string
         ended_at: string
+        last_activity_at: string | null
         host: string | null
         repo: string | null
         branch: string | null
@@ -683,12 +684,14 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
       const key = `${venture}:${workDate}`
       const existing = aggregation.get(key)
 
+      const effectiveEnd = row.last_activity_at || row.ended_at
+
       if (existing) {
         if (row.created_at < existing.earliest_start) {
           existing.earliest_start = row.created_at
         }
-        if (row.ended_at > existing.latest_end) {
-          existing.latest_end = row.ended_at
+        if (effectiveEnd > existing.latest_end) {
+          existing.latest_end = effectiveEnd
         }
         existing.session_count++
       } else {
@@ -696,7 +699,7 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
           venture,
           work_date: workDate,
           earliest_start: row.created_at,
-          latest_end: row.ended_at,
+          latest_end: effectiveEnd,
           session_count: 1,
           hosts: new Set(),
           repos: new Set(),

--- a/workers/crane-context/src/endpoints/sessions.ts
+++ b/workers/crane-context/src/endpoints/sessions.ts
@@ -64,6 +64,7 @@ interface EndOfDayBody {
   summary: string
   payload?: Record<string, unknown>
   end_reason?: string
+  last_activity_at?: string
   update_id?: string
 }
 
@@ -518,7 +519,12 @@ export async function handleEndOfDay(request: Request, env: Env): Promise<Respon
       })
 
       // 6. End session
-      const endedAt = await endSession(env.DB, body.session_id, body.end_reason || 'manual')
+      const endedAt = await endSession(
+        env.DB,
+        body.session_id,
+        body.end_reason || 'manual',
+        body.last_activity_at
+      )
 
       // 7. Build response
       const responseData = {

--- a/workers/crane-context/src/sessions.ts
+++ b/workers/crane-context/src/sessions.ts
@@ -269,13 +269,16 @@ export async function updateSession(
 export async function endSession(
   db: D1Database,
   sessionId: string,
-  end_reason: string = 'manual'
+  end_reason: string = 'manual',
+  last_activity_at?: string
 ): Promise<string> {
   const now = nowIso()
 
   await db
-    .prepare('UPDATE sessions SET status = ?, ended_at = ?, end_reason = ? WHERE id = ?')
-    .bind('ended', now, end_reason, sessionId)
+    .prepare(
+      'UPDATE sessions SET status = ?, ended_at = ?, end_reason = ?, last_activity_at = ? WHERE id = ?'
+    )
+    .bind('ended', now, end_reason, last_activity_at || null, sessionId)
     .run()
 
   return now
@@ -288,12 +291,13 @@ export async function endSession(
  * @param sessionId - Session ID
  */
 export async function markSessionAbandoned(db: D1Database, sessionId: string): Promise<void> {
-  // Use last_heartbeat_at as ended_at for abandoned sessions
+  // Use last_heartbeat_at as ended_at and last_activity_at for abandoned sessions
   await db
     .prepare(
       `UPDATE sessions
        SET status = 'abandoned',
            ended_at = last_heartbeat_at,
+           last_activity_at = last_heartbeat_at,
            end_reason = 'stale'
        WHERE id = ?`
     )

--- a/workers/crane-context/src/types.ts
+++ b/workers/crane-context/src/types.ts
@@ -69,6 +69,7 @@ export interface SessionRecord {
   started_at: string
   last_heartbeat_at: string
   ended_at: string | null
+  last_activity_at: string | null
   end_reason: EndReason | null
 
   // Grouping (for parallel agent awareness)

--- a/workers/crane-context/test/sessions.test.ts
+++ b/workers/crane-context/test/sessions.test.ts
@@ -39,6 +39,7 @@ function createMockSession(overrides: Partial<SessionRecord> = {}): SessionRecor
     started_at: nowIso(),
     last_heartbeat_at: nowIso(),
     ended_at: null,
+    last_activity_at: null,
     end_reason: null,
     schema_version: '1.0',
     actor_key_id: '9f86d081884c7d65',


### PR DESCRIPTION
## Summary

- When `/eod` runs late (minutes/hours after actual work ends), `ended_at` reflects when `/eod` was called, not when the agent stopped working — this skews `/calendar-sync` reporting
- At handoff time, the MCP server now reads the Claude Code session JSONL log to find the timestamp of the last assistant message before `/eod`
- Stored as `last_activity_at` on the session record; session history aggregation uses it (falling back to `ended_at`) so calendar-sync automatically gets accurate work blocks

## Changes

**Worker (crane-context):**
- D1 migration 0018: add `last_activity_at TEXT` column to sessions
- `endSession()` and `markSessionAbandoned()` store `last_activity_at`
- EOD endpoint accepts `last_activity_at` from request body
- Session history aggregation uses `last_activity_at || ended_at` for `latest_end`

**MCP (crane-mcp):**
- New `session-log.ts`: discovers Claude Code JSONL via PID-based lookup, extracts last activity timestamp
- `handoff.ts`: calls `getLastActivityTimestamp()` before creating handoff (best-effort, falls back gracefully)
- `crane-api.ts`: `HandoffRequest` includes `last_activity_at` field

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + 268 tests + build)
- [ ] Deploy migration to staging + production
- [ ] Deploy worker to staging + production
- [ ] Build + link crane-mcp locally
- [ ] Run `/sod` → do work → wait → run `/eod` → verify `last_activity_at < ended_at` in D1
- [ ] Run `/calendar-sync` → verify calendar event end time reflects actual work

🤖 Generated with [Claude Code](https://claude.com/claude-code)