### PR TITLE
feat: add SMD Services (ss) venture

### DIFF
--- a/.agents/skills/new-venture/SKILL.md
+++ b/.agents/skills/new-venture/SKILL.md
@@ -11,9 +11,11 @@ This command walks through setting up a new venture with Crane infrastructure.
 
 Before running this command, the user must have completed:
 
-1. Created a GitHub organization (github.com/organizations/new)
-2. Installed "Crane Relay" GitHub App on the org
-3. Noted the installation ID from GitHub App settings
+1. Created a GitHub organization (github.com/account/organizations/new?plan=free)
+2. Installed the **venturecrane-github** GitHub App on the new org:
+   - Go to https://github.com/settings/apps (personal Developer Settings, NOT the venturecrane org)
+   - Click **Edit** on **venturecrane-github** → **Install App** → select the new org → All repositories
+3. Noted the installation ID from the post-install URL (`/settings/installations/{ID}`)
 
 ## Execution
 

--- a/config/ventures.json
+++ b/config/ventures.json
@@ -93,6 +93,22 @@
       }
     },
     {
+      "code": "ss",
+      "name": "SMD Services",
+      "org": "smdservices",
+      "repos": ["ss-console"],
+      "capabilities": [],
+      "portfolio": {
+        "status": "building",
+        "bvmStage": "IDEATION",
+        "tagline": "Operations consulting for Phoenix-area small businesses",
+        "description": "SMD Services helps 5-50 employee businesses fix the operational chaos that keeps owners working until 9pm. Fixed-price engagements covering process documentation, lead management, financial visibility, and workflow automation.",
+        "techStack": [],
+        "url": null,
+        "showInPortfolio": false
+      }
+    },
+    {
       "code": "dc",
       "name": "Draft Crane",
       "org": "venturecrane",

--- a/docs/process/new-venture-setup-checklist.md
+++ b/docs/process/new-venture-setup-checklist.md
@@ -28,14 +28,14 @@ Most of this checklist can be automated using `scripts/setup-new-venture.sh`.
 
 ### What Requires Manual Steps
 
-| Step                             | Why Manual                         |
-| -------------------------------- | ---------------------------------- |
-| Create GitHub organization       | GitHub API limitation              |
-| Install "Crane Relay" GitHub App | Requires browser/OAuth             |
-| Get installation ID              | From GitHub App settings page      |
-| Seed venture documentation       | Content is venture-specific        |
-| Define venture design system     | Creative decisions, needs context  |
-| PWA setup                        | Framework-specific, needs branding |
+| Step                            | Why Manual                                                   |
+| ------------------------------- | ------------------------------------------------------------ |
+| Create GitHub organization      | GitHub API limitation                                        |
+| Install venturecrane-github App | Requires browser (personal settings → apps → install on org) |
+| Get installation ID             | From post-install URL                                        |
+| Seed venture documentation      | Content is venture-specific                                  |
+| Define venture design system    | Creative decisions, needs context                            |
+| PWA setup                       | Framework-specific, needs branding                           |
 
 ### Quick Start (After Manual Prerequisites)
 
@@ -128,8 +128,17 @@ This creates a repo with:
 
 ### 1.5 GitHub App Installation (for auto-classification)
 
-- [ ] Install "Crane Relay" GitHub App on the org
-- [ ] Grant access to the console repository
+The GitHub App is named **venturecrane-github** and is registered under the **personal account** (not the venturecrane org). To install on a new org:
+
+1. Go to **https://github.com/settings/apps** (personal Developer Settings)
+2. Click **Edit** on **venturecrane-github**
+3. Click **Install App** in the left sidebar
+4. Select the new organization
+5. Grant access to **All repositories**
+6. Note the installation ID from the post-install URL: `https://github.com/organizations/{org}/settings/installations/{ID}`
+
+- [ ] Install venturecrane-github app on the new org
+- [ ] Grant access to all repositories
 - [ ] Note the installation ID (needed for crane-watch config)
 
 ---

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -60,6 +60,7 @@ export const INFISICAL_PATHS: Record<string, string> = {
   dfg: '/dfg',
   smd: '/smd',
   dc: '/dc',
+  ss: '/ss',
 }
 
 export interface VentureWithRepo extends Venture {

--- a/packages/crane-mcp/src/cli/launch.test.ts
+++ b/packages/crane-mcp/src/cli/launch.test.ts
@@ -128,6 +128,7 @@ describe('INFISICAL_PATHS', () => {
     expect(INFISICAL_PATHS['dfg']).toBe('/dfg')
     expect(INFISICAL_PATHS['dc']).toBe('/dc')
     expect(INFISICAL_PATHS['smd']).toBe('/smd')
+    expect(INFISICAL_PATHS['ss']).toBe('/ss')
   })
 })
 

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -127,9 +127,12 @@ else
         *venturecrane/dc-console*|*dc-console*)
           SCOPE="dc"
           ;;
+        *smdservices/ss-console*|*ss-console*)
+          SCOPE="ss"
+          ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc}-console"
+          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc}-console, smdservices/ss-console"
           exit 1
           ;;
       esac

--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -181,6 +181,7 @@ export const VERCEL_PROJECT_TO_VENTURE: Record<string, string> = {
   'sc-console': 'sc',
   'dfg-console': 'dfg',
   'dc-console': 'dc',
+  'ss-console': 'ss',
   'vc-web': 'vc',
 }
 

--- a/workers/crane-watch/CLAUDE.md
+++ b/workers/crane-watch/CLAUDE.md
@@ -49,6 +49,7 @@ Uses the same Crane Relay GitHub App for authentication:
 | venturecrane     | 104223482       |
 | siliconcrane     | 104223351       |
 | kidexpenses      | 106532992       |
+| smdservices      | 118744407       |
 
 ## API Endpoints
 

--- a/workers/crane-watch/wrangler.toml
+++ b/workers/crane-watch/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 # Default = staging
 [vars]
 GH_APP_ID = "2619905"
-GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482"}'
+GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482","smdservices":"118744407"}'
 CRANE_CONTEXT_URL = "https://crane-context-staging.automation-ab6.workers.dev"
 
 # Secrets (set via `wrangler secret put`):
@@ -41,5 +41,5 @@ service = "crane-context"
 
 [env.production.vars]
 GH_APP_ID = "2619905"
-GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482"}'
+GH_INSTALLATIONS_JSON = '{"venturecrane":"104223482","smdservices":"118744407"}'
 CRANE_CONTEXT_URL = "https://crane-context.automation-ab6.workers.dev"


### PR DESCRIPTION
## Summary
- Register new **SMD Services** venture (`ss`) across all Crane subsystems: venture config, crane-watch, crane-context, launcher, doc upload script
- Add `smdservices` GitHub App installation (ID: 118744407) to crane-watch for auto-classification
- Fix `/new-venture` docs and skill to clarify GitHub App location — it's **venturecrane-github** under personal Developer Settings, not the venturecrane org

## Test plan
- [x] `npm run verify` passes (268/268 tests, typecheck, lint, format)
- [x] crane-watch deployed to staging + production
- [x] crane-context deployed to staging + production
- [x] Infisical `/ss` folder created with shared secrets synced
- [x] `crane ss` launches successfully, `/sod` creates session

🤖 Generated with [Claude Code](https://claude.com/claude-code)