### PR TITLE
docs: add PR completion rule — agents must merge PRs in same session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Full verification runs before push:
 - **Scope discipline.** Discover additional work mid-task - finish current scope, file a new issue.
 - **Never switch ventures or repos** without explicit Captain approval. If cross-venture work is discovered, state what needs to happen and where, then ask. Announce all context switches clearly.
 - **Never remove, deprecate, or disable existing features** without explicit Captain directive. "Unused" is not sufficient justification. See `guardrails.md`.
+- **PRs must be merged in the same session.** The agent that opens a PR owns it through merge. "Needs merge next session" is incomplete work. See `pr-workflow.md`.
 - **Escalation triggers.** Credential not found in 2 min, same error 3 times, blocked >30 min - stop and escalate.
 
 ## Environment Variables

--- a/docs/process/new-venture-setup-checklist.md
+++ b/docs/process/new-venture-setup-checklist.md
@@ -59,6 +59,8 @@ gh repo create kidexpenses/ke-console --template venturecrane/venture-template -
 CRANE_ADMIN_KEY=$KEY ./scripts/upload-doc-to-context-worker.sh docs/my-prd.md {venture-code}
 ```
 
+> **Important:** Do NOT hand off with an unmerged PR. Wait for CI to pass and merge before ending the session. If CI fails, fix it in the same session. See `docs/process/pr-workflow.md` for the full PR Completion Rule.
+
 ---
 
 ## Overview

--- a/docs/process/pr-workflow.md
+++ b/docs/process/pr-workflow.md
@@ -203,22 +203,42 @@ Include in your handoff or completion report:
 
 ---
 
+## PR Completion Rule
+
+The agent that creates a PR is responsible for merging it. "Needs merge next session" is not an acceptable handoff state.
+
+**Required before ending a session with an open PR:**
+
+1. CI must pass (if it fails, fix it in the same session)
+2. PR must be merged
+3. Post-merge verification must confirm the change is live (e.g., deploy succeeded, API reflects changes)
+
+**Exceptions (must be stated explicitly in handoff):**
+
+- Captain has requested the PR be held for review
+- CI is broken by an upstream issue outside this PR's scope (file an issue)
+- The PR requires a manual QA step (qa-grade:2+) that cannot be completed by the agent
+
+Any other reason for leaving a PR unmerged is an incomplete session.
+
+---
+
 ## After Creating the PR
 
-Your job stops here. Report the PR and wait.
+Your job is NOT done at PR creation. See the PR Completion Rule above — you own this PR through merge.
 
 **Do NOT:**
 
-- **Merge your own PR.** Captain directs merges. You create the PR, report it, and wait for the merge directive. Never run `gh pr merge` unless Captain explicitly tells you to merge.
 - **Deploy to production.** Running `npx wrangler deploy --env production`, `vercel --prod`, or any production deployment is a Captain-directed action. Never deploy on your own initiative.
 - **Run post-merge steps.** Migrations, remediation scripts, cache invalidation, secret provisioning - these go in the PR's Deployment Notes section as proposals. Captain decides when and whether to execute them.
 - **Close issues.** Issue closure happens after merge and deployment verification. Captain or PM directs this.
 
 **Do:**
 
+- Wait for CI to pass. If it fails, fix it in the same session.
+- Merge the PR once CI is green (unless Captain has requested a hold).
 - Report the PR URL, issue number, QA grade, and test evidence
 - List any post-merge steps needed in Deployment Notes
-- Move on to the next task or wait for further direction
 
 ---
 
@@ -293,7 +313,7 @@ Captain decides whether and when to run QA. Your job is to propose the verificat
 | Missing `Closes #N`                                | PR won't auto-link to issue. Always include it.                     |
 | No QA grade                                        | PR can't proceed to verification. Always assign one.                |
 | Skipping local verify                              | CI will catch it, but you waste a round-trip. Verify locally first. |
-| Merging your own PR                                | Never. Create the PR and report. Captain directs merges.            |
+| Leaving a PR unmerged at end of session            | Merge it. You own the PR through merge. See PR Completion Rule.     |
 | Deploying to production after merge                | Never. List deploy steps in Deployment Notes. Captain executes.     |
 | Running remediation/migration scripts in prod      | Never. Document the commands. Captain decides when to run them.     |
 


### PR DESCRIPTION
## Summary

- Adds "PR Completion Rule" section to `docs/process/pr-workflow.md` requiring agents to merge their own PRs before ending a session
- Updates "After Creating the PR" section for consistency (agents now own PRs through merge)
- Adds callout to `docs/process/new-venture-setup-checklist.md` after PR creation steps
- Adds enterprise rule to `CLAUDE.md` for quick reference

Closes #376

## Changes

- `docs/process/pr-workflow.md`: New "PR Completion Rule" section with requirements and exceptions; updated "After Creating the PR" to remove "stop here" language; updated Common Mistakes table
- `docs/process/new-venture-setup-checklist.md`: Added callout after Quick Start about not handing off with unmerged PRs
- `CLAUDE.md`: Added PR merge-in-session rule to Enterprise Rules

## Test Plan

- [x] Typecheck passes
- [x] Lint passes (0 errors, 27 pre-existing warnings)
- [x] Prettier format check passes
- [x] 279 tests pass

## Feature Impact

None — docs-only change adding a new directive.

## Module Impact

**Module impact:** `pr-workflow.md` is the module being updated.

## QA Grade

**Grade:** qa:0

## Deployment Notes

Standard deploy — docs only, no runtime changes. The updated `pr-workflow.md` should also be re-uploaded to crane-context so `crane_doc('global', 'pr-workflow.md')` reflects the new rule.