### PR TITLE
fix: scope cadence briefing to exact venture

### DIFF
--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -75,10 +75,9 @@ export async function handleGetScheduleBriefing(request: Request, env: Env): Pro
     let params: string[]
 
     if (scope) {
-      // Return items matching the scope OR global items
-      query =
-        'SELECT * FROM schedule_items WHERE enabled = 1 AND (scope = ?1 OR scope = ?2) ORDER BY priority ASC'
-      params = [scope, 'global']
+      // Return only items matching the exact scope
+      query = 'SELECT * FROM schedule_items WHERE enabled = 1 AND scope = ?1 ORDER BY priority ASC'
+      params = [scope]
     } else {
       query = 'SELECT * FROM schedule_items WHERE enabled = 1 ORDER BY priority ASC'
       params = []


### PR DESCRIPTION
## Summary
- Schedule briefing query now matches only the exact `scope` value instead of also including `scope = 'global'` items
- Each venture SOD only shows cadence items tagged to that venture (e.g., DC sees only `[DC]` items, VC sees only `[VC]` items)
- Global items remain visible via unscoped queries (`crane_schedule(action: "list")` with no scope)

## Test plan
- [x] `npm run verify` passes (279 tests, typecheck, lint, format)
- [ ] Deploy to staging and verify `GET /schedule/briefing?scope=dc` returns only DC-scoped items
- [ ] Verify `GET /schedule/briefing?scope=vc` returns only VC-scoped items (no global)
- [ ] Verify `GET /schedule/briefing` (no scope) still returns all items

🤖 Generated with [Claude Code](https://claude.com/claude-code)