### PR TITLE
fix: inject STITCH_API_KEY into Stitch MCP server env from GEMINI_API_KEY

### DIFF
--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -94,16 +94,19 @@ Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM chang
 
 ### Authentication
 
-Stitch uses **OAuth via gcloud Application Default Credentials (ADC)** - not API keys. API keys return 401.
+Stitch proxy mode requires a **Google AI API key** (`GEMINI_API_KEY`) passed as `STITCH_API_KEY`, plus `STITCH_PROJECT_ID` for project scoping.
 
-The fleet launcher configures Stitch MCP with `STITCH_PROJECT_ID=smdurgan-tools`. The MCP server authenticates using the machine's gcloud ADC token automatically.
+The fleet launcher configures Stitch MCP with both keys automatically:
 
-**If Stitch tools return 401 or auth errors:**
+- `STITCH_API_KEY` — sourced from `GEMINI_API_KEY` in the launcher environment (Infisical)
+- `STITCH_PROJECT_ID` — hardcoded to `smdurgan-tools`
 
-1. Verify gcloud ADC is set up: `gcloud auth application-default print-access-token`
-2. If that fails, re-authenticate: `gcloud auth application-default login`
-3. The GCP project is `smdurgan-tools` - this is set by the launcher, not by the agent
-4. Do NOT attempt API key auth - it does not work
+**If Stitch tools fail to connect:**
+
+1. Check `GEMINI_API_KEY` is set in the launcher environment: `echo $GEMINI_API_KEY | head -c 10`
+2. If missing, check Infisical: `infisical secrets --path /vc --env prod | grep GEMINI`
+3. The GCP project is `smdurgan-tools` — this is set by the launcher, not by the agent
+4. A session restart is needed after fixing launcher secrets (they're frozen at launch time)
 
 **Per-machine setup** (one-time, handled during fleet bootstrap):
 

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -61,6 +61,7 @@ const EXPECTED_ENV_KEYS = [
   'GH_TOKEN',
   'VERCEL_TOKEN',
   'CLOUDFLARE_API_TOKEN',
+  'STITCH_API_KEY',
 ]
 
 function getWritten(): Record<string, unknown> {
@@ -70,6 +71,11 @@ function getWritten(): Record<string, unknown> {
 describe('setupGeminiMcp', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env.GEMINI_API_KEY = 'test-gemini-key'
+  })
+
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY
   })
 
   it('creates settings.json with all env vars and security allowlist when no file exists', () => {
@@ -185,12 +191,13 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+            STITCH_API_KEY: '$GEMINI_API_KEY',
           },
         },
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
       },
       security: {
@@ -375,9 +382,14 @@ describe('setupClaudeMcp', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    process.env.GEMINI_API_KEY = 'test-gemini-key'
   })
 
