### PR TITLE
fix: restrict global cadence items to VC enterprise sessions

### DIFF
--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -74,8 +74,13 @@ export async function handleGetScheduleBriefing(request: Request, env: Env): Pro
     let query: string
     let params: string[]
 
-    if (scope) {
-      // Return only items matching the exact scope
+    if (scope && scope === 'vc') {
+      // VC is the enterprise venture — show venture-specific + global cadence items
+      query =
+        'SELECT * FROM schedule_items WHERE enabled = 1 AND (scope = ?1 OR scope = ?2) ORDER BY priority ASC'
+      params = [scope, 'global']
+    } else if (scope) {
+      // Non-VC ventures only see their own venture-scoped items
       query = 'SELECT * FROM schedule_items WHERE enabled = 1 AND scope = ?1 ORDER BY priority ASC'
       params = [scope]
     } else {


### PR DESCRIPTION
## Summary
- Global cadence items (portfolio review, fleet health, etc.) were showing in every venture's SOD briefing
- Now only VC (the enterprise venture) sees `scope=global` items; other ventures see only their own scoped cadence items
- Adds `/ship` command for full commit-PR-CI-merge pipeline

## Test plan
- [x] `npm run verify` passes
- [ ] SOD on a non-VC venture (e.g., KE) should not show global cadence items
- [ ] SOD on VC should still show both global and VC-scoped items

🤖 Generated with [Claude Code](https://claude.com/claude-code)