### PR TITLE
fix: complete /eod to /eos rename across scripts, tests, and fleet sync

### DIFF
--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: context-refresh
+description: Enterprise Context Refresh
+---
+
+# /context-refresh - Enterprise Context Refresh
+
+Audit and update all enterprise context: D1 docs, VCMS executive summaries, and venture metadata. Produces a refresh report and records cadence completion.
+
+## Arguments
+
+```
+/context-refresh [venture-code | --audit-only]
+```
+
+- No argument: Full audit + fix across all ventures
+- Venture code (e.g., `vc`): Audit + fix for a single venture
+- `--audit-only`: Report only, no changes
+
+## Execution
+
+### Step 1: Audit Documentation
+
+Run the doc audit to get the full status matrix:
+
+- **All ventures**: `crane_doc_audit(all: true)`
+- **Single venture**: `crane_doc_audit(venture: "{code}")`
+
+Display the audit results showing present, missing, and stale docs per venture.
+
+### Step 2: Auto-Regenerate Stale and Missing Docs
+
+Unless `--audit-only` is set:
+
+- **All ventures**: `crane_doc_audit(all: true, fix: true)`
+- **Single venture**: `crane_doc_audit(venture: "{code}", fix: true)`
+
+This regenerates all auto-generable missing AND stale docs. The content-hash guard prevents no-op uploads when source files haven't changed.
+
+Report which docs were generated, refreshed, unchanged, or failed.
+
+### Step 3: Check Executive Summary Freshness
+
+For each venture (or the specified venture), check the executive summary age:
+
+```
+crane_notes(tag: "executive-summary", venture: "{code}")
+```
+
+Flag any summary older than 30 days as stale. For stale summaries:
+
+1. Gather current data:
+   - Read `config/ventures.json` for portfolio metadata (status, BVM stage, tagline, tech stack)
+   - Check recent handoffs for the venture (last 3 from SOS continuity)
+   - Check recent VCMS notes tagged `prd` or `strategy` for the venture
+2. Draft an updated executive summary
+3. **Present the draft to Captain for approval before saving**
+4. If approved, update via `crane_note(action: "update", id: "{note_id}", content: "...")`
+
+### Step 4: Verify ventures.json Accuracy
+
+Read `config/ventures.json`. For each venture:
+
+- Check that `capabilities` match reality (look for `workers/*/src` for `has_api`, `migrations/` for `has_database`)
+- Check that `portfolio.bvmStage` matches the executive summary
+- Check that `repos` list is current
+
+Flag any drift but do NOT auto-fix - present findings to Captain.
+
+### Step 5: Display Refresh Report
+
+```
+## Context Refresh Report
+
+| Venture | Docs | Exec Summary | Drift |
+|---------|------|--------------|-------|
+| vc      | 3/3 refreshed | Updated (was 49d old) | None |
+| sc      | 3/3 unchanged | Stale (49d) - pending approval | None |
+...
+
+### Summary
+- Docs: N generated, M refreshed, K unchanged, J failed
+- Exec Summaries: X updated, Y pending approval, Z current
+```
+
+### Step 6: Record Cadence Completion
+
+```
+crane_schedule(action: "complete", name: "context-refresh", result: "{success|warning|failure}", completed_by: "crane-mcp-{hostname}", summary: "{brief outcome}")
+```
+
+Result mapping:
+
+- `success`: All docs refreshed, all exec summaries current or updated
+- `warning`: Some docs failed or exec summaries still stale (pending approval)
+- `failure`: Audit or regeneration failed entirely
+
+## Rules
+
+- Auto-regenerated docs (machine-derived from source files) upload without approval
+- Executive summaries ALWAYS require Captain approval before update - never auto-save
+- Must run from crane-console (needs local repo access for all ventures via `~/dev/{code}-console`)
+- Do NOT modify `config/ventures.json` without Captain approval
+- Do NOT create GitHub issues for drift findings - just report them

--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -63,11 +63,9 @@ Using conversation history and gathered context, the agent generates a summary c
 - "2. Run npm test — expect 2 new tests to pass"
 - "3. Create PR for issue #123"
 
-### 3. Auto-Save (No Confirmation Needed)
+### 3. Display and Save (Auto-Save)
 
