### PR TITLE
fix: inject GOOGLE_APPLICATION_CREDENTIALS for Stitch MCP proxy auth

### DIFF
--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -94,26 +94,28 @@ Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM chang
 
 ### Authentication
 
-Stitch proxy mode requires a **Google AI API key** (`GEMINI_API_KEY`) passed as `STITCH_API_KEY`, plus `STITCH_PROJECT_ID` for project scoping.
+Stitch uses **OAuth2 via gcloud Application Default Credentials (ADC)** - API keys are rejected by the Stitch API.
 
-The fleet launcher configures Stitch MCP with both keys automatically:
+The fleet launcher configures Stitch MCP automatically:
 
-- `STITCH_API_KEY` — sourced from `GEMINI_API_KEY` in the launcher environment (Infisical)
 - `STITCH_PROJECT_ID` — hardcoded to `smdurgan-tools`
+- `GOOGLE_APPLICATION_CREDENTIALS` — points to the system ADC file (`~/.config/gcloud/application_default_credentials.json`)
+
+The proxy server handles token refresh automatically using the ADC refresh token.
 
 **If Stitch tools fail to connect:**
 
-1. Check `GEMINI_API_KEY` is set in the launcher environment: `echo $GEMINI_API_KEY | head -c 10`
-2. If missing, check Infisical: `infisical secrets --path /vc --env prod | grep GEMINI`
-3. The GCP project is `smdurgan-tools` — this is set by the launcher, not by the agent
-4. A session restart is needed after fixing launcher secrets (they're frozen at launch time)
+1. Verify ADC exists: `ls ~/.config/gcloud/application_default_credentials.json`
+2. If missing, run: `gcloud auth application-default login`
+3. Test auth: `gcloud auth application-default print-access-token | head -c 10`
+4. A session restart is needed after fixing auth (MCP servers are initialized at launch time)
 
 **Per-machine setup** (one-time, handled during fleet bootstrap):
 
 ```bash
 gcloud auth login
 gcloud auth application-default login
-npx @_davideast/stitch-mcp@0.5.1 init -c cc  # select OAuth > Proxy
+npx @_davideast/stitch-mcp@0.5.0 init -c cc  # select OAuth > Proxy
 ```
 
 ### MCP Tools (Fleet-Managed)

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -45,6 +45,8 @@ vi.mock('./ssh-auth.js', () => ({
   prepareSSHAuth: vi.fn(() => ({ env: {} })),
 }))
 
+import { join } from 'path'
+import { homedir } from 'os'
 import {
   setupGeminiMcp,
   setupClaudeMcp,
@@ -190,7 +192,15 @@ describe('setupGeminiMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: {
+            STITCH_PROJECT_ID: 'smdurgan-tools',
+            GOOGLE_APPLICATION_CREDENTIALS: join(
+              homedir(),
+              '.config',
+              'gcloud',
+              'application_default_credentials.json'
+            ),
+          },
         },
       },
       security: {
@@ -362,13 +372,22 @@ describe('setupGeminiMcp', () => {
 })
 
 describe('setupClaudeMcp', () => {
+  const STITCH_ENV = {
+    STITCH_PROJECT_ID: 'smdurgan-tools',
+    GOOGLE_APPLICATION_CREDENTIALS: join(
+      homedir(),
+      '.config',
+      'gcloud',
+      'application_default_credentials.json'
+    ),
+  }
   const SOURCE_CONFIG = {
     mcpServers: {
       crane: { command: 'crane-mcp', args: [], env: {} },
       stitch: {
         command: 'npx',
         args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-        env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+        env: STITCH_ENV,
       },
     },
   }
@@ -461,7 +480,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: STITCH_ENV,
         },
       },
     }
@@ -507,7 +526,7 @@ describe('setupClaudeMcp', () => {
         stitch: {
           command: 'npx',
           args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: { STITCH_PROJECT_ID: 'smdurgan-tools' },
+          env: STITCH_ENV,
         },
         custom: { command: 'custom-mcp', args: [] },
       },

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -35,9 +35,20 @@ const STITCH_MCP_VERSION = '0.5.0' // v0.5.1 has broken MCP stdio handshake
  *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
 const STITCH_PROJECT_ID = 'smdurgan-tools'
 
-/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup. */
+/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup.
+ *  The proxy uses an isolated gcloud config (~/.stitch-mcp/config/) that lacks ADC
+ *  credentials. GOOGLE_APPLICATION_CREDENTIALS bypasses this by pointing directly
+ *  at the system ADC file, which has a refresh token for automatic token renewal.
+ *  Recovery: if tokens break, re-run `gcloud auth application-default login` on the machine. */
 function resolveStitchEnv(): Record<string, string> {
-  return { STITCH_PROJECT_ID }
+  const adcPath = join(homedir(), '.config', 'gcloud', 'application_default_credentials.json')
+  if (!existsSync(adcPath)) {
+    console.warn(
+      `-> Warning: gcloud ADC not found at ${adcPath}. Stitch MCP will fail to authenticate.\n` +
+        `   Run 'gcloud auth application-default login' on this machine.`
+    )
+  }
+  return { STITCH_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS: adcPath }
 }
 
 // Resolve crane-console root relative to this script
@@ -640,7 +651,7 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
-  // Inject Stitch env (STITCH_PROJECT_ID) into source .mcp.json
+  // Inject Stitch env (STITCH_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS) into source .mcp.json
   const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
   if (servers.stitch) {
     const existing = (servers.stitch.env ?? {}) as Record<string, string>
@@ -890,12 +901,15 @@ export function setupCodexMcp(): void {
     updated = true
   }
 
-  // --- Stitch MCP server (proxy mode: needs STITCH_PROJECT_ID, auth via ADC) ---
+  // --- Stitch MCP server (proxy mode: needs STITCH_PROJECT_ID + GOOGLE_APPLICATION_CREDENTIALS) ---
   if (!content.includes('[mcp_servers.stitch]')) {
+    const stitchEnvKeys = Object.keys(resolveStitchEnv())
+      .map((k) => `"${k}"`)
+      .join(', ')
     const stitchEntry =
       `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
       `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
-      `env_vars = ["STITCH_PROJECT_ID"]\n`
+      `env_vars = [${stitchEnvKeys}]\n`
     content = content.trimEnd() + '\n' + stitchEntry
     updated = true
   }


### PR DESCRIPTION
## Summary
- **Root cause**: stitch-mcp proxy uses an isolated gcloud config (`~/.stitch-mcp/config/`) without ADC credentials, while `stitch-mcp doctor` checks the system gcloud (which passes). Setting `GOOGLE_APPLICATION_CREDENTIALS` to the system ADC file bypasses the isolated config.
- `resolveStitchEnv()` now injects `GOOGLE_APPLICATION_CREDENTIALS` with `existsSync()` guard for unbootstrapped machines
- Codex `env_vars` whitelist derived dynamically from `resolveStitchEnv()` keys (was hardcoded to `["STITCH_PROJECT_ID"]`)
- Wireframe guidelines updated: stale API key docs replaced with OAuth/ADC, init pinned to v0.5.0

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 283 tests, build)
- [x] Stitch MCP stdio handshake succeeds with `GOOGLE_APPLICATION_CREDENTIALS` set
- [x] Stitch `tools/list` returns full tool catalog
- [x] Live smoke test: Stitch connected and authenticated in new `crane vc` session

🤖 Generated with [Claude Code](https://claude.com/claude-code)