### PR TITLE
docs: add instructions/ and runbooks/ section index pages

### DIFF
--- a/docs/instructions/index.md
+++ b/docs/instructions/index.md
@@ -1,0 +1,40 @@
+---
+title: 'Agent Directives'
+sidebar:
+  order: 0
+---
+
+# Agent Directives
+
+This section mirrors the instruction modules listed in CLAUDE.md. If you're mid-session, use the table in CLAUDE.md for quick `crane_doc()` lookups. If you're exploring or learning the system, continue here for context on each directive.
+
+Agent directives are governance docs - the rules agents must follow when working across the Venture Crane portfolio. They codify policy decisions that were discovered through practice: what went wrong when an agent made assumptions, what patterns prevent drift, which boundaries keep the system coherent.
+
+## Who This Is For
+
+**Agents in active sessions:** Reference the CLAUDE.md instruction modules table. Load directives via `crane_doc('global', '<module>')` when the context requires it.
+
+**Agents learning the system:** Read this section to understand the full governance model before taking on production work.
+
+**Team leads and Captain:** Update directives when new governance gaps are discovered. The SOD summary mechanism keeps these in sync with session context automatically.
+
+## How This Section Is Organized
+
+### Content & Publishing
+
+- **[Content Policy](content-policy.md)** - VCMS storage rules, tag vocabulary, AI agent authorship stance, and writing style standards.
+- **[Creating GitHub Issues](creating-issues.md)** - Work item templates, label conventions, and target repos for backlog management.
+
+### Development
+
+- **[Guardrails](guardrails.md)** - Protected actions requiring Captain approval: feature deprecation, schema changes, and auth modifications.
+
+### Design
+
+- **[Wireframe Guidelines](wireframe-guidelines.md)** - When to generate wireframes, file conventions, quality bar, and conflict resolution between ACs and wireframes.
+- **[Design System](design-system.md)** - How to load venture design specs, token naming conventions, and design maturity tiers.
+
+### Infrastructure
+
+- **[Fleet Operations](fleet-ops.md)** - SSH mesh setup, Tailscale bootstrap phases, macOS hardening, and remote conflict patterns.
+- **[Secrets Management](secrets.md)** - Infisical integration, GitHub App details, vault storage, and secret provisioning rules.

--- a/docs/runbooks/index.md
+++ b/docs/runbooks/index.md
@@ -1,0 +1,35 @@
+---
+title: 'Runbooks'
+sidebar:
+  order: 0
+---
+
+# Runbooks
+
+Step-by-step procedures for infrastructure setup, operations, and troubleshooting. Runbooks are task-oriented - they assume you have a specific goal and walk you through the exact commands to achieve it.
+
+These are not governance docs (see [Agent Directives](../instructions/index.md) for policy). Runbooks are executable checklists: bootstrap a new machine, configure an iPad for remote access, diagnose a TLS failure. They tell you what to do, not why the policy exists.
+
+## Who This Is For
+
+**Setting up a new machine?** Start with the setup runbook for your platform type, then verify the environment with the post-setup checklist.
+
+**Operating from iPad or mobile?** Follow the Blink Shell guide to configure SSH and Mosh access to fleet machines.
+
+**Debugging infrastructure issues?** Check the troubleshooting runbooks for known failure patterns and diagnostic commands.
+
+## How This Section Is Organized
+
+### Setup
+
+- **[New Mac Setup](new-mac-setup.md)** - Bootstrap a macOS machine into the fleet: Tailscale, dev tools, SSH mesh, and security hardening.
+- **[New Box Onboarding](new-box-onboarding.md)** - Add an Ubuntu/Xubuntu machine with automated bootstrap script and manual verification steps.
+- **[New Environment Setup](new-environment-setup.md)** - General development environment checklist for any platform: tools, secrets, permissions, and validation tests.
+
+### Operations
+
+- **[Blink Shell Quick Start](blink-shell-quick-start.md)** - Configure iPad/iPhone SSH access using Blink Shell for remote fleet operations.
+
+### Troubleshooting
+
+- **[PM Container TLS Troubleshooting](pm-container-tls-troubleshooting.md)** - Diagnose and fix TLS certificate verification failures in Claude Desktop containers.


### PR DESCRIPTION
## Summary

- Created index pages for the instructions/ (Agent Directives) and runbooks/ sections
- instructions/ (7 files): explicitly complements the CLAUDE.md instruction modules table, grouped by Content & Publishing, Development, Design, Infrastructure
- runbooks/ (5 files): task-oriented grouping by Setup, Operations, Troubleshooting
- Both follow the design-system index pattern: problem-solution intro, persona routing, annotated TOC

## Test plan

- [x] Read all files for accurate one-line descriptions
- [x] Verified frontmatter (sidebar order: 0)
- [x] No em dashes
- [x] Pre-push verification passed (typecheck, format, lint, 268 tests)
- [ ] Site build passes
- [ ] Index appears first in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)