-Display the generated handoff for visibility, then immediately proceed to save it. Do NOT ask for confirmation — save directly to D1.
-
-If the user wants to review or edit before saving, they will say so explicitly.
+Display the generated handoff, then **immediately save it to D1 without asking for confirmation.** Do not prompt the user with "Save to D1?" or any yes/no question. Just show the summary and save.
 
 ### 4. End Work Day
 
@@ -108,6 +106,8 @@ Handoff saved to D1. Next session will see this via crane_sos.
 
 ## Key Principle
 
-**The agent summarizes. The agent saves.**
+**The agent summarizes. The agent saves. No confirmation needed.**
 
-The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff and save it directly without asking for confirmation.
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything.
+
+Auto-save directly to D1. Never ask "Save to D1?" or any confirmation question.

--- a/.agents/skills/sos/SKILL.md
+++ b/.agents/skills/sos/SKILL.md
@@ -5,99 +5,16 @@ description: Start of Session
 
 # /sos - Start of Session
 
-This command prepares your session using MCP tools to validate context, show work priorities, and ensure you're ready to code.
+1. Call `crane_sos` MCP tool (returns formatted briefing).
+2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
+3. Display briefing. Highlight any Resume block or P0 issues.
+4. If weekly plan stale/missing, suggest `/work-plan`.
+5. If cadence items overdue, ask: "Execute any now, or skip?"
+6. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
 
-## Execution
+## Rules
 
