### PR TITLE
docs: add Stitch OAuth guidance and instruction module coupling guardrail

### DIFF
--- a/docs/instructions/guardrails.md
+++ b/docs/instructions/guardrails.md
@@ -8,6 +8,7 @@
 - Never drop database columns/tables or run destructive migrations without Captain directive
 - Never modify authentication flows or remove access controls without Captain directive
 - "Unused" is not sufficient justification - external consumers, bookmarks, and integrations may depend on it
+- Infrastructure changes that affect agent-facing tools must update the corresponding instruction modules in the same PR
 - When in doubt, STOP and escalate using the format below
 <!-- SOD_SUMMARY_END -->
 
@@ -80,6 +81,53 @@ When a guardrail is triggered, stop work and report using this format:
 
 Awaiting Captain directive to proceed or adjust scope.
 ```
+
+---
+
+## Instruction Module Coupling
+
+Infrastructure changes have two audiences: **machines** (config, code) and **agents**
+(instruction modules). When you change how a tool, service, or integration works,
+you must update the instruction modules that teach agents how to use it - in the
+same PR.
+
+### What Counts
+
+Any change to authentication, configuration, MCP setup, CLI behavior, or
+deployment that affects how an agent would interact with the tool:
+
+- Changing auth mechanisms (API key to OAuth, token rotation, new credentials)
+- Adding, removing, or reconfiguring MCP servers
+- Changing CLI flags, environment variables, or launch behavior
+- Modifying deployment targets or infrastructure endpoints
+
+### How to Check
+
+Before marking a PR complete, search for instruction modules that reference
+the tool or service you changed:
+
+```bash
+grep -rl "{tool_name}" docs/instructions/
+```
+
+Also check: `crane_doc_audit()` for the full doc index. Instruction modules
+are listed in `CLAUDE.md` under "Instruction Modules."
+
+### Concrete Examples
+
+- **Switching Stitch auth from API key to OAuth** - MUST update `wireframe-guidelines.md`
+  (tells agents how to use Stitch) and remove any API key references
+- **Changing how `crane` injects secrets** - MUST update `secrets.md` and any
+  venture-specific docs that reference secret access patterns
+- **Reconfiguring an MCP server** - MUST update any instruction module that
+  references that server's tools or capabilities
+- **Changing fleet bootstrap steps** - MUST update `fleet-ops.md`
+
+### Why This Matters
+
+Agents read instruction modules to learn how to use tools. If the infrastructure
+changes but the docs don't, agents will follow stale instructions and waste time
+on approaches that no longer work. The code fix is incomplete without the doc fix.
 
 ---
 

--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -92,6 +92,27 @@ Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM chang
 - **Complex interaction patterns** (multi-panel editors, drag-and-drop, streaming feedback) - Stitch
 - **Simple layouts** (landing pages, forms, lists) - direct wireframe generation per the prompt template above
 
+### Authentication
+
+Stitch uses **OAuth via gcloud Application Default Credentials (ADC)** - not API keys. API keys return 401.
+
+The fleet launcher configures Stitch MCP with `STITCH_PROJECT_ID=smdurgan-tools`. The MCP server authenticates using the machine's gcloud ADC token automatically.
+
+**If Stitch tools return 401 or auth errors:**
+
+1. Verify gcloud ADC is set up: `gcloud auth application-default print-access-token`
+2. If that fails, re-authenticate: `gcloud auth application-default login`
+3. The GCP project is `smdurgan-tools` - this is set by the launcher, not by the agent
+4. Do NOT attempt API key auth - it does not work
+
+**Per-machine setup** (one-time, handled during fleet bootstrap):
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+npx @_davideast/stitch-mcp@0.5.1 init -c cc  # select OAuth > Proxy
+```
+
 ### MCP Tools (Fleet-Managed)
 
 The `stitch` MCP server is registered fleet-wide via `.mcp.json`. Available tools:
@@ -116,16 +137,6 @@ Stitch output feeds into the same pipeline as hand-written wireframes:
 2. Export via `get_screen_code` into `/docs/wireframes/{issue-number}/`
 3. Commit as the wireframe artifact - same freeze rule applies
 4. Dev implements from the wireframe + ACs (ACs are still canonical)
-
-### Alternative: Official Google MCP Endpoint
-
-For ad-hoc use outside the fleet, the official HTTP endpoint is available:
-
-```
-claude mcp add stitch --transport http --url https://stitch.googleapis.com/mcp --header "x-goog-api-key: YOUR_KEY"
-```
-
-This is not fleet-managed. Prefer the stdio server in `.mcp.json` for consistency.
 
 ## What Wireframes Are NOT
 

--- a/docs/process/pr-workflow.md
+++ b/docs/process/pr-workflow.md
@@ -46,6 +46,16 @@ Closes #{issue_number}
 
 **Feature impact:** None
 
+## Instruction Module Impact
+
+<!-- Does this PR change how agents interact with a tool, service, or integration? -->
+<!-- (auth changes, MCP config, CLI behavior, env vars, deployment targets) -->
+<!-- If yes: list which instruction modules you checked/updated. -->
+<!-- If no: write "None" -->
+<!-- Run: grep -rl "{tool_name}" docs/instructions/ to find affected modules -->
+
+**Module impact:** None
+
 ## QA Grade
 
 **Grade:** qa:{0-3}


### PR DESCRIPTION
## Summary

- Add Stitch authentication section to `wireframe-guidelines.md` with OAuth/gcloud ADC guidance and 401 troubleshooting. Remove broken API key alternative that caused DC agent to waste 30 minutes.
- Add "Instruction Module Coupling" guardrail to `guardrails.md` requiring infrastructure changes to update corresponding instruction modules in the same PR.
- Add "Instruction Module Impact" field to PR template in `pr-workflow.md`, parallel to existing Feature Impact declaration.

## Related Issues

Follow-up to #371 (Stitch OAuth switch that missed the doc update)

## Changes

- `docs/instructions/wireframe-guidelines.md`: New Authentication section, removed stale API key alternative
- `docs/instructions/guardrails.md`: New Instruction Module Coupling section with concrete heuristics
- `docs/process/pr-workflow.md`: New Module Impact field in PR template

## Test plan

- [x] `npm run verify` passes (279 tests, 0 errors)
- [x] Docs are markdown-only, no code changes

## Feature Impact

**Feature impact:** None

## Instruction Module Impact

**Module impact:** This PR IS the module update. Checked `wireframe-guidelines.md`, `guardrails.md`, `pr-workflow.md`.

## QA Grade

**Grade:** qa:0

## Deployment Notes

Post-merge: upload updated docs to D1 via `./scripts/upload-doc-to-context-worker.sh` for `guardrails.md`, `wireframe-guidelines.md`, and `pr-workflow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)