### PR TITLE
feat: integrate Google Stitch MCP server fleet-wide

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,6 +4,11 @@
       "command": "crane-mcp",
       "args": [],
       "env": {}
+    },
+    "stitch": {
+      "command": "npx",
+      "args": ["@_davideast/stitch-mcp@0.5.1", "proxy"],
+      "env": {}
     }
   }
 }

--- a/config/ventures.json
+++ b/config/ventures.json
@@ -8,7 +8,8 @@
       "CRANE_ADMIN_KEY",
       "GH_TOKEN",
       "VERCEL_TOKEN",
-      "CLOUDFLARE_API_TOKEN"
+      "CLOUDFLARE_API_TOKEN",
+      "STITCH_API_KEY"
     ]
   },
   "ventures": [

--- a/docs/design/ventures/dc/DESIGN.md
+++ b/docs/design/ventures/dc/DESIGN.md
@@ -1,0 +1,250 @@
+# Draft Crane - Stitch Design Spec
+
+Design system definition for Google Stitch project import. Derived from the canonical
+`design-spec.md` - when values conflict, design-spec.md wins.
+
+## Design System Overview
+
+- **Brand:** Draft Crane - Book-writing tool for experts
+- **Audience:** Subject matter experts and professionals writing non-fiction books
+- **Platform:** iPad-first web app (Next.js 16, Tailwind v4, Vercel)
+- **Theme:** Light-only
+- **Voice:** Professional, focused, supportive
+- **Interaction Model:** Dual-zone - Author zone (Blue/Primary) for content creation, Editor zone (Violet/Escalation) for AI-powered review and feedback
+
+## Color Palette
+
+### Text
+
+| Token                         | Hex       | Usage                            |
+| ----------------------------- | --------- | -------------------------------- |
+| `--dc-color-text-primary`     | `#111827` | Headings, prominent labels       |
+| `--dc-color-text-secondary`   | `#374151` | Body text, descriptions          |
+| `--dc-color-text-muted`       | `#6b7280` | Captions, hints, idle labels     |
+| `--dc-color-text-placeholder` | `#9ca3af` | Input placeholders               |
+| `--dc-color-text-inverse`     | `#ffffff` | Text on dark/colored backgrounds |
+
+### Surfaces
+
+| Token                          | Hex               | Usage                                |
+| ------------------------------ | ----------------- | ------------------------------------ |
+| `--dc-color-surface-primary`   | `#ffffff`         | Panel backgrounds, toggle indicators |
+| `--dc-color-surface-secondary` | `#f9fafb`         | Subtle background tint               |
+| `--dc-color-surface-tertiary`  | `#f3f4f6`         | Toggle tracks, hover backgrounds     |
+| `--dc-color-surface-overlay`   | `rgba(0,0,0,0.5)` | Modal/dialog backdrops               |
+
+### Borders
+
+| Token                       | Hex       | Usage                              |
+| --------------------------- | --------- | ---------------------------------- |
+| `--dc-color-border-default` | `#e5e7eb` | Standard borders                   |
+| `--dc-color-border-subtle`  | `#f3f4f6` | Dividers, separators               |
+| `--dc-color-border-strong`  | `#d1d5db` | Emphasized borders, input outlines |
+| `--dc-color-border-focus`   | `#2563eb` | Focus rings                        |
+
+### Primary Interactive (Blue - Author Zone)
+
+| Token                                      | Hex       | Usage                       |
+| ------------------------------------------ | --------- | --------------------------- |
+| `--dc-color-interactive-primary`           | `#2563eb` | Primary actions, links      |
+| `--dc-color-interactive-primary-subtle`    | `#eff6ff` | Light blue tint backgrounds |
+| `--dc-color-interactive-primary-on-subtle` | `#1d4ed8` | Blue text on blue-subtle    |
+| `--dc-color-interactive-primary-hover`     | `#1d4ed8` | Hover state                 |
+| `--dc-color-interactive-primary-active`    | `#1e40af` | Active/pressed state        |
+| `--dc-color-interactive-primary-border`    | `#93c5fd` | Focus/selection borders     |
+
+### Escalation Interactive (Violet - Editor Zone)
+
+| Token                                      | Hex       | Usage                         |
+| ------------------------------------------ | --------- | ----------------------------- |
+| `--dc-color-interactive-escalation`        | `#7c3aed` | Editor actions, AI escalation |
+| `--dc-color-interactive-escalation-subtle` | `#f5f3ff` | Light violet tint backgrounds |
+| `--dc-color-interactive-escalation-hover`  | `#6d28d9` | Hover state                   |
+| `--dc-color-interactive-escalation-border` | `#c4b5fd` | Focus/selection borders       |
+
+### Destructive
+
+| Token                                       | Hex       | Usage                               |
+| ------------------------------------------- | --------- | ----------------------------------- |
+| `--dc-color-interactive-destructive`        | `#dc2626` | Delete buttons, destructive actions |
+| `--dc-color-interactive-destructive-hover`  | `#b91c1c` | Hover on destructive actions        |
+| `--dc-color-interactive-destructive-subtle` | `#fef2f2` | Light red tint backgrounds          |
+
+### Status
+
+| Token                          | Hex       | Usage                   |
+| ------------------------------ | --------- | ----------------------- |
+| `--dc-color-status-error`      | `#dc2626` | Error states            |
+| `--dc-color-error-bg`          | `#fef2f2` | Error background tint   |
+| `--dc-color-status-success`    | `#059669` | Success states          |
+| `--dc-color-success-bg`        | `#ecfdf5` | Success background tint |
+| `--dc-color-status-warning`    | `#d97706` | Warnings, cautions      |
+| `--dc-color-status-warning-bg` | `#fffbeb` | Warning background tint |
+
+## Typography
+
+### Font Stacks
+
+| Role           | Stack                                                          |
+| -------------- | -------------------------------------------------------------- |
+| Sans (UI)      | `var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif` |
+| Serif (Editor) | `var(--font-lora), ui-serif, Georgia, serif`                   |
+| Mono (Code)    | `var(--font-geist-mono), ui-monospace, monospace`              |
+
+Geist Sans and Geist Mono loaded via Next.js font optimization. Lora (serif) is used for long-form reading in the editor.
+
+### Size Scale
+
+| Token            | Size            | Usage                  |
+| ---------------- | --------------- | ---------------------- |
+| `--dc-text-xs`   | 0.75rem (12px)  | Fine print, metadata   |
+| `--dc-text-sm`   | 0.875rem (14px) | Captions, secondary UI |
+| `--dc-text-base` | 1rem (16px)     | Body text (default)    |
+| `--dc-text-lg`   | 1.125rem (18px) | Prominent body text    |
+| `--dc-text-xl`   | 1.25rem (20px)  | Small headings         |
+| `--dc-text-2xl`  | 1.5rem (24px)   | Medium headings        |
+| `--dc-text-3xl`  | 1.875rem (30px) | Large headings         |
+
+### Line Heights
+
+| Token                  | Value | Usage             |
+| ---------------------- | ----- | ----------------- |
+| `--dc-leading-tight`   | 1.25  | Headings          |
+| `--dc-leading-snug`    | 1.375 | Subheadings       |
+| `--dc-leading-normal`  | 1.5   | Body text         |
+| `--dc-leading-relaxed` | 1.625 | Long-form reading |
+| `--dc-leading-loose`   | 1.75  | Spacious reading  |
+
+### Font Weights
+
+- Regular (400): Body text, descriptions
+- Medium (500): Labels, UI elements
+- Semibold (600): Headings, emphasis
+- Bold (700): Strong emphasis, primary CTAs
+
+## Spacing
+
+**Base Unit:** 4px grid
+
+| Token              | Value | Usage                     |
+| ------------------ | ----- | ------------------------- |
+| `--dc-spacing-xs`  | 4px   | Minimal gaps              |
+| `--dc-spacing-sm`  | 8px   | Small gaps, tight padding |
+| `--dc-spacing-md`  | 12px  | Medium gaps               |
+| `--dc-spacing-lg`  | 16px  | Standard padding, gaps    |
+| `--dc-spacing-xl`  | 24px  | Section spacing           |
+| `--dc-spacing-2xl` | 32px  | Large section spacing     |
+| `--dc-spacing-3xl` | 48px  | Major section breaks      |
+
+### Border Radius
+
+| Token              | Value  | Usage                   |
+| ------------------ | ------ | ----------------------- |
+| `--dc-radius-sm`   | 4px    | Small elements, chips   |
+| `--dc-radius-md`   | 8px    | Buttons, inputs, cards  |
+| `--dc-radius-lg`   | 12px   | Panels, modals          |
+| `--dc-radius-xl`   | 16px   | Large panels            |
+| `--dc-radius-full` | 9999px | Pills, circular avatars |
+
+## Component Patterns
+
+### Toolbar
+
+- Height: 48px (`--dc-toolbar-height`)
+- Horizontal padding: 16px
+- Item gap: 8px
+- Touch-target compliant buttons
+
+### Toggle Controls
+
+- Height: 44px (`--dc-toggle-height`)
+- Option height: 40px
+- Minimum option width: 72px
+- Background: surface-tertiary, active indicator: surface-primary
+
+### Feedback Sheet
+
+- Max height: 85vh
+- Textarea minimum height: 120px
+- Background: surface-primary with border-default
+
+### Onboarding Cards
+
+- Width: 300px (max: calc(100vw - 32px))
+- Arrow indicators (8px) and dot navigation
+- Shadow: `0 8px 32px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.04)`
+
+### Editor Panel
+
+- TipTap (ProseMirror) rich text editor
+- Serif font (Lora) for content, sans for UI chrome
+- Full-width content area with structured toolbar
+
+### Touch Targets
+
+- Minimum: 44px (Apple HIG / WCAG 2.5.8)
+- AI action buttons: 48px
+- Compact suggestion chips: 36px
+
+### ARIA Patterns
+
+- All interactive zones use proper `role`, `aria-label`, and keyboard navigation
+- Focus management for modals and overlays
+- Screen reader announcements for state changes
+- Consistent 2px focus ring in `#2563eb`
+
+## Layout Rules
+
+### Responsive Design
+
+- iPad-first responsive layout
+- Safe area support for iPad notch/status bar and home indicator
+- Safe area tokens: `env(safe-area-inset-top)`, `env(safe-area-inset-bottom)`, etc.
+- Virtual keyboard offset managed via `--keyboard-height` CSS variable
+
+### Z-Index Scale
+
+| Layer                     | Value |
+| ------------------------- | ----- |
+| Base                      | 0     |
+| Sidebar pills             | 40    |
+| Dropdowns/Overlays/Modals | 50    |
+| Onboarding                | 100   |
+| Toasts                    | 9999  |
+
+### Shadows
+
+| Level   | Value                                                               |
+| ------- | ------------------------------------------------------------------- |
+| Small   | `0 1px 2px rgba(0,0,0,0.05)`                                        |
+| Medium  | `0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1)`    |
+| Large   | `0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1)`  |
+| XL      | `0 20px 25px -5px rgba(0,0,0,0.1), 0 8px 10px -6px rgba(0,0,0,0.1)` |
+| Tooltip | `0 4px 12px rgba(0,0,0,0.15)`                                       |
+
+## Motion
+
+Maximum duration: 300ms across all animations. All animations respect `prefers-reduced-motion`.
+
+| Token                 | Duration | Usage                              |
+| --------------------- | -------- | ---------------------------------- |
+| `--dc-motion-instant` | 100ms    | Immediate feedback (hover, active) |
+| `--dc-motion-fast`    | 150ms    | Quick transitions                  |
+| `--dc-motion-normal`  | 200ms    | Standard transitions               |
+| `--dc-motion-slow`    | 300ms    | Deliberate, emphasized transitions |
+
+Easing: `ease-in-out` for state changes, `ease-out` for entrances, `ease-in` for exits, `cubic-bezier(0.34, 1.56, 0.64, 1)` for playful micro-interactions.
+
+## Interaction Model
+
+### Author Zone (Blue/Primary)
+
+- All content creation actions use the primary blue palette
+- `--dc-color-interactive-primary` (#2563eb) as the base
+- Applied to: write, edit, save, format, navigate
+
+### Editor Zone (Violet/Escalation)
+
+- All AI-powered review and feedback actions use the violet palette
+- `--dc-color-interactive-escalation` (#7c3aed) as the base
+- Applied to: AI suggestions, editor feedback, review panels, escalation controls

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -91,6 +91,19 @@ When adding new tokens during implementation:
 - **Quick start:** Copy `templates/venture/docs/design/design-spec.md`, substitute `--{code}-` prefix
 - **Full process:** Run `/design-brief` for a multi-agent design brief, then generate the design spec from its output
 
+## Stitch DESIGN.md Files
+
+For ventures using Google Stitch for UI generation, a `DESIGN.md` file provides Stitch with design system context. These are derivative of the canonical `design-spec.md` - formatted for Stitch project import.
+
+**Location:** `docs/design/ventures/{code}/DESIGN.md`
+
+**Relationship to design-spec.md:** `design-spec.md` is the canonical source of truth. `DESIGN.md` is a Stitch-compatible derivative. When they conflict, `design-spec.md` wins. Update `DESIGN.md` when `design-spec.md` changes.
+
+| Venture        | Code | DESIGN.md                           | Status            |
+| -------------- | ---- | ----------------------------------- | ----------------- |
+| Draft Crane    | `dc` | `docs/design/ventures/dc/DESIGN.md` | Available         |
+| Other ventures | -    | -                                   | Created on demand |
+
 ## Versioning
 
 Design specs track HEAD. If working on an old branch with outdated design tokens, update the spec or rebase - do not implement against stale tokens.

--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -83,6 +83,50 @@ If Dev finds a conflict between wireframe and AC:
 
 Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM changes after that point require Captain approval.
 
+## Google Stitch Integration
+
+[Stitch](https://stitch.withgoogle.com) generates visual UI from text prompts. Use it for complex interaction UI where describing layout through text alone is inefficient.
+
+### When to Use Stitch
+
+- **Complex interaction patterns** (multi-panel editors, drag-and-drop, streaming feedback) - Stitch
+- **Simple layouts** (landing pages, forms, lists) - direct wireframe generation per the prompt template above
+
+### MCP Tools (Fleet-Managed)
+
+The `stitch` MCP server is registered fleet-wide via `.mcp.json`. Available tools:
+
+| Tool               | Purpose                                         |
+| ------------------ | ----------------------------------------------- |
+| `build_site`       | Create or update a Stitch project from a prompt |
+| `get_screen_code`  | Export HTML/CSS/JS for a specific screen        |
+| `get_screen_image` | Export a screenshot of a specific screen        |
+
+### Project Conventions
+
+- **Project name:** `{venture-code}-{issue-number}` (e.g., `dc-395`)
+- **Screen naming:** Descriptive kebab-case (e.g., `editor-panel-feedback`, `mobile-nav`)
+- Import the venture's `DESIGN.md` into the Stitch project for brand-accurate output
+
+### Stitch Output in the Wireframe Pipeline
+
+Stitch output feeds into the same pipeline as hand-written wireframes:
+
+1. Generate screens in Stitch (iterate on prompts until interaction model is right)
+2. Export via `get_screen_code` into `/docs/wireframes/{issue-number}/`
+3. Commit as the wireframe artifact - same freeze rule applies
+4. Dev implements from the wireframe + ACs (ACs are still canonical)
+
+### Alternative: Official Google MCP Endpoint
+
+For ad-hoc use outside the fleet, the official HTTP endpoint is available:
+
+```
+claude mcp add stitch --transport http --url https://stitch.googleapis.com/mcp --header "x-goog-api-key: YOUR_KEY"
+```
+
+This is not fleet-managed. Prefer the stdio server in `.mcp.json` for consistency.
+
 ## What Wireframes Are NOT
 
 - Not final designs (no brand colors, exact typography, or pixel-perfect asset placement)

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
@@ -37,7 +37,7 @@ vi.mock('./ssh-auth.js', () => ({
   prepareSSHAuth: vi.fn(() => ({ env: {} })),
 }))
 
-import { setupGeminiMcp, extractPassthroughArgs } from './launch-lib.js'
+import { setupGeminiMcp, setupClaudeMcp, extractPassthroughArgs } from './launch-lib.js'
 
 const EXPECTED_ENV_KEYS = [
   'CRANE_CONTEXT_KEY',
@@ -48,6 +48,7 @@ const EXPECTED_ENV_KEYS = [
   'GH_TOKEN',
   'VERCEL_TOKEN',
   'CLOUDFLARE_API_TOKEN',
+  'STITCH_API_KEY',
 ]
 
 function getWritten(): Record<string, unknown> {
@@ -172,6 +173,7 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+            STITCH_API_KEY: '$STITCH_API_KEY',
           },
         },
       },
@@ -276,6 +278,7 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+            STITCH_API_KEY: '$STITCH_API_KEY',
           },
         },
       },