-### Step 1: Start Session
-
-Call the `crane_sos` MCP tool to initialize the session.
-
-The tool returns a structured briefing with:
-
-- Session context (venture, repo, branch)
-- Behavioral directives (enterprise rules)
-- Continuity (recent handoffs)
-- Alerts (P0 issues, active sessions)
-- Weekly plan status
-- Cadence briefing (overdue/due recurring activities)
-- Knowledge base and enterprise context
-
-### Step 2: Handle Continuity
-
-If the Continuity section contains a **Resume** block (in_progress or blocked):
-
-1. Display the full handoff content prominently
-2. Note the status: "Previous session left work **in progress**" or "Previous session is **blocked**"
-3. If an issue number is referenced, note it for context
-
-### Step 3: Display Context Confirmation
-
-Present a clear context confirmation box:
-
-```
-VENTURE:  {venture_name} ({venture_code})
-REPO:     {repo}
-BRANCH:   {branch}
-SESSION:  {session_id}
-```
-
-State: "You're in the correct repository and on the {branch} branch."
-
-### Step 4: Handle P0 Issues
-
-If the Alerts section shows P0 issues:
-
-1. Display prominently with warning icon
-2. Say: "**There are P0 issues that need immediate attention.**"
-3. List each issue
-
-### Step 5: Check Work Plan
-
-Query D1 for today's planned events:
-
-- Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`
-- **If found**: Display "Today: **{VENTURE} Work**, 6:30am - 10:30pm" in the context box
-- **If not found**: Suggest "No work plan for today. Run `/work-plan` to set up your schedule."
-
-Also check the weekly plan file status from the `crane_sos` response:
-
-- **valid**: Note the priority venture and proceed
-- **stale**: Warn user: "Weekly plan is {age_days} days old. Consider running `/work-plan`."
-- **missing**: Suggest running `/work-plan`
-
-### Step 6: Cadence Decision Prompt
-
-The `crane_sos` response includes cadence status (overdue/due items).
-
-For any overdue items:
-
-1. Display the overdue items list
-2. Ask: "**Want to execute any of these now, or skip?**"
-3. If user chooses to execute: run the appropriate command (e.g., `/portfolio-review`)
-4. If user skips: proceed to next step
-
-Do NOT create Google Calendar events for cadence items. Do NOT create Apple Reminders here (that is `/work-plan`'s job).
-
-### Step 7: STOP and Wait
-
-**CRITICAL**: Do NOT automatically start working.
-
-- If there is an in_progress or blocked handoff in the Resume block:
-  **"Previous session was working on: [one-line summary]. Resume this, or focus on something else?"**
-- Otherwise:
-  **"What would you like to focus on?"**
-
-If user wants to see the full work queue, call `crane_status` MCP tool.
-
-## Wrong Repo Prevention
-
-All GitHub issues created this session MUST target the repo shown in context confirmation. If you find yourself targeting a different repo, STOP and verify with the user.
-
-## Troubleshooting
-
-If MCP tools aren't available:
-
-1. Check `claude mcp list` shows crane connected
-2. Ensure started with: `crane vc`
-3. Try: `cd ~/dev/crane-console/packages/crane-mcp && npm run build && npm link`
+- All GitHub issues this session target the repo shown in context. Targeting a different repo? STOP.
+- Do NOT start working automatically.
+- Do NOT create calendar events for cadence items.
+- If MCP tools unavailable: check `claude mcp list`, ensure started with `crane vc`.

--- a/.gemini/commands/context-refresh.toml
+++ b/.gemini/commands/context-refresh.toml
@@ -1,0 +1,102 @@
+description = "Enterprise Context Refresh"
+
+prompt = """
+
+Audit and update all enterprise context: D1 docs, VCMS executive summaries, and venture metadata. Produces a refresh report and records cadence completion.
+
+## Arguments
+
+```
+/context-refresh [venture-code | --audit-only]
+```
+
+- No argument: Full audit + fix across all ventures
+- Venture code (e.g., `vc`): Audit + fix for a single venture
+- `--audit-only`: Report only, no changes
+
+## Execution
+
+### Step 1: Audit Documentation
+
+Run the doc audit to get the full status matrix:
+
+- **All ventures**: `crane_doc_audit(all: true)`
+- **Single venture**: `crane_doc_audit(venture: "{code}")`
+
+Display the audit results showing present, missing, and stale docs per venture.
+
+### Step 2: Auto-Regenerate Stale and Missing Docs
+
+Unless `--audit-only` is set:
+
+- **All ventures**: `crane_doc_audit(all: true, fix: true)`
+- **Single venture**: `crane_doc_audit(venture: "{code}", fix: true)`
+
+This regenerates all auto-generable missing AND stale docs. The content-hash guard prevents no-op uploads when source files haven't changed.
+
+Report which docs were generated, refreshed, unchanged, or failed.
+
+### Step 3: Check Executive Summary Freshness
+
+For each venture (or the specified venture), check the executive summary age:
+
+```
+crane_notes(tag: "executive-summary", venture: "{code}")
+```
+
+Flag any summary older than 30 days as stale. For stale summaries:
+
+1. Gather current data:
+   - Read `config/ventures.json` for portfolio metadata (status, BVM stage, tagline, tech stack)
+   - Check recent handoffs for the venture (last 3 from SOS continuity)
+   - Check recent VCMS notes tagged `prd` or `strategy` for the venture
+2. Draft an updated executive summary
+3. **Present the draft to Captain for approval before saving**
+4. If approved, update via `crane_note(action: "update", id: "{note_id}", content: "...")`
+
+### Step 4: Verify ventures.json Accuracy
+
+Read `config/ventures.json`. For each venture:
+
+- Check that `capabilities` match reality (look for `workers/*/src` for `has_api`, `migrations/` for `has_database`)
+- Check that `portfolio.bvmStage` matches the executive summary
+- Check that `repos` list is current
+
+Flag any drift but do NOT auto-fix - present findings to Captain.
+
+### Step 5: Display Refresh Report
+
+```
+## Context Refresh Report
+
+| Venture | Docs | Exec Summary | Drift |
+|---------|------|--------------|-------|
+| vc      | 3/3 refreshed | Updated (was 49d old) | None |
+| sc      | 3/3 unchanged | Stale (49d) - pending approval | None |
+...
+
+### Summary
+- Docs: N generated, M refreshed, K unchanged, J failed
+- Exec Summaries: X updated, Y pending approval, Z current
+```
+
+### Step 6: Record Cadence Completion
+
+```
+crane_schedule(action: "complete", name: "context-refresh", result: "{success|warning|failure}", completed_by: "crane-mcp-{hostname}", summary: "{brief outcome}")
+```
+
+Result mapping:
+
+- `success`: All docs refreshed, all exec summaries current or updated
+- `warning`: Some docs failed or exec summaries still stale (pending approval)
+- `failure`: Audit or regeneration failed entirely
+
+## Rules
+
+- Auto-regenerated docs (machine-derived from source files) upload without approval
+- Executive summaries ALWAYS require Captain approval before update - never auto-save
+- Must run from crane-console (needs local repo access for all ventures via `~/dev/{code}-console`)
+- Do NOT modify `config/ventures.json` without Captain approval
+- Do NOT create GitHub issues for drift findings - just report them
+"""

--- a/.gemini/commands/eos.toml
+++ b/.gemini/commands/eos.toml
@@ -60,11 +60,9 @@ Using conversation history and gathered context, the agent generates a summary c
 - "2. Run npm test — expect 2 new tests to pass"
 - "3. Create PR for issue #123"
 
-### 3. Auto-Save (No Confirmation Needed)
+### 3. Display and Save (Auto-Save)
 
-Display the generated handoff for visibility, then immediately proceed to save it. Do NOT ask for confirmation — save directly to D1.
-
-If the user wants to review or edit before saving, they will say so explicitly.
+Display the generated handoff, then **immediately save it to D1 without asking for confirmation.** Do not prompt the user with "Save to D1?" or any yes/no question. Just show the summary and save.
 
 ### 4. End Work Day
 
@@ -105,7 +103,9 @@ Handoff saved to D1. Next session will see this via crane_sos.
 
 ## Key Principle
 
-**The agent summarizes. The agent saves.**
+**The agent summarizes. The agent saves. No confirmation needed.**
 
-The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff and save it directly without asking for confirmation.
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything.
+
+Auto-save directly to D1. Never ask "Save to D1?" or any confirmation question.
 """

--- a/.gemini/commands/portfolio-review.toml
+++ b/.gemini/commands/portfolio-review.toml
@@ -25,14 +25,47 @@ Review and update venture portfolio data. Collects live signals, compares agains
 
 ### Step 1: Collect Signals
 
-For each venture in `config/ventures.json` where `portfolio.showInPortfolio` is `true`:
+For each venture in `config/ventures.json` (all ventures, regardless of `showInPortfolio`):
 
-1. **GitHub activity** - Use `gh api repos/{org}/{venture-code}-console` to get last push date and open issue/PR count
-2. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status
-3. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions
-4. **Cloudflare resources** - Use `workers_list` and `d1_databases_list` MCP tools to inventory deployed infrastructure
+1. **Real development activity** - For each repo, fetch the last 30 days of commits on main:
 
-Also check ventures with `showInPortfolio: false` (like vc and smd) but only for basic health.
+   ```
+   gh api "repos/{org}/{repo}/commits?sha=main&since={30-days-ago-ISO}&per_page=100" --jq '.[] | {date: .commit.committer.date, message: .commit.message | split("\n")[0]}'
+   ```
+
+   Classify each commit as **real development** or **automated/infrastructure**. Automated commits match patterns like:
+   - `chore: sync enterprise commands`
+   - `chore: sync *` (any sync from another repo)
+   - npm audit fix / security fix commits
+   - Dependabot version bumps
+
+   Report: total commits, real dev commits, last real dev commit date + message.
+
+2. **Session history** - Use `crane_schedule(action: "session-history", days: 30)` to get session counts per venture. This shows where Captain time is actually going.
+
+3. **Merged PR velocity** - For each repo, count PRs merged in the last 30 days:
+
+   ```
+   gh api "repos/{org}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100" --jq '[.[] | select(.merged_at != null and .merged_at > "{30-days-ago-ISO}")] | length'
+   ```
+
+4. **Open issues and PRs** - Use `gh api repos/{org}/{repo}` for open issue count and `gh api repos/{org}/{repo}/pulls` for open PR count.
+
+5. **Production URL** - If `portfolio.url` is set, run `curl -s -o /dev/null -w "%{http_code}" {url}` to check HTTP status.
+
+6. **VCMS executive summaries** - Use `crane_notes` MCP tool with `tag: "executive-summary"` to get current stage descriptions.
+
+### Step 1b: Classify Venture Activity
+
+Based on collected signals, classify each venture's activity level:
+
+| Classification   | Criteria                                                                   |
+| ---------------- | -------------------------------------------------------------------------- |
+| **Active**       | Sessions in last 30d AND real dev commits in last 14d                      |
+| **Low activity** | Real dev commits in last 30d but no sessions (e.g., one-off maintenance)   |
+| **Parked**       | Zero sessions AND zero real dev commits in last 30d (only automated syncs) |
+
+This classification is for reporting only - it does not automatically change venture status.
 
 ### Step 2: Detect Drift
 
@@ -40,9 +73,11 @@ Compare collected signals against current portfolio data. Flag:
 
 - Status says `live` or `beta` but URL returns non-200 or is missing
 - Status says `building` but URL is healthy (might be ready for `beta`)
-- No commits in 30+ days for a `building` venture
+- Venture classified as **parked** for a `building` venture - note but do not auto-promote to `paused` (Captain decision)
 - BVM stage in VCMS doesn't match `bvmStage` in ventures.json
 - `portfolio.url` being removed but URL still returns HTTP 200
+- Open PR count > 20 (PR accumulation warning)
+- Open issue count growing with no sessions (backlog drift)
 
 ### Step 2b: Collect Code Health
 
@@ -56,24 +91,38 @@ Extract the overall grade and review date. If no scorecard exists, mark as "-". 
 
 ### Step 3: Present Review Table
 
-Display collected data in a table:
+First, show where time is going:
 
 ```
-### Portfolio Review - {date}
+### Where the Time Is Going
 
-| Venture | Status | Proposed | BVM Stage | Code Health | Last Commit | URL Health | Signals |
-|---------|--------|----------|-----------|-------------|-------------|------------|---------|
-| Kid Expenses | building | building | PROTOTYPE | B | 2d ago | n/a | 3 open issues |
-| Durgan Field Guide | building | building | PROTOTYPE | C (stale) | 5d ago | n/a | 1 open PR |
-| Draft Crane | building | building | IDEATION | - | 14d ago | n/a | D1 exists |
-| Silicon Crane | building | building | IDEATION | - | 30d ago | n/a | No activity |
+| | Sessions (30d) | Merged PRs | Real Dev Commits | Activity | Focus |
+|---|---|---|---|---|---|
+| Venture Crane (platform) | 27 | 71 | 85 | Active | Calendar, fleet, docs |
+| SMD Services | 19 | 57 | 64 | Active | Greenfield build |
+| Draft Crane | 6 | 36 | 33 | Active | Design system overhaul |
+| Kid Expenses | 0 | 5 | 3 | Parked | One-off maintenance |
 ```
+
+Then the status review:
+
+```
+### Honest Status Assessment
+
+| Venture | Status | Proposed | BVM Stage | Code Health | Last Real Dev | Activity | Signals |
+|---------|--------|----------|-----------|-------------|---------------|----------|---------|
+| Kid Expenses | building | building | PROTOTYPE | B (stale) | Mar 15 | Parked | 54 issues, 15 PRs |
+| Draft Crane | building | building | PROTOTYPE | B | 2d ago | Active | 21 issues, 6 PRs |
+```
+
+"Last Real Dev" must be the date of the last non-automated commit. Never use `pushed_at` or include automated syncs in this column.
 
 If any drift was detected, display it prominently:
 
 ```
 ### Drift Detected
-- Silicon Crane: No commits in 30+ days - consider `paused`?
+- Silicon Crane: Parked (0 sessions, 0 real dev commits in 30d)
+- crane-console: 27 open PRs - cleanup pass needed
 ```
 
 ### Step 4: Captain Approval
@@ -130,4 +179,7 @@ If any BVM stage or description changed, update the corresponding VCMS executive
 - Signals are ephemeral - collected live, displayed once, not persisted
 - `config/ventures.json` is the single source of truth for portfolio data
 - `vc-web/src/data/ventures.ts` is a derivative that can be regenerated anytime
+- **Never use GitHub's `pushed_at` field for activity reporting.** It reflects pushes to any branch (including fleet dispatch and automated syncs) and is misleading. Always use main branch commit history with automated commits filtered out.
+- **"Last commit" must mean "last real development commit."** Automated syncs, Dependabot bumps, and CI-triggered commits do not count as development activity.
+- The report should answer: "Is time allocation aligned with venture priority?" not just "what happened in git?"
 """

--- a/.gemini/commands/sos.toml
+++ b/.gemini/commands/sos.toml
@@ -2,100 +2,17 @@ description = "Start of Session"
 
 prompt = """
 
-This command prepares your session using MCP tools to validate context, show work priorities, and ensure you're ready to code.
+1. Call `crane_sos` MCP tool (returns formatted briefing).
+2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
+3. Display briefing. Highlight any Resume block or P0 issues.
+4. If weekly plan stale/missing, suggest `/work-plan`.
+5. If cadence items overdue, ask: "Execute any now, or skip?"
+6. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
 
-## Execution
+## Rules
 
-### Step 1: Start Session
-
-Call the `crane_sos` MCP tool to initialize the session.
-
-The tool returns a structured briefing with:
-
-- Session context (venture, repo, branch)
-- Behavioral directives (enterprise rules)
-- Continuity (recent handoffs)
-- Alerts (P0 issues, active sessions)
-- Weekly plan status
-- Cadence briefing (overdue/due recurring activities)
-- Knowledge base and enterprise context
-
-### Step 2: Handle Continuity
-
-If the Continuity section contains a **Resume** block (in_progress or blocked):
-
-1. Display the full handoff content prominently
-2. Note the status: "Previous session left work **in progress**" or "Previous session is **blocked**"
-3. If an issue number is referenced, note it for context
-
-### Step 3: Display Context Confirmation
-
-Present a clear context confirmation box:
-
-```
-VENTURE:  {venture_name} ({venture_code})
-REPO:     {repo}
-BRANCH:   {branch}
-SESSION:  {session_id}
-```
-
-State: "You're in the correct repository and on the {branch} branch."
-
-### Step 4: Handle P0 Issues
-
-If the Alerts section shows P0 issues:
-
-1. Display prominently with warning icon
-2. Say: "**There are P0 issues that need immediate attention.**"
-3. List each issue
-
-### Step 5: Check Work Plan
-
-Query D1 for today's planned events:
-
-- Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`
-- **If found**: Display "Today: **{VENTURE} Work**, 6:30am - 10:30pm" in the context box
-- **If not found**: Suggest "No work plan for today. Run `/work-plan` to set up your schedule."
-
-Also check the weekly plan file status from the `crane_sos` response:
-
-- **valid**: Note the priority venture and proceed
-- **stale**: Warn user: "Weekly plan is {age_days} days old. Consider running `/work-plan`."
-- **missing**: Suggest running `/work-plan`
-
-### Step 6: Cadence Decision Prompt
-
-The `crane_sos` response includes cadence status (overdue/due items).
-
-For any overdue items:
-
-1. Display the overdue items list
-2. Ask: "**Want to execute any of these now, or skip?**"
-3. If user chooses to execute: run the appropriate command (e.g., `/portfolio-review`)
-4. If user skips: proceed to next step
-
-Do NOT create Google Calendar events for cadence items. Do NOT create Apple Reminders here (that is `/work-plan`'s job).
-
-### Step 7: STOP and Wait
-
-**CRITICAL**: Do NOT automatically start working.
-
-- If there is an in_progress or blocked handoff in the Resume block:
-  **"Previous session was working on: [one-line summary]. Resume this, or focus on something else?"**
-- Otherwise:
-  **"What would you like to focus on?"**
-
-If user wants to see the full work queue, call `crane_status` MCP tool.
-
-## Wrong Repo Prevention
-
-All GitHub issues created this session MUST target the repo shown in context confirmation. If you find yourself targeting a different repo, STOP and verify with the user.
-
-## Troubleshooting
-
-If MCP tools aren't available:
-
-1. Check `claude mcp list` shows crane connected
-2. Ensure started with: `crane vc`
-3. Try: `cd ~/dev/crane-console/packages/crane-mcp && npm run build && npm link`
+- All GitHub issues this session target the repo shown in context. Targeting a different repo? STOP.
+- Do NOT start working automatically.
+- Do NOT create calendar events for cadence items.
+- If MCP tools unavailable: check `claude mcp list`, ensure started with `crane vc`.
 """

--- a/packages/crane-mcp/src/lib/session-log.test.ts
+++ b/packages/crane-mcp/src/lib/session-log.test.ts
@@ -95,7 +95,7 @@ describe('session-log', () => {
     expect(result).toBe('2026-03-23T10:02:00.000Z')
   })
 
-  it('returns last assistant message before /eod boundary', async () => {
+  it('returns last assistant message before /eos boundary', async () => {
     const { getLastActivityTimestamp } = await getModule()
 
     setupSessionFiles('sess-002', [
@@ -103,7 +103,7 @@ describe('session-log', () => {
       assistantMsg('2026-03-23T10:01:00.000Z', 'Done fixing.'),
       userMsg(
         '2026-03-23T14:00:00.000Z',
-        '# /eod - End of Day Handoff\n\nAuto-generate handoff...'
+        '# /eos - End of Session Handoff\n\nAuto-generate handoff...'
       ),
       assistantMsg('2026-03-23T14:00:05.000Z', 'Here is your handoff summary...'),
       assistantMsg('2026-03-23T14:00:10.000Z', 'Handoff saved to D1.'),

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -94,7 +94,7 @@ describe('handoff tool', () => {
       status: 'done',
     })
 
-    // Verify all required fields were passed to the /eod endpoint
+    // Verify all required fields were passed to the /eos endpoint
     const eodCall = mockFetch.mock.calls[1]
     const body = JSON.parse(eodCall[1].body)
     expect(body.schema_version).toBe('1.0')

--- a/scripts/golden-path-audit.sh
+++ b/scripts/golden-path-audit.sh
@@ -54,18 +54,18 @@ audit_repo() {
     fail "CLAUDE.md missing"
   fi
 
-  # .claude/commands/sod.md
-  if [ -f "$REPO_PATH/.claude/commands/sod.md" ]; then
-    pass ".claude/commands/sod.md exists"
+  # .claude/commands/sos.md
+  if [ -f "$REPO_PATH/.claude/commands/sos.md" ]; then
+    pass ".claude/commands/sos.md exists"
   else
-    fail ".claude/commands/sod.md missing"
+    fail ".claude/commands/sos.md missing"
   fi
 
-  # .claude/commands/eod.md
-  if [ -f "$REPO_PATH/.claude/commands/eod.md" ]; then
-    pass ".claude/commands/eod.md exists"
+  # .claude/commands/eos.md
+  if [ -f "$REPO_PATH/.claude/commands/eos.md" ]; then
+    pass ".claude/commands/eos.md exists"
   else
-    fail ".claude/commands/eod.md missing"
+    fail ".claude/commands/eos.md missing"
   fi
 
   # package.json (if it's a JS/TS project)

--- a/scripts/sync-commands.sh
+++ b/scripts/sync-commands.sh
@@ -344,6 +344,7 @@ if [ "$DRY_RUN" = true ]; then
   echo ""
 fi
 
+REMOVED_COUNT=0
 REPO_COUNT=0
 NEW_COUNT=0
 UPDATED_COUNT=0
@@ -406,6 +407,22 @@ for repo_dir in "$HOME"/dev/*-console; do
     fi
   done
 
+  # Remove stale Claude commands (files in target that no longer exist in source)
+  if [ -d "$CLAUDE_TARGET" ]; then
+    for target_file in "$CLAUDE_TARGET"/*.md; do
+      [ -f "$target_file" ] || continue
+      filename=$(basename "$target_file")
+      if [ ! -f "$CLAUDE_SOURCE/$filename" ]; then
+        echo -e "  ${RED}- stale${NC}    claude  $filename"
+        ((REMOVED_COUNT++)) || true
+        repo_changed=true
+        if [ "$DRY_RUN" = false ]; then
+          rm "$target_file"
+        fi
+      fi
+    done
+  fi
+
   # ------------------------------------------------------------------
   # Codex CLI: .agents/skills/*/SKILL.md
   # ------------------------------------------------------------------
