### PR TITLE
fix: correct Gemini MCP test fixture stitch server nesting

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -188,15 +188,6 @@ describe('setupGeminiMcp', () => {
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
             STITCH_API_KEY: '$STITCH_API_KEY',
           },
-          ...(process.env.STITCH_API_KEY
-            ? {
-                stitch: {
-                  command: 'npx',
-                  args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-                  env: { STITCH_API_KEY: '$STITCH_API_KEY' },
-                },
-              }
-            : {}),
         },
       },
       security: {


### PR DESCRIPTION
## Summary

- The `setupGeminiMcp > skips write when config already has all required vars` test was failing because the stitch server was spread inside the `crane` object instead of as a sibling under `mcpServers`
- When `STITCH_API_KEY` is in the environment, `setupGeminiMcp` expects `stitch` at `mcpServers.stitch` - the fixture had it nested at `mcpServers.crane.stitch`
- The conditional block (lines 210-217) already correctly adds stitch as a sibling - the broken spread operator (lines 191-199) was redundant and wrong

## Test plan

- [x] `npm test` passes: 279/279 (was 273/274 with the fixture bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)