### PR TITLE
feat: improve /portfolio-review with real dev signals

### DIFF
--- a/.agents/skills/portfolio-review/SKILL.md
+++ b/.agents/skills/portfolio-review/SKILL.md
@@ -28,14 +28,47 @@ Review and update venture portfolio data. Collects live signals, compares agains
 
 ### Step 1: Collect Signals
 
-For each venture in `config/ventures.json` where `portfolio.showInPortfolio` is `true`:
+For each venture in `config/ventures.json` (all ventures, regardless of `showInPortfolio`):
 
-1. **GitHub activity** - Use `gh api repos/{org}/{venture-code}-console` to get last push date and open issue/PR count
-2. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status
-3. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions
-4. **Cloudflare resources** - Use `workers_list` and `d1_databases_list` MCP tools to inventory deployed infrastructure
+1. **Real development activity** - For each repo, fetch the last 30 days of commits on main:
 
-Also check ventures with `showInPortfolio: false` (like vc and smd) but only for basic health.
+   ```
+   gh api "repos/{org}/{repo}/commits?sha=main&since={30-days-ago-ISO}&per_page=100" --jq '.[] | {date: .commit.committer.date, message: .commit.message | split("\n")[0]}'
+   ```
+
+   Classify each commit as **real development** or **automated/infrastructure**. Automated commits match patterns like:
+   - `chore: sync enterprise commands`
+   - `chore: sync *` (any sync from another repo)
+   - npm audit fix / security fix commits
+   - Dependabot version bumps
+
+   Report: total commits, real dev commits, last real dev commit date + message.
+
+2. **Session history** - Use `crane_schedule(action: "session-history", days: 30)` to get session counts per venture. This shows where Captain time is actually going.
+
+3. **Merged PR velocity** - For each repo, count PRs merged in the last 30 days:
+
+   ```
+   gh api "repos/{org}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" --jq '[.[] | select(.merged_at != null and .merged_at > "{30-days-ago-ISO}")] | length'
+   ```
+
+4. **Open issues and PRs** - Use `gh api repos/{org}/{repo}` for open issue count and `gh api repos/{org}/{repo}/pulls` for open PR count.
+
+5. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status.
+
+6. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions.
+
+### Step 1b: Classify Venture Activity
+
+Based on collected signals, classify each venture's activity level:
+
+| Classification   | Criteria                                                                   |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Active**       | Sessions in last 30d AND real dev commits in last 14d                      |
+| **Low activity** | Real dev commits in last 30d but no sessions (e.g., one-off maintenance)   |
+| **Parked**       | Zero sessions AND zero real dev commits in last 30d (only automated syncs) |
+
+This classification is for reporting only - it does not automatically change venture status.
 
 ### Step 2: Detect Drift
 
@@ -43,9 +76,11 @@ Compare collected signals against current portfolio data. Flag:
 
 - Status says `live` or `beta` but URL returns non-200 or is missing
 - Status says `building` but URL is healthy (might be ready for `beta`)
-- No commits in 30+ days for a `building` venture
+- Venture classified as **parked** for a `building` venture - note but do not auto-promote to `paused` (Captain decision)
 - BVM stage in VCMS doesn't match `bvmStage` in ventures.json
 - `portfolio.url` being removed but URL still returns HTTP 200
+- Open PR count > 20 (PR accumulation warning)
+- Open issue count growing with no sessions (backlog drift)
 
 ### Step 2b: Collect Code Health
 
@@ -59,24 +94,38 @@ Extract the overall grade and review date. If no scorecard exists, mark as "-". 
 
 ### Step 3: Present Review Table
 
-Display collected data in a table:
+First, show where time is going:
 
 ```
-### Portfolio Review - {date}
+### Where the Time Is Going
 
-| Venture | Status | Proposed | BVM Stage | Code Health | Last Commit | URL Health | Signals |
-|---------|--------|----------|-----------|-------------|-------------|------------|---------|
-| Kid Expenses | building | building | PROTOTYPE | B | 2d ago | n/a | 3 open issues |
-| Durgan Field Guide | building | building | PROTOTYPE | C (stale) | 5d ago | n/a | 1 open PR |
-| Draft Crane | building | building | IDEATION | - | 14d ago | n/a | D1 exists |
-| Silicon Crane | building | building | IDEATION | - | 30d ago | n/a | No activity |
+| | Sessions (30d) | Merged PRs | Real Dev Commits | Activity | Focus |
+|---|---|---|---|---|---|
+| Venture Crane (platform) | 27 | 71 | 85 | Active | Calendar, fleet, docs |
+| SMD Services | 19 | 57 | 64 | Active | Greenfield build |
+| Draft Crane | 6 | 36 | 33 | Active | Design system overhaul |
+| Kid Expenses | 0 | 5 | 3 | Parked | One-off maintenance |
 ```
