### PR TITLE
fix: auto-remove legacy user-scope Stitch MCP on fleet machines

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -964,6 +964,22 @@ export function checkMcpSetup(repoPath: string, agent: string): void {
   // Sync enterprise commands/agents (all agent types benefit, but only Claude uses .claude/)
   syncClaudeAssets(repoPath)
 
+  // MIGRATION (2026-03-31): Remove stitch from user-scope MCP.
+  // Stitch is now gated behind `crane --stitch` using project-scope registration.
+  // Fleet machines may still have the old user-scope entry. Safe to remove after
+  // all fleet machines have run at least one `crane` launch. Delete this block after 2026-04-14.
+  if (agent === 'claude') {
+    try {
+      const check = spawnSync('claude', ['mcp', 'list'], { encoding: 'utf-8', stdio: 'pipe' })
+      if (check.stdout?.includes('stitch') && check.stdout?.includes('googleapis.com')) {
+        spawnSync('claude', ['mcp', 'remove', 'stitch', '-s', 'user'], { stdio: 'pipe' })
+        console.log('-> Removed legacy user-scope Stitch MCP (now gated behind --stitch)')
+      }
+    } catch {
+      // Best-effort migration
+    }
+  }
+
   // Register crane MCP server for the target agent
   switch (agent) {
     case 'claude':


### PR DESCRIPTION
## Summary

- Migration block in `checkMcpSetup()` removes stitch from user-scope if found
- Runs on every `crane` launch, self-heals all fleet machines automatically
- Marked for removal after 2026-04-14

Companion to #399 (--stitch gating). Fleet machines still have the old user-scope registration.

## Test plan

- [x] `npm run verify` passes (284 tests)
- [ ] First `crane` launch on a fleet machine logs "Removed legacy user-scope Stitch MCP"
- [ ] Subsequent launches skip silently (stitch no longer in `claude mcp list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)