### PR TITLE
fix: restore STITCH_API_KEY in .mcp.json env block

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -389,7 +389,7 @@ describe('setupClaudeMcp', () => {
     delete process.env.GEMINI_API_KEY
   })
 
-  it('copies from source when target does not exist', () => {
+  it('patches source with STITCH_API_KEY and copies to target', () => {
     vi.mocked(existsSync).mockImplementation((filePath: string) => {
       if (String(filePath).includes('crane-console')) return true
       return false
@@ -405,8 +405,10 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source already clean (no STITCH_API_KEY), target copied
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source patched with STITCH_API_KEY, target copied
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
     expect(copyFileSync).toHaveBeenCalledTimes(1)
   })
 
@@ -430,11 +432,10 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source clean, target gets stitch added
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(targetWritten.mcpServers.stitch.env.STITCH_PROJECT_ID).toBe('smdurgan-tools')
-    expect(targetWritten.mcpServers.stitch.env.STITCH_API_KEY).toBeUndefined()
+    // Source patched, target synced with STITCH_API_KEY
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
+    expect(targetWritten.mcpServers.stitch.env.STITCH_API_KEY).toBe('test-gemini-key')
   })
 
   it('updates stale server configs when source has newer version', () => {
@@ -462,20 +463,20 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source clean, target updated with newer stitch version
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    // Source patched + target updated with newer stitch version
+    expect(writeFileSync).toHaveBeenCalledTimes(2)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
     expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
   })
 
-  it('strips stale STITCH_API_KEY from source .mcp.json', () => {
-    const staleSource = {
+  it('skips write when source already has current STITCH_API_KEY', () => {
+    const currentSource = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'old-key' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
       },
     }
@@ -487,16 +488,13 @@ describe('setupClaudeMcp', () => {
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
         })
       }
-      return JSON.stringify(staleSource)
+      return JSON.stringify(currentSource)
     })
 
     setupClaudeMcp('/fake/repo')
 
-    // Source patched to remove STITCH_API_KEY, target synced
-    expect(writeFileSync).toHaveBeenCalled()
-    const sourceWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(sourceWritten.mcpServers.stitch.env.STITCH_API_KEY).toBeUndefined()
-    expect(sourceWritten.mcpServers.stitch.env.STITCH_PROJECT_ID).toBe('smdurgan-tools')
+    // Source and target already match — no writes
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 
   it('overwrites malformed target JSON', () => {
@@ -513,8 +511,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source clean, target overwritten via copy
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source patched with STITCH_API_KEY, then target overwritten via copy
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
     expect(copyFileSync).toHaveBeenCalledTimes(1)
   })
 
@@ -525,7 +523,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
         custom: { command: 'custom-mcp', args: [] },
       },
@@ -544,8 +542,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source servers match target. Custom server preserved. No writes needed.
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source patched (1 write), but patched source now matches target. Custom server preserved.
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -35,9 +35,7 @@ const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
  *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
 const STITCH_PROJECT_ID = 'smdurgan-tools'
 
-/** Resolve Stitch MCP env vars for config files (Gemini, Codex).
- *  Claude Code strips KEY/TOKEN/SECRET vars from MCP subprocess envs,
- *  so for Claude the API key goes into childEnv instead (see launchAgent). */
+/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup. */
 function resolveStitchEnv(): Record<string, string> {
   const env: Record<string, string> = { STITCH_PROJECT_ID }
   const geminiKey = process.env.GEMINI_API_KEY
@@ -647,17 +645,13 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
-  // Ensure STITCH_PROJECT_ID is in source .mcp.json (but NOT STITCH_API_KEY —
-  // Claude Code strips KEY/TOKEN/SECRET from MCP subprocess envs. The API key
-  // is injected into childEnv instead, where MCP subprocesses inherit it.)
+  // Inject Stitch env (STITCH_PROJECT_ID + STITCH_API_KEY) into source .mcp.json
   const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
   if (servers.stitch) {
     const existing = (servers.stitch.env ?? {}) as Record<string, string>
-    const wanted = { ...existing, STITCH_PROJECT_ID }
-    // Remove STITCH_API_KEY from .mcp.json if present (it gets stripped by Claude Code)
-    delete (wanted as Record<string, string | undefined>).STITCH_API_KEY
-    if (JSON.stringify(existing) !== JSON.stringify(wanted)) {
-      servers.stitch.env = wanted
+    const merged = { ...existing, ...resolveStitchEnv() }
+    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
+      servers.stitch.env = merged
       writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
     }
   }


### PR DESCRIPTION
## Summary
- Reverts #384's removal of STITCH_API_KEY from .mcp.json — Claude Code does NOT strip KEY vars from MCP subprocess envs
- The "Failed to connect" errors were all stale sessions launched before the fix, not env stripping
- Key is now in both .mcp.json (for MCP subprocess) and childEnv (belt-and-suspenders)

## Test plan
- [x] `npm run verify` passes (283 tests)
- [x] Confirmed STITCH_API_KEY reaches MCP subprocess via `echo $STITCH_API_KEY` in fresh session
- [x] Confirmed stitch-mcp proxy discovers 12 tools when run with these env vars
- [ ] Fresh `crane vc` or `crane dc` session — Stitch tools available

🤖 Generated with [Claude Code](https://claude.com/claude-code)