### PR TITLE
feat: session history block merging

### DIFF
--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -380,16 +380,21 @@ export interface CreatePlannedEventInput {
   type?: 'planned' | 'actual' | 'cancelled'
 }
 
-export interface SessionHistoryEntry {
-  venture: string
-  work_date: string
-  earliest_start: string
-  latest_end: string
+export interface SessionHistoryBlock {
+  start: string
+  end: string
   session_count: number
   hosts: string[]
   repos: string[]
   branches: string[]
   issues: number[]
+}
+
+export interface SessionHistoryEntry {
+  venture: string
+  work_date: string
+  blocks: SessionHistoryBlock[]
+  total_sessions: number
 }
 
 // ============================================================================

--- a/packages/crane-mcp/src/tools/schedule.ts
+++ b/packages/crane-mcp/src/tools/schedule.ts
@@ -404,26 +404,30 @@ export async function executeSchedule(input: ScheduleInput): Promise<ScheduleRes
       }
       let table = '| Date | Venture | Start | End | Sessions | Detail |\n'
       table += '|------|---------|-------|-----|----------|--------|\n'
-      for (const e of entries) {
-        const start = new Date(e.earliest_start).toLocaleTimeString('en-US', {
-          hour: 'numeric',
-          minute: '2-digit',
-          timeZone: 'America/Phoenix',
-        })
-        const end = new Date(e.latest_end).toLocaleTimeString('en-US', {
-          hour: 'numeric',
-          minute: '2-digit',
-          timeZone: 'America/Phoenix',
-        })
-        const detail =
-          (e.hosts?.[0] || '-') +
-          (e.repos?.[0] ? ' | ' + e.repos[0].split('/').pop() : '') +
-          (e.issues?.[0] ? ' #' + e.issues[0] : '')
-        table += `| ${e.work_date} | ${e.venture.toUpperCase()} | ${start} | ${end} | ${e.session_count} | ${detail} |\n`
+      let totalBlocks = 0
+      for (const entry of entries) {
+        for (const block of entry.blocks) {
+          totalBlocks++
+          const start = new Date(block.start).toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZone: 'America/Phoenix',
+          })
+          const end = new Date(block.end).toLocaleTimeString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZone: 'America/Phoenix',
+          })
+          const detail =
+            (block.hosts?.[0] || '-') +
+            (block.repos?.[0] ? ' · ' + block.repos[0].split('/').pop() : '') +
+            (block.issues?.[0] ? ' #' + block.issues[0] : '')
+          table += `| ${entry.work_date} | ${entry.venture.toUpperCase()} | ${start} | ${end} | ${block.session_count} | ${detail} |\n`
+        }
       }
       return {
         success: true,
-        message: `## Session History (${days} days)\n\n${table}\n${entries.length} entries`,
+        message: `## Session History (${days} days)\n\n${table}\n${totalBlocks} blocks across ${entries.length} venture-days`,
       }
     } catch (error) {
       return {

--- a/workers/crane-context/src/endpoints/__tests__/merge-blocks.test.ts
+++ b/workers/crane-context/src/endpoints/__tests__/merge-blocks.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest'
+import { mergeSessionsIntoBlocks, type SessionForMerge } from '../queries'
+
+function session(
+  start: string,
+  endedAt: string,
+  opts?: { displayEnd?: string; host?: string; repo?: string; branch?: string; issue?: number }
+): SessionForMerge {
+  return {
+    start,
+    ended_at: endedAt,
+    display_end: opts?.displayEnd || endedAt,
+    host: opts?.host || 'm16.local',
+    repo: opts?.repo || 'crane-console',
+    branch: opts?.branch || 'main',
+    issue_number: opts?.issue || null,
+  }
+}
+
+describe('mergeSessionsIntoBlocks', () => {
+  it('returns empty array for empty input', () => {
+    expect(mergeSessionsIntoBlocks([])).toEqual([])
+  })
+
+  it('single session produces one block', () => {
+    const sessions = [session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z')]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toEqual({
+      start: '2026-03-21T11:00:00Z',
+      end: '2026-03-21T12:00:00Z',
+      session_count: 1,
+      hosts: ['m16.local'],
+      repos: ['crane-console'],
+      branches: ['main'],
+      issues: [],
+    })
+  })
+
+  it('two adjacent sessions (gap < 30 min) merge into one block', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z'),
+      session('2026-03-21T12:15:00Z', '2026-03-21T13:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].start).toBe('2026-03-21T11:00:00Z')
+    expect(blocks[0].end).toBe('2026-03-21T13:00:00Z')
+    expect(blocks[0].session_count).toBe(2)
+  })
+
+  it('two distant sessions (gap > 30 min) produce two blocks', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z'),
+      session('2026-03-21T19:00:00Z', '2026-03-21T20:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].start).toBe('2026-03-21T11:00:00Z')
+    expect(blocks[0].end).toBe('2026-03-21T12:00:00Z')
+    expect(blocks[1].start).toBe('2026-03-21T19:00:00Z')
+    expect(blocks[1].end).toBe('2026-03-21T20:00:00Z')
+  })
+
+  it('gap exactly 30 min merges (≤ threshold)', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z'),
+      // Exactly 30 minutes after ended_at
+      session('2026-03-21T12:30:00Z', '2026-03-21T13:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].session_count).toBe(2)
+  })
+
+  it('gap of 30 min + 1 ms creates separate blocks', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z'),
+      // 30 minutes and 1 second after ended_at
+      session('2026-03-21T12:30:01Z', '2026-03-21T13:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(2)
+  })
+
+  it('overlapping sessions merge into one block', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:30:00Z'),
+      session('2026-03-21T12:00:00Z', '2026-03-21T13:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].start).toBe('2026-03-21T11:00:00Z')
+    expect(blocks[0].end).toBe('2026-03-21T13:00:00Z')
+    expect(blocks[0].session_count).toBe(2)
+  })
+
+  it('multiple merges in sequence: A-B adjacent, B-C adjacent, C-D distant → two blocks', () => {
+    const sessions = [
+      session('2026-03-21T10:00:00Z', '2026-03-21T10:30:00Z'), // A
+      session('2026-03-21T10:45:00Z', '2026-03-21T11:15:00Z'), // B (15 min gap from A)
+      session('2026-03-21T11:30:00Z', '2026-03-21T12:00:00Z'), // C (15 min gap from B)
+      session('2026-03-21T15:00:00Z', '2026-03-21T16:00:00Z'), // D (3 hour gap from C)
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].start).toBe('2026-03-21T10:00:00Z')
+    expect(blocks[0].end).toBe('2026-03-21T12:00:00Z')
+    expect(blocks[0].session_count).toBe(3)
+    expect(blocks[1].start).toBe('2026-03-21T15:00:00Z')
+    expect(blocks[1].end).toBe('2026-03-21T16:00:00Z')
+    expect(blocks[1].session_count).toBe(1)
+  })
+
+  it('uses display_end for block end time, ended_at for gap calculation', () => {
+    // Session 1: ended_at is 12:00, but display_end (last_activity_at) is 11:50
+    // Session 2: starts at 12:25 — gap from ended_at is 25 min (merge), but gap from display_end would be 35 min
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z', {
+        displayEnd: '2026-03-21T11:50:00Z',
+      }),
+      session('2026-03-21T12:25:00Z', '2026-03-21T13:00:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    // Should merge because gap is calculated from ended_at (25 min < 30 min threshold)
+    expect(blocks).toHaveLength(1)
+    // End time should use the later display_end
+    expect(blocks[0].end).toBe('2026-03-21T13:00:00Z')
+  })
+
+  it('aggregates hosts, repos, branches, and issues across merged sessions', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z', {
+        host: 'm16.local',
+        repo: 'crane-console',
+        branch: 'main',
+        issue: 100,
+      }),
+      session('2026-03-21T12:10:00Z', '2026-03-21T13:00:00Z', {
+        host: 'mac-mini.local',
+        repo: 'dc-console',
+        branch: 'feat/blocks',
+        issue: 200,
+      }),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].hosts).toEqual(['m16.local', 'mac-mini.local'])
+    expect(blocks[0].repos).toEqual(['crane-console', 'dc-console'])
+    expect(blocks[0].branches).toEqual(['feat/blocks', 'main'])
+    expect(blocks[0].issues).toEqual([100, 200])
+  })
+
+  it('deduplicates metadata across merged sessions', () => {
+    const sessions = [
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z', {
+        host: 'm16.local',
+        repo: 'crane-console',
+        issue: 100,
+      }),
+      session('2026-03-21T12:10:00Z', '2026-03-21T13:00:00Z', {
+        host: 'm16.local',
+        repo: 'crane-console',
+        issue: 100,
+      }),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].hosts).toEqual(['m16.local'])
+    expect(blocks[0].repos).toEqual(['crane-console'])
+    expect(blocks[0].issues).toEqual([100])
+  })
+
+  it('handles out-of-order input by sorting before merging', () => {
+    const sessions = [
+      session('2026-03-21T13:00:00Z', '2026-03-21T14:00:00Z'),
+      session('2026-03-21T11:00:00Z', '2026-03-21T12:00:00Z'),
+      session('2026-03-21T12:10:00Z', '2026-03-21T12:50:00Z'),
+    ]
+    const blocks = mergeSessionsIntoBlocks(sessions)
+
+    // Sessions 2 and 3 should merge (10 min gap), session 1 is separate (10 min gap from 12:50 to 13:00, merges)
+    // Actually: 11:00-12:00, 12:10-12:50, 13:00-14:00
+    // Gap between block ending at 12:50 (ended_at) and 13:00 start = 10 min → merges
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].start).toBe('2026-03-21T11:00:00Z')
+    expect(blocks[0].end).toBe('2026-03-21T14:00:00Z')
+    expect(blocks[0].session_count).toBe(3)
+  })
+})

