### PR TITLE
docs: add per-venture index pages and sidebar ordering

### DIFF
--- a/docs/ventures/dc/index.md
+++ b/docs/ventures/dc/index.md
@@ -1,0 +1,23 @@
+---
+sidebar:
+  order: 0
+---
+
+# Draft Crane
+
+Draft Crane is a structured writing environment for consultants, coaches, and subject-matter experts turning their expertise into publishable nonfiction books. It replaces scattered docs and half-finished drafts with a focused tool built around how nonfiction actually gets written.
+
+The core interaction model separates Author zone (content creation) from Editor zone (AI-powered review) - AI assists the writing process rather than replacing it. iPad-first design targets professional writers who work away from their desks.
+
+## Who This Is For
+
+**Building DC features?** Start with the [product overview](product-overview.md) for the interaction model, tech stack, and key principles. The [roadmap](roadmap.md) covers the current InstructionList integration and dependency upgrade priorities.
+
+**Checking venture status?** [Metrics](metrics.md) tracks technical health including the 400+ variable design token system and open issue count.
+
+## How This Section Is Organized
+
+- **[Product Overview](product-overview.md)** - Mission, target market, value proposition, tech stack, and key principles.
+- **[Design Spec](design-spec.md)** - Design tokens, visual language, and component patterns for DC interfaces.
+- **[Metrics & KPIs](metrics.md)** - North star metric, leading indicators, financial metrics, and technical health.
+- **[Roadmap](roadmap.md)** - Current focus, near-term plans, completed milestones, and dependency tracking.

--- a/docs/ventures/dc/metrics.md
+++ b/docs/ventures/dc/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 3
+---
+
 # Metrics & KPIs
 
 ## North Star Metric

--- a/docs/ventures/dc/product-overview.md
+++ b/docs/ventures/dc/product-overview.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # Draft Crane
 
 **Tagline:** Book-writing tool for experts

--- a/docs/ventures/dc/roadmap.md
+++ b/docs/ventures/dc/roadmap.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 4
+---
+
 # Roadmap
 
 **Current Stage:** Prototype

--- a/docs/ventures/dfg/index.md
+++ b/docs/ventures/dfg/index.md
@@ -1,0 +1,23 @@
+---
+sidebar:
+  order: 0
+---
+
+# Durgan Field Guide
+
+Durgan Field Guide is an AI-powered toolkit for buying and flipping physical goods at auction. It replaces gut-feel bidding with structured evaluation - conservative cost modeling, comp-based valuation, and deal-killer detection before wasting time on marginal lots.
+
+The target market is side-hustlers and small operators working trailers, light equipment, and vehicles. The core principle: discipline over opportunity. Pass on marginal deals, wait for strong ones.
+
+## Who This Is For
+
+**Building DFG features?** Start with the [product overview](product-overview.md) for the full capability map across Scout, Evaluate, Acquire, Inspect, Sell, and Learn phases.
+
+**Checking venture status?** [Metrics](metrics.md) tracks leading indicators and financials. [Roadmap](roadmap.md) covers current focus and near-term priorities including subscription infrastructure.
+
+## How This Section Is Organized
+
+- **[Product Overview](product-overview.md)** - Mission, target market, core capabilities across all six workflow phases, revenue model, and key principles.
+- **[Design Spec](design-spec.md)** - Design tokens, visual language, and component patterns for DFG interfaces.
+- **[Metrics & KPIs](metrics.md)** - North star metric, leading indicators, and financial metrics.
+- **[Roadmap](roadmap.md)** - Current focus, near-term plans, completed milestones, and dependency tracking.

--- a/docs/ventures/dfg/metrics.md
+++ b/docs/ventures/dfg/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 3
+---
+
 # Metrics & KPIs
 
 ## North Star Metric

--- a/docs/ventures/dfg/product-overview.md
+++ b/docs/ventures/dfg/product-overview.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # Durgan Field Guide
 
 ## What It Is

--- a/docs/ventures/dfg/roadmap.md
+++ b/docs/ventures/dfg/roadmap.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 4
+---
+
 # Roadmap
 
 ## Current Focus

