### PR TITLE
docs: Design System section quality upgrade

### DIFF
--- a/docs/design-system/brand-architecture.md
+++ b/docs/design-system/brand-architecture.md
@@ -1,37 +1,45 @@
-# Design & Branding
+---
+title: 'Brand Architecture'
+sidebar:
+  order: 30
+---
 
-Shared visual identity and design standards across all Venture Crane products.
+# Brand Architecture
 
-## Brand Architecture
+Brand architecture defines how a portfolio of products relates visually. In a multi-venture operation, the challenge is balance: ventures need enough shared DNA to feel like they belong together, but enough distinction that users don't confuse one product for another. This page documents the visual family, shared elements, and principles that hold the portfolio together.
 
-| Brand              | Purpose                      | Domain               |
-| ------------------ | ---------------------------- | -------------------- |
-| Venture Crane      | Development lab, methodology | venturecrane.com     |
-| Durgan Field Guide | Auction intelligence         | durganfieldguide.com |
-| Silicon Crane      | VaaS product                 | siliconcrane.com     |
-| Kid Expenses       | Expense tracking             | TBD                  |
-| Draft Crane        | Book-writing tool            | TBD                  |
+## The Venture Family
+
+| Brand              | Purpose                      | Tagline                              | Domain               |
+| ------------------ | ---------------------------- | ------------------------------------ | -------------------- |
+| Venture Crane      | Development lab, methodology | Build what matters, measure the rest | venturecrane.com     |
+| Durgan Field Guide | Auction intelligence         | Navigate auctions with confidence    | durganfieldguide.com |
+| Silicon Crane      | VaaS product                 | Venture-as-a-Service                 | siliconcrane.com     |
+| Kid Expenses       | Expense tracking             | Teach money by tracking it           | TBD                  |
+| Draft Crane        | Book-writing tool            | From draft to done                   | TBD                  |
 
 ## Shared Elements
 
 ### Color System
 
-See per-venture design specs for token definitions: `crane_doc('{code}', 'design-spec.md')`
+Each venture defines its own color tokens through a design spec (`crane_doc('{code}', 'design-spec.md')`), but the palette philosophy is shared: high-contrast, accessibility-first, and built for dark interfaces. The portfolio leans toward deep indigo backgrounds with amber and gold accents - a visual signature that connects ventures without making them identical.
 
 ### Typography
 
-- Headlines: System fonts for performance
-- Body: Optimized for readability
+All ventures use system font stacks for headlines and body text. This is a deliberate performance choice: system fonts load instantly, render consistently across platforms, and eliminate the layout shift that web fonts cause. The trade-off (less typographic personality) is acceptable because the ventures' identity comes from color, spacing, and layout - not from a custom typeface.
+
+Individual ventures may layer on specific fonts where justified. Kid Expenses uses Geist for its app interface; Draft Crane may adopt a serif for long-form reading. These are venture-level decisions, not portfolio-level.
 
 ### Imagery
 
-- Crane bird motif across all brands
-- Golden orb/blueprint symbolism
-- Deep indigo backgrounds with amber/gold highlights
+- **Crane bird motif** across all brands - the unifying visual element
+- **Golden orb/blueprint symbolism** - represents precision and methodology
+- **Deep indigo backgrounds with amber/gold highlights** - the portfolio's color signature
+- **Photography: minimal** - the ventures are tool-focused, not lifestyle brands
 
 ## Design Principles
 
-1. **Configuration over custom** - Use design tokens and component patterns, not custom CSS
-2. **Performance first** - Every visual choice considers load time
-3. **Portable** - Designs exportable as JSON/CSS tokens
-4. **Cohesive family** - Products share DNA but have distinct personality
+1. **Tokens over magic numbers** - Named variables that communicate intent. `var(--vc-color-accent)` tells the next developer what that color means; `#f59e0b` tells them nothing.
+2. **Performance first** - Every visual choice considers load time. System fonts over web fonts. CSS custom properties over runtime theming. No decorative assets that don't earn their bytes.
+3. **Portable identity** - Designs export as JSON and CSS tokens, not as framework-specific components. A venture's visual identity works in Astro, Next.js, or anything that reads CSS custom properties.
+4. **Family, not clones** - Ventures share DNA (color philosophy, typography approach, spacing scale) but express distinct personalities. Kid Expenses is bright and approachable. Venture Crane is dark and technical. The system enables both without either breaking the family resemblance.