@@ -444,6 +461,22 @@ for repo_dir in "$HOME"/dev/*-console; do
         ((UNCHANGED_COUNT++)) || true
       fi
     done
+
+    # Remove stale Codex skills (dirs in target that no longer exist in source)
+    if [ -d "$CODEX_TARGET" ]; then
+      for target_dir in "$CODEX_TARGET"/*/; do
+        [ -d "$target_dir" ] || continue
+        skill_name=$(basename "$target_dir")
+        if [ ! -d "$CODEX_SOURCE/$skill_name" ]; then
+          echo -e "  ${RED}- stale${NC}    codex   $skill_name/"
+          ((REMOVED_COUNT++)) || true
+          repo_changed=true
+          if [ "$DRY_RUN" = false ]; then
+            rm -rf "$target_dir"
+          fi
+        fi
+      done
+    fi
   fi
 
   # ------------------------------------------------------------------
@@ -483,6 +516,22 @@ for repo_dir in "$HOME"/dev/*-console; do
         ((UNCHANGED_COUNT++)) || true
       fi
     done
+
+    # Remove stale Gemini commands (files in target that no longer exist in source)
+    if [ -d "$GEMINI_TARGET" ]; then
+      for target_file in "$GEMINI_TARGET"/*.toml; do
+        [ -f "$target_file" ] || continue
+        filename=$(basename "$target_file")
+        if [ ! -f "$GEMINI_SOURCE/$filename" ]; then
+          echo -e "  ${RED}- stale${NC}    gemini  $filename"
+          ((REMOVED_COUNT++)) || true
+          repo_changed=true
+          if [ "$DRY_RUN" = false ]; then
+            rm "$target_file"
+          fi
+        fi
+      done
+    fi
   fi
 
   if [ "$repo_changed" = true ]; then
@@ -505,6 +554,7 @@ echo ""
 echo -e "${BLUE}Repos scanned:${NC}  $REPO_COUNT"
 echo -e "${GREEN}New files:${NC}      $NEW_COUNT"
 echo -e "${YELLOW}Updated files:${NC}  $UPDATED_COUNT"
+echo -e "${RED}Removed stale:${NC}  $REMOVED_COUNT"
 echo -e "Unchanged:      $UNCHANGED_COUNT"
 echo ""
 

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -45,7 +45,7 @@ GLOBAL_DOCS=(
   "team-workflow.md"
   "slash-commands-guide.md"
   "parallel-dev-track-runbook.md"
-  "eod-sod-process.md"
+  "eos-sos-process.md"
   "dev-directive-pr-workflow.md"
   "dev-directive-qa-grading.md"
   "agent-persona-briefs.md"

--- a/workers/crane-context/src/endpoints/sessions.ts
+++ b/workers/crane-context/src/endpoints/sessions.ts
@@ -1,7 +1,7 @@
 /**
  * Crane Context Worker - Session Lifecycle Endpoints
  *
- * Handlers for POST /sos, /eod, /update, /heartbeat
+ * Handlers for POST /sos, /eos, /update, /heartbeat
  * Implements session lifecycle patterns from ADR 025.
  */
 

