### PR TITLE
fix: add missing name field to sprint-worker agent frontmatter

### DIFF
--- a/.claude/agents/sprint-worker.md
+++ b/.claude/agents/sprint-worker.md
@@ -1,4 +1,5 @@
 ---
+name: sprint-worker
 model: sonnet
 tools:
   - Bash


### PR DESCRIPTION
## Summary
- Adds required `name` field to `.claude/agents/sprint-worker.md` frontmatter
- Fixes agent parse error reported by `claude /doctor`

## Test plan
- [x] `npm run verify` passes
- [x] `claude /doctor` no longer reports parse error for sprint-worker.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)