--- a/docs/design-system/index.md
+++ b/docs/design-system/index.md
@@ -1,0 +1,25 @@
+---
+title: 'Design System'
+sidebar:
+  order: 0
+---
+
+# Design System
+
+A design system is the shared language between design decisions and code. It defines the colors, typography, spacing, and component patterns that make a product look and feel intentional - not accidental.
+
+Venture Crane runs a portfolio of products. Without a shared system, each venture would drift into its own visual dialect: different button styles, inconsistent spacing, incompatible color palettes. The design system prevents that. It gives every venture a common foundation while preserving room for distinct personality. Venture Crane and Kid Expenses share DNA, but they don't look like clones.
+
+## Who This Is For
+
+**Implementing UI for a venture?** Start with [Design System Overview](overview.md). It explains how specs are structured, where tokens live, and how to contribute new ones. Then load the venture's design spec (`crane_doc('{code}', 'design-spec.md')`) for the actual values.
+
+**Launching a new venture?** Read [Brand Architecture](brand-architecture.md) first to understand the visual family, then follow the new venture setup process in the overview.
+
+**Maintaining or extending tokens?** [Token Taxonomy](token-taxonomy.md) is your reference. It covers naming conventions, categories, and the standards that keep the system coherent as it grows.
+
+## How This Section Is Organized
+
+- **[Design System Overview](overview.md)** - How the system works end-to-end: spec structure, maturity tiers, contribution process, and per-venture references.
+- **[Token Taxonomy](token-taxonomy.md)** - The naming conventions and rules that govern CSS custom properties across all ventures.
+- **[Brand Architecture](brand-architecture.md)** - Shared visual identity, design principles, and the family relationships between ventures.

--- a/docs/design-system/overview.md
+++ b/docs/design-system/overview.md
@@ -1,6 +1,14 @@
+---
+title: 'Design System Overview'
+sidebar:
+  order: 10
+---
+
 # Design System Overview
 
-The Venture Crane design system is a multi-venture, token-based approach to visual design. Each venture maintains its own design spec with venture-prefixed CSS custom properties, while sharing a common taxonomy, contribution process, and maturity model.
+Running six ventures means six codebases, six sets of UI decisions, and six opportunities for visual drift. Without guardrails, every new feature becomes an ad hoc design exercise - agents pick colors by gut, spacing by eyeball, and typography by whatever the last commit used. Multiply that across a portfolio and you get products that feel disconnected from each other and inconsistent within themselves.
+
+The Venture Crane design system solves this with a token-based approach. Each venture maintains its own design spec - a single document defining that venture's visual identity through CSS custom properties. The specs share a common naming taxonomy (`--{prefix}-{category}-{variant}`) and contribution process, but the actual values are venture-specific. The result: agents always have a clear, authoritative source for every visual decision, and ventures look like members of the same family without looking identical.
 
 ## How It Works
 
@@ -25,7 +33,7 @@ Each spec contains:
 
 ## Design Maturity Tiers
 
-Not all ventures are at the same level of design maturity. The tier determines how agents approach design work:
+Not all ventures are at the same stage. A Tier 1 venture like Kid Expenses has a complete token system with documented components - agents can build confidently. A Tier 3 venture like Silicon Crane has proposed tokens that may not be implemented yet. The tier determines how agents approach design work:
 
 | Tier            | Ventures   | State                                         | Approach                                                               |
 | --------------- | ---------- | --------------------------------------------- | ---------------------------------------------------------------------- |