--- a/workers/crane-context/src/schemas.ts
+++ b/workers/crane-context/src/schemas.ts
@@ -124,7 +124,7 @@ export const startOfSessionSchema: JSONSchemaType<StartOfSessionRequest> = {
 }
 
 /**
- * Schema for POST /eod (End of Session)
+ * Schema for POST /eos (End of Session)
  */
 export const endOfSessionSchema: JSONSchemaType<EndOfSessionRequest> = {
   type: 'object',

--- a/workers/crane-context/test/integration/README.md
+++ b/workers/crane-context/test/integration/README.md
@@ -27,8 +27,9 @@ Integration tests require the worker to be running locally with access to the D1
 test/integration/
 ├── README.md           # This file
 ├── setup.ts            # Test fixtures and helpers
-├── sod.test.ts         # POST /sod - Session resume logic
-├── eod.test.ts         # POST /eod - End session with handoff
+├── sod.test.ts         # POST /sos - Session resume logic (legacy filename)
+├── sos.test.ts         # POST /sos - Session resume logic
+
 ├── update.test.ts      # POST /update - Session updates
 ├── heartbeat.test.ts   # POST /heartbeat - Keep-alive
 ├── queries.test.ts     # GET /active, /handoffs/*
@@ -65,7 +66,7 @@ npx vitest watch test/integration/
 - ⏸ Multiple active sessions → supersede extras (requires DB manipulation)
 - ✓ Idempotency → return cached response
 
-### POST /eod
+### POST /eos
 
 - ✓ Create handoff with canonical JSON storage
 - ✓ Idempotency replay (same key returns cached)


### PR DESCRIPTION
## Summary
- **sync-commands.sh** now detects and removes stale command files from target repos (was add-only, causing renamed skills like `eod.md` to linger alongside `eos.md`)
- **upload-doc-to-context-worker.sh** updated to reference `eos-sos-process.md` instead of stale `eod-sod-process.md` (this is what agents read via `crane_doc`)
- **golden-path-audit.sh** checks for `eos.md`/`sos.md` instead of old `eod.md`/`sod.md`
- Worker comments, test descriptions, and integration README updated from `/eod` to `/eos`

## Context
The March 23 `/eod` → `/eos` rename updated source docs but left scripts, tests, and the sync pipeline behind. Fleet agents (SS on m16) couldn't recognize `/eos` because `ss-console` never received `eos.md` and the stale `eod.md` was never cleaned up. Fleet sync with stale cleanup has been run on all machines.

## Test plan
- [x] `npm run verify` passes (284 tests, 0 errors)
- [x] `sync-commands.sh --dry-run` correctly identifies stale files
- [x] `sync-commands.sh` removes stale `eod.md`/`sod.md` from all 5 venture repos locally
- [x] `sync-commands.sh --fleet` succeeds on all 3 remote machines (mbp27, think, mini)

🤖 Generated with [Claude Code](https://claude.com/claude-code)