--- a/docs/ventures/ke/index.md
+++ b/docs/ventures/ke/index.md
@@ -1,0 +1,23 @@
+---
+sidebar:
+  order: 0
+---
+
+# Kid Expenses
+
+Kid Expenses is an early-stage venture building expense tracking for co-parents. Shared custody means shared costs and shared disagreements about money - this app gives divorced and separated parents a structured way to log, split, and settle child-related expenses without the conflict.
+
+The venture is in prototype stage, working through its P0/P1 backlog (privacy policy, accessibility, security hardening) before beta launch.
+
+## Who This Is For
+
+**Building KE features?** Start with the [product overview](product-overview.md) for the tech stack and current stage, then check the [roadmap](roadmap.md) for the prioritized backlog.
+
+**Checking venture health?** [Metrics](metrics.md) tracks technical health indicators and open bugs alongside the pre-launch financial metrics.
+
+## How This Section Is Organized
+
+- **[Product Overview](product-overview.md)** - Mission, tech stack, revenue model, and current stage.
+- **[Design Spec](design-spec.md)** - Design tokens, visual language, and component patterns for KE interfaces.
+- **[Metrics & KPIs](metrics.md)** - North star metric, leading indicators, financial metrics, and technical health.
+- **[Roadmap](roadmap.md)** - Current focus (P0/P1 sweep), near-term plans, and dependency tracking.

--- a/docs/ventures/ke/metrics.md
+++ b/docs/ventures/ke/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 3
+---
+
 # Metrics & KPIs
 
 ## North Star Metric

--- a/docs/ventures/ke/product-overview.md
+++ b/docs/ventures/ke/product-overview.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # Kid Expenses
 
 **Tagline:** Expense tracking for co-parents

--- a/docs/ventures/ke/roadmap.md
+++ b/docs/ventures/ke/roadmap.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 4
+---
+
 # Roadmap
 
 **Current Stage:** Prototype

--- a/docs/ventures/sc/index.md
+++ b/docs/ventures/sc/index.md
@@ -1,0 +1,23 @@
+---
+sidebar:
+  order: 0
+---
+
+# Silicon Crane
+
+Founders waste months building products nobody wants. Investors fund ideas with no market evidence. Silicon Crane closes that gap with Validation-as-a-Service - structured 30-day sprints that produce a clear Go, Kill, or Pivot decision backed by real customer behavior, not surveys or opinions.
+
+Each sprint follows a five-phase process (Intake, Design, Run, Analyze, Deliver) and ends with a decision memo and a permanent Learning Ledger entry documenting what was tested and what was learned.
+
+## Who This Is For
+
+**Building SC tooling or materials?** Start with the [product overview](product-overview.md) for the full service model, sprint structure, and deliverables.
+
+**Checking venture status?** [Metrics](metrics.md) tracks sprint completion and financial health. [Roadmap](roadmap.md) covers current focus areas including client-facing materials and the first pilot engagement.
+
+## How This Section Is Organized
+
+- **[Product Overview](product-overview.md)** - Mission, target market, sprint structure, deliverables, revenue model, and differentiators.
+- **[Design Spec](design-spec.md)** - Design tokens, visual language, and component patterns for SC interfaces.
+- **[Metrics & KPIs](metrics.md)** - North star metric, leading indicators, and financial metrics.
+- **[Roadmap](roadmap.md)** - Current focus, near-term plans, completed milestones, and dependency tracking.

--- a/docs/ventures/sc/metrics.md
+++ b/docs/ventures/sc/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 3
+---
+
 # Metrics & KPIs
 
 ## North Star Metric

--- a/docs/ventures/sc/product-overview.md
+++ b/docs/ventures/sc/product-overview.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # Silicon Crane
 
 ## What It Is

--- a/docs/ventures/sc/roadmap.md
+++ b/docs/ventures/sc/roadmap.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 4
+---
+
 # Roadmap
 
 ## Current Focus

