### PR TITLE
chore: portfolio review 2026-04-02

### DIFF
--- a/config/ventures.json
+++ b/config/ventures.json
@@ -1,5 +1,5 @@
 {
-  "lastPortfolioReview": "2026-02-23",
+  "lastPortfolioReview": "2026-04-02",
   "portfolioReviewCadenceDays": 7,
   "sharedSecrets": {
     "source": "/vc",
@@ -107,7 +107,7 @@
       "stitchProjectId": null,
       "portfolio": {
         "status": "building",
-        "bvmStage": "IDEATION",
+        "bvmStage": "PROTOTYPE",
         "tagline": "Operations consulting for Phoenix-area small businesses",
         "description": "SMD Services helps 5-50 employee businesses fix the operational chaos that keeps owners working until 9pm. Fixed-price engagements covering process documentation, lead management, financial visibility, and workflow automation.",
         "techStack": [],


### PR DESCRIPTION
## Summary
- Updated `lastPortfolioReview` to 2026-04-02
- Promoted SMD Services BVM stage from `IDEATION` to `PROTOTYPE` (full-stack product built in 9-day sprint: site, admin portal, client auth, quote builder, e-signature, pipeline Workers)

## Portfolio Snapshot
| Venture | Status | BVM Stage | 30d PRs | Activity |
|---------|--------|-----------|---------|----------|
| Venture Crane | internal | - | 71 | Heavy platform investment |
| SMD Services | building | **PROTOTYPE** (was IDEATION) | 57 | Greenfield sprint, fastest to revenue |
| Draft Crane | building | PROTOTYPE | 36 | Design system overhaul |
| Kid Expenses | building | PROTOTYPE | 5 | Parked (no sessions) |
| Silicon Crane | building | IDEATION | 7 | Parked (no sessions) |
| Durgan Field Guide | building | PROTOTYPE | 3 | Parked (zero real dev commits) |

## Test plan
- [ ] Verify `config/ventures.json` parses correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)