### PR TITLE
docs: add company/, standards/, and adr/ section index pages

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,36 @@
+---
+title: 'Decisions'
+sidebar:
+  order: 0
+---
+
+# Architecture Decision Records
+
+ADRs are immutable records of significant technical decisions. They capture the context, alternatives considered, and consequences of architectural choices that shape Venture Crane infrastructure.
+
+## Current Records
+
+- **[025: Crane Context Worker](025-crane-context-worker.md)** - Structured session tracking and typed handoffs via Cloudflare Worker + D1
+- **[026: Environment Strategy](026-environment-strategy.md)** - Staging/production split using Cloudflare native environments
+
+## What ADRs Are
+
+Architecture Decision Records document decisions that are hard to reverse and affect multiple ventures or the core platform. They provide historical context for why systems are designed the way they are.
+
+Each ADR includes:
+
+- The context and problem being solved
+- The decision and its rationale
+- Alternatives considered and why they were rejected
+- Consequences (positive, negative, and neutral)
+
+## Proposing New ADRs
+
+When facing a significant architectural choice:
+
+1. Draft the ADR following the format of existing records
+2. Include context, alternatives, and trade-offs
+3. Get review from the Captain and relevant stakeholders
+4. Merge as committed once approved
+
+ADRs are numbered sequentially (025, 026, etc.) and stored in this directory.

--- a/docs/company/index.md
+++ b/docs/company/index.md
@@ -1,0 +1,23 @@
+---
+title: 'Company'
+sidebar:
+  order: 0
+---
+
+# Company
+
+SMDurgan LLC is the parent entity for all Venture Crane operations. It provides the legal, financial, and operational foundation for building and scaling profitable digital businesses.
+
+## What You'll Find Here
+
+- **[Company Overview](company-overview.md)** - Mission, entity structure, and organizational identity
+- **[Financial Dashboard](financial-dashboard.md)** - Portfolio performance, revenue streams, expense categories, and banking setup
+- **[Strategic Planning](strategic-planning.md)** - Capital allocation principles, portfolio evaluation framework, and risk register
+
+## Who This Is For
+
+**Need company context for a venture decision?** Start with Company Overview to understand the entity structure and what SMDurgan LLC is (and isn't).
+
+**Working on financial planning or budget allocation?** The Financial Dashboard provides current portfolio performance metrics and expense tracking.
+
+**Evaluating new ventures or making portfolio decisions?** Strategic Planning outlines the framework for capital allocation and risk assessment.

--- a/docs/standards/index.md
+++ b/docs/standards/index.md
@@ -1,0 +1,27 @@
+---
+title: 'Standards'
+sidebar:
+  order: 0
+---
+
+# Standards
+
+Templates and patterns for building quality software across the Venture Crane portfolio. These standards make best practices the easy path.
+
+## What You'll Find Here
+
+- **[Golden Path](golden-path.md)** - The supported way to build Venture Crane products, with tiered compliance requirements
+- **[API Structure Template](api-structure-template.md)** - Standard directory structure for Hono-based Cloudflare Workers APIs
+- **[NFR Assessment Template](nfr-assessment-template.md)** - Code quality and non-functional requirements review checklist
+
+## Who This Is For
+
+**Starting a new venture?** The Golden Path defines the infrastructure stack, tooling, and quality gates at each stage (Validation, Growth, Scale/Exit).
+
+**Building a new API worker?** The API Structure Template provides the standard directory layout, middleware patterns, and service layer separation.
+
+**Reviewing code quality across ventures?** The NFR Assessment Template ensures consistent evaluation of testing, security, accessibility, and documentation.
+
+## How These Standards Work
+
+Standards are enablement, not enforcement. The Golden Path makes the right thing the easy thing - ventures that follow it get faster setup, shared tooling, and better positioning for scale or exit. Exceptions are fine; undocumented exceptions are not.


### PR DESCRIPTION
## Summary

- Created `docs/company/index.md` with TOC for organizational context (company overview, financial dashboard, strategic planning)
- Created `docs/standards/index.md` with TOC for templates and patterns (golden path, API structure template, NFR assessment template)
- Created `docs/adr/index.md` with TOC for architecture decision records (ADR 025, 026)

All three follow the established pattern from `docs/design-system/index.md` (no em dashes, relative .md links, `sidebar: order: 0`, minimal-but-useful persona sections).

## Test Plan

- [x] Build site locally: `cd site && npm run build`
- [x] Verify no broken links in index pages
- [x] Verify frontmatter renders correctly in Starlight
- [x] Run `npm run verify` from repo root

Generated with [Claude Code](https://claude.com/claude-code)