### PR TITLE
fix: strip STITCH_API_KEY from shell env to prevent OAuth2 override

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1095,6 +1095,13 @@ export function launchAgent(
     MCP_TIMEOUT: process.env.MCP_TIMEOUT ?? '30000',
   }
 
+  // Strip STITCH_API_KEY from shell env. The Stitch API rejects API keys and
+  // requires OAuth2/ADC. The .mcp.json env block blanks it for the MCP server,
+  // but if Infisical still has the key, it leaks into the shell env via ...secrets
+  // and MCP servers inherit the shell env as their base. Deleting it here ensures
+  // it never reaches any child process regardless of .mcp.json state.
+  delete (childEnv as Record<string, string | undefined>).STITCH_API_KEY
+
   // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)
   if (agent === 'claude' && !extraArgs.includes('-p') && !extraArgs.includes('--print')) {
     const hasPrompt = extraArgs.some((a) => !a.startsWith('-'))


### PR DESCRIPTION
## Summary

- Deletes `STITCH_API_KEY` from the launcher's `childEnv` before spawning agent processes, preventing the key from reaching any child process via shell env inheritance
- Follows the existing `OPENAI_API_KEY` deletion pattern used for Hermes (line 1112)
- Closes the gap where `.mcp.json` env overlay only applied at initial MCP spawn but not on reconnection (e.g. after `/clear`)

## Root Cause

The `.mcp.json` blank (`STITCH_API_KEY: ""`) suppressed the key at MCP server startup, but after `/clear` triggered MCP reconnection, the server re-read `process.env` and found the real API key inherited from the shell. This caused the Stitch proxy to switch from OAuth2 to API key auth, which Google rejects.

The key was being injected into the shell env via `...secrets` from Infisical at launch time. Even though the key was deleted from all Infisical paths on 2026-03-28, sessions launched before the cleanup still carried it.

## Defense-in-depth layers (now 3)

1. Deleted from all Infisical venture paths (2026-03-28)
2. Blanked in `.mcp.json` env block via `resolveStitchEnv()` (#392)
3. **NEW:** Deleted from shell env in `childEnv` before spawn

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + 283 tests)
- [x] Confirmed `STITCH_API_KEY` absent from all Infisical paths (`/vc`, `/dc`, `/ke`, `/sc`, `/dfg`)
- [ ] DC agent restarts with `crane dc` and Stitch OAuth works through `/clear` cycles

`qa-grade:0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)