### PR TITLE
docs: add infra/ and operations/ section index pages

### DIFF
--- a/docs/infra/index.md
+++ b/docs/infra/index.md
@@ -1,0 +1,27 @@
+---
+title: 'Infrastructure'
+sidebar:
+  order: 0
+---
+
+# Infrastructure
+
+Infrastructure is how we provision machines, manage secrets, connect services, and operate the fleet. These documents cover the platform architecture, the development machine fleet, and security foundations.
+
+## Who This Is For
+
+**Managing the fleet?** Start with [Machine Inventory](machine-inventory.md) for the current machine roster and [SSH Access via Tailscale](ssh-tailscale-access.md) for connectivity setup.
+
+**Understanding the platform?** Read [Product Infrastructure Strategy](product-infrastructure-strategy.md) for the entity structure and Cloudflare naming conventions, then [Crane Context MCP Server Spec](crane-context-mcp-spec.md) for the session management architecture.
+
+**Working with secrets?** Go straight to [Secrets Management](secrets-management.md) for Infisical setup, venture paths, and provisioning patterns.
+
+Not finding what you need? Browse the full list below - these categories are starting points, not silos.
+
+## How This Section Is Organized
+
+- **[Crane Context MCP Server Spec](crane-context-mcp-spec.md)** - The architecture for SOD/EOD workflow via MCP tools instead of bash scripts
+- **[Machine Inventory](machine-inventory.md)** - Development machine roster with Tailscale IPs, SSH aliases, and installed tooling
+- **[Product Infrastructure Strategy](product-infrastructure-strategy.md)** - The entity structure, GitHub orgs, Cloudflare account model, and resource naming conventions
+- **[Secrets Management](secrets-management.md)** - Infisical setup, venture folder structure, shared secrets, and safe provisioning patterns
+- **[SSH Access via Tailscale](ssh-tailscale-access.md)** - Complete guide for SSH connections across the fleet using Tailscale network

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,24 @@
+---
+title: 'Operations'
+sidebar:
+  order: 0
+---
+
+# Operations
+
+Operations describes how the business runs - the philosophy guiding resource allocation, the portfolio of ventures, and the infrastructure backbone that supports them all.
+
+## Who This Is For
+
+**Understanding the philosophy?** Read [Operating Principles](operating-principles.md) for the core tenets (demand is the compass, kill fast, reusable always) and lifecycle stages.
+
+**Reviewing the portfolio?** Check [Product Portfolio](product-portfolio.md) for the current roster of active ventures and their lifecycle stages.
+
+**Setting up a product workspace?** Reference [Product Teamspace Template](product-teamspace-template.md) for the standard documentation structure, then [Shared Infrastructure](shared-infrastructure.md) for the technical backbone every venture uses.
+
+## How This Section Is Organized
+
+- **[Operating Principles](operating-principles.md)** - Core philosophy, product lifecycle stages, resource allocation priority, and quality standards
+- **[Product Portfolio](product-portfolio.md)** - Overview of all products built and operated by Venture Crane with lifecycle stages
+- **[Product Teamspace Template](product-teamspace-template.md)** - Standard structure for venture documentation (overview, roadmap, metrics, feedback)
+- **[Shared Infrastructure](shared-infrastructure.md)** - The technical backbone (workers, analytics, Cloudflare stack) shared across all ventures


### PR DESCRIPTION
## Summary

- Created index pages for the infra/ and operations/ documentation sections
- infra/ (5 files): grouped by concern - fleet management, platform architecture, security
- operations/ (4 files): lighter treatment framing how the business operates
- Both follow the design-system index pattern: problem-solution intro, persona routing, annotated TOC

## Test plan

- [x] Read all files in both sections for accurate one-line descriptions
- [x] Verified frontmatter follows pattern (sidebar order: 0)
- [x] No em dashes used
- [ ] Site build passes
- [ ] Full verification suite passes
- [ ] Index appears first in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)