### PR TITLE
feat: cross-venture handoff support and venture switch guardrail

### DIFF
--- a/.claude/commands/eod.md
+++ b/.claude/commands/eod.md
@@ -86,6 +86,21 @@ Call the `crane_handoff` MCP tool with:
 
 This writes to D1 via the Crane Context API. The next session's `crane_sod` will read it.
 
+#### Cross-venture sessions
+
+If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
+
+1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
+2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
+3. Each handoff summary should cover only the work relevant to that venture.
+
+Example for a session that touched both `dc` and `vc`:
+
+```
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
+crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
+```
+
 ### 6. Report Completion
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Full verification runs before push:
 - **Verify secret VALUES, not just key existence.** Agents have stored descriptions as values before.
 - **Never auto-save to VCMS** without explicit Captain approval.
 - **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
+- **Never switch ventures or repos** without explicit Captain approval. If cross-venture work is discovered, state what needs to happen and where, then ask. Announce all context switches clearly.
 - **Never remove, deprecate, or disable existing features** without explicit Captain directive. "Unused" is not sufficient justification. See `guardrails.md`.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
 

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -321,6 +321,79 @@ describe('handoff tool', () => {
     expect(result.message).toContain('500')
   })
 
+  it('creates handoff with venture override, bypassing repo mismatch', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    // Session is for vc/crane-console, but we want to write a handoff for dc
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_cross',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    // Current repo doesn't match the override venture - that's fine with venture override
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+
+    // Add dc venture to mock ventures for this test
+    const venturesWithDc = [
+      ...mockVentures,
+      { code: 'dc', name: 'Draft Crane', org: 'venturecrane', repos: ['dc-console'] },
+    ]
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: venturesWithDc }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    const result = await executeHandoff({
+      summary: 'Cross-venture work on Draft Crane',
+      status: 'done',
+      venture: 'dc',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Draft Crane')
+
+    // Verify the handoff was written with the override venture's repo, not the current repo
+    const eodCall = mockFetch.mock.calls[1]
+    const body = JSON.parse(eodCall[1].body)
+    expect(body.venture).toBe('dc')
+    expect(body.repo).toBe('venturecrane/dc-console')
+  })
+
+  it('returns error for unknown venture code override', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_test',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ventures: mockVentures }),
+    })
+
+    const result = await executeHandoff({
+      summary: 'Test',
+      status: 'done',
+      venture: 'nonexistent',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('venture code: nonexistent')
+  })
+
   it('returns error for unknown org', async () => {
     const { executeHandoff } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -18,6 +18,12 @@ export const handoffInputSchema = z.object({
     .enum(['in_progress', 'blocked', 'done'])
     .describe('Current status: in_progress, blocked, or done'),
   issue_number: z.number().optional().describe('GitHub issue number if applicable'),
+  venture: z
+    .string()
+    .optional()
+    .describe(
+      'Venture code override for cross-venture sessions. When set, writes the handoff for this venture instead of auto-detecting from the current repo.'
+    ),
 })
 
 export type HandoffInput = z.infer<typeof handoffInputSchema>
@@ -50,7 +56,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
     }
   }
 
-  // Validate current repo matches session
+  // Validate current repo matches session (skip check if venture override provided)
   const repoInfo = getCurrentRepoInfo()
   if (!repoInfo) {
     return {
@@ -60,7 +66,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
   }
 
   const currentRepo = `${repoInfo.org}/${repoInfo.repo}`
-  if (currentRepo !== session.repo) {
+  if (!input.venture && currentRepo !== session.repo) {
     return {
       success: false,
       message:
@@ -71,11 +77,15 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
 
   const api = new CraneApi(apiKey, getApiBase())
 
-  // Find venture
+  // Find venture - use override if provided, otherwise detect from repo
   let venture
   try {
     const ventures = await api.getVentures()
-    venture = findVentureByRepo(ventures, repoInfo.org, repoInfo.repo)
+    if (input.venture) {
+      venture = ventures.find((v) => v.code === input.venture)
+    } else {
+      venture = findVentureByRepo(ventures, repoInfo.org, repoInfo.repo)
+    }
   } catch {
     return {
       success: false,
@@ -84,11 +94,16 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
   }
 
   if (!venture) {
+    const target = input.venture ? `venture code: ${input.venture}` : `org: ${repoInfo.org}`
     return {
       success: false,
-      message: `Unknown org: ${repoInfo.org}. Cannot create handoff.`,
+      message: `Unknown ${target}. Cannot create handoff.`,
     }
   }
+
+  // When using venture override, resolve the repo from the venture config
+  const handoffRepo =
+    input.venture && venture.repos.length > 0 ? `${venture.org}/${venture.repos[0]}` : currentRepo
 
   try {
     // Best-effort: discover last real activity from Claude Code session log
@@ -101,7 +116,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
 
     await api.createHandoff({
       venture: venture.code,
-      repo: currentRepo,
+      repo: handoffRepo,
       agent: getAgentName(),
       summary: input.summary,
       status: input.status,

--- a/packages/crane-mcp/src/tools/sod.ts
+++ b/packages/crane-mcp/src/tools/sod.ts
@@ -478,6 +478,7 @@ export function buildSodMessage(params: BuildSodMessageParams): string {
   message += `- Never remove, deprecate, or disable features without Captain directive.\n`
   message += `- Run \`npm run verify\` before pushing. Fix root causes, not symptoms.\n`
   message += `- Scope discipline: finish current task, file new issues for discovered work.\n`
+  message += `- Never switch repos or ventures without explicit Captain approval. Announce all context switches.\n`
 
   // Inlined from guardrails.md SOD markers (avoids HTTP fetch per session)
   message += `- Never drop database columns/tables or run destructive migrations without Captain directive.\n`


### PR DESCRIPTION
## Summary
- Add optional `venture` parameter to `crane_handoff` tool for writing handoffs to ventures other than the current repo (#366)
- Update `/eod` skill to detect multi-venture sessions and write separate handoffs per venture
- Add venture switch guardrail directive to SOD and CLAUDE.md enterprise rules (#367)

Closes #366
Closes #367

## Test plan
- [x] `npm run verify` passes (279 tests, 0 errors)
- [x] New tests: venture override creates handoff with correct venture/repo, unknown venture code returns error
- [x] Existing handoff tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)