### PR TITLE
feat: gate Stitch MCP behind --stitch flag, separate VC-only skills

### DIFF
--- a/config/skill-exclusions.json
+++ b/config/skill-exclusions.json
@@ -1,0 +1,12 @@
+[
+  "analytics",
+  "content-scan",
+  "enterprise-review",
+  "new-venture",
+  "portfolio-review",
+  "build-log",
+  "edit-article",
+  "edit-log",
+  "docs-refresh",
+  "go-live"
+]

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -160,6 +160,7 @@ const CRANE_FLAGS = new Set([
   '-h',
   '--secrets-audit',
   '--fix',
+  '--stitch',
   ...AGENT_FLAGS,
   '--agent',
 ])
@@ -690,6 +691,18 @@ export function setupClaudeMcp(repoPath: string): void {
  * Overwrites stale files silently. Only copies .md files.
  * Skips sync when repoPath IS crane-console (source === target).
  */
+/** Load VC-only skill names from config/skill-exclusions.json */
+function loadSkillExclusions(): Set<string> {
+  try {
+    const exclusionPath = join(CRANE_CONSOLE_ROOT, 'config', 'skill-exclusions.json')
+    const content = readFileSync(exclusionPath, 'utf-8')
+    const names: string[] = JSON.parse(content)
+    return new Set(names.map((n) => `${n}.md`))
+  } catch {
+    return new Set()
+  }
+}
+
 export function syncClaudeAssets(repoPath: string): void {
   const resolvedRepo = readdirSync(repoPath).length >= 0 ? repoPath : repoPath // validate exists
   const resolvedConsole = CRANE_CONSOLE_ROOT
@@ -701,6 +714,7 @@ export function syncClaudeAssets(repoPath: string): void {
     // If stat fails, proceed with sync anyway
   }
 
+  const excluded = loadSkillExclusions()
   const dirs = ['commands', 'agents'] as const
   let totalSynced = 0
 
@@ -710,7 +724,9 @@ export function syncClaudeAssets(repoPath: string): void {
 
     if (!existsSync(sourceDir)) continue
 
-    const sourceFiles = readdirSync(sourceDir).filter((f) => f.endsWith('.md'))
+    const sourceFiles = readdirSync(sourceDir).filter(
+      (f) => f.endsWith('.md') && (dir !== 'commands' || !excluded.has(f))
+    )
     if (!sourceFiles.length) continue
 
     mkdirSync(targetDir, { recursive: true })
@@ -976,7 +992,8 @@ export function launchAgent(
   venture: VentureWithRepo,
   agent: string,
   debug: boolean = false,
-  extraArgs: string[] = []
+  extraArgs: string[] = [],
+  enableStitch: boolean = false
 ): void {
   const infisicalPath = INFISICAL_PATHS[venture.code]
   if (!infisicalPath) {
@@ -1061,6 +1078,36 @@ export function launchAgent(
     ENABLE_CLAUDEAI_MCP_SERVERS: 'false',
   }
 
+  // Inject Stitch MCP when --stitch is passed (project-scope, writes to gitignored settings.local.json)
+  if (enableStitch && agent === 'claude') {
+    const stitchApiKey = secrets.STITCH_API_KEY || process.env.STITCH_API_KEY
+    if (stitchApiKey) {
+      try {
+        spawnSync(
+          'claude',
+          [
+            'mcp',
+            'add',
+            'stitch',
+            '--transport',
+            'http',
+            STITCH_MCP_URL,
+            '-H',
+            `X-Goog-Api-Key: ${stitchApiKey}`,
+            '-s',
+            'project',
+          ],
+          { cwd: venture.localPath!, stdio: debug ? 'inherit' : 'pipe' }
+        )
+        console.log('-> Stitch MCP enabled for this session')
+      } catch {
+        console.warn('-> Warning: failed to add Stitch MCP')
+      }
+    } else {
+      console.warn('-> Warning: --stitch passed but STITCH_API_KEY not found in secrets')
+    }
+  }
+
   // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)
   if (agent === 'claude' && !extraArgs.includes('-p') && !extraArgs.includes('--print')) {
     const hasPrompt = extraArgs.some((a) => !a.startsWith('-'))
@@ -1112,6 +1159,18 @@ export function launchAgent(
   })
 
   child.on('exit', (code, signal) => {
+    // Clean up Stitch MCP project-scope registration on exit
+    if (enableStitch && agent === 'claude') {
+      try {
+        spawnSync('claude', ['mcp', 'remove', 'stitch', '-s', 'project'], {
+          cwd: venture.localPath!,
+          stdio: 'pipe',
+        })
+      } catch {
+        // Best-effort cleanup - harmless if it fails
+      }
+    }
+
     if (signal) {
       if (debug) {
         console.log(`[debug] Process terminated by signal: ${signal}`)
@@ -1166,6 +1225,7 @@ Usage:
   crane --hermes     Launch with Hermes
   crane --agent X    Launch with agent X
   crane --list       Show ventures without launching
+  crane --stitch     Enable Stitch design MCP for this session
   crane --secrets-audit       Audit shared secrets across all ventures
   crane --secrets-audit --fix Fix missing shared secrets
   crane --debug      Enable debug output for troubleshooting
@@ -1220,6 +1280,7 @@ Examples:
 
   // Extract passthrough args for agent binary (e.g., -p "prompt" for headless mode)
   const passthrough = extractPassthroughArgs(args)
+  const enableStitch = args.includes('--stitch')
 
   // Direct launch by code
   const nonFlagArgs = cleanArgs.filter((a) => !a.startsWith('-'))
@@ -1242,7 +1303,7 @@ Examples:
       venture.localPath = clonedPath
     }
 
-    launchAgent(venture, agent, debug, passthrough)
+    launchAgent(venture, agent, debug, passthrough, enableStitch)
     return
   }
 
@@ -1257,5 +1318,5 @@ Examples:
     process.exit(0)
   }
 
-  launchAgent(selected, agent, debug, passthrough)
+  launchAgent(selected, agent, debug, passthrough, enableStitch)
 }

--- a/scripts/setup-new-venture.sh
+++ b/scripts/setup-new-venture.sh
@@ -311,9 +311,20 @@ MCPEOF
 SETTINGSEOF
   echo -e "  ${GREEN}.claude/settings.json created${NC}"
 
-  # Copy all slash commands from crane-console
+  # Copy slash commands from crane-console, excluding VC-only skills
   if ls "$REPO_ROOT/.claude/commands/"*.md 1>/dev/null 2>&1; then
-    cp "$REPO_ROOT/.claude/commands/"*.md .claude/commands/
+    EXCLUSION_FILE="$REPO_ROOT/config/skill-exclusions.json"
+    if [ -f "$EXCLUSION_FILE" ] && command -v jq &>/dev/null; then
+      EXCLUDE_NAMES=$(jq -r '.[]' "$EXCLUSION_FILE")
+      for cmd_file in "$REPO_ROOT/.claude/commands/"*.md; do
+        base=$(basename "$cmd_file" .md)
+        if ! echo "$EXCLUDE_NAMES" | grep -qx "$base"; then
+          cp "$cmd_file" .claude/commands/
+        fi
+      done
+    else
+      cp "$REPO_ROOT/.claude/commands/"*.md .claude/commands/
+    fi
   fi
 
   # Copy sos-universal.sh

--- a/scripts/sync-commands.sh
+++ b/scripts/sync-commands.sh
@@ -70,14 +70,17 @@ FLEET_MACHINES=(mbp27 think mini m16)
 CURRENT_HOST=$(hostname -s)
 
 # Global-only skills that stay in crane-console (cross-venture tools).
-# Keyed by skill name (no extension). Applied to all three CLIs.
-EXCLUDE_SKILLS=(
-  analytics
-  content-scan
-  enterprise-review
-  new-venture
-  portfolio-review
-)
+# Single source of truth: config/skill-exclusions.json
+# Read JSON array into bash array (jq strips quotes, one name per line)
+EXCLUDE_SKILLS=()
+EXCLUSION_FILE="$REPO_ROOT/config/skill-exclusions.json"
+if [ -f "$EXCLUSION_FILE" ]; then
+  while IFS= read -r name; do
+    EXCLUDE_SKILLS+=("$name")
+  done < <(jq -r '.[]' "$EXCLUSION_FILE")
+else
+  echo "Warning: $EXCLUSION_FILE not found, using empty exclusion list"
+fi
 
 # Commands where the execution model fundamentally differs between agents.
 # These maintain separate hand-written files per agent format.


### PR DESCRIPTION
## Summary

- **`--stitch` flag**: Stitch MCP (12 tools, ~5,440 tokens) no longer loads in every session. Use `crane vc --stitch` for design work. Uses project-scope registration (gitignored) with cleanup on exit.
- **Skill exclusions**: New `config/skill-exclusions.json` as single source of truth for VC-only skills. Read by `syncClaudeAssets()`, `sync-commands.sh`, and `setup-new-venture.sh`.
- Added 5 new exclusions: build-log, edit-article, edit-log, docs-refresh, go-live (all hardcode vc-web paths or crane-console config)

Companion to #398. Together they reduce session startup from ~22,400 to ~7,500 tokens (~66%).

## Test plan

- [x] `npm run verify` passes (284 tests)
- [ ] `crane vc` launches without stitch tools in `claude mcp list`
- [ ] `crane vc --stitch` launches WITH stitch tools
- [ ] `crane ke` does not sync excluded skills to ke-console
- [ ] `crane --help` shows `--stitch` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)