### PR TITLE
fix: remove STITCH_API_KEY from launcher environment injection

### DIFF
--- a/config/ventures.json
+++ b/config/ventures.json
@@ -8,8 +8,7 @@
       "CRANE_ADMIN_KEY",
       "GH_TOKEN",
       "VERCEL_TOKEN",
-      "CLOUDFLARE_API_TOKEN",
-      "STITCH_API_KEY"
+      "CLOUDFLARE_API_TOKEN"
     ]
   },
   "ventures": [

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -786,9 +786,7 @@ export function setupGeminiMcp(repoPath: string): void {
   if (mcpServers.stitch) {
     const stitch = mcpServers.stitch as Record<string, unknown>
     const existing = (stitch.env ?? {}) as Record<string, string>
-    // Remove legacy STITCH_API_KEY if present (API keys don't work with Stitch)
-    const { STITCH_API_KEY: _, ...cleanExisting } = existing
-    const merged = { ...cleanExisting, ...stitchEnv }
+    const merged = { ...existing, ...stitchEnv }
     if (JSON.stringify(existing) !== JSON.stringify(merged)) {
       stitch.env = merged
       dirty = true


### PR DESCRIPTION
## Summary
- Remove `STITCH_API_KEY` from `sharedSecrets` in `ventures.json` — this was being pulled from Infisical and injected into every agent session's process environment
- Stitch MCP server inherited the key via process env (even though launch-lib stripped it from `.mcp.json`), used key-based auth instead of OAuth, and got 401 errors
- Remove the now-dead STITCH_API_KEY cleanup code from `launch-lib.ts` — its existence was misleading and agents kept rediscovering/re-adding the key

## Test plan
- [x] `npm run verify` passes (283 tests, typecheck, lint, format)
- [ ] Launch `crane dc` and confirm `STITCH_API_KEY` is not in the environment
- [ ] Verify Stitch MCP connects via OAuth (gcloud ADC) without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)