### PR TITLE
fix: disable Claude.ai remote MCP servers in CLI sessions

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1054,6 +1054,11 @@ export function launchAgent(
     CRANE_VENTURE_NAME: venture.name,
     CRANE_REPO: repoName,
     MCP_TIMEOUT: process.env.MCP_TIMEOUT ?? '30000',
+    // Disable Claude.ai remote MCP integrations in CLI sessions.
+    // The local crane MCP + gh CLI cover everything agents need.
+    // Without this, remote servers like crane-context expose redundant
+    // GitHub tools that bloat context and mislead agents.
+    ENABLE_CLAUDEAI_MCP_SERVERS: 'false',
   }
 
   // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)


### PR DESCRIPTION
## Summary
- Adds `ENABLE_CLAUDEAI_MCP_SERVERS: 'false'` to the `childEnv` in `launchAgent()` so CLI sessions launched via `crane` no longer load remote MCP integrations from Claude.ai
- Prevents agents from reaching for remote `crane-context` GitHub tools (`github_list_issues`, etc.) instead of `gh` CLI
- Eliminates 14 redundant tool definitions from every CLI session's context

## Context
An SS agent launched on m16 and immediately reached for `mcp__claude_ai_crane_context__github_list_issues` - a remote MCP tool routed through Claude.ai's crane-context integration - instead of using `gh` directly. The remote path is slower (Claude.ai -> Cloudflare Worker -> GitHub API) and the 14 extra GitHub tool definitions bloat context tokens.

## Test plan
- [x] `npm run verify` passes (283 tests, 0 errors)
- [ ] Launch a CLI session via `crane` and confirm no `claude.ai` remote MCP tools appear in deferred tools list
- [ ] Verify `gh` CLI still works normally for GitHub operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)