### PR TITLE
fix: prevent stale in_progress handoffs from showing in SOS Resume block

### DIFF
--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -11,6 +11,7 @@ import { sosInputSchema, executeSos } from './tools/sos.js'
 import { venturesInputSchema, executeVentures } from './tools/ventures.js'
 import { contextInputSchema, executeContext } from './tools/context.js'
 import { handoffInputSchema, executeHandoff } from './tools/handoff.js'
+import { handoffUpdateInputSchema, executeHandoffUpdate } from './tools/handoff-update.js'
 import { preflightInputSchema, executePreflight } from './tools/preflight.js'
 import { statusInputSchema, executeStatus } from './tools/status.js'
 import { planInputSchema, executePlan } from './tools/plan.js'
@@ -190,6 +191,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ['summary', 'status'],
+        },
+      },
+      {
+        name: 'crane_handoff_update',
+        description:
+          'Update the status of an existing handoff. Use to close out stale in_progress or blocked handoffs ' +
+          'that were superseded by subsequent sessions.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            handoff_id: {
+              type: 'string',
+              description: 'The handoff ID to update (e.g., ho_01HQXV4NK8...)',
+            },
+            status: {
+              type: 'string',
+              enum: ['done', 'in_progress', 'blocked'],
+              description: 'New status for the handoff',
+            },
+          },
+          required: ['handoff_id', 'status'],
         },
       },
       {
@@ -621,6 +643,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'crane_handoff': {
         const input = handoffInputSchema.parse(args)
         const result = await executeHandoff(input)
+        return {
+          content: [{ type: 'text', text: result.message }],
+        }
+      }
+
+      case 'crane_handoff_update': {
+        const input = handoffUpdateInputSchema.parse(args)
+        const result = await executeHandoffUpdate(input)
         return {
           content: [{ type: 'text', text: result.message }],
         }

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -988,6 +988,30 @@ export class CraneApi {
 
     return (await response.json()) as QueryHandoffsResponse
   }
+
+  async updateHandoffStatus(
+    handoffId: string,
+    statusLabel: string
+  ): Promise<{ handoff: HandoffRecord }> {
+    const response = await fetch(
+      `${this.apiBase}/handoffs/${encodeURIComponent(handoffId)}/status`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Relay-Key': this.apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ status_label: statusLabel }),
+      }
+    )
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Update handoff status failed (${response.status}): ${text}`)
+    }
+
+    return (await response.json()) as { handoff: HandoffRecord }
+  }
 }
 
 function getHostname(): string {

--- a/packages/crane-mcp/src/tools/handoff-update.ts
+++ b/packages/crane-mcp/src/tools/handoff-update.ts
@@ -1,0 +1,54 @@
+/**
+ * crane_handoff_update tool - Update status on an existing handoff
+ *
+ * Used to close out stale in_progress/blocked handoffs that were
+ * superseded by subsequent sessions.
+ */
+
+import { z } from 'zod'
+import { CraneApi } from '../lib/crane-api.js'
+import { getApiBase } from '../lib/config.js'
+
+export const handoffUpdateInputSchema = z.object({
+  handoff_id: z.string().describe('The handoff ID to update (e.g., ho_01HQXV4NK8...)'),
+  status: z.enum(['done', 'in_progress', 'blocked']).describe('New status for the handoff'),
+})
+
+export type HandoffUpdateInput = z.infer<typeof handoffUpdateInputSchema>
+
+export interface HandoffUpdateResult {
+  success: boolean
+  message: string
+}
+
+export async function executeHandoffUpdate(
+  input: HandoffUpdateInput
+): Promise<HandoffUpdateResult> {
+  const apiKey = process.env.CRANE_CONTEXT_KEY
+  if (!apiKey) {
+    return {
+      success: false,
+      message: 'CRANE_CONTEXT_KEY not found. Cannot update handoff.',
+    }
+  }
+
+  const api = new CraneApi(apiKey, getApiBase())
+
+  try {
+    const result = await api.updateHandoffStatus(input.handoff_id, input.status)
+
+    return {
+      success: true,
+      message:
+        `Handoff ${result.handoff.id} updated to "${input.status}".\n` +
+        `From: ${result.handoff.from_agent}\n` +
+        `Created: ${result.handoff.created_at}`,
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown error'
+    return {
+      success: false,
+      message: `Failed to update handoff: ${detail}`,
+    }
+  }
+}

--- a/packages/crane-mcp/src/tools/sos.test.ts
+++ b/packages/crane-mcp/src/tools/sos.test.ts
@@ -416,7 +416,7 @@ describe('sos tool', () => {
     expect(result.message).toContain('Other ventures')
   })
 
-  it('shows recent handoffs when queryHandoffs returns results', async () => {
+  it('treats in_progress handoff as stale when newer done handoff exists', async () => {
     const { executeSos } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
     const { getP0Issues } = await import('../lib/github.js')
@@ -427,7 +427,8 @@ describe('sos tool', () => {
     vi.mocked(existsSync).mockReturnValue(false)
 
     const now = new Date()
-    const recentTime = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString() // 2h ago
+    const newerTime = new Date(now.getTime() - 1 * 60 * 60 * 1000).toISOString() // 1h ago
+    const olderTime = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString() // 2h ago
 
     mockFetch
       .mockResolvedValueOnce({
@@ -450,7 +451,7 @@ describe('sos tool', () => {
               from_agent: 'agent-mac23',
               summary: 'Fixed the handoff system',
               status_label: 'done',
-              created_at: recentTime,
+              created_at: newerTime,
             },
             {
               id: 'h2',
@@ -460,7 +461,7 @@ describe('sos tool', () => {
               from_agent: 'agent-m16',
               summary: 'Design work in progress',
               status_label: 'in_progress',
-              created_at: recentTime,
+              created_at: olderTime,
             },
           ],
           has_more: false,
@@ -471,7 +472,70 @@ describe('sos tool', () => {
 
     expect(result.status).toBe('valid')
     expect(result.message).toContain('## Continuity')
-    // in_progress handoff renders as Resume block with full summary
+    // Stale in_progress should NOT show as Resume - a newer done handoff supersedes it
+    expect(result.message).not.toContain('### Resume: in_progress')
+    // Both handoffs should appear in the one-liner list
+    expect(result.message).toContain('Fixed the handoff system')
+    expect(result.recent_handoffs).toHaveLength(2)
+  })
+
+  it('shows Resume block when in_progress handoff is newer than all done handoffs', async () => {
+    const { executeSos } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getP0Issues } = await import('../lib/github.js')
+
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+    vi.mocked(getP0Issues).mockReturnValue({ success: true, issues: [] })
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    const now = new Date()
+    const newerTime = new Date(now.getTime() - 1 * 60 * 60 * 1000).toISOString() // 1h ago
+    const olderTime = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString() // 2h ago
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: mockVentures }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSosResponse,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          handoffs: [
+            {
+              id: 'h1',
+              session_id: 'sess_1',
+              venture: 'vc',
+              repo: 'venturecrane/crane-console',
+              from_agent: 'agent-m16',
+              summary: 'Design work in progress',
+              status_label: 'in_progress',
+              created_at: newerTime,
+            },
+            {
+              id: 'h2',
+              session_id: 'sess_2',
+              venture: 'vc',
+              repo: 'venturecrane/crane-console',
+              from_agent: 'agent-mac23',
+              summary: 'Fixed the handoff system',
+              status_label: 'done',
+              created_at: olderTime,
+            },
+          ],
+          has_more: false,
+        }),
+      })
+
+    const result = await executeSos({})
+
+    expect(result.status).toBe('valid')
+    expect(result.message).toContain('## Continuity')
+    // Fresh in_progress should show as Resume
     expect(result.message).toContain('### Resume: in_progress')
     expect(result.message).toContain('Design work in progress')
     // done handoff renders as truncated one-liner

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -494,12 +494,20 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
     const MAX_OTHER_HANDOFFS = 3
     if (recentHandoffs.length > 0) {
       // Separate active (in_progress/blocked) from completed handoffs
-      const activeHandoffs = recentHandoffs.filter(
+      // recentHandoffs is sorted newest-first (created_at DESC)
+      const allActiveHandoffs = recentHandoffs.filter(
         (h) => h.status_label === 'in_progress' || h.status_label === 'blocked'
       )
       const otherHandoffs = recentHandoffs.filter(
         (h) => h.status_label !== 'in_progress' && h.status_label !== 'blocked'
       )
+
+      // Filter out stale active handoffs: if a newer completed handoff exists,
+      // the in_progress/blocked one was superseded by a subsequent session
+      const newestCompleted = otherHandoffs.length > 0 ? otherHandoffs[0] : null
+      const activeHandoffs = newestCompleted
+        ? allActiveHandoffs.filter((h) => h.created_at > newestCompleted.created_at)
+        : allActiveHandoffs
 
       // Show full summary for the most recent active handoff
       if (activeHandoffs.length > 0) {

--- a/workers/crane-context/src/endpoints/queries.ts
+++ b/workers/crane-context/src/endpoints/queries.ts
@@ -7,7 +7,7 @@
 
 import type { Env, SessionHistoryEntry, SessionHistoryBlock } from '../types'
 import { findActiveSessions } from '../sessions'
-import { getLatestHandoff, queryHandoffs } from '../handoffs'
+import { getLatestHandoff, queryHandoffs, updateHandoffStatus } from '../handoffs'
 import { fetchDocsMetadata, fetchDoc } from '../docs'
 import { runDocAudit, runDocAuditAll } from '../audit'
 import { buildRequestContext, isResponse } from '../auth'
@@ -380,6 +380,82 @@ export async function handleQueryHandoffs(request: Request, env: Env): Promise<R
       )
     }
 
+    return errorResponse(
+      error instanceof Error ? error.message : 'Internal server error',
+      HTTP_STATUS.INTERNAL_ERROR,
+      context.correlationId
+    )
+  }
+}
+
+// ============================================================================
+// POST /handoffs/:id/status - Update Handoff Status
+// ============================================================================
+
+/**
+ * POST /handoffs/:id/status - Update status_label on an existing handoff
+ *
+ * Used to close out stale in_progress/blocked handoffs that were
+ * superseded by subsequent sessions.
+ *
+ * Request body:
+ * {
+ *   status_label: string (required) - New status: "done", "in_progress", "blocked"
+ * }
+ *
+ * Response:
+ * {
+ *   handoff: HandoffRecord
+ * }
+ */
+export async function handleUpdateHandoffStatus(
+  request: Request,
+  env: Env,
+  handoffId: string
+): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) {
+    return context
+  }
+
+  try {
+    const body = (await request.json()) as { status_label?: string }
+
+    if (!body.status_label || typeof body.status_label !== 'string') {
+      return validationErrorResponse(
+        [{ field: 'status_label', message: 'Required string field' }],
+        context.correlationId
+      )
+    }
+
+    const validStatuses = ['done', 'in_progress', 'blocked', 'ready']
+    if (!validStatuses.includes(body.status_label)) {
+      return validationErrorResponse(
+        [
+          {
+            field: 'status_label',
+            message: `Must be one of: ${validStatuses.join(', ')}`,
+          },
+        ],
+        context.correlationId
+      )
+    }
+
+    const handoff = await updateHandoffStatus(env.DB, handoffId, body.status_label)
+
+    if (!handoff) {
+      return errorResponse('Handoff not found', HTTP_STATUS.NOT_FOUND, context.correlationId, {
+        handoff_id: handoffId,
+      })
+    }
+
+    return jsonResponse(
+      { handoff, correlation_id: context.correlationId },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /handoffs/:id/status error:', error)
     return errorResponse(
       error instanceof Error ? error.message : 'Internal server error',
       HTTP_STATUS.INTERNAL_ERROR,

--- a/workers/crane-context/src/handoffs.ts
+++ b/workers/crane-context/src/handoffs.ts
@@ -325,6 +325,39 @@ export async function queryHandoffs(
 }
 
 // ============================================================================
+// Handoff Status Update
+// ============================================================================
+
+/**
+ * Update a handoff's status_label
+ *
+ * Used to close out stale in_progress/blocked handoffs that were
+ * superseded by subsequent sessions.
+ *
+ * @param db - D1 database binding
+ * @param handoffId - Handoff ID to update
+ * @param statusLabel - New status label (e.g., 'done')
+ * @returns Updated handoff record or null if not found
+ */
+export async function updateHandoffStatus(
+  db: D1Database,
+  handoffId: string,
+  statusLabel: string
+): Promise<HandoffRecord | null> {
+  const existing = await getHandoff(db, handoffId)
+  if (!existing) {
+    return null
+  }
+
+  await db
+    .prepare('UPDATE handoffs SET status_label = ? WHERE id = ?')
+    .bind(statusLabel, handoffId)
+    .run()
+
+  return await getHandoff(db, handoffId)
+}
+
+// ============================================================================
 // Handoff Statistics (Optional - for monitoring)
 // ============================================================================
 

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -19,6 +19,7 @@ import {
   handleGetActiveSessions,
   handleGetLatestHandoff,
   handleQueryHandoffs,
+  handleUpdateHandoffStatus,
   handleListDocsPublic,
   handleGetDoc,
   handleGetVentures,
@@ -150,6 +151,12 @@ export default {
 
       if (pathname === '/handoffs' && method === 'GET') {
         return await handleQueryHandoffs(request, env)
+      }
+
+      if (pathname.match(/^\/handoffs\/[^/]+\/status$/) && method === 'POST') {
+        const parts = pathname.split('/')
+        const handoffId = parts[2]
+        return await handleUpdateHandoffStatus(request, env, handoffId)
       }
 
       // ========================================================================


### PR DESCRIPTION
## Summary
- SOS resume logic now filters out `in_progress`/`blocked` handoffs that are older than the newest `done` handoff, preventing stale work from surfacing on every session start
- Added `POST /handoffs/:id/status` endpoint to crane-context worker so agents can close out stale handoffs
- Added `crane_handoff_update` MCP tool exposing the new endpoint

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 284 tests, build)
- [x] New test: stale `in_progress` handoff hidden when newer `done` exists
- [x] New test: fresh `in_progress` handoff still shows Resume block correctly
- [ ] Deploy crane-context worker and verify endpoint responds
- [ ] Rebuild crane-mcp on fleet and verify stale resume no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)