### PR TITLE
chore: strip dead legacy fields from SosResult

### DIFF
--- a/packages/crane-mcp/src/tools/sos.test.ts
+++ b/packages/crane-mcp/src/tools/sos.test.ts
@@ -1004,7 +1004,7 @@ describe('sos tool', () => {
 
     const result = await executeSos({})
 
-    // All structured fields must be populated for backward compatibility
+    // Core structured fields must be populated
     expect(result.status).toBe('valid')
     expect(result.current_dir).toBeDefined()
     expect(result.context).toBeDefined()
@@ -1013,10 +1013,6 @@ describe('sos tool', () => {
     expect(result.active_sessions).toBeDefined()
     expect(result.message).toBeDefined()
     expect(typeof result.message).toBe('string')
-    // Legacy fields
-    expect(result.detected_venture).toBe('vc')
-    expect(result.detected_repo).toBe('venturecrane/crane-console')
-    expect(result.session_id).toBe('sess_test123')
   })
 
   it('shows full summary in Resume block for in_progress handoff', async () => {

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -66,14 +66,11 @@ export interface SosResult {
   schedule_briefing?: ScheduleBriefingItem[]
   active_sessions: ActiveSession[]
   documentation?: VentureDoc[]
-  // Legacy fields for backwards compatibility
-  detected_venture?: string
-  detected_repo?: string
+  // Navigation/selection fields (non-valid cases only)
   target_venture?: string
   target_path?: string
   clone_command?: string
   nav_command?: string
-  session_id?: string
   ventures?: Array<{ code: string; name: string; installed: boolean }>
   message: string
 }
@@ -281,18 +278,12 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
           schedule_briefing: scheduleBriefing.length > 0 ? scheduleBriefing : undefined,
           active_sessions: activeSessions,
           recent_handoffs: recentHandoffs.length > 0 ? recentHandoffs : undefined,
-          documentation: undefined,
-          // Legacy fields
-          detected_venture: venture.code,
-          detected_repo: fullRepo,
-          session_id: session.session.id,
           message,
         }
       } catch (error) {
         return {
           ...defaultResult,
           status: 'error',
-          detected_venture: venture.code,
           message: 'Failed to start session. Check API connectivity.',
         } as SosResult
       }


### PR DESCRIPTION
## Summary

- Remove `detected_venture`, `detected_repo`, `session_id`, `documentation` from valid return path
- These fields were never consumed by the MCP handler (`index.ts:590` only returns `result.message`)
- Navigation fields retained for non-valid cases
- Update backward compatibility test to match

Final cleanup for the SOS token reduction project (#398, #399).

## Test plan

- [x] `npm run verify` passes (284 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)