@@ -311,6 +314,7 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+            STITCH_API_KEY: '$STITCH_API_KEY',
           },
         },
       },
@@ -340,6 +344,149 @@ describe('setupGeminiMcp', () => {
     for (const key of EXPECTED_ENV_KEYS) {
       expect(allowed).toContain(key)
     }
+  })
+})
+
+describe('setupClaudeMcp', () => {
+  const SOURCE_CONFIG = {
+    mcpServers: {
+      crane: { command: 'crane-mcp', args: [], env: {} },
+      stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'], env: {} },
+    },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('copies from source when target does not exist', () => {
+    vi.mocked(existsSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('crane-console')) return true
+      return false
+    })
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      return JSON.stringify(SOURCE_CONFIG)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(copyFileSync).toHaveBeenCalledTimes(1)
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('syncs missing servers from source into target', () => {
+    const targetConfig = {
+      mcpServers: {
+        crane: { command: 'crane-mcp', args: [], env: {} },
+      },
+    }
+
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      if (String(filePath).includes('crane-console')) return JSON.stringify(SOURCE_CONFIG)
+      return JSON.stringify(targetConfig)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.mcpServers.stitch).toEqual(SOURCE_CONFIG.mcpServers.stitch)
+  })
+
+  it('updates stale server configs when source has newer version', () => {
+    const targetConfig = {
+      mcpServers: {
+        crane: { command: 'crane-mcp', args: [], env: {} },
+        stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.4.0', 'proxy'], env: {} },
+      },
+    }
+
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      if (String(filePath).includes('crane-console')) return JSON.stringify(SOURCE_CONFIG)
+      return JSON.stringify(targetConfig)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
+  })
+
+  it('skips write when target matches source', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      return JSON.stringify(SOURCE_CONFIG)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('overwrites malformed target JSON', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      if (String(filePath).includes('crane-console')) return JSON.stringify(SOURCE_CONFIG)
+      return '{invalid json'
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(copyFileSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves target-only servers not in source', () => {
+    const targetConfig = {
+      mcpServers: {
+        crane: { command: 'crane-mcp', args: [], env: {} },
+        stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'], env: {} },
+        custom: { command: 'custom-mcp', args: [] },
+      },
+    }
+
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      if (String(filePath).includes('crane-console')) return JSON.stringify(SOURCE_CONFIG)
+      return JSON.stringify(targetConfig)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    // No write needed - source servers match target. Custom server is preserved.
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -26,6 +26,10 @@ import { API_BASE_PRODUCTION, getCraneEnv, getStagingInfisicalPath } from '../li
 import { scanLocalRepos, LocalRepo } from '../lib/repo-scanner.js'
 import { prepareSSHAuth } from './ssh-auth.js'
 
+/** Pinned stitch-mcp version. Update here AND in .mcp.json together.
+ *  Verify: npm view @_davideast/stitch-mcp version */
+const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
+
 // Resolve crane-console root relative to this script
 // Compiled path: packages/crane-mcp/dist/cli/launch-lib.js -> 4 levels up
 const __filename = fileURLToPath(import.meta.url)
@@ -611,14 +615,56 @@ export function checkMcpBinary(): void {
 
 export function setupClaudeMcp(repoPath: string): void {
   const mcpJson = join(repoPath, '.mcp.json')
+  const source = join(CRANE_CONSOLE_ROOT, '.mcp.json')
+
+  if (!existsSync(source)) {
+    console.warn('-> Warning: .mcp.json missing in crane-console')
+    return
+  }
+
+  let sourceConfig: Record<string, unknown>
+  try {
+    sourceConfig = JSON.parse(readFileSync(source, 'utf-8'))
+  } catch {
+    console.warn('-> Warning: .mcp.json in crane-console is malformed')
+    return
+  }
+
+  const sourceServers = (sourceConfig.mcpServers ?? {}) as Record<string, unknown>
+
+  // If target doesn't exist, copy from source
   if (!existsSync(mcpJson)) {
-    const source = join(CRANE_CONSOLE_ROOT, '.mcp.json')
-    if (existsSync(source)) {
-      copyFileSync(source, mcpJson)
-      console.log('-> Copied .mcp.json from crane-console')
-    } else {
-      console.warn('-> Warning: .mcp.json missing - crane MCP tools may not work')
+    copyFileSync(source, mcpJson)
+    console.log('-> Copied .mcp.json from crane-console')
+    return
+  }
+
+  // Sync: add missing servers AND update stale configs from source
+  let targetConfig: Record<string, unknown>
+  try {
+    targetConfig = JSON.parse(readFileSync(mcpJson, 'utf-8'))
+  } catch {
+    copyFileSync(source, mcpJson)
+    console.log('-> Replaced malformed .mcp.json from crane-console')
+    return
+  }
+
+  if (!targetConfig.mcpServers) {
+    targetConfig.mcpServers = {}
+  }
+  const targetServers = targetConfig.mcpServers as Record<string, unknown>
+
+  let dirty = false
+  for (const [name, config] of Object.entries(sourceServers)) {
+    if (JSON.stringify(targetServers[name]) !== JSON.stringify(config)) {
+      targetServers[name] = config
+      dirty = true
     }
+  }
+
+  if (dirty) {
+    writeFileSync(mcpJson, JSON.stringify(targetConfig, null, 2) + '\n')
+    console.log('-> Updated .mcp.json (synced MCP servers from crane-console)')
   }
 }
 
@@ -650,6 +696,7 @@ export function setupGeminiMcp(repoPath: string): void {
     GH_TOKEN: '$GH_TOKEN',
     VERCEL_TOKEN: '$VERCEL_TOKEN',
     CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+    STITCH_API_KEY: '$STITCH_API_KEY',
   }
 
   // Gemini CLI sanitizes process.env before passing to MCP servers, stripping
@@ -676,6 +723,26 @@ export function setupGeminiMcp(repoPath: string): void {
       env: mcpEnv,
     }
     dirty = true
+  }
+
+  // --- Stitch MCP server (only if STITCH_API_KEY is available) ---
+  if (process.env.STITCH_API_KEY) {
+    if (mcpServers.stitch) {
+      const stitch = mcpServers.stitch as Record<string, unknown>
+      const existing = (stitch.env ?? {}) as Record<string, string>
+      const merged = { ...existing, STITCH_API_KEY: '$STITCH_API_KEY' }
+      if (JSON.stringify(existing) !== JSON.stringify(merged)) {
+        stitch.env = merged
+        dirty = true
+      }
+    } else {
+      mcpServers.stitch = {
+        command: 'npx',
+        args: [`@_davideast/stitch-mcp@${STITCH_MCP_VERSION}`, 'proxy'],
+        env: { STITCH_API_KEY: '$STITCH_API_KEY' },
+      }
+      dirty = true
+    }
   }
 
   // --- Security allowlist for env sanitization bypass ---
@@ -720,7 +787,7 @@ export function setupCodexMcp(): void {
   //   2. shell_environment_policy - stops the default filter for shell
   //      commands so gh CLI etc. can access GH_TOKEN
   const envVars =
-    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN"]'
+    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN", "STITCH_API_KEY"]'
 
   let updated = false
 
@@ -749,6 +816,18 @@ export function setupCodexMcp(): void {
     const fullEntry = '\n[mcp_servers.crane]\ncommand = "crane-mcp"\n' + `env_vars = ${envVars}\n`
     content = content.trimEnd() + '\n' + fullEntry
     updated = true
+  }
+
+  // --- Stitch MCP server (only if STITCH_API_KEY is available) ---
+  if (process.env.STITCH_API_KEY) {
+    if (!content.includes('[mcp_servers.stitch]')) {
+      const stitchEntry =
+        `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
+        `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
+        'env_vars = ["STITCH_API_KEY"]\n'
+      content = content.trimEnd() + '\n' + stitchEntry
+      updated = true
+    }
   }
 
   // --- Shell environment policy ---


### PR DESCRIPTION
## Summary

- Register `@_davideast/stitch-mcp@0.5.1` across Claude (`.mcp.json`), Gemini, and Codex agent configs for fleet-wide visual UI generation via MCP
- Upgrade `setupClaudeMcp` from copy-if-missing to JSON sync so version bumps in crane-console propagate to target repos on next `crane` launch
- Add `STITCH_API_KEY` to shared secrets, Gemini security allowlist, and Codex env whitelist (guarded - stitch server only registered when key is present in Gemini/Codex)
- Create DC `DESIGN.md` for Stitch project import (derived from `design-spec.md`)
- Document Stitch workflow in `wireframe-guidelines.md` and `design-system.md`

## Captain Action Required

Before end-to-end verification:
1. Store `STITCH_API_KEY` in Infisical: `infisical secrets set STITCH_API_KEY="<key>" --path /vc --env prod`
2. Proof-of-concept: import `docs/design/ventures/dc/DESIGN.md` into a Stitch project, validate colors/typography match DC tokens

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, 274 tests)
- [x] New `setupClaudeMcp` tests: sync missing servers, update stale versions, skip when matching, copy on missing, overwrite malformed, preserve target-only servers
- [x] Pre-implementation verification: `stitch-mcp` runs without crashing when `STITCH_API_KEY` is unset
- [ ] After M1: run `crane vc`, verify stitch appears in MCP tools
- [ ] Graceful degradation: unset `STITCH_API_KEY`, run `crane vc` - stitch NOT in Gemini/Codex configs
- [ ] Sync check: modify stitch version in `.mcp.json`, run `crane vc` in target repo - verify target updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)