### PR TITLE
feat: switch Stitch MCP from local proxy to remote HTTP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,14 +4,6 @@
       "command": "crane-mcp",
       "args": [],
       "env": {}
-    },
-    "stitch": {
-      "command": "npx",
-      "args": ["@_davideast/stitch-mcp@0.5.0", "proxy"],
-      "env": {
-        "STITCH_PROJECT_ID": "smdurgan-tools",
-        "GOOGLE_APPLICATION_CREDENTIALS": "/Users/scottdurgan/.config/gcloud/application_default_credentials.json"
-      }
     }
   }
 }

--- a/config/ventures.json
+++ b/config/ventures.json
@@ -8,7 +8,8 @@
       "CRANE_ADMIN_KEY",
       "GH_TOKEN",
       "VERCEL_TOKEN",
-      "CLOUDFLARE_API_TOKEN"
+      "CLOUDFLARE_API_TOKEN",
+      "STITCH_API_KEY"
     ]
   },
   "ventures": [

--- a/docs/instructions/guardrails.md
+++ b/docs/instructions/guardrails.md
@@ -115,8 +115,8 @@ are listed in `CLAUDE.md` under "Instruction Modules."
 
 ### Concrete Examples
 
-- **Switching Stitch auth from API key to OAuth** - MUST update `wireframe-guidelines.md`
-  (tells agents how to use Stitch) and remove any API key references
+- **Changing Stitch MCP auth method** - MUST update `wireframe-guidelines.md`
+  (tells agents how to use Stitch) and update relevant launcher code
 - **Changing how `crane` injects secrets** - MUST update `secrets.md` and any
   venture-specific docs that reference secret access patterns
 - **Reconfiguring an MCP server** - MUST update any instruction module that

--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -94,29 +94,24 @@ Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM chang
 
 ### Authentication
 
-Stitch uses **OAuth2 via gcloud Application Default Credentials (ADC)** - API keys are rejected by the Stitch API.
+Stitch is a **remote HTTP MCP server** at `https://stitch.googleapis.com/mcp`. Auth is via API key header - no local subprocess, no gcloud, no OAuth tokens to expire.
 
-The fleet launcher configures Stitch MCP automatically:
+- `STITCH_API_KEY` — stored in Infisical `/vc` (shared secret, propagated to all ventures)
+- No per-machine gcloud setup required
 
-- `STITCH_PROJECT_ID` — hardcoded to `smdurgan-tools`
-- `GOOGLE_APPLICATION_CREDENTIALS` — points to the system ADC file (`~/.config/gcloud/application_default_credentials.json`)
+**Per-machine setup** (one-time):
 
-The proxy server handles token refresh automatically using the ADC refresh token.
+```bash
+claude mcp add stitch --transport http https://stitch.googleapis.com/mcp \
+  -H "X-Goog-Api-Key: <key-from-infisical>" -s user
+```
 
 **If Stitch tools fail to connect:**
 
-1. Verify ADC exists: `ls ~/.config/gcloud/application_default_credentials.json`
-2. If missing, run: `gcloud auth application-default login`
-3. Test auth: `gcloud auth application-default print-access-token | head -c 10`
-4. A session restart is needed after fixing auth (MCP servers are initialized at launch time)
-
-**Per-machine setup** (one-time, handled during fleet bootstrap):
-
-```bash
-gcloud auth login
-gcloud auth application-default login
-npx @_davideast/stitch-mcp@0.5.0 init -c cc  # select OAuth > Proxy
-```
+1. Verify the API key: `infisical secrets get STITCH_API_KEY --path /vc --env prod`
+2. Verify MCP registration: `claude mcp list` should show `stitch` as connected
+3. If missing, re-run the setup command above with the current key from Infisical
+4. Docs: https://stitch.withgoogle.com/docs/mcp/setup
 
 ### MCP Tools (Fleet-Managed)
 

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -189,20 +189,6 @@ describe('setupGeminiMcp', () => {
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
           },
         },
-        stitch: {
-          command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: {
-            STITCH_PROJECT_ID: 'smdurgan-tools',
-            GOOGLE_APPLICATION_CREDENTIALS: join(
-              homedir(),
-              '.config',
-              'gcloud',
-              'application_default_credentials.json'
-            ),
-            STITCH_API_KEY: '',
-          },
-        },
       },
       security: {
         environmentVariableRedaction: {
@@ -373,24 +359,9 @@ describe('setupGeminiMcp', () => {
 })
 
 describe('setupClaudeMcp', () => {
-  const STITCH_ENV = {
-    STITCH_PROJECT_ID: 'smdurgan-tools',
-    GOOGLE_APPLICATION_CREDENTIALS: join(
-      homedir(),
-      '.config',
-      'gcloud',
-      'application_default_credentials.json'
-    ),
-    STITCH_API_KEY: '',
-  }
   const SOURCE_CONFIG = {
     mcpServers: {
       crane: { command: 'crane-mcp', args: [], env: {} },
-      stitch: {
-        command: 'npx',
-        args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-        env: STITCH_ENV,
-      },
     },
   }
 
@@ -438,13 +409,11 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source unchanged, target synced with missing servers
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(targetWritten.mcpServers.stitch.env.STITCH_PROJECT_ID).toBe('smdurgan-tools')
+    // Source has no stitch — target should not get stitch either
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 
-  it('updates stale server configs when source has newer version', () => {
+  it('removes legacy stitch subprocess from target', () => {
     const targetConfig = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
@@ -469,24 +438,13 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Target updated with newer stitch version
+    // Target updated: legacy stitch subprocess removed
     expect(writeFileSync).toHaveBeenCalledTimes(1)
     const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
-    expect(targetWritten.mcpServers.stitch.args[0]).toBe('@_davideast/stitch-mcp@0.5.0')
+    expect(targetWritten.mcpServers.stitch).toBeUndefined()
   })
 
   it('skips write when source and target already match', () => {
-    const currentSource = {
-      mcpServers: {
-        crane: { command: 'crane-mcp', args: [], env: {} },
-        stitch: {
-          command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: STITCH_ENV,
-        },
-      },
-    }
-
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
       if (String(filePath).includes('ventures.json')) {
@@ -494,7 +452,7 @@ describe('setupClaudeMcp', () => {
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
         })
       }
-      return JSON.stringify(currentSource)
+      return JSON.stringify(SOURCE_CONFIG)
     })
 
     setupClaudeMcp('/fake/repo')
@@ -525,11 +483,6 @@ describe('setupClaudeMcp', () => {
     const targetConfig = {
       mcpServers: {
         crane: { command: 'crane-mcp', args: [], env: {} },
-        stitch: {
-          command: 'npx',
-          args: ['@_davideast/stitch-mcp@0.5.0', 'proxy'],
-          env: STITCH_ENV,
-        },
         custom: { command: 'custom-mcp', args: [] },
       },
     }
@@ -547,7 +500,7 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source unchanged, target already matches. Custom server preserved.
+    // Source and target match on crane, custom preserved. No writes needed.
     expect(writeFileSync).not.toHaveBeenCalled()
   })
 })

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -26,33 +26,10 @@ import { API_BASE_PRODUCTION, getCraneEnv, getStagingInfisicalPath } from '../li
 import { scanLocalRepos, LocalRepo } from '../lib/repo-scanner.js'
 import { prepareSSHAuth } from './ssh-auth.js'
 
-/** Pinned stitch-mcp version. Update here AND in .mcp.json together.
- *  Verify: npm view @_davideast/stitch-mcp version */
-const STITCH_MCP_VERSION = '0.5.0' // v0.5.1 has broken MCP stdio handshake
-
-/** GCP project for Stitch. Proxy mode uses ADC (gcloud auth application-default login)
- *  for authentication — API keys are rejected by the Stitch API.
- *  Auth setup: npx @_davideast/stitch-mcp init -c cc (select OAuth + Proxy) */
-const STITCH_PROJECT_ID = 'smdurgan-tools'
-
-/** Resolve Stitch MCP env vars. Shared by Claude, Gemini, and Codex setup.
- *  The proxy uses an isolated gcloud config (~/.stitch-mcp/config/) that lacks ADC
- *  credentials. GOOGLE_APPLICATION_CREDENTIALS bypasses this by pointing directly
- *  at the system ADC file, which has a refresh token for automatic token renewal.
- *  Recovery: if tokens break, re-run `gcloud auth application-default login` on the machine. */
-function resolveStitchEnv(): Record<string, string> {
-  const adcPath = join(homedir(), '.config', 'gcloud', 'application_default_credentials.json')
-  if (!existsSync(adcPath)) {
-    console.warn(
-      `-> Warning: gcloud ADC not found at ${adcPath}. Stitch MCP will fail to authenticate.\n` +
-        `   Run 'gcloud auth application-default login' on this machine.`
-    )
-  }
-  // Blank STITCH_API_KEY to prevent parent env leakage. The Stitch API rejects
-  // API keys and requires OAuth2/ADC. If a key leaks through (e.g. from Infisical),
-  // the proxy uses it instead of ADC and gets 401.
-  return { STITCH_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS: adcPath, STITCH_API_KEY: '' }
-}
+/** Stitch remote MCP endpoint. Stitch is a remote HTTP MCP server — no local
+ *  subprocess needed. Auth is via API key header (STITCH_API_KEY from Infisical).
+ *  Docs: https://stitch.withgoogle.com/docs/mcp/setup */
+const STITCH_MCP_URL = 'https://stitch.googleapis.com/mcp'
 
 // Resolve crane-console root relative to this script
 // Compiled path: packages/crane-mcp/dist/cli/launch-lib.js -> 4 levels up
@@ -654,15 +631,14 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
-  // Inject Stitch env (STITCH_PROJECT_ID, GOOGLE_APPLICATION_CREDENTIALS) into source .mcp.json
+  // Stitch is now a remote HTTP MCP server — no local subprocess needed.
+  // The user-level config (~/.claude.json) handles the API key header.
+  // Remove any legacy subprocess stitch entry from .mcp.json so it doesn't conflict.
   const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
-  if (servers.stitch) {
-    const existing = (servers.stitch.env ?? {}) as Record<string, string>
-    const merged = { ...existing, ...resolveStitchEnv() }
-    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
-      servers.stitch.env = merged
-      writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
-    }
+  if (servers.stitch && (servers.stitch as Record<string, unknown>).command) {
+    delete servers.stitch
+    writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
+    console.log('-> Removed legacy Stitch subprocess from .mcp.json (now remote HTTP)')
   }
 
   const sourceServers = (sourceConfig.mcpServers ?? {}) as Record<string, unknown>
@@ -695,6 +671,12 @@ export function setupClaudeMcp(repoPath: string): void {
       targetServers[name] = config
       dirty = true
     }
+  }
+
+  // Remove legacy Stitch subprocess from target (now remote HTTP, configured per-user)
+  if (targetServers.stitch && (targetServers.stitch as Record<string, unknown>).command) {
+    delete targetServers.stitch
+    dirty = true
   }
 
   if (dirty) {
@@ -812,22 +794,9 @@ export function setupGeminiMcp(repoPath: string): void {
     dirty = true
   }
 
-  // --- Stitch MCP server (proxy mode: needs STITCH_PROJECT_ID, auth via ADC) ---
-  const stitchEnv = resolveStitchEnv()
-  if (mcpServers.stitch) {
-    const stitch = mcpServers.stitch as Record<string, unknown>
-    const existing = (stitch.env ?? {}) as Record<string, string>
-    const merged = { ...existing, ...stitchEnv }
-    if (JSON.stringify(existing) !== JSON.stringify(merged)) {
-      stitch.env = merged
-      dirty = true
-    }
-  } else {
-    mcpServers.stitch = {
-      command: 'npx',
-      args: [`@_davideast/stitch-mcp@${STITCH_MCP_VERSION}`, 'proxy'],
-      env: stitchEnv,
-    }
+  // --- Stitch: remove legacy subprocess entry (now remote HTTP, configured per-user) ---
+  if (mcpServers.stitch && (mcpServers.stitch as Record<string, unknown>).command) {
+    delete mcpServers.stitch
     dirty = true
   }
 
@@ -904,16 +873,10 @@ export function setupCodexMcp(): void {
     updated = true
   }
 
-  // --- Stitch MCP server (proxy mode: needs STITCH_PROJECT_ID + GOOGLE_APPLICATION_CREDENTIALS) ---
-  if (!content.includes('[mcp_servers.stitch]')) {
-    const stitchEnvKeys = Object.keys(resolveStitchEnv())
-      .map((k) => `"${k}"`)
-      .join(', ')
-    const stitchEntry =
-      `\n[mcp_servers.stitch]\ncommand = "npx"\n` +
-      `args = ["@_davideast/stitch-mcp@${STITCH_MCP_VERSION}", "proxy"]\n` +
-      `env_vars = [${stitchEnvKeys}]\n`
-    content = content.trimEnd() + '\n' + stitchEntry
+  // Stitch is now a remote HTTP MCP server — no Codex config needed.
+  // Remove legacy subprocess entry if present.
+  if (content.includes('[mcp_servers.stitch]')) {
+    content = content.replace(/\[mcp_servers\.stitch][^[]*/, '')
     updated = true
   }
 
@@ -1090,17 +1053,8 @@ export function launchAgent(
     CRANE_VENTURE_CODE: venture.code,
     CRANE_VENTURE_NAME: venture.name,
     CRANE_REPO: repoName,
-    // Stitch proxy takes ~2s to connect to googleapis.com before MCP handshake.
-    // Default MCP_TIMEOUT is too short; 30s gives headroom for slow networks.
     MCP_TIMEOUT: process.env.MCP_TIMEOUT ?? '30000',
   }
-
-  // Strip STITCH_API_KEY from shell env. The Stitch API rejects API keys and
-  // requires OAuth2/ADC. The .mcp.json env block blanks it for the MCP server,
-  // but if Infisical still has the key, it leaks into the shell env via ...secrets
-  // and MCP servers inherit the shell env as their base. Deleting it here ensures
-  // it never reaches any child process regardless of .mcp.json state.
-  delete (childEnv as Record<string, string | undefined>).STITCH_API_KEY
 
   // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)
   if (agent === 'claude' && !extraArgs.includes('-p') && !extraArgs.includes('--print')) {


### PR DESCRIPTION
## Summary

- Replaces the entire local Stitch proxy architecture (`npx @_davideast/stitch-mcp proxy` + OAuth/ADC + gcloud) with Stitch's native remote HTTP MCP endpoint at `https://stitch.googleapis.com/mcp`
- Removes `resolveStitchEnv()`, `STITCH_MCP_VERSION`, `STITCH_PROJECT_ID` constant, `GOOGLE_APPLICATION_CREDENTIALS` injection, `STITCH_API_KEY` deletion logic, and all Stitch subprocess config from Claude/Gemini/Codex setup
- Adds `STITCH_API_KEY` to shared secrets in `ventures.json` for fleet propagation
- Net -105 lines (47 added, 152 removed)

## Context

Stitch MCP auth caused 4+ incidents and 40+ hours of agent time across version pinning, API key leakage, Infisical cleanup, and Workspace session control token expiry. The official Stitch docs show it's a remote HTTP MCP server - the local proxy was unnecessary. API key auth via header is the recommended approach for Claude Code.

Per-user setup: `claude mcp add stitch --transport http https://stitch.googleapis.com/mcp -H "X-Goog-Api-Key: <key>" -s user`

## Test plan

- [x] `npm run verify` passes (283 tests, 0 errors)
- [x] DC agent confirmed remote HTTP Stitch working (listed 5 projects)
- [x] API key stored in Infisical `/vc`
- [ ] Fleet machines: `crane vc` removes legacy stitch from `.mcp.json` on next launch

`qa-grade:0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)