--- a/docs/ventures/vc/index.md
+++ b/docs/ventures/vc/index.md
@@ -1,0 +1,26 @@
+---
+sidebar:
+  order: 0
+---
+
+# Venture Crane
+
+Venture Crane is the operating system for the entire portfolio. It provides session management, context persistence, secrets distribution, fleet orchestration, and agent tooling - the infrastructure that lets AI development agents work effectively across multiple ventures and machines.
+
+Without it, every agent session starts from scratch: no memory of prior work, no coordinated handoffs, no shared secrets. Venture Crane turns a collection of isolated agent runs into a coherent development operation.
+
+## Who This Is For
+
+**Starting a dev session?** You're already using Venture Crane - the `/sod` command, crane-context API, and MCP server are all VC infrastructure. See the [product overview](product-overview.md) for the full component map.
+
+**Working on the public website?** venturecrane.com has its own docs in the [venturecrane.com](#) sub-group below - design brief, design charter, and site architecture.
+
+**Evaluating platform health?** Check [metrics](metrics.md) for operational KPIs and infrastructure costs, then [roadmap](roadmap.md) for what's in progress.
+
+## How This Section Is Organized
+
+- **[Product Overview](product-overview.md)** - What Venture Crane is, its components (crane-context, crane-watch, crane-mcp, crane CLI, crane-command), tech stack, and development model.
+- **[Design Spec](design-spec.md)** - Design tokens, visual language, and component patterns for VC interfaces.
+- **[Metrics & KPIs](metrics.md)** - North star metric, operational metrics, and infrastructure cost breakdown.
+- **[Roadmap](roadmap.md)** - Current focus areas, near-term initiatives, and completed work.
+- **venturecrane.com** - The public-facing website: [site overview](website.md), [design brief](design-brief.md), and [design charter](design-charter.md).

--- a/docs/ventures/vc/metrics.md
+++ b/docs/ventures/vc/metrics.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 3
+---
+
 # Metrics & KPIs
 
 ## North Star Metric

--- a/docs/ventures/vc/product-overview.md
+++ b/docs/ventures/vc/product-overview.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # Venture Crane
 
 **Tagline:** AI-native venture studio infrastructure

--- a/docs/ventures/vc/roadmap.md
+++ b/docs/ventures/vc/roadmap.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 4
+---
+
 # Roadmap
 
 **Current Stage:** Operating

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -38,7 +38,24 @@ export default defineConfig({
           items: [
             // Manual entry - ventures/index.md isn't picked up by per-venture autogenerate
             { label: 'Portfolio Overview', slug: 'ventures' },
-            { label: 'Venture Crane', autogenerate: { directory: 'ventures/vc' } },
+            {
+              label: 'Venture Crane',
+              items: [
+                { slug: 'ventures/vc' },
+                { slug: 'ventures/vc/product-overview' },
+                { slug: 'ventures/vc/design-spec' },
+                { slug: 'ventures/vc/metrics' },
+                { slug: 'ventures/vc/roadmap' },
+                {
+                  label: 'venturecrane.com',
+                  items: [
+                    { slug: 'ventures/vc/website' },
+                    { slug: 'ventures/vc/design-brief' },
+                    { slug: 'ventures/vc/design-charter' },
+                  ],
+                },
+              ],
+            },
             { label: 'Durgan Field Guide', autogenerate: { directory: 'ventures/dfg' } },
             { label: 'Silicon Crane', autogenerate: { directory: 'ventures/sc' } },
             { label: 'Kid Expenses', autogenerate: { directory: 'ventures/ke' } },

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -353,7 +353,13 @@ if (existsSync(DESIGN_SPEC_DIR)) {
       content = replaceTemplateVars(content)
       content = rewriteMarkdownLinks(content, specFile)
       const processed = injectFrontmatter(content, specFile)
-      writeFileSync(destFile, processed, 'utf-8')
+      // Inject sidebar order for Starlight rendering
+      const fmEnd = processed.indexOf('\n---', 3)
+      let withOrder = processed
+      if (fmEnd !== -1 && !processed.slice(0, fmEnd).includes('sidebar:')) {
+        withOrder = processed.slice(0, fmEnd) + '\nsidebar:\n  order: 2' + processed.slice(fmEnd)
+      }
+      writeFileSync(destFile, withOrder, 'utf-8')
       stalenessReport.push(checkStaleness(content, join('ventures', entry, 'design-spec.md')))
       fileCount++
     }


### PR DESCRIPTION
## Summary

- Add landing pages (index.md) for all 5 ventures with problem-solution framing, persona-based entry points, and annotated doc listings
- Add sidebar order frontmatter to all 15 existing venture docs so pages render logically (overview, design-spec, metrics, roadmap) instead of alphabetically
- Switch VC sidebar from autogenerate to manual config with "venturecrane.com" sub-group for website docs (design-brief, design-charter, website)
- Inject sidebar order into synced design-specs via sync-docs.mjs

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + tests)
- [x] `cd site && npm run build` - all 101 pages build without errors
- [x] No em dashes in new content
- [x] No broken `.md` links in built venture pages
- [x] All 5 venture index pages render at `/ventures/{code}/`
- [x] VC sidebar shows manual ordering with venturecrane.com sub-group
- [x] DFG/SC/KE/DC sidebars show ordered pages (index, overview, design-spec, metrics, roadmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)