### PR TITLE
feat: sync enterprise commands and agents to all repos on launch

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -3,7 +3,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { existsSync, copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import {
+  existsSync,
+  copyFileSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} from 'fs'
 
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
@@ -37,7 +45,12 @@ vi.mock('./ssh-auth.js', () => ({
   prepareSSHAuth: vi.fn(() => ({ env: {} })),
 }))
 
-import { setupGeminiMcp, setupClaudeMcp, extractPassthroughArgs } from './launch-lib.js'
+import {
+  setupGeminiMcp,
+  setupClaudeMcp,
+  syncClaudeAssets,
+  extractPassthroughArgs,
+} from './launch-lib.js'
 
 const EXPECTED_ENV_KEYS = [
   'CRANE_CONTEXT_KEY',
@@ -506,6 +519,79 @@ describe('setupClaudeMcp', () => {
 
     // No write needed - source servers match target. Custom server is preserved.
     expect(writeFileSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncClaudeAssets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('copies new command files from crane-console to target repo', () => {
+    // statSync returns different inodes so repos are different
+    vi.mocked(statSync)
+      .mockReturnValueOnce({ ino: 1 } as ReturnType<typeof statSync>)
+      .mockReturnValueOnce({ ino: 2 } as ReturnType<typeof statSync>)
+
+    // Source directories exist with .md files
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('.claude/commands') && !s.endsWith('.md')) return true
+      if (s.includes('.claude/agents') && !s.endsWith('.md')) return true
+      return false // target files don't exist yet
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('.claude/commands'))
+        return ['ship.md', 'sod.md'] as unknown as ReturnType<typeof readdirSync>
+      if (s.includes('.claude/agents'))
+        return ['sprint-worker.md'] as unknown as ReturnType<typeof readdirSync>
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    syncClaudeAssets('/fake/repo')
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('.claude/commands'), {
+      recursive: true,
+    })
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('.claude/agents'), {
+      recursive: true,
+    })
+    expect(copyFileSync).toHaveBeenCalledTimes(3) // ship.md + sod.md + sprint-worker.md
+  })
+
+  it('skips files that are already identical', () => {
+    vi.mocked(statSync)
+      .mockReturnValueOnce({ ino: 1 } as ReturnType<typeof statSync>)
+      .mockReturnValueOnce({ ino: 2 } as ReturnType<typeof statSync>)
+
+    vi.mocked(existsSync).mockReturnValue(true)
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('.claude/commands'))
+        return ['ship.md'] as unknown as ReturnType<typeof readdirSync>
+      if (s.includes('.claude/agents')) return [] as unknown as ReturnType<typeof readdirSync>
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    // Both source and target return same content
+    vi.mocked(readFileSync).mockReturnValue('# same content')
+
+    syncClaudeAssets('/fake/repo')
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+  })
+
+  it('skips sync when target is crane-console itself', () => {
+    // Same inode = same directory
+    vi.mocked(statSync).mockReturnValue({ ino: 999 } as ReturnType<typeof statSync>)
+
+    syncClaudeAssets('/fake/repo')
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(mkdirSync).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -668,6 +668,59 @@ export function setupClaudeMcp(repoPath: string): void {
   }
 }
 
+/**
+ * Sync .claude/commands/ and .claude/agents/ from crane-console to the target repo.
+ * Overwrites stale files silently. Only copies .md files.
+ * Skips sync when repoPath IS crane-console (source === target).
+ */
+export function syncClaudeAssets(repoPath: string): void {
+  const resolvedRepo = readdirSync(repoPath).length >= 0 ? repoPath : repoPath // validate exists
+  const resolvedConsole = CRANE_CONSOLE_ROOT
+
+  // Skip if target is crane-console itself
+  try {
+    if (statSync(resolvedRepo).ino === statSync(resolvedConsole).ino) return
+  } catch {
+    // If stat fails, proceed with sync anyway
+  }
+
+  const dirs = ['commands', 'agents'] as const
+  let totalSynced = 0
+
+  for (const dir of dirs) {
+    const sourceDir = join(resolvedConsole, '.claude', dir)
+    const targetDir = join(resolvedRepo, '.claude', dir)
+
+    if (!existsSync(sourceDir)) continue
+
+    const sourceFiles = readdirSync(sourceDir).filter((f) => f.endsWith('.md'))
+    if (!sourceFiles.length) continue
+
+    mkdirSync(targetDir, { recursive: true })
+
+    for (const file of sourceFiles) {
+      const sourcePath = join(sourceDir, file)
+      const targetPath = join(targetDir, file)
+
+      // Skip if target file is identical
+      if (existsSync(targetPath)) {
+        const sourceContent = readFileSync(sourcePath, 'utf-8')
+        const targetContent = readFileSync(targetPath, 'utf-8')
+        if (sourceContent === targetContent) continue
+      }
+
+      copyFileSync(sourcePath, targetPath)
+      totalSynced++
+    }
+  }
+
+  if (totalSynced > 0) {
+    console.log(
+      `-> Synced ${totalSynced} Claude command/agent file${totalSynced > 1 ? 's' : ''} from crane-console`
+    )
+  }
+}
+
 export function setupGeminiMcp(repoPath: string): void {
   const geminiDir = join(repoPath, '.gemini')
   const settingsPath = join(geminiDir, 'settings.json')
@@ -894,6 +947,9 @@ export function setupHermesMcp(): void {
 export function checkMcpSetup(repoPath: string, agent: string): void {
   // Ensure crane-mcp binary is on PATH
   checkMcpBinary()
+
+  // Sync enterprise commands/agents (all agent types benefit, but only Claude uses .claude/)
+  syncClaudeAssets(repoPath)
 
   // Register crane MCP server for the target agent
   switch (agent) {


### PR DESCRIPTION
## Summary

- Adds `syncClaudeAssets()` to the crane launcher that copies `.claude/commands/` and `.claude/agents/` from crane-console to the target repo on every `crane` launch
- Skips identical files (content comparison) and skips when target IS crane-console
- All 24 enterprise skills (/ship, /sod, /sprint, /critique, etc.) are now available in every repo automatically

## Test plan

- [ ] 277 tests pass (`npm run verify`)
- [ ] `crane dc` syncs commands to dc-console (verify with `ls dc-console/.claude/commands/`)
- [ ] `crane vc` in crane-console itself does NOT duplicate files

🤖 Generated with [Claude Code](https://claude.com/claude-code)