--- a/docs/design-system/token-taxonomy.md
+++ b/docs/design-system/token-taxonomy.md
@@ -1,4 +1,12 @@
+---
+title: 'Token Taxonomy'
+sidebar:
+  order: 20
+---
+
 # Token Taxonomy
+
+Design tokens are named variables that replace raw values in code. Instead of scattering `#f59e0b` through stylesheets - where it means nothing to the next person reading it - you write `var(--vc-color-accent)`. The name communicates intent: this is Venture Crane's accent color. If the accent color changes, it changes everywhere. If an agent is building a new component, the token name tells it exactly which value to use without consulting a design file.
 
 All ventures use a shared naming convention for CSS custom properties. This ensures consistency across the portfolio while allowing each venture its own visual identity.
 
@@ -28,14 +36,14 @@ The following categories are the cross-venture minimum. Individual ventures may 
 | `radius-`    | Border radius    | `--vc-radius-md`                             |
 | `shadow-`    | Box shadows      | `--dc-shadow-card`                           |
 
-## Token Discipline
+## Token Standards
 
 These rules apply to all ventures:
 
-- **Always use venture-prefixed tokens.** Write `var(--vc-surface)`, `var(--ke-accent)` — never hardcode hex values.
-- **No raw Tailwind color classes** in ventures that have semantic tokens. Use `bg-ke-bg` not `bg-slate-50`.
-- **Check the spec's Tailwind @theme mapping** to find the correct utility class name for each token.
-- **Respect design maturity.** Tier 1 ventures (VC, KE, DC) have complete systems — use what exists. Tier 3 ventures (SC, DFG) have proposed tokens — confirm they're implemented before using.
+- **Always use venture-prefixed tokens.** Write `var(--vc-surface)`, `var(--ke-accent)` - never hardcode hex values. Raw values create invisible coupling: when a color changes, you have to find every place it was copy-pasted.
+- **No raw Tailwind color classes** in ventures that have semantic tokens. Use `bg-ke-bg` not `bg-slate-50`. Semantic classes map to tokens, so theme changes propagate automatically.
+- **Check the spec's Tailwind @theme mapping** to find the correct utility class name for each token. The mapping is the bridge between the token system and Tailwind's utility layer.
+- **Respect design maturity.** Tier 1 ventures (VC, KE, DC) have complete systems - use what exists. Tier 3 ventures (SC, DFG) have proposed tokens - confirm they're implemented before using.
 - **Spacing uses scale steps, not pixel names.** `--vc-space-4` not `--vc-space-16px`. The value may change across breakpoints; the name stays stable.
 
 ## Adding Tokens

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -61,7 +61,7 @@ All ventures use a common taxonomy: `--{prefix}-{category}-{variant}`
 
 Some ventures have additional categories (DC has `motion-`, `z-`, `safe-area-`). The categories above are the minimum.
 
-## Token Discipline
+## Token Standards
 
 - **Always use venture-prefixed tokens** (`var(--vc-surface)`, `var(--ke-accent)`). Never hardcode hex values.
 - **No raw Tailwind color classes** in ventures that have semantic tokens. Use `bg-ke-bg` not `bg-slate-50`.


### PR DESCRIPTION
## Summary

- **New landing page** (`index.md`) with reader personas and section orientation - "Design System" sidebar label becomes clickable
- **Enhanced overview and token taxonomy** with introductory context explaining the why, not just the what
- **Rewrote brand architecture** with expanded principles, tagline column, and rationale for shared elements
- **Renamed "Token Discipline" to "Token Standards"** in both human-facing docs and agent directive for consistency

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, 268 tests)
- [x] `cd site && npm run build` succeeds - all 4 design-system pages render
- [ ] Preview deploy: "Design System" sidebar label is clickable, pages appear in order (index, overview, taxonomy, brand-architecture)
- [ ] No duplicate h1 on any page
- [ ] All existing technical content preserved

`qa-grade:0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)