### PR TITLE
fix: pass STITCH_API_KEY via parent env to bypass Claude Code env stripping

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -389,7 +389,7 @@ describe('setupClaudeMcp', () => {
     delete process.env.GEMINI_API_KEY
   })
 
-  it('copies from source when target does not exist and patches source with STITCH_API_KEY', () => {
+  it('copies from source when target does not exist', () => {
     vi.mocked(existsSync).mockImplementation((filePath: string) => {
       if (String(filePath).includes('crane-console')) return true
       return false
@@ -405,11 +405,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source .mcp.json is patched with STITCH_API_KEY
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(written.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
-    // Target is copied from (now-patched) source
+    // Source already clean (no STITCH_API_KEY), target copied
+    expect(writeFileSync).not.toHaveBeenCalled()
     expect(copyFileSync).toHaveBeenCalledTimes(1)
   })
 
@@ -433,10 +430,11 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // First write: patch source with STITCH_API_KEY, second write: sync to target
-    expect(writeFileSync).toHaveBeenCalledTimes(2)
-    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
-    expect(targetWritten.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
+    // Source clean, target gets stitch added
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(targetWritten.mcpServers.stitch.env.STITCH_PROJECT_ID).toBe('smdurgan-tools')
+    expect(targetWritten.mcpServers.stitch.env.STITCH_API_KEY).toBeUndefined()
   })
 
   it('updates stale server configs when source has newer version', () => {
@@ -446,7 +444,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.4.0', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
         },
       },
     }
@@ -464,20 +462,20 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // First write: patch source with STITCH_API_KEY, second write: sync stale version to target
-    expect(writeFileSync).toHaveBeenCalledTimes(2)
-    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
+    // Source clean, target updated with newer stitch version
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
     expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
   })
 
-  it('skips target write when target already matches patched source', () => {
-    const patchedSource = {
+  it('strips stale STITCH_API_KEY from source .mcp.json', () => {
+    const staleSource = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'old-key' },
         },
       },
     }
@@ -489,13 +487,16 @@ describe('setupClaudeMcp', () => {
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
         })
       }
-      return JSON.stringify(patchedSource)
+      return JSON.stringify(staleSource)
     })
 
     setupClaudeMcp('/fake/repo')
 
-    // Source already has STITCH_API_KEY, target matches — no writes needed
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source patched to remove STITCH_API_KEY, target synced
+    expect(writeFileSync).toHaveBeenCalled()
+    const sourceWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(sourceWritten.mcpServers.stitch.env.STITCH_API_KEY).toBeUndefined()
+    expect(sourceWritten.mcpServers.stitch.env.STITCH_PROJECT_ID).toBe('smdurgan-tools')
   })
 
   it('overwrites malformed target JSON', () => {
@@ -512,8 +513,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source patched with STITCH_API_KEY, then target overwritten via copy
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    // Source clean, target overwritten via copy
+    expect(writeFileSync).not.toHaveBeenCalled()
     expect(copyFileSync).toHaveBeenCalledTimes(1)
   })
 
@@ -524,7 +525,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
         },
         custom: { command: 'custom-mcp', args: [] },
       },
@@ -543,8 +544,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source patched with STITCH_API_KEY (1 write), but source servers now match target. Custom server preserved.
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    // Source servers match target. Custom server preserved. No writes needed.
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -35,7 +35,9 @@ const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
  *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
 const STITCH_PROJECT_ID = 'smdurgan-tools'
 
-/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup. */
+/** Resolve Stitch MCP env vars for config files (Gemini, Codex).
+ *  Claude Code strips KEY/TOKEN/SECRET vars from MCP subprocess envs,
+ *  so for Claude the API key goes into childEnv instead (see launchAgent). */
 function resolveStitchEnv(): Record<string, string> {
   const env: Record<string, string> = { STITCH_PROJECT_ID }
   const geminiKey = process.env.GEMINI_API_KEY
@@ -645,13 +647,17 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
-  // Inject STITCH_API_KEY into source .mcp.json from GEMINI_API_KEY env var
+  // Ensure STITCH_PROJECT_ID is in source .mcp.json (but NOT STITCH_API_KEY —
+  // Claude Code strips KEY/TOKEN/SECRET from MCP subprocess envs. The API key
+  // is injected into childEnv instead, where MCP subprocesses inherit it.)
   const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
   if (servers.stitch) {
     const existing = (servers.stitch.env ?? {}) as Record<string, string>
-    const merged = { ...existing, ...resolveStitchEnv() }
-    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
-      servers.stitch.env = merged
+    const wanted = { ...existing, STITCH_PROJECT_ID }
+    // Remove STITCH_API_KEY from .mcp.json if present (it gets stripped by Claude Code)
+    delete (wanted as Record<string, string | undefined>).STITCH_API_KEY
+    if (JSON.stringify(existing) !== JSON.stringify(wanted)) {
+      servers.stitch.env = wanted
       writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
     }
   }
@@ -1071,7 +1077,7 @@ export function launchAgent(
   // Build child env: process.env + fetched secrets + SSH auth env
   // Propagate normalized CRANE_ENV so the MCP server uses the correct worker URL
   // Include venture identity vars for statusline and other tools
-  const childEnv = {
+  const childEnv: Record<string, string | undefined> = {
     ...process.env,
     ...secrets,
     ...sshAuth.env,
@@ -1079,6 +1085,9 @@ export function launchAgent(
     CRANE_VENTURE_CODE: venture.code,
     CRANE_VENTURE_NAME: venture.name,
     CRANE_REPO: repoName,
+    // Stitch MCP proxy needs STITCH_API_KEY in the process env (not .mcp.json)
+    // because Claude Code strips KEY/TOKEN/SECRET vars from MCP subprocess envs.
+    ...(process.env.GEMINI_API_KEY ? { STITCH_API_KEY: process.env.GEMINI_API_KEY } : {}),
   }
 
   // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)


### PR DESCRIPTION
## Summary
- Claude Code strips env vars containing KEY/TOKEN/SECRET from MCP subprocess environments, so `STITCH_API_KEY` in `.mcp.json` env block never reaches the stitch-mcp proxy
- Moves `STITCH_API_KEY` into `childEnv` (parent process env) so MCP subprocesses inherit it naturally
- Strips stale `STITCH_API_KEY` from existing `.mcp.json` files to prevent confusion

## Test plan
- [x] `npm run verify` passes (283 tests)
- [x] Manually confirmed stitch-mcp proxy connects with env-inherited STITCH_API_KEY
- [ ] Launch `crane dc` and verify Stitch tools appear in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)