-  it('copies from source when target does not exist', () => {
+  afterEach(() => {
+    delete process.env.GEMINI_API_KEY
+  })
+
+  it('copies from source when target does not exist and patches source with STITCH_API_KEY', () => {
     vi.mocked(existsSync).mockImplementation((filePath: string) => {
       if (String(filePath).includes('crane-console')) return true
       return false
@@ -393,8 +405,12 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
+    // Source .mcp.json is patched with STITCH_API_KEY
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
+    // Target is copied from (now-patched) source
     expect(copyFileSync).toHaveBeenCalledTimes(1)
-    expect(writeFileSync).not.toHaveBeenCalled()
   })
 
   it('syncs missing servers from source into target', () => {
@@ -417,9 +433,10 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(written.mcpServers.stitch).toEqual(SOURCE_CONFIG.mcpServers.stitch)
+    // First write: patch source with STITCH_API_KEY, second write: sync to target
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
+    expect(targetWritten.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
   })
 
   it('updates stale server configs when source has newer version', () => {
@@ -429,7 +446,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.4.0', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
       },
     }
@@ -447,12 +464,24 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(written.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
+    // First write: patch source with STITCH_API_KEY, second write: sync stale version to target
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
+    expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
   })
 
-  it('skips write when target matches source', () => {
+  it('skips target write when target already matches patched source', () => {
+    const patchedSource = {
+      mcpServers: {
+        crane: { command: 'crane-mcp', args: [], env: {} },
+        stitch: {
+          command: 'npx',
+          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
+        },
+      },
+    }
+
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
       if (String(filePath).includes('ventures.json')) {
@@ -460,11 +489,12 @@ describe('setupClaudeMcp', () => {
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
         })
       }
-      return JSON.stringify(SOURCE_CONFIG)
+      return JSON.stringify(patchedSource)
     })
 
     setupClaudeMcp('/fake/repo')
 
+    // Source already has STITCH_API_KEY, target matches — no writes needed
     expect(writeFileSync).not.toHaveBeenCalled()
   })
 
@@ -482,6 +512,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
+    // Source patched with STITCH_API_KEY, then target overwritten via copy
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
     expect(copyFileSync).toHaveBeenCalledTimes(1)
   })
 
@@ -492,7 +524,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
         custom: { command: 'custom-mcp', args: [] },
       },
@@ -511,8 +543,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // No write needed - source servers match target. Custom server is preserved.
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source patched with STITCH_API_KEY (1 write), but source servers now match target. Custom server preserved.
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -30,9 +30,20 @@ import { prepareSSHAuth } from './ssh-auth.js'
  *  Verify: npm view @_davideast/stitch-mcp version */
 const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
 
-/** GCP project for Stitch. Stitch uses OAuth (gcloud ADC), not API keys.
+/** GCP project for Stitch. Proxy mode requires a Google AI API key (GEMINI_API_KEY)
+ *  passed as STITCH_API_KEY, plus STITCH_PROJECT_ID for project scoping.
  *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
 const STITCH_PROJECT_ID = 'smdurgan-tools'
+
+/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup. */
+function resolveStitchEnv(): Record<string, string> {
+  const env: Record<string, string> = { STITCH_PROJECT_ID }
+  const geminiKey = process.env.GEMINI_API_KEY
+  if (geminiKey) {
+    env.STITCH_API_KEY = geminiKey
+  }
+  return env
+}
 
 // Resolve crane-console root relative to this script
 // Compiled path: packages/crane-mcp/dist/cli/launch-lib.js -> 4 levels up
@@ -634,6 +645,17 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
+  // Inject STITCH_API_KEY into source .mcp.json from GEMINI_API_KEY env var
+  const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
+  if (servers.stitch) {
+    const existing = (servers.stitch.env ?? {}) as Record<string, string>
+    const merged = { ...existing, ...resolveStitchEnv() }
+    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
+      servers.stitch.env = merged
+      writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
+    }
+  }
+
   const sourceServers = (sourceConfig.mcpServers ?? {}) as Record<string, unknown>
 
   // If target doesn't exist, copy from source
@@ -753,6 +775,7 @@ export function setupGeminiMcp(repoPath: string): void {
     GH_TOKEN: '$GH_TOKEN',
     VERCEL_TOKEN: '$VERCEL_TOKEN',
     CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+    STITCH_API_KEY: '$GEMINI_API_KEY',
   }
 
   // Gemini CLI sanitizes process.env before passing to MCP servers, stripping
@@ -781,8 +804,8 @@ export function setupGeminiMcp(repoPath: string): void {
     dirty = true
   }
 
-  // --- Stitch MCP server (OAuth via gcloud ADC, always configured) ---
-  const stitchEnv = { STITCH_PROJECT_ID }
+  // --- Stitch MCP server (proxy mode: needs STITCH_API_KEY + STITCH_PROJECT_ID) ---
+  const stitchEnv = resolveStitchEnv()
   if (mcpServers.stitch) {
     const stitch = mcpServers.stitch as Record<string, unknown>
     const existing = (stitch.env ?? {}) as Record<string, string>
@@ -873,12 +896,12 @@ export function setupCodexMcp(): void {
     updated = true
   }
 
-  // --- Stitch MCP server (OAuth via gcloud ADC, always configured) ---
+  // --- Stitch MCP server (proxy mode: needs STITCH_API_KEY + STITCH_PROJECT_ID) ---
   if (!content.includes('[mcp_servers.stitch]')) {
     const stitchEntry =
       `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
       `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
-      `env_vars = ["STITCH_PROJECT_ID"]\n`
+      `env_vars = ["STITCH_PROJECT_ID", "STITCH_API_KEY"]\n`
     content = content.trimEnd() + '\n' + stitchEntry
     updated = true
   }


### PR DESCRIPTION
## Summary
- Stitch MCP proxy mode requires `STITCH_API_KEY` (a Google AI API key) but the launcher only passed `STITCH_PROJECT_ID` — causing silent connection failures across all ventures using Stitch
- Adds `resolveStitchEnv()` helper shared by Claude, Gemini, and Codex setup paths, sourcing `STITCH_API_KEY` from the existing `GEMINI_API_KEY` env var
- Corrects wireframe-guidelines.md which incorrectly stated Stitch uses "OAuth only, no API keys"

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 283 tests, build)
- [x] Manually confirmed `STITCH_API_KEY=$GEMINI_API_KEY stitch-mcp proxy` connects and discovers 12 tools
- [ ] Launch a venture session (`crane dc`) and verify Stitch tools appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)