--- a/workers/crane-context/src/endpoints/queries.ts
+++ b/workers/crane-context/src/endpoints/queries.ts
@@ -5,7 +5,7 @@
  * Implements query patterns from ADR 025.
  */
 
-import type { Env, SessionHistoryEntry } from '../types'
+import type { Env, SessionHistoryEntry, SessionHistoryBlock } from '../types'
 import { findActiveSessions } from '../sessions'
 import { getLatestHandoff, queryHandoffs } from '../handoffs'
 import { fetchDocsMetadata, fetchDoc } from '../docs'
@@ -585,6 +585,101 @@ export async function handleGetDoc(
 // GET /sessions/history - Aggregated session history by venture and date
 // ============================================================================
 
+/** Gap threshold in milliseconds. Sessions separated by ≤ this are merged into one block. */
+const BLOCK_GAP_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes
+
+export interface SessionForMerge {
+  start: string
+  ended_at: string
+  display_end: string
+  host: string | null
+  repo: string | null
+  branch: string | null
+  issue_number: number | null
+}
+
+/**
+ * Merge sessions into contiguous blocks, preserving gaps > 30 minutes.
+ *
+ * Uses `ended_at` for gap calculation (reliable end time) and
+ * `display_end` (last_activity_at || ended_at) for the block's display end time.
+ */
+export function mergeSessionsIntoBlocks(sessions: SessionForMerge[]): SessionHistoryBlock[] {
+  if (sessions.length === 0) return []
+
+  // Sort by start time
+  const sorted = [...sessions].sort((a, b) => a.start.localeCompare(b.start))
+
+  interface BlockAccumulator {
+    start: string
+    ended_at: string
+    display_end: string
+    session_count: number
+    hosts: Set<string>
+    repos: Set<string>
+    branches: Set<string>
+    issues: Set<number>
+  }
+
+  function newBlock(session: SessionForMerge): BlockAccumulator {
+    const block: BlockAccumulator = {
+      start: session.start,
+      ended_at: session.ended_at,
+      display_end: session.display_end,
+      session_count: 1,
+      hosts: new Set(),
+      repos: new Set(),
+      branches: new Set(),
+      issues: new Set(),
+    }
+    if (session.host) block.hosts.add(session.host)
+    if (session.repo) block.repos.add(session.repo)
+    if (session.branch) block.branches.add(session.branch)
+    if (session.issue_number) block.issues.add(session.issue_number)
+    return block
+  }
+
+  function addToBlock(block: BlockAccumulator, session: SessionForMerge): void {
+    if (session.ended_at > block.ended_at) block.ended_at = session.ended_at
+    if (session.display_end > block.display_end) block.display_end = session.display_end
+    block.session_count++
+    if (session.host) block.hosts.add(session.host)
+    if (session.repo) block.repos.add(session.repo)
+    if (session.branch) block.branches.add(session.branch)
+    if (session.issue_number) block.issues.add(session.issue_number)
+  }
+
+  function finalizeBlock(block: BlockAccumulator): SessionHistoryBlock {
+    return {
+      start: block.start,
+      end: block.display_end,
+      session_count: block.session_count,
+      hosts: Array.from(block.hosts).sort(),
+      repos: Array.from(block.repos).sort(),
+      branches: Array.from(block.branches).sort(),
+      issues: Array.from(block.issues).sort((a, b) => a - b),
+    }
+  }
+
+  const blocks: BlockAccumulator[] = [newBlock(sorted[0])]
+
+  for (let i = 1; i < sorted.length; i++) {
+    const current = sorted[i]
+    const lastBlock = blocks[blocks.length - 1]
+
+    // Use ended_at for gap calculation — it's the reliable end time
+    const gap = new Date(current.start).getTime() - new Date(lastBlock.ended_at).getTime()
+
+    if (gap <= BLOCK_GAP_THRESHOLD_MS) {
+      addToBlock(lastBlock, current)
+    } else {
+      blocks.push(newBlock(current))
+    }
+  }
+
+  return blocks.map(finalizeBlock)
+}
+
 /**
  * GET /sessions/history - Query ended sessions aggregated by venture and date
  *
@@ -658,20 +753,10 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
       return VENTURE_ALIASES[lower] || lower
     }
 
-    // Aggregate by venture + work_date (Arizona time)
-    const aggregation = new Map<
+    // Group sessions by venture + work_date (Arizona time)
+    const groups = new Map<
       string,
-      {
-        venture: string
-        work_date: string
-        earliest_start: string
-        latest_end: string
-        session_count: number
-        hosts: Set<string>
-        repos: Set<string>
-        branches: Set<string>
-        issues: Set<number>
-      }
+      { venture: string; work_date: string; sessions: SessionForMerge[] }
     >()
 
     for (const row of rows) {
@@ -682,50 +767,28 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
 
       const venture = normalizeVenture(row.venture)
       const key = `${venture}:${workDate}`
-      const existing = aggregation.get(key)
 
-      const effectiveEnd = row.last_activity_at || row.ended_at
-
-      if (existing) {
-        if (row.created_at < existing.earliest_start) {
-          existing.earliest_start = row.created_at
-        }
-        if (effectiveEnd > existing.latest_end) {
-          existing.latest_end = effectiveEnd
-        }
-        existing.session_count++
-      } else {
-        aggregation.set(key, {
-          venture,
-          work_date: workDate,
-          earliest_start: row.created_at,
-          latest_end: effectiveEnd,
-          session_count: 1,
-          hosts: new Set(),
-          repos: new Set(),
-          branches: new Set(),
-          issues: new Set(),
-        })
+      if (!groups.has(key)) {
+        groups.set(key, { venture, work_date: workDate, sessions: [] })
       }
 
-      const entry = aggregation.get(key)!
-      if (row.host) entry.hosts.add(row.host)
-      if (row.repo) entry.repos.add(row.repo)
-      if (row.branch) entry.branches.add(row.branch)
-      if (row.issue_number) entry.issues.add(row.issue_number)
+      groups.get(key)!.sessions.push({
+        start: row.created_at,
+        ended_at: row.ended_at,
+        display_end: row.last_activity_at || row.ended_at,
+        host: row.host,
+        repo: row.repo,
+        branch: row.branch,
+        issue_number: row.issue_number,
+      })
     }
 
-    const entries: SessionHistoryEntry[] = Array.from(aggregation.values())
-      .map((e) => ({
-        venture: e.venture,
-        work_date: e.work_date,
-        earliest_start: e.earliest_start,
-        latest_end: e.latest_end,
-        session_count: e.session_count,
-        hosts: Array.from(e.hosts).sort(),
-        repos: Array.from(e.repos).sort(),
-        branches: Array.from(e.branches).sort(),
-        issues: Array.from(e.issues).sort((a, b) => a - b),
+    const entries: SessionHistoryEntry[] = Array.from(groups.values())
+      .map((g) => ({
+        venture: g.venture,
+        work_date: g.work_date,
+        blocks: mergeSessionsIntoBlocks(g.sessions),
+        total_sessions: g.sessions.length,
       }))
       .sort((a, b) => a.work_date.localeCompare(b.work_date) || a.venture.localeCompare(b.venture))
 

--- a/workers/crane-context/src/types.ts
+++ b/workers/crane-context/src/types.ts
@@ -279,16 +279,21 @@ export interface PlannedEventRecord {
   updated_at: string
 }
 
-export interface SessionHistoryEntry {
-  venture: string
-  work_date: string
-  earliest_start: string
-  latest_end: string
+export interface SessionHistoryBlock {
+  start: string
+  end: string
   session_count: number
   hosts: string[]
   repos: string[]
   branches: string[]
   issues: number[]
+}
+
+export interface SessionHistoryEntry {
+  venture: string
+  work_date: string
+  blocks: SessionHistoryBlock[]
+  total_sessions: number
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Sessions separated by > 30 minutes now produce separate blocks instead of being aggregated into a single misleading time span (e.g., 11am-8pm when work was 11am-noon + 7pm-8pm)
- Extracted `mergeSessionsIntoBlocks()` pure function for gap-aware block merging with 12 unit tests
- Updated `SessionHistoryEntry` type: flat `earliest_start`/`latest_end` replaced with `blocks: SessionHistoryBlock[]` + `total_sessions`
- MCP formatter now renders one table row per block

## Test plan

- [x] `tsc --noEmit` passes in crane-context and crane-mcp
- [x] `npm run build` passes in crane-mcp
- [x] 12 unit tests cover: single session, adjacent merge, distant split, exact boundary, overlapping, chained merges, display_end vs ended_at, metadata aggregation/dedup, out-of-order input
- [x] Full pre-push verification (typecheck + format + lint + 268 tests) passes
- [ ] Deploy worker and verify `crane_schedule(action: "session-history")` returns blocks
- [ ] Run `/calendar-sync` and verify separate calendar events per block

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)