### PR TITLE
fix: switch Stitch MCP from API key to OAuth (gcloud ADC)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -8,7 +8,7 @@
     "stitch": {
       "command": "npx",
       "args": ["@_davideast/stitch-mcp@0.5.1", "proxy"],
-      "env": {}
+      "env": { "STITCH_PROJECT_ID": "smdurgan-tools" }
     }
   }
 }

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -61,7 +61,6 @@ const EXPECTED_ENV_KEYS = [
   'GH_TOKEN',
   'VERCEL_TOKEN',
   'CLOUDFLARE_API_TOKEN',
-  'STITCH_API_KEY',
 ]
 
 function getWritten(): Record<string, unknown> {
@@ -186,8 +185,12 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
-            STITCH_API_KEY: '$STITCH_API_KEY',
           },
+        },
+        stitch: {
+          command: 'npx',
+          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
         },
       },
       security: {
@@ -195,16 +198,6 @@ describe('setupGeminiMcp', () => {
           allowed: EXPECTED_ENV_KEYS,
         },
       },
-    }
-
-    // When STITCH_API_KEY is in the environment, setupGeminiMcp expects a stitch server entry
-    if (process.env.STITCH_API_KEY) {
-      const servers = currentSettings.mcpServers as Record<string, unknown>
-      servers.stitch = {
-        command: 'npx',
-        args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-        env: { STITCH_API_KEY: '$STITCH_API_KEY' },
-      }
     }
 
     vi.mocked(existsSync).mockReturnValue(true)
@@ -301,7 +294,6 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
-            STITCH_API_KEY: '$STITCH_API_KEY',
           },
         },
       },
@@ -337,7 +329,6 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
-            STITCH_API_KEY: '$STITCH_API_KEY',
           },
         },
       },
