### PR TITLE
feat: add GitHub API tools to crane-mcp-remote

### DIFF
--- a/packages/crane-mcp/src/tools/schedule.ts
+++ b/packages/crane-mcp/src/tools/schedule.ts
@@ -408,16 +408,32 @@ export async function executeSchedule(input: ScheduleInput): Promise<ScheduleRes
       for (const entry of entries) {
         for (const block of entry.blocks) {
           totalBlocks++
-          const start = new Date(block.start).toLocaleTimeString('en-US', {
+          const startDate = new Date(block.start)
+          const endDate = new Date(block.end)
+          const timeOpts: Intl.DateTimeFormatOptions = {
             hour: 'numeric',
             minute: '2-digit',
             timeZone: 'America/Phoenix',
-          })
-          const end = new Date(block.end).toLocaleTimeString('en-US', {
-            hour: 'numeric',
-            minute: '2-digit',
-            timeZone: 'America/Phoenix',
-          })
+          }
+          const start = startDate.toLocaleTimeString('en-US', timeOpts)
+
+          // Show date on end time when the block spans midnight
+          const startDay = new Date(
+            startDate.toLocaleString('en-US', { timeZone: 'America/Phoenix' })
+          ).getDate()
+          const endDay = new Date(
+            endDate.toLocaleString('en-US', { timeZone: 'America/Phoenix' })
+          ).getDate()
+          const end =
+            endDay !== startDay
+              ? endDate.toLocaleString('en-US', {
+                  ...timeOpts,
+                  month: 'numeric',
+                  day: 'numeric',
+                  timeZone: 'America/Phoenix',
+                })
+              : endDate.toLocaleTimeString('en-US', timeOpts)
+
           const detail =
             (block.hosts?.[0] || '-') +
             (block.repos?.[0] ? ' · ' + block.repos[0].split('/').pop() : '') +

--- a/workers/crane-mcp-remote/CLAUDE.md
+++ b/workers/crane-mcp-remote/CLAUDE.md
@@ -1,13 +1,13 @@
 # CLAUDE.md - Crane MCP Remote Worker
 
-Remote MCP server for claude.ai and Claude Desktop. Exposes a read-only
-subset of crane-context tools over Streamable HTTP with GitHub OAuth.
+Remote MCP server for claude.ai and Claude Desktop. Exposes crane-context
+tools and GitHub API access over Streamable HTTP with GitHub OAuth.
 
 ## About
 
 This worker serves MCP tools over HTTP so that claude.ai (browser) and
-Claude Desktop can access VCMS, portfolio state, handoffs, docs, and
-cadence data without a local crane-mcp installation.
+Claude Desktop can access VCMS, portfolio state, handoffs, docs, cadence
+data, and GitHub repositories without a local crane-mcp installation.
 
 **Staging URL:** https://crane-mcp-remote-staging.automation-ab6.workers.dev
 **Production URL:** https://crane-mcp-remote.automation-ab6.workers.dev
@@ -31,10 +31,10 @@ claude.ai / Claude Desktop
       | Streamable HTTP + OAuth
       v
   crane-mcp-remote (this worker)
-      |
-      | fetch() + X-Relay-Key
-      v
-  crane-context (existing worker)
+      |                     |
+      | fetch() + Key       | fetch() + Bearer token
+      v                     v
+  crane-context         GitHub API
       |
       v
      D1
@@ -43,9 +43,12 @@ claude.ai / Claude Desktop
 - OAuthProvider handles DCR, token exchange, and auth routing
 - McpAgent (Durable Object) handles MCP protocol per session
 - CraneContextClient proxies reads to crane-context REST API
+- GitHubApiClient makes authenticated GitHub REST API calls
 - KV provides OAuth storage (OAUTH_KV) and read cache (CACHE_KV)
 
 ## Tools Exposed
+
+### Crane Context Tools
 
 | Tool                  | Description                                                           | Type       |
 | --------------------- | --------------------------------------------------------------------- | ---------- |
@@ -59,11 +62,36 @@ claude.ai / Claude Desktop
 | crane_handoffs        | Query handoff history                                                 | Read       |
 | crane_active_sessions | List active agent sessions                                            | Read       |
 
+### GitHub Tools
+
+| Tool                  | Description                                | Type  |
+| --------------------- | ------------------------------------------ | ----- |
+| github_list_issues    | List issues in a repository                | Read  |
+| github_get_issue      | Get issue details with body and comments   | Read  |
+| github_create_issue   | Create a new issue                         | Write |
+| github_update_issue   | Update issue (title, body, state, labels)  | Write |
+| github_add_comment    | Comment on an issue or PR                  | Write |
+| github_list_pulls     | List pull requests                         | Read  |
+| github_get_pull       | Get PR details with merge status           | Read  |
+| github_get_pull_diff  | Get PR diff (truncated for large diffs)    | Read  |
+| github_get_file       | Get file contents (1MB GitHub API limit)   | Read  |
+| github_list_directory | List directory contents                    | Read  |
+| github_search_code    | Search code (defaults to org:venturecrane) | Read  |
+| github_list_runs      | List CI/CD workflow runs                   | Read  |
+| github_get_run        | Get run details with jobs and steps        | Read  |
+| github_whoami         | Show auth status, scopes, and rate limit   | Read  |
+
 ## Auth Model
 
-GitHub OAuth via existing venturecrane-github App (ID: 2619905).
+GitHub OAuth via venturecrane-github App (ID: 2619905).
+OAuth scopes: `read:user user:email repo`.
 ALLOWED_GITHUB_USERS env var controls access (comma-separated logins).
 X-Actor-Identity header passed to crane-context for audit trail.
+
+The GitHub access token is persisted in the encrypted OAuth session props
+and used by GitHubApiClient for repository operations. Pre-existing sessions
+(connected before the repo scope was added) will see a helpful reconnect
+message when using GitHub tools.
 
 ## Secrets
 

--- a/workers/crane-mcp-remote/src/github-api.ts
+++ b/workers/crane-mcp-remote/src/github-api.ts
@@ -1,0 +1,474 @@
+/**
+ * GitHub REST API client for the MCP remote worker.
+ *
+ * Uses raw fetch() - no Octokit dependency. Designed for Cloudflare Workers
+ * where bundle size matters and we only need a handful of endpoints.
+ */
+
+const OWNER_REPO_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+
+function validateOwnerRepo(value: string, field: string): void {
+  if (!value || !OWNER_REPO_PATTERN.test(value)) {
+    throw new Error(
+      `Invalid ${field}: "${value}". Must match pattern: alphanumeric, hyphens, underscores, dots.`
+    )
+  }
+}
+
+export interface PaginatedResponse<T> {
+  data: T
+  total_count?: number
+  page: number
+  has_next_page: boolean
+}
+
+interface GitHubErrorBody {
+  message?: string
+  errors?: Array<{ message?: string; code?: string; field?: string }>
+}
+
+export class GitHubApiClient {
+  private token: string
+  private actorLogin: string
+
+  constructor(token: string, actorLogin: string) {
+    this.token = token
+    this.actorLogin = actorLogin
+  }
+
+  get hasToken(): boolean {
+    return this.token.length > 0
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    opts?: {
+      body?: Record<string, unknown>
+      accept?: string
+      params?: Record<string, string | number | undefined>
+      rawText?: boolean
+    }
+  ): Promise<{ data: T; headers: Headers }> {
+    if (!this.token) {
+      throw new Error(
+        'GitHub tools require reconnecting the crane MCP integration in claude.ai to enable repository access. Go to claude.ai Settings > Integrations, disconnect crane, then reconnect.'
+      )
+    }
+
+    const url = new URL(path, 'https://api.github.com')
+    if (opts?.params) {
+      for (const [key, val] of Object.entries(opts.params)) {
+        if (val !== undefined) url.searchParams.set(key, String(val))
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.token}`,
+      'User-Agent': 'crane-mcp-remote',
+      Accept: opts?.accept || 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    }
+
+    const resp = await fetch(url.toString(), {
+      method,
+      headers,
+      body: opts?.body ? JSON.stringify(opts.body) : undefined,
+    })
+
+    if (!resp.ok) {
+      await this.handleError(resp)
+    }
+
+    if (opts?.rawText) {
+      const text = await resp.text()
+      return { data: text as unknown as T, headers: resp.headers }
+    }
+
+    const data = (await resp.json()) as T
+    return { data, headers: resp.headers }
+  }
+
+  private async handleError(resp: Response): Promise<never> {
+    const status = resp.status
+    let body: GitHubErrorBody = {}
+    try {
+      body = (await resp.json()) as GitHubErrorBody
+    } catch {
+      // Body may not be JSON
+    }
+
+    if (status === 401) {
+      throw new Error(
+        'GitHub token is invalid or revoked. To fix: disconnect the crane MCP integration in claude.ai Settings > Integrations, then reconnect.'
+      )
+    }
+
+    if (status === 403) {
+      const rateLimitRemaining = resp.headers.get('x-ratelimit-remaining')
+      const rateLimitReset = resp.headers.get('x-ratelimit-reset')
+
+      if (rateLimitRemaining === '0' && rateLimitReset) {
+        const resetDate = new Date(parseInt(rateLimitReset, 10) * 1000)
+        throw new Error(`GitHub API rate limit exceeded. Resets at ${resetDate.toISOString()}.`)
+      }
+
+      throw new Error(
+        `Permission denied. The GitHub App may not have access to this repository. ${body.message || ''}`
+      )
+    }
+
+    if (status === 404) {
+      throw new Error(
+        `Not found. The repository may not exist or the GitHub App is not installed there. ${body.message || ''}`
+      )
+    }
+
+    if (status === 422) {
+      const details = body.errors?.map((e) => e.message || e.code).join(', ') || body.message
+      throw new Error(`Invalid request: ${details || 'validation error'}`)
+    }
+
+    throw new Error(`GitHub API error ${status}: ${body.message || resp.statusText}`)
+  }
+
+  private parsePagination(headers: Headers, currentPage: number) {
+    const link = headers.get('link') || ''
+    const hasNext = link.includes('rel="next"')
+    return { page: currentPage, has_next_page: hasNext }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Issues
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async listIssues(
+    owner: string,
+    repo: string,
+    params?: {
+      state?: string
+      labels?: string
+      assignee?: string
+      per_page?: number
+      page?: number
+    }
+  ): Promise<PaginatedResponse<Array<Record<string, unknown>>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const page = params?.page || 1
+    const { data, headers } = await this.request<Array<Record<string, unknown>>>(
+      'GET',
+      `/repos/${owner}/${repo}/issues`,
+      {
+        params: {
+          state: params?.state,
+          labels: params?.labels,
+          assignee: params?.assignee,
+          per_page: params?.per_page || 30,
+          page,
+        },
+      }
+    )
+    return { data, ...this.parsePagination(headers, page) }
+  }
+
+  async getIssue(owner: string, repo: string, number: number): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'GET',
+      `/repos/${owner}/${repo}/issues/${number}`
+    )
+    return data
+  }
+
+  async getIssueComments(
+    owner: string,
+    repo: string,
+    number: number,
+    params?: { per_page?: number; page?: number }
+  ): Promise<PaginatedResponse<Array<Record<string, unknown>>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const page = params?.page || 1
+    const { data, headers } = await this.request<Array<Record<string, unknown>>>(
+      'GET',
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      { params: { per_page: params?.per_page || 30, page } }
+    )
+    return { data, ...this.parsePagination(headers, page) }
+  }
+
+  async createIssue(
+    owner: string,
+    repo: string,
+    params: {
+      title: string
+      body?: string
+      labels?: string[]
+      assignees?: string[]
+    }
+  ): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'POST',
+      `/repos/${owner}/${repo}/issues`,
+      { body: params }
+    )
+    return data
+  }
+
+  async updateIssue(
+    owner: string,
+    repo: string,
+    number: number,
+    params: {
+      title?: string
+      body?: string
+      state?: string
+      labels?: string[]
+      assignees?: string[]
+    }
+  ): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'PATCH',
+      `/repos/${owner}/${repo}/issues/${number}`,
+      { body: params }
+    )
+    return data
+  }
+
+  async createComment(
+    owner: string,
+    repo: string,
+    number: number,
+    body: string
+  ): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'POST',
+      `/repos/${owner}/${repo}/issues/${number}/comments`,
+      { body: { body } }
+    )
+    return data
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Pull Requests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async listPRs(
+    owner: string,
+    repo: string,
+    params?: {
+      state?: string
+      head?: string
+      base?: string
+      per_page?: number
+      page?: number
+    }
+  ): Promise<PaginatedResponse<Array<Record<string, unknown>>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const page = params?.page || 1
+    const { data, headers } = await this.request<Array<Record<string, unknown>>>(
+      'GET',
+      `/repos/${owner}/${repo}/pulls`,
+      {
+        params: {
+          state: params?.state,
+          head: params?.head,
+          base: params?.base,
+          per_page: params?.per_page || 30,
+          page,
+        },
+      }
+    )
+    return { data, ...this.parsePagination(headers, page) }
+  }
+
+  async getPR(owner: string, repo: string, number: number): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'GET',
+      `/repos/${owner}/${repo}/pulls/${number}`
+    )
+    return data
+  }
+
+  async getPRDiff(owner: string, repo: string, number: number): Promise<string> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<string>('GET', `/repos/${owner}/${repo}/pulls/${number}`, {
+      accept: 'application/vnd.github.diff',
+      rawText: true,
+    })
+    return data
+  }
+
+  async getPRFiles(
+    owner: string,
+    repo: string,
+    number: number,
+    params?: { per_page?: number; page?: number }
+  ): Promise<PaginatedResponse<Array<Record<string, unknown>>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const page = params?.page || 1
+    const { data, headers } = await this.request<Array<Record<string, unknown>>>(
+      'GET',
+      `/repos/${owner}/${repo}/pulls/${number}/files`,
+      { params: { per_page: params?.per_page || 30, page } }
+    )
+    return { data, ...this.parsePagination(headers, page) }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Repository contents
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async getFileContents(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string
+  ): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'GET',
+      `/repos/${owner}/${repo}/contents/${path}`,
+      { params: { ref } }
+    )
+    return data
+  }
+
+  async listDirectory(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string
+  ): Promise<Array<Record<string, unknown>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Array<Record<string, unknown>>>(
+      'GET',
+      `/repos/${owner}/${repo}/contents/${path}`,
+      { params: { ref } }
+    )
+    return data
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Code search
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async searchCode(
+    query: string,
+    qualifiers?: { owner?: string; repo?: string }
+  ): Promise<{ total_count: number; items: Array<Record<string, unknown>> }> {
+    let q = query
+    if (qualifiers?.repo) {
+      q += ` repo:${qualifiers.repo}`
+    } else if (qualifiers?.owner) {
+      q += ` org:${qualifiers.owner}`
+    } else {
+      q += ' org:venturecrane'
+    }
+
+    const { data } = await this.request<{
+      total_count: number
+      items: Array<Record<string, unknown>>
+    }>('GET', '/search/code', { params: { q, per_page: 30 } })
+    return data
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Actions
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async listWorkflowRuns(
+    owner: string,
+    repo: string,
+    params?: {
+      branch?: string
+      status?: string
+      per_page?: number
+      page?: number
+    }
+  ): Promise<PaginatedResponse<Array<Record<string, unknown>>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const page = params?.page || 1
+    const { data, headers } = await this.request<{
+      total_count: number
+      workflow_runs: Array<Record<string, unknown>>
+    }>('GET', `/repos/${owner}/${repo}/actions/runs`, {
+      params: {
+        branch: params?.branch,
+        status: params?.status,
+        per_page: params?.per_page || 30,
+        page,
+      },
+    })
+    return {
+      data: data.workflow_runs,
+      total_count: data.total_count,
+      ...this.parsePagination(headers, page),
+    }
+  }
+
+  async getWorkflowRun(
+    owner: string,
+    repo: string,
+    runId: number
+  ): Promise<Record<string, unknown>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<Record<string, unknown>>(
+      'GET',
+      `/repos/${owner}/${repo}/actions/runs/${runId}`
+    )
+    return data
+  }
+
+  async listRunJobs(
+    owner: string,
+    repo: string,
+    runId: number
+  ): Promise<Array<Record<string, unknown>>> {
+    validateOwnerRepo(owner, 'owner')
+    validateOwnerRepo(repo, 'repo')
+    const { data } = await this.request<{
+      total_count: number
+      jobs: Array<Record<string, unknown>>
+    }>('GET', `/repos/${owner}/${repo}/actions/runs/${runId}/jobs`)
+    return data.jobs
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // User / diagnostics
+  // ──────────────────────────────────────────────────────────────────────────
+
+  async getAuthenticatedUser(): Promise<{
+    user: Record<string, unknown>
+    scopes: string
+    rateLimit: { remaining: string; limit: string; reset: string }
+  }> {
+    const { data, headers } = await this.request<Record<string, unknown>>('GET', '/user')
+    return {
+      user: data,
+      scopes: headers.get('x-oauth-scopes') || 'unknown',
+      rateLimit: {
+        remaining: headers.get('x-ratelimit-remaining') || 'unknown',
+        limit: headers.get('x-ratelimit-limit') || 'unknown',
+        reset: headers.get('x-ratelimit-reset') || 'unknown',
+      },
+    }
+  }
+}

--- a/workers/crane-mcp-remote/src/github-handler.ts
+++ b/workers/crane-mcp-remote/src/github-handler.ts
@@ -35,7 +35,7 @@ app.get('/authorize', async (c) => {
     upstream_url: 'https://github.com/login/oauth/authorize',
     client_id: c.env.GITHUB_CLIENT_ID,
     redirect_uri: new URL('/callback', c.req.url).href,
-    scope: 'read:user user:email',
+    scope: 'read:user user:email repo',
     state: stateToken,
   })
 
@@ -118,6 +118,7 @@ app.get('/callback', async (c) => {
       login: user.login,
       name: user.name || user.login,
       email: user.email || '',
+      github_token: accessToken,
     },
   })
 

--- a/workers/crane-mcp-remote/src/github-tools.ts
+++ b/workers/crane-mcp-remote/src/github-tools.ts
@@ -1,0 +1,656 @@
+/**
+ * GitHub MCP tool registrations for the remote crane worker.
+ *
+ * 14 tools providing Issues, PRs, Repository, Actions, and diagnostics
+ * access via the GitHub REST API. All tools use the `github_` prefix.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import type { GitHubApiClient } from './github-api.js'
+
+const RECONNECT_MESSAGE =
+  'GitHub tools require reconnecting the crane MCP integration. Go to claude.ai Settings > Integrations, disconnect crane, then reconnect to get a token with repository access.'
+
+const MAX_DIFF_CHARS = 50_000
+
+/**
+ * Register all GitHub MCP tools on the given server instance.
+ */
+export function registerGitHubTools(server: McpServer, client: GitHubApiClient): void {
+  // Helper: guard for missing token (pre-existing sessions)
+  function requireToken(): string | null {
+    if (!client.hasToken) return RECONNECT_MESSAGE
+    return null
+  }
+
+  // Helper: format error response
+  function errorResult(message: string) {
+    return {
+      content: [{ type: 'text' as const, text: message }],
+      isError: true,
+    }
+  }
+
+  // Helper: wrap tool handler with token guard and error handling
+  function safeHandler(
+    fn: () => Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }>
+  ) {
+    return async () => {
+      const tokenError = requireToken()
+      if (tokenError) return errorResult(tokenError)
+      try {
+        return await fn()
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err))
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Issues
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'github_list_issues',
+    'List issues in a GitHub repository. Returns title, number, state, labels, and assignees.',
+    {
+      owner: z.string().describe('Repository owner (org or user)'),
+      repo: z.string().describe('Repository name'),
+      state: z
+        .enum(['open', 'closed', 'all'])
+        .optional()
+        .describe('Filter by state (default: open)'),
+      labels: z.string().optional().describe('Comma-separated label names to filter by'),
+      assignee: z.string().optional().describe('Filter by assignee login'),
+      per_page: z.number().optional().describe('Results per page (default: 30, max: 100)'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+    },
+    async ({ owner, repo, state, labels, assignee, per_page, page }) => {
+      return safeHandler(async () => {
+        const result = await client.listIssues(owner, repo, {
+          state,
+          labels,
+          assignee,
+          per_page,
+          page,
+        })
+
+        if (result.data.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No issues found.' }] }
+        }
+
+        let text = `## Issues - ${owner}/${repo}\n`
+        for (const issue of result.data) {
+          const labels_str = Array.isArray(issue.labels)
+            ? (issue.labels as Array<{ name?: string }>).map((l) => l.name).join(', ')
+            : ''
+          const assignees_str = Array.isArray(issue.assignees)
+            ? (issue.assignees as Array<{ login?: string }>).map((a) => a.login).join(', ')
+            : ''
+          text += `\n### #${issue.number} ${issue.title}`
+          text += `\nState: ${issue.state}`
+          if (labels_str) text += ` | Labels: ${labels_str}`
+          if (assignees_str) text += ` | Assignees: ${assignees_str}`
+          text += `\nCreated: ${issue.created_at} | Updated: ${issue.updated_at}`
+          if (issue.pull_request) text += ' (pull request)'
+          text += '\n'
+        }
+
+        if (result.has_next_page) {
+          text += `\n---\nPage ${result.page}. Use page: ${result.page + 1} to see more.`
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_get_issue',
+    'Get full issue details including body and comments.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      number: z.number().describe('Issue number'),
+    },
+    async ({ owner, repo, number }) => {
+      return safeHandler(async () => {
+        const issue = await client.getIssue(owner, repo, number)
+        const comments = await client.getIssueComments(owner, repo, number, { per_page: 50 })
+
+        let text = `# #${issue.number} ${issue.title}\n`
+        text += `State: ${issue.state}`
+
+        const labels = issue.labels as Array<{ name?: string }> | undefined
+        if (labels?.length) text += ` | Labels: ${labels.map((l) => l.name).join(', ')}`
+
+        const assignees = issue.assignees as Array<{ login?: string }> | undefined
+        if (assignees?.length) text += ` | Assignees: ${assignees.map((a) => a.login).join(', ')}`
+
+        const user = issue.user as { login?: string } | undefined
+        text += `\nAuthor: ${user?.login || 'unknown'} | Created: ${issue.created_at} | Updated: ${issue.updated_at}`
+
+        if (issue.milestone) {
+          const ms = issue.milestone as { title?: string }
+          text += `\nMilestone: ${ms.title}`
+        }
+
+        text += `\n\n---\n\n${issue.body || '*No description*'}`
+
+        if (comments.data.length > 0) {
+          text += '\n\n---\n\n## Comments\n'
+          for (const c of comments.data) {
+            const cUser = c.user as { login?: string } | undefined
+            text += `\n### ${cUser?.login || 'unknown'} - ${c.created_at}\n${c.body}\n`
+          }
+          if (comments.has_next_page) {
+            text += `\n(${comments.data.length} comments shown. More comments exist.)`
+          }
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_create_issue',
+    'Create a new issue in a GitHub repository.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      title: z.string().describe('Issue title'),
+      body: z.string().optional().describe('Issue body (markdown)'),
+      labels: z.array(z.string()).optional().describe('Labels to apply'),
+      assignees: z.array(z.string()).optional().describe('GitHub logins to assign'),
+    },
+    async ({ owner, repo, title, body, labels, assignees }) => {
+      return safeHandler(async () => {
+        const issue = await client.createIssue(owner, repo, { title, body, labels, assignees })
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Issue created: #${issue.number} ${issue.title}\nURL: ${issue.html_url}`,
+            },
+          ],
+        }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_update_issue',
+    'Update an existing issue (title, body, state, labels, assignees).',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      number: z.number().describe('Issue number'),
+      title: z.string().optional().describe('New title'),
+      body: z.string().optional().describe('New body'),
+      state: z.enum(['open', 'closed']).optional().describe('New state'),
+      labels: z.array(z.string()).optional().describe('Replace labels (full list)'),
+      assignees: z.array(z.string()).optional().describe('Replace assignees (full list)'),
+    },
+    async ({ owner, repo, number, title, body, state, labels, assignees }) => {
+      return safeHandler(async () => {
+        const issue = await client.updateIssue(owner, repo, number, {
+          title,
+          body,
+          state,
+          labels,
+          assignees,
+        })
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Issue updated: #${issue.number} ${issue.title} (${issue.state})\nURL: ${issue.html_url}`,
+            },
+          ],
+        }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_add_comment',
+    'Add a comment to an issue or pull request.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      number: z.number().describe('Issue or PR number'),
+      body: z.string().describe('Comment body (markdown)'),
+    },
+    async ({ owner, repo, number, body }) => {
+      return safeHandler(async () => {
+        const comment = await client.createComment(owner, repo, number, body)
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Comment added to #${number}\nURL: ${comment.html_url}`,
+            },
+          ],
+        }
+      })()
+    }
+  )
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Pull Requests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'github_list_pulls',
+    'List pull requests in a GitHub repository.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      state: z
+        .enum(['open', 'closed', 'all'])
+        .optional()
+        .describe('Filter by state (default: open)'),
+      head: z.string().optional().describe('Filter by head branch (format: "user:branch")'),
+      base: z.string().optional().describe('Filter by base branch'),
+      per_page: z.number().optional().describe('Results per page (default: 30, max: 100)'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+    },
+    async ({ owner, repo, state, head, base, per_page, page }) => {
+      return safeHandler(async () => {
+        const result = await client.listPRs(owner, repo, { state, head, base, per_page, page })
+
+        if (result.data.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No pull requests found.' }] }
+        }
+
+        let text = `## Pull Requests - ${owner}/${repo}\n`
+        for (const pr of result.data) {
+          const user = pr.user as { login?: string } | undefined
+          const headRef = pr.head as { ref?: string } | undefined
+          const baseRef = pr.base as { ref?: string } | undefined
+          text += `\n### #${pr.number} ${pr.title}`
+          text += `\nState: ${pr.state} | Author: ${user?.login || 'unknown'}`
+          text += ` | ${headRef?.ref || '?'} -> ${baseRef?.ref || '?'}`
+          text += `\nCreated: ${pr.created_at} | Updated: ${pr.updated_at}`
+          if (pr.draft) text += ' | DRAFT'
+          if (pr.merged_at) text += ` | Merged: ${pr.merged_at}`
+          text += '\n'
+        }
+
+        if (result.has_next_page) {
+          text += `\n---\nPage ${result.page}. Use page: ${result.page + 1} to see more.`
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_get_pull',
+    'Get full pull request details including body, merge status, and review state.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      number: z.number().describe('PR number'),
+    },
+    async ({ owner, repo, number }) => {
+      return safeHandler(async () => {
+        const pr = await client.getPR(owner, repo, number)
+
+        let text = `# PR #${pr.number} ${pr.title}\n`
+        text += `State: ${pr.state}`
+        if (pr.draft) text += ' (DRAFT)'
+        if (pr.merged) text += ' (MERGED)'
+
+        const user = pr.user as { login?: string } | undefined
+        text += `\nAuthor: ${user?.login || 'unknown'}`
+
+        const head = pr.head as { ref?: string; sha?: string } | undefined
+        const base = pr.base as { ref?: string } | undefined
+        text += ` | ${head?.ref || '?'} -> ${base?.ref || '?'}`
+
+        text += `\nCreated: ${pr.created_at} | Updated: ${pr.updated_at}`
+        if (pr.merged_at) text += ` | Merged: ${pr.merged_at}`
+
+        const labels = pr.labels as Array<{ name?: string }> | undefined
+        if (labels?.length) text += `\nLabels: ${labels.map((l) => l.name).join(', ')}`
+
+        text += `\nChanges: +${pr.additions || 0} -${pr.deletions || 0} across ${pr.changed_files || 0} files`
+        text += `\nMergeable: ${pr.mergeable ?? 'unknown'} | Mergeable state: ${pr.mergeable_state || 'unknown'}`
+
+        text += `\n\n---\n\n${pr.body || '*No description*'}`
+        text += `\n\nURL: ${pr.html_url}`
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_get_pull_diff',
+    'Get the diff for a pull request. Large diffs (>50K chars) are truncated with a file summary.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      number: z.number().describe('PR number'),
+    },
+    async ({ owner, repo, number }) => {
+      return safeHandler(async () => {
+        let diff = await client.getPRDiff(owner, repo, number)
+
+        if (diff.length <= MAX_DIFF_CHARS) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `## Diff for PR #${number}\n\n\`\`\`diff\n${diff}\n\`\`\``,
+              },
+            ],
+          }
+        }
+
+        // Diff is too large - get file summary and truncate
+        const files = await client.getPRFiles(owner, repo, number, { per_page: 100 })
+
+        let text = `## Diff for PR #${number} (truncated - ${diff.length} chars total)\n\n`
+        text += '### File Summary\n'
+        for (const f of files.data) {
+          text += `- ${f.filename} (+${f.additions || 0} -${f.deletions || 0}) [${f.status}]\n`
+        }
+        text += `\n### Truncated Diff (first ${MAX_DIFF_CHARS} chars)\n\n`
+
+        diff = diff.substring(0, MAX_DIFF_CHARS)
+        // Truncate at the last complete line
+        const lastNewline = diff.lastIndexOf('\n')
+        if (lastNewline > 0) diff = diff.substring(0, lastNewline)
+
+        text += `\`\`\`diff\n${diff}\n\`\`\``
+        text += `\n\n*Diff truncated. Use github_get_file to view specific files.*`
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Repository
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'github_get_file',
+    'Get file contents from a repository. GitHub API has a 1MB limit for this endpoint - use github_get_pull_diff for large files.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      path: z.string().describe('File path within the repository'),
+      ref: z
+        .string()
+        .optional()
+        .describe('Git ref (branch, tag, or SHA). Defaults to default branch.'),
+    },
+    async ({ owner, repo, path, ref }) => {
+      return safeHandler(async () => {
+        const file = await client.getFileContents(owner, repo, path, ref)
+
+        if (file.type !== 'file') {
+          return errorResult(
+            `Path "${path}" is a ${file.type}, not a file. Use github_list_directory instead.`
+          )
+        }
+
+        let content: string
+        if (typeof file.content === 'string' && file.encoding === 'base64') {
+          content = atob(file.content.replace(/\n/g, ''))
+        } else {
+          content = String(file.content || '')
+        }
+
+        let text = `## ${path}\n`
+        text += `SHA: ${file.sha} | Size: ${file.size} bytes`
+        if (ref) text += ` | Ref: ${ref}`
+        text += `\n\n${content}`
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_list_directory',
+    'List directory contents in a repository.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      path: z.string().optional().describe('Directory path (empty or "/" for root)'),
+      ref: z
+        .string()
+        .optional()
+        .describe('Git ref (branch, tag, or SHA). Defaults to default branch.'),
+    },
+    async ({ owner, repo, path, ref }) => {
+      return safeHandler(async () => {
+        const entries = await client.listDirectory(owner, repo, path || '', ref)
+
+        if (!Array.isArray(entries)) {
+          return errorResult(
+            `Path "${path}" is a file, not a directory. Use github_get_file instead.`
+          )
+        }
+
+        let text = `## ${owner}/${repo}/${path || ''}\n`
+        if (ref) text += `Ref: ${ref}\n`
+
+        // Sort: directories first, then files
+        const sorted = [...entries].sort((a, b) => {
+          if (a.type === 'dir' && b.type !== 'dir') return -1
+          if (a.type !== 'dir' && b.type === 'dir') return 1
+          return String(a.name).localeCompare(String(b.name))
+        })
+
+        for (const entry of sorted) {
+          const icon = entry.type === 'dir' ? '/' : ''
+          const size = entry.type === 'file' ? ` (${entry.size} bytes)` : ''
+          text += `\n- ${entry.name}${icon}${size}`
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_search_code',
+    'Search for code across GitHub repositories. Best results when scoped to an owner or repo. Defaults to org:venturecrane when no scope is provided.',
+    {
+      query: z.string().describe('Search query (code, filename, etc.)'),
+      owner: z.string().optional().describe('Scope to repositories owned by this user/org'),
+      repo: z.string().optional().describe('Scope to a specific repo (format: "owner/repo")'),
+    },
+    async ({ query, owner, repo }) => {
+      return safeHandler(async () => {
+        const result = await client.searchCode(query, { owner, repo })
+
+        if (result.items.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No code matches found.' }] }
+        }
+
+        let text = `## Code Search Results (${result.total_count} total)\n`
+        for (const item of result.items) {
+          const itemRepo = item.repository as { full_name?: string } | undefined
+          text += `\n### ${item.name}`
+          text += `\nRepo: ${itemRepo?.full_name || 'unknown'} | Path: ${item.path}`
+          text += `\nURL: ${item.html_url}\n`
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Actions
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'github_list_runs',
+    'List recent workflow runs (CI/CD) for a repository.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      branch: z.string().optional().describe('Filter by branch name'),
+      status: z
+        .enum([
+          'completed',
+          'action_required',
+          'cancelled',
+          'failure',
+          'neutral',
+          'skipped',
+          'stale',
+          'success',
+          'timed_out',
+          'in_progress',
+          'queued',
+          'requested',
+          'waiting',
+          'pending',
+        ])
+        .optional()
+        .describe('Filter by status'),
+      per_page: z.number().optional().describe('Results per page (default: 30, max: 100)'),
+      page: z.number().optional().describe('Page number (default: 1)'),
+    },
+    async ({ owner, repo, branch, status, per_page, page }) => {
+      return safeHandler(async () => {
+        const result = await client.listWorkflowRuns(owner, repo, {
+          branch,
+          status,
+          per_page,
+          page,
+        })
+
+        if (result.data.length === 0) {
+          return { content: [{ type: 'text' as const, text: 'No workflow runs found.' }] }
+        }
+
+        let text = `## Workflow Runs - ${owner}/${repo}`
+        if (result.total_count !== undefined) text += ` (${result.total_count} total)`
+        text += '\n'
+
+        for (const run of result.data) {
+          const conclusion = run.conclusion ? ` - ${run.conclusion}` : ''
+          text += `\n### ${run.name || 'Unnamed'} #${run.run_number}`
+          text += `\nStatus: ${run.status}${conclusion}`
+          text += ` | Branch: ${(run.head_branch as string) || '?'}`
+          text += ` | Run ID: ${run.id}`
+          text += `\nTriggered: ${run.created_at} | Event: ${run.event}`
+
+          const actor = run.actor as { login?: string } | undefined
+          if (actor?.login) text += ` | Actor: ${actor.login}`
+
+          text += `\nURL: ${run.html_url}\n`
+        }
+
+        if (result.has_next_page) {
+          text += `\n---\nPage ${result.page}. Use page: ${result.page + 1} to see more.`
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  server.tool(
+    'github_get_run',
+    'Get workflow run details including individual job statuses and steps.',
+    {
+      owner: z.string().describe('Repository owner'),
+      repo: z.string().describe('Repository name'),
+      run_id: z.number().describe('Workflow run ID'),
+    },
+    async ({ owner, repo, run_id }) => {
+      return safeHandler(async () => {
+        const [run, jobs] = await Promise.all([
+          client.getWorkflowRun(owner, repo, run_id),
+          client.listRunJobs(owner, repo, run_id),
+        ])
+
+        let text = `# ${run.name || 'Unnamed'} #${run.run_number}\n`
+        text += `Status: ${run.status}`
+        if (run.conclusion) text += ` - ${run.conclusion}`
+        text += `\nBranch: ${(run.head_branch as string) || '?'} | Event: ${run.event}`
+        text += `\nStarted: ${run.run_started_at || run.created_at}`
+        if (run.updated_at) text += ` | Updated: ${run.updated_at}`
+
+        const actor = run.actor as { login?: string } | undefined
+        if (actor?.login) text += `\nActor: ${actor.login}`
+
+        text += `\nURL: ${run.html_url}`
+
+        if (jobs.length > 0) {
+          text += '\n\n---\n\n## Jobs\n'
+          for (const job of jobs) {
+            const conclusion = job.conclusion ? ` - ${job.conclusion}` : ''
+            text += `\n### ${job.name}${conclusion}`
+            text += `\nStatus: ${job.status}${conclusion}`
+            if (job.started_at) text += ` | Started: ${job.started_at}`
+            if (job.completed_at) text += ` | Completed: ${job.completed_at}`
+
+            const steps = job.steps as
+              | Array<{
+                  name?: string
+                  status?: string
+                  conclusion?: string
+                  number?: number
+                }>
+              | undefined
+            if (steps?.length) {
+              text += '\nSteps:'
+              for (const step of steps) {
+                const stepConclusion = step.conclusion ? ` - ${step.conclusion}` : ''
+                text += `\n  ${step.number}. ${step.name}: ${step.status}${stepConclusion}`
+              }
+            }
+            text += '\n'
+          }
+        }
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Utility
+  // ──────────────────────────────────────────────────────────────────────────
+
+  server.tool(
+    'github_whoami',
+    'Show authenticated GitHub user, token scopes, and rate limit status. Use this to diagnose connectivity issues.',
+    {},
+    async () => {
+      return safeHandler(async () => {
+        const { user, scopes, rateLimit } = await client.getAuthenticatedUser()
+
+        const resetDate =
+          rateLimit.reset !== 'unknown'
+            ? new Date(parseInt(rateLimit.reset, 10) * 1000).toISOString()
+            : 'unknown'
+
+        let text = `## GitHub Authentication Status\n`
+        text += `\nLogin: ${user.login}`
+        text += `\nName: ${user.name || 'not set'}`
+        text += `\nEmail: ${user.email || 'not set'}`
+        text += `\n\n### Token Scopes\n${scopes}`
+        text += `\n\n### Rate Limit`
+        text += `\nRemaining: ${rateLimit.remaining} / ${rateLimit.limit}`
+        text += `\nResets: ${resetDate}`
+
+        return { content: [{ type: 'text' as const, text }] }
+      })()
+    }
+  )
+}

--- a/workers/crane-mcp-remote/src/index.ts
+++ b/workers/crane-mcp-remote/src/index.ts
@@ -16,7 +16,9 @@ import OAuthProvider from '@cloudflare/workers-oauth-provider'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { McpAgent } from 'agents/mcp'
 import { CraneContextClient } from './crane-api.js'
+import { GitHubApiClient } from './github-api.js'
 import { GitHubHandler } from './github-handler.js'
+import { registerGitHubTools } from './github-tools.js'
 import { registerTools } from './tools.js'
 import type { Env, Props } from './types.js'
 
@@ -34,7 +36,13 @@ export class CraneMCP extends McpAgent<Env, Record<string, never>, Props> {
       this.env.CACHE_KV
     )
 
+    const github = new GitHubApiClient(
+      this.props?.github_token || '',
+      this.props?.login || 'anonymous'
+    )
+
     registerTools(this.server, api)
+    registerGitHubTools(this.server, github)
   }
 }
 

--- a/workers/crane-mcp-remote/src/types.ts
+++ b/workers/crane-mcp-remote/src/types.ts
@@ -20,4 +20,5 @@ export type Props = {
   login: string
   name: string
   email: string
+  github_token: string
 }


### PR DESCRIPTION
## Summary
- Adds 14 GitHub REST API tools (`github_` prefix) to crane-mcp-remote, giving claude.ai and Claude Desktop full GitHub access for issues, PRs, repo contents, CI/CD, and code search
- Persists GitHub OAuth token in encrypted session props with `repo` scope
- Fixes session history display bug where overnight blocks showed end time before start time

## Changes
- **New**: `github-api.ts` - GitHub REST API client with centralized error handling, input validation, pagination
- **New**: `github-tools.ts` - 14 MCP tool registrations with empty-token guard for pre-existing sessions
- **Modified**: `github-handler.ts` - Added `repo` OAuth scope, persist access token in props
- **Modified**: `index.ts` - Wire up GitHubApiClient and registerGitHubTools
- **Modified**: `types.ts` - Add `github_token` to Props
- **Modified**: `schedule.ts` - Show date when session blocks span midnight
- **Modified**: `CLAUDE.md` - Updated architecture diagram and tools table

## Test plan
- [x] `npm run verify` passes (typecheck + format + lint + 268 tests)
- [x] Deployed to staging and production
- [x] User confirmed tools working after OAuth reconnect in Claude Desktop
- [ ] Verify GitHub App permissions (Issues R/W, PRs R/W, Contents Read, Actions Read)
- [ ] Test write operations (create issue, add comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)