### PR TITLE
docs: add ventures/ portfolio index page

### DIFF
--- a/docs/ventures/index.md
+++ b/docs/ventures/index.md
@@ -1,0 +1,31 @@
+---
+title: 'Portfolio Overview'
+sidebar:
+  order: 0
+---
+
+# Portfolio Overview
+
+SMDurgan LLC builds and operates a portfolio of digital products. Each venture targets a distinct market and operates on its own timeline, but they share infrastructure, design DNA, and the same AI-native development process.
+
+This page is the entry point for understanding what we're building and where each venture stands.
+
+## The Portfolio
+
+{{portfolio:table}}
+
+## Who This Is For
+
+**Evaluating a venture?** Start with its product overview for mission, market, and current stage. Then check its roadmap for what's planned and its metrics for how it's performing.
+
+**Working on a specific venture?** Go directly to the venture's section in the sidebar. Each venture has its own product overview, roadmap, and metrics - load the venture's design spec (`crane_doc('{code}', 'design-spec.md')`) if you're doing UI work.
+
+**Understanding the portfolio strategy?** Read [Strategic Planning](../company/strategic-planning.md) for capital allocation principles and the evaluation framework, or [Product Portfolio](../operations/product-portfolio.md) for the operational view.
+
+## Venture Entry Points
+
+- **[Venture Crane](vc/product-overview.md)** - AI-native venture studio infrastructure: session management, context persistence, fleet orchestration, and agent tooling.
+- **[Durgan Field Guide](dfg/product-overview.md)** - AI-powered toolkit for buying and flipping physical goods at auction with structured evaluation and discipline enforcement.
+- **[Silicon Crane](sc/product-overview.md)** - Validation-as-a-Service: structured 30-day sprints that produce Go/Kill/Pivot decisions with real market evidence.
+- **[Kid Expenses](ke/product-overview.md)** - Expense tracking for co-parents: log, split, and settle child-related costs without conflict.
+- **[Draft Crane](dc/product-overview.md)** - Structured writing environment for experts turning their knowledge into publishable nonfiction books.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -36,6 +36,8 @@ export default defineConfig({
         {
           label: 'Ventures',
           items: [
+            // Manual entry - ventures/index.md isn't picked up by per-venture autogenerate
+            { label: 'Portfolio Overview', slug: 'ventures' },
             { label: 'Venture Crane', autogenerate: { directory: 'ventures/vc' } },
             { label: 'Durgan Field Guide', autogenerate: { directory: 'ventures/dfg' } },
             { label: 'Silicon Crane', autogenerate: { directory: 'ventures/sc' } },


### PR DESCRIPTION
## Summary

- Created portfolio index page for the ventures/ section with entry points to all 5 ventures
- Uses `{{portfolio:table}}` template token (processed by sync-docs.mjs) for dynamic portfolio table
- Added manual sidebar entry in astro.config.mjs since ventures/index.md isn't picked up by per-venture autogenerate
- Includes persona-based routing for venture evaluation, venture-specific work, and portfolio strategy

## Changes

- `docs/ventures/index.md` - new portfolio overview index page
- `site/astro.config.mjs` - added manual "Portfolio Overview" sidebar entry at top of Ventures group

## Test plan

- [x] Read all 5 venture product-overviews for accurate descriptions
- [x] Verified frontmatter (sidebar order: 0)
- [x] No em dashes
- [x] Pre-push verification passed (typecheck, format, lint, 268 tests)
- [ ] Site build passes ({{portfolio:table}} token is replaced by sync-docs.mjs at build time)
- [ ] Portfolio Overview appears first in Ventures sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)