### PR TITLE
fix: pin stitch-mcp to v0.5.0 — v0.5.1 has broken MCP stdio handshake

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -196,7 +196,7 @@ describe('setupGeminiMcp', () => {
         },
         stitch: {
           command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
           env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
       },
@@ -374,7 +374,7 @@ describe('setupClaudeMcp', () => {
       crane: { command: 'crane-mcp', args: [], env: {} },
       stitch: {
         command: 'npx',
-        args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+        args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
         env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
       },
     },
@@ -466,7 +466,7 @@ describe('setupClaudeMcp', () => {
     // Source patched + target updated with newer stitch version
     expect(writeFileSync).toHaveBeenCalledTimes(2)
     const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[1][1] as string)
-    expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.1')
+    expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.0')
   })
 
   it('skips write when source already has current STITCH_API_KEY', () => {
@@ -475,7 +475,7 @@ describe('setupClaudeMcp', () => {
         crane: { command: 'crane-mcp', args: [], env: {} },
         stitch: {
           command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
           env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
       },
@@ -522,7 +522,7 @@ describe('setupClaudeMcp', () => {
         crane: { command: 'crane-mcp', args: [], env: {} },
         stitch: {
           command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.1', 'proxy'],
+          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
           env: { STITCH_PROJECT_ID: 'smdurgan-tools', STITCH_API_KEY: 'test-gemini-key' },
         },
         custom: { command: 'custom-mcp', args: [] },

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -28,7 +28,7 @@ import { prepareSSHAuth } from './ssh-auth.js'
 
 /** Pinned stitch-mcp version. Update here AND in .mcp.json together.
  *  Verify: npm view @_davideast/stitch-mcp version */
-const STITCH_MCP_VERSION = '0.5.1' // verified 2026-03-26
+const STITCH_MCP_VERSION = '0.5.0' // v0.5.1 has broken MCP stdio handshake
 
 /** GCP project for Stitch. Proxy mode requires a Google AI API key (GEMINI_API_KEY)
  *  passed as STITCH_API_KEY, plus STITCH_PROJECT_ID for project scoping.


### PR DESCRIPTION
## Summary
- v0.5.1 of `@_davideast/stitch-mcp` connects to googleapis but never responds to the MCP initialize handshake on stdio, causing "Failed to connect" on every Claude Code session
- Verified by sending JSON-RPC initialize to each version: v0.3.2, v0.4.0, v0.5.0 all respond; v0.5.1 produces no stdout
- Pins to v0.5.0 which has proxy mode and working handshake

## Test plan
- [x] `npm run verify` passes (283 tests)
- [x] Verified v0.5.0 responds to MCP initialize handshake
- [x] Fresh `crane vc` session shows Stitch as Connected in `claude mcp list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)