@@ -374,7 +365,11 @@ describe('setupClaudeMcp', () => {
   const SOURCE_CONFIG = {
     mcpServers: {
       crane: { command: 'crane-mcp', args: [], env: {} },
-      stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'], env: {} },
+      stitch: {
+        command: 'npx',
+        args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+        env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+      },
     },
   }
 
@@ -431,7 +426,11 @@ describe('setupClaudeMcp', () => {
     const targetConfig = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
-        stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.4.0', 'proxy'], env: {} },
+        stitch: {
+          command: 'npx',
+          args: ['@_davideast/stitch-mcp@0.4.0', 'proxy'],
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+        },
       },
     }
 
@@ -490,7 +489,11 @@ describe('setupClaudeMcp', () => {
     const targetConfig = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
-        stitch: { command: 'npx', args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'], env: {} },
+        stitch: {
+          command: 'npx',
+          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+        },
         custom: { command: 'custom-mcp', args: [] },
       },
     }

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -30,6 +30,10 @@ import { prepareSSHAuth } from './ssh-auth.js'
  *  Verify: npm view @_davideast/stitch-mcp version */
 const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
 
+/** GCP project for Stitch. Stitch uses OAuth (gcloud ADC), not API keys.
+ *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
+const STITCH_PROJECT_ID = 'smdurgan-tools'
+
 // Resolve crane-console root relative to this script
 // Compiled path: packages/crane-mcp/dist/cli/launch-lib.js -> 4 levels up
 const __filename = fileURLToPath(import.meta.url)
@@ -749,7 +753,6 @@ export function setupGeminiMcp(repoPath: string): void {
     GH_TOKEN: '$GH_TOKEN',
     VERCEL_TOKEN: '$VERCEL_TOKEN',
     CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
-    STITCH_API_KEY: '$STITCH_API_KEY',
   }
 
   // Gemini CLI sanitizes process.env before passing to MCP servers, stripping
@@ -778,24 +781,25 @@ export function setupGeminiMcp(repoPath: string): void {
     dirty = true
   }
 
-  // --- Stitch MCP server (only if STITCH_API_KEY is available) ---
-  if (process.env.STITCH_API_KEY) {
-    if (mcpServers.stitch) {
-      const stitch = mcpServers.stitch as Record<string, unknown>
-      const existing = (stitch.env ?? {}) as Record<string, string>
-      const merged = { ...existing, STITCH_API_KEY: '$STITCH_API_KEY' }
-      if (JSON.stringify(existing) !== JSON.stringify(merged)) {
-        stitch.env = merged
-        dirty = true
-      }
-    } else {
-      mcpServers.stitch = {
-        command: 'npx',
-        args: [`@_davideast/stitch-mcp@${STITCH_MCP_VERSION}`, 'proxy'],
-        env: { STITCH_API_KEY: '$STITCH_API_KEY' },
-      }
+  // --- Stitch MCP server (OAuth via gcloud ADC, always configured) ---
+  const stitchEnv = { STITCH_PROJECT_ID }
+  if (mcpServers.stitch) {
+    const stitch = mcpServers.stitch as Record<string, unknown>
+    const existing = (stitch.env ?? {}) as Record<string, string>
+    // Remove legacy STITCH_API_KEY if present (API keys don't work with Stitch)
+    const { STITCH_API_KEY: _, ...cleanExisting } = existing
+    const merged = { ...cleanExisting, ...stitchEnv }
+    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
+      stitch.env = merged
       dirty = true
     }
+  } else {
+    mcpServers.stitch = {
+      command: 'npx',
+      args: [`@_davideast/stitch-mcp@${STITCH_MCP_VERSION}`, 'proxy'],
+      env: stitchEnv,
+    }
+    dirty = true
   }
 
   // --- Security allowlist for env sanitization bypass ---
@@ -840,7 +844,7 @@ export function setupCodexMcp(): void {
   //   2. shell_environment_policy - stops the default filter for shell
   //      commands so gh CLI etc. can access GH_TOKEN
   const envVars =
-    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN", "STITCH_API_KEY"]'
+    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN"]'
 
   let updated = false
 
@@ -871,16 +875,14 @@ export function setupCodexMcp(): void {
     updated = true
   }
 
-  // --- Stitch MCP server (only if STITCH_API_KEY is available) ---
-  if (process.env.STITCH_API_KEY) {
-    if (!content.includes('[mcp_servers.stitch]')) {
-      const stitchEntry =
-        `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
-        `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
-        'env_vars = ["STITCH_API_KEY"]\n'
-      content = content.trimEnd() + '\n' + stitchEntry
-      updated = true
-    }
+  // --- Stitch MCP server (OAuth via gcloud ADC, always configured) ---
+  if (!content.includes('[mcp_servers.stitch]')) {
+    const stitchEntry =
+      `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
+      `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
+      `env_vars = ["STITCH_PROJECT_ID"]\n`
+    content = content.trimEnd() + '\n' + stitchEntry
+    updated = true
   }
 
   // --- Shell environment policy ---


### PR DESCRIPTION
## Summary
- Stitch API rejects API keys with 401 - it requires OAuth2 (gcloud ADC)
- Replace `STITCH_API_KEY` with `STITCH_PROJECT_ID` across launcher, `.mcp.json`, and all agent configs (Claude, Gemini, Codex)
- Remove conditional stitch setup (always configured now since auth is filesystem-based, not secret-injected)
- `STITCH_API_KEY` deleted from Infisical `/vc` (was never valid for Stitch)

## Fleet impact
Each machine needs one-time OAuth setup:
```
npx @_davideast/stitch-mcp@0.5.1 init -c cc
```
Select OAuth + Proxy. Use `--no-launch-browser` for gcloud steps (Safari HTTPS-Only blocks localhost callbacks).

## Test plan
- [x] `npm run verify` passes (279 tests, typecheck, lint, format)
- [x] `stitch-mcp doctor` returns 200 OK with OAuth
- [x] Pre-push hooks pass
- [ ] QA: Launch a venture session, verify stitch proxy connects and tools load

🤖 Generated with [Claude Code](https://claude.com/claude-code)