+
+Then the status review:
+
+```
+### Honest Status Assessment
+
+| Venture | Status | Proposed | BVM Stage | Code Health | Last Real Dev | Activity | Signals |
+|---------|--------|----------|-----------|-------------|---------------|----------|---------|
+| Kid Expenses | building | building | PROTOTYPE | B (stale) | Mar 15 | Parked | 54 issues, 15 PRs |
+| Draft Crane | building | building | PROTOTYPE | B | 2d ago | Active | 21 issues, 6 PRs |
+```
+
+"Last Real Dev" must be the date of the last non-automated commit. Never use `pushed_at` or include automated syncs in this column.
 
 If any drift was detected, display it prominently:
 
 ```
 ### Drift Detected
-- Silicon Crane: No commits in 30+ days - consider `paused`?
+- Silicon Crane: Parked (0 sessions, 0 real dev commits in 30d)
+- crane-console: 27 open PRs - cleanup pass needed
 ```
 
 ### Step 4: Captain Approval
@@ -133,3 +182,6 @@ If any BVM stage or description changed, update the corresponding VCMS executive
 - Signals are ephemeral - collected live, displayed once, not persisted
 - `config/ventures.json` is the single source of truth for portfolio data
 - `vc-web/src/data/ventures.ts` is a derivative that can be regenerated anytime
+- **Never use GitHub's `pushed_at` field for activity reporting.** It reflects pushes to any branch (including fleet dispatch and automated syncs) and is misleading. Always use main branch commit history with automated commits filtered out.
+- **"Last commit" must mean "last real development commit."** Automated syncs, Dependabot bumps, and CI-triggered commits do not count as development activity.
+- The report should answer: "Is time allocation aligned with venture priority?" not just "what happened in git?"

--- a/.claude/commands/portfolio-review.md
+++ b/.claude/commands/portfolio-review.md
@@ -23,14 +23,47 @@ Review and update venture portfolio data. Collects live signals, compares agains
 
 ### Step 1: Collect Signals
 
-For each venture in `config/ventures.json` where `portfolio.showInPortfolio` is `true`:
+For each venture in `config/ventures.json` (all ventures, regardless of `showInPortfolio`):
 
-1. **GitHub activity** - Use `gh api repos/{org}/{venture-code}-console` to get last push date and open issue/PR count
-2. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status
-3. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions
-4. **Cloudflare resources** - Use `workers_list` and `d1_databases_list` MCP tools to inventory deployed infrastructure
+1. **Real development activity** - For each repo, fetch the last 30 days of commits on main:
 
-Also check ventures with `showInPortfolio: false` (like vc and smd) but only for basic health.
+   ```
+   gh api "repos/{org}/{repo}/commits?sha=main&since={30-days-ago-ISO}&per_page=100" --jq '.[] | {date: .commit.committer.date, message: .commit.message | split("\n")[0]}'
+   ```
+
+   Classify each commit as **real development** or **automated/infrastructure**. Automated commits match patterns like:
+   - `chore: sync enterprise commands`
+   - `chore: sync *` (any sync from another repo)
+   - npm audit fix / security fix commits
+   - Dependabot version bumps
+
+   Report: total commits, real dev commits, last real dev commit date + message.
+
+2. **Session history** - Use `crane_schedule(action: "session-history", days: 30)` to get session counts per venture. This shows where Captain time is actually going.
+
+3. **Merged PR velocity** - For each repo, count PRs merged in the last 30 days:
+
+   ```
+   gh api "repos/{org}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" --jq '[.[] | select(.merged_at != null and .merged_at > "{30-days-ago-ISO}")] | length'
+   ```
+
+4. **Open issues and PRs** - Use `gh api repos/{org}/{repo}` for open issue count and `gh api repos/{org}/{repo}/pulls` for open PR count.
+
+5. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status.
+
+6. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions.
+
+### Step 1b: Classify Venture Activity
+
+Based on collected signals, classify each venture's activity level:
+
+| Classification   | Criteria                                                                   |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Active**       | Sessions in last 30d AND real dev commits in last 14d                      |
+| **Low activity** | Real dev commits in last 30d but no sessions (e.g., one-off maintenance)   |
+| **Parked**       | Zero sessions AND zero real dev commits in last 30d (only automated syncs) |
+
+This classification is for reporting only - it does not automatically change venture status.
 
 ### Step 2: Detect Drift
 
@@ -38,9 +71,11 @@ Compare collected signals against current portfolio data. Flag:
 
 - Status says `live` or `beta` but URL returns non-200 or is missing
 - Status says `building` but URL is healthy (might be ready for `beta`)
-- No commits in 30+ days for a `building` venture
+- Venture classified as **parked** for a `building` venture - note but do not auto-promote to `paused` (Captain decision)
 - BVM stage in VCMS doesn't match `bvmStage` in ventures.json
 - `portfolio.url` being removed but URL still returns HTTP 200
+- Open PR count > 20 (PR accumulation warning)
+- Open issue count growing with no sessions (backlog drift)
 
 ### Step 2b: Collect Code Health
 
@@ -54,24 +89,38 @@ Extract the overall grade and review date. If no scorecard exists, mark as "-". 
 
 ### Step 3: Present Review Table
 
-Display collected data in a table:
+First, show where time is going:
 
 ```
-### Portfolio Review - {date}
+### Where the Time Is Going
 
-| Venture | Status | Proposed | BVM Stage | Code Health | Last Commit | URL Health | Signals |
-|---------|--------|----------|-----------|-------------|-------------|------------|---------|
-| Kid Expenses | building | building | PROTOTYPE | B | 2d ago | n/a | 3 open issues |
-| Durgan Field Guide | building | building | PROTOTYPE | C (stale) | 5d ago | n/a | 1 open PR |
-| Draft Crane | building | building | IDEATION | - | 14d ago | n/a | D1 exists |
-| Silicon Crane | building | building | IDEATION | - | 30d ago | n/a | No activity |
+| | Sessions (30d) | Merged PRs | Real Dev Commits | Activity | Focus |
+|---|---|---|---|---|---|
+| Venture Crane (platform) | 27 | 71 | 85 | Active | Calendar, fleet, docs |
+| SMD Services | 19 | 57 | 64 | Active | Greenfield build |
+| Draft Crane | 6 | 36 | 33 | Active | Design system overhaul |
+| Kid Expenses | 0 | 5 | 3 | Parked | One-off maintenance |
 ```
+
+Then the status review:
+
+```
+### Honest Status Assessment
+
+| Venture | Status | Proposed | BVM Stage | Code Health | Last Real Dev | Activity | Signals |
+|---------|--------|----------|-----------|-------------|---------------|----------|---------|
+| Kid Expenses | building | building | PROTOTYPE | B (stale) | Mar 15 | Parked | 54 issues, 15 PRs |
+| Draft Crane | building | building | PROTOTYPE | B | 2d ago | Active | 21 issues, 6 PRs |
+```
+
+"Last Real Dev" must be the date of the last non-automated commit. Never use `pushed_at` or include automated syncs in this column.
 
 If any drift was detected, display it prominently:
 
 ```
 ### Drift Detected
-- Silicon Crane: No commits in 30+ days - consider `paused`?
+- Silicon Crane: Parked (0 sessions, 0 real dev commits in 30d)
+- crane-console: 27 open PRs - cleanup pass needed
 ```
 
 ### Step 4: Captain Approval
@@ -128,3 +177,6 @@ If any BVM stage or description changed, update the corresponding VCMS executive
 - Signals are ephemeral - collected live, displayed once, not persisted
 - `config/ventures.json` is the single source of truth for portfolio data
 - `vc-web/src/data/ventures.ts` is a derivative that can be regenerated anytime
+- **Never use GitHub's `pushed_at` field for activity reporting.** It reflects pushes to any branch (including fleet dispatch and automated syncs) and is misleading. Always use main branch commit history with automated commits filtered out.
+- **"Last commit" must mean "last real development commit."** Automated syncs, Dependabot bumps, and CI-triggered commits do not count as development activity.
+- The report should answer: "Is time allocation aligned with venture priority?" not just "what happened in git?"


### PR DESCRIPTION
## Summary
- Replace GitHub `pushed_at` with filtered main-branch commit analysis (excludes syncs, Dependabot, audit fixes)
- Add session history (`crane_schedule`) and merged PR velocity as primary activity signals
- Classify ventures as Active/Low activity/Parked based on sessions + real dev commits
- Add drift detection for PR accumulation (>20) and backlog growth with no sessions

Closes #405

## Test plan
- [ ] `npm run verify` passes
- [ ] Next `/portfolio-review` run uses the updated signal collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)