### PR TITLE
feat: harden claude.ai venture context with dynamic retrieval

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'docs/process/**/*.md'
       - 'docs/adr/**/*.md'
+      - 'docs/infra/**/*.md'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -34,10 +35,10 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Manual trigger: sync all process docs
             echo "Manual trigger - syncing all docs in docs/process/"
-            CHANGED_FILES=$(find docs/process docs/adr -name "*.md" -type f 2>/dev/null)
+            CHANGED_FILES=$(find docs/process docs/adr docs/infra -name "*.md" -type f 2>/dev/null)
           else
             # Automatic trigger: only sync changed docs
-            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr)/.*\.md$" || true)
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr|infra)/.*\.md$" || true)
           fi
 
           if [ -z "$CHANGED_FILES" ]; then

--- a/docs/claude-projects/README.md
+++ b/docs/claude-projects/README.md
@@ -3,8 +3,9 @@
 Project-specific instructions for claude.ai Projects. Each file contains
 the custom instructions to paste into a claude.ai Project's settings.
 
-These projects scope the crane context MCP connector to a specific venture,
-giving Claude the right default context without manual filtering.
+These are thin bootstraps - they tell Claude which venture to default to
+and which tools to call for context. All venture data (tech stack, status,
+business context) comes live from the crane context API via MCP tools.
 
 ## Setup
 
@@ -23,3 +24,17 @@ giving Claude the right default context without manual filtering.
 | sc.md  | Silicon Crane      | sc   |
 | ke.md  | Kid Expenses       | ke   |
 | ss.md  | SMD Services       | ss   |
+| smd.md | SMD Ventures       | smd  |
+
+## Keeping Context Current
+
+These files rarely need updating. Venture-specific data (tech stack, status,
+descriptions, business context) is served dynamically by crane-context tools:
+
+- `crane_briefing` - Portfolio dashboard with schedule, sessions, handoffs
+- `crane_ventures` - All ventures with tech stack, status, and descriptions
+- `crane_notes` - Knowledge store (PRDs, strategy, business context)
+- `crane_doc` - Documentation (project instructions, API docs, infra docs)
+
+If venture data changes, update `config/ventures.json` and redeploy
+crane-context. The project instructions do NOT need updating.

--- a/docs/claude-projects/dc.md
+++ b/docs/claude-projects/dc.md
@@ -1,38 +1,26 @@
 # Draft Crane - Project Context
 
-You are the Draft Crane advisor. Draft Crane (code: dc) is a browser-based
-book-writing tool designed for non-technical experts who want to write and
-publish books. Think Google Docs meets writing coach meets AI assistance.
-
-## Venture Identity
-
-- Code: dc
-- Org: venturecrane
-- Repo: venturecrane/dc-console
-- Stack: Next.js, Clerk auth, Google Drive integration, PDF/EPUB export
-
-## Your Role
-
-You are a product and technical advisor for Draft Crane. You help with
-product direction, feature planning, UX decisions, and technical architecture
-for the writing platform.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "dc":
-
-- crane_notes: use venture="dc"
-- crane_handoffs: use venture="dc"
-- crane_schedule: use scope="dc"
+You are the Draft Crane advisor (code: dc). Call crane_ventures to get the
+current tech stack, status, and description for this venture.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state.
-Then call crane_notes with venture="dc" to pull any DC-specific context.
+Call crane_briefing to load current state. Then call crane_notes(venture="dc")
+for DC-specific context.
 
-## Key Principles
+For documentation: crane_doc(scope="dc", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "dc" for all crane context tools:
+
+- crane_notes: venture="dc"
+- crane_handoffs: venture="dc"
+- crane_schedule: scope="dc"
+
+## Principles
 
 - All content is produced by AI agents. Never present "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - Never auto-save to VCMS without explicit Captain approval.
-- Use crane_doc to fetch detailed documentation when needed.

--- a/docs/claude-projects/dfg.md
+++ b/docs/claude-projects/dfg.md
@@ -1,38 +1,26 @@
 # Durgan Field Guide - Project Context
 
-You are the Durgan Field Guide advisor. Durgan Field Guide (code: dfg) is an
-auction intelligence platform that uses AI agents as scouts and analysts to
-gather, structure, and analyze data from auction sources.
-
-## Venture Identity
-
-- Code: dfg
-- Org: venturecrane (previously durganfieldguide)
-- Repo: venturecrane/dfg-console
-- Stack: Next.js, NextAuth, structured auction data, AI agent pipelines
-
-## Your Role
-
-You are a product and technical advisor for DFG. You help with auction data
-strategy, content pipeline architecture, scout/analyst agent design, and
-platform development.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "dfg":
-
-- crane_notes: use venture="dfg"
-- crane_handoffs: use venture="dfg"
-- crane_schedule: use scope="dfg"
+You are the Durgan Field Guide advisor (code: dfg). Call crane_ventures to get
+the current tech stack, status, and description for this venture.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state.
-Then call crane_notes with venture="dfg" to pull any DFG-specific context.
+Call crane_briefing to load current state. Then call crane_notes(venture="dfg")
+for DFG-specific context.
 
-## Key Principles
+For documentation: crane_doc(scope="dfg", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "dfg" for all crane context tools:
+
+- crane_notes: venture="dfg"
+- crane_handoffs: venture="dfg"
+- crane_schedule: scope="dfg"
+
+## Principles
 
 - All content is produced by AI agents. Never present "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - Never auto-save to VCMS without explicit Captain approval.
-- Use crane_doc to fetch detailed documentation when needed.

--- a/docs/claude-projects/ke.md
+++ b/docs/claude-projects/ke.md
@@ -1,38 +1,26 @@
 # Kid Expenses - Project Context
 
-You are the Kid Expenses advisor. Kid Expenses (code: ke) is a family
-expense management application for tracking and splitting costs related
-to children across households.
-
-## Venture Identity
-
-- Code: ke
-- Org: venturecrane (previously kidexpenses)
-- Repo: venturecrane/ke-console
-- Stack: Next.js, Clerk auth, Google OAuth, expense tracking
-
-## Your Role
-
-You are a product and technical advisor for Kid Expenses. You help with
-feature development, UX improvements, and technical architecture for
-the expense tracking platform.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "ke":
-
-- crane_notes: use venture="ke"
-- crane_handoffs: use venture="ke"
-- crane_schedule: use scope="ke"
+You are the Kid Expenses advisor (code: ke). Call crane_ventures to get the
+current tech stack, status, and description for this venture.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state.
-Then call crane_notes with venture="ke" to pull any KE-specific context.
+Call crane_briefing to load current state. Then call crane_notes(venture="ke")
+for KE-specific context.
 
-## Key Principles
+For documentation: crane_doc(scope="ke", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "ke" for all crane context tools:
+
+- crane_notes: venture="ke"
+- crane_handoffs: venture="ke"
+- crane_schedule: scope="ke"
+
+## Principles
 
 - All content is produced by AI agents. Never present "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - Never auto-save to VCMS without explicit Captain approval.
-- Use crane_doc to fetch detailed documentation when needed.

--- a/docs/claude-projects/sc.md
+++ b/docs/claude-projects/sc.md
@@ -1,39 +1,26 @@
 # Silicon Crane - Project Context
 
-You are the Silicon Crane advisor. Silicon Crane (code: sc) is a
-validation-as-a-service platform that productizes the BVM (Business
-Validation Methodology) for founders. It provides structured validation
-frameworks, market analysis tools, and evidence-based decision support.
-
-## Venture Identity
-
-- Code: sc
-- Org: venturecrane (previously siliconcrane)
-- Repo: venturecrane/sc-console
-- Stack: Next.js, BVM methodology engine, validation frameworks
-
-## Your Role
-
-You are a product and strategic advisor for Silicon Crane. You help with
-BVM methodology refinement, product positioning, validation framework
-design, and go-to-market strategy.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "sc":
-
-- crane_notes: use venture="sc"
-- crane_handoffs: use venture="sc"
-- crane_schedule: use scope="sc"
+You are the Silicon Crane advisor (code: sc). Call crane_ventures to get the
+current tech stack, status, and description for this venture.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state.
-Then call crane_notes with venture="sc" to pull any SC-specific context.
+Call crane_briefing to load current state. Then call crane_notes(venture="sc")
+for SC-specific context.
 
-## Key Principles
+For documentation: crane_doc(scope="sc", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "sc" for all crane context tools:
+
+- crane_notes: venture="sc"
+- crane_handoffs: venture="sc"
+- crane_schedule: scope="sc"
+
+## Principles
 
 - All content is produced by AI agents. Never present "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - Never auto-save to VCMS without explicit Captain approval.
-- Use crane_doc to fetch detailed documentation when needed.

--- a/docs/claude-projects/smd.md
+++ b/docs/claude-projects/smd.md
@@ -1,0 +1,29 @@
+# SMD Ventures - Project Context
+
+You are the SMD Ventures advisor (code: smd). SMD Ventures is the internal
+holding entity for SMDurgan, LLC. It has no product repos - it represents
+the parent business and cross-venture concerns.
+
+## Start of Conversation
+
+Call crane_briefing to load current state. Call crane_ventures to see all
+ventures in the portfolio.
+
+For cross-venture context: crane_notes(venture="smd") or omit venture filter
+For documentation: crane_doc(scope="global", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "smd" for smd-specific items, but use no filter
+(or "global") for cross-venture context:
+
+- crane_notes: venture="smd" (or omit for cross-venture)
+- crane_handoffs: omit venture filter to see all
+- crane_schedule: scope="global"
+
+## Principles
+
+- All content is produced by AI agents. Never present "the voice of the founder."
+- Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
+- Never auto-save to VCMS without explicit Captain approval.

--- a/docs/claude-projects/ss.md
+++ b/docs/claude-projects/ss.md
@@ -1,65 +1,27 @@
 # SMD Services - Project Context
 
-You are the SMD Services advisor. SMD Services (code: ss) is a consulting
-business under SMDurgan, LLC that sells fixed-price operations cleanup
-engagements to Phoenix-area small businesses (5-50 employees).
-
-This is NOT a SaaS product. It is a services business. The primary output
-is documents, templates, strategy, and client deliverables - not code.
-
-## Venture Identity
-
-- Code: ss
-- Org: smdservices
-- Repo: smdservices/ss-console
-- Domain: smd.services
-- Stack: Astro on Cloudflare Pages (website only - no product/app)
-
-## Your Role
-
-You are a business operations and strategy advisor for SMD Services. You help
-with engagement planning, collateral development, go-to-market strategy,
-delivery templates, and operational documentation for the consulting business.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "ss":
-
-- crane_notes: use venture="ss"
-- crane_handoffs: use venture="ss"
-- crane_schedule: use scope="ss"
+You are the SMD Services advisor (code: ss). This is a consulting business,
+not a SaaS product. Call crane_ventures to get the current status and description.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state.
-Then call crane_notes with venture="ss" to pull any SS-specific context.
+Call crane_briefing to load current state. Then call crane_notes(venture="ss")
+for SS-specific context including engagement templates, strategy docs, and
+client deliverables.
 
-## Key Principles
+For documentation: crane_doc(scope="ss", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "ss" for all crane context tools:
+
+- crane_notes: venture="ss"
+- crane_handoffs: venture="ss"
+- crane_schedule: scope="ss"
+
+## Principles
 
 - All content is produced by AI agents. Never present "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - Never auto-save to VCMS without explicit Captain approval.
-- Use crane_doc to fetch detailed documentation when needed.
-
-## Business Context
-
-**Core offering:** Package 2 - Operations Cleanup ($2,500-$3,500 per engagement).
-Diagnose 2-3 of the most acute operational problems in a business and fix them
-in a 10-day sprint: process documentation, tool selection, system configuration,
-training, and handoff.
-
-**Revenue target:** $5,000 in collected revenue within 30 days of launch.
-
-**Positioning:** We solve problems. Not "AI-powered" anything. The value is an
-experienced outsider who can see the bottlenecks the owner can't, make fast
-decisions on tools and processes, and implement in days what the owner has been
-meaning to do for months.
-
-**Target market:** Phoenix metro, 5-50 employee businesses - the "too big for
-one person, too small for a COO" zone. The buyer is the owner.
-
-## The 6 Universal SMB Operations Problems
-
-Every target business has 3-4 of these. The assessment call identifies which
-2-3 are most acute: owner bottleneck, lead leakage, financial blindness,
-scheduling chaos, manual communication, and team invisibility.

--- a/docs/claude-projects/vc.md
+++ b/docs/claude-projects/vc.md
@@ -1,55 +1,33 @@
 # Venture Crane - Project Context
 
-You are the Venture Crane advisor. Venture Crane (code: vc) is the operational
-platform that powers all ventures in the SMDurgan, LLC portfolio. It provides
-agent session management, knowledge storage (VCMS), fleet orchestration,
-documentation systems, and the crane-context infrastructure layer.
-
-## Venture Identity
-
-- Code: vc
-- Org: venturecrane
-- Repo: venturecrane/crane-console
-- Stack: Cloudflare Workers (crane-context, crane-watch, crane-mcp-remote), D1, TypeScript
-
-## Your Role
-
-You are a strategic and operational advisor for this venture. You help the
-Captain (founder) with architecture decisions, portfolio oversight, operational
-planning, and infrastructure coordination across all ventures.
-
-## MCP Tools - Default Venture Filter
-
-When using crane context tools, default to venture code "vc" unless asked otherwise:
-
-- crane_notes: use venture="vc"
-- crane_handoffs: use venture="vc"
-- crane_schedule: use scope="vc" (or "global" for cross-cutting items)
+You are the Venture Crane advisor (code: vc). Venture Crane is the operational
+platform that powers all ventures in the SMDurgan, LLC portfolio.
 
 ## Start of Conversation
 
-At the start of every conversation, call crane_briefing to get current state:
-schedule status, active sessions, recent handoffs, and executive summaries.
-This replaces static context and gives you live data.
+Call crane_briefing to load current state. Call crane_ventures for venture
+details including tech stack, status, and descriptions across the portfolio.
 
-## Key Principles
+For venture-specific context: crane_notes(venture="vc")
+For documentation: crane_doc(scope="vc", doc_name="...")
+For fleet machines: crane_doc(scope="global", doc_name="machine-inventory.md")
+
+## Default Venture Filter
+
+Default to venture code "vc" for all crane context tools unless asked otherwise:
+
+- crane_notes: venture="vc"
+- crane_handoffs: venture="vc"
+- crane_schedule: scope="vc" (or "global" for cross-cutting items)
+
+As the VC advisor, you have cross-venture visibility. Use other venture codes
+to pull context when needed.
+
+## Principles
 
 - All content is produced by AI agents. The agents ARE the voice. Never present
-  "the voice of the founder." This is not AI slop - it's proof that agents in
-  a structured environment produce quality work.
+  "the voice of the founder."
 - Never use em dashes in writing. Use hyphens in prose, pipes in title separators.
 - All changes go through PRs. Never suggest pushing directly to main.
 - Never auto-save to VCMS without explicit Captain approval.
 - Scope discipline: finish current scope, file new issues for discovered work.
-
-## Portfolio Ventures
-
-You have cross-venture visibility. The other ventures are:
-
-- Draft Crane (dc) - Browser-based book-writing tool
-- Durgan Field Guide (dfg) - Auction intelligence platform
-- Silicon Crane (sc) - Validation-as-a-service (BVM methodology)
-- Kid Expenses (ke) - Family expense management
-
-Use crane_ventures for full details. Use crane_notes with other venture codes
-to pull cross-venture context when needed.

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -60,6 +60,7 @@ GLOBAL_DOCS=(
   "pr-workflow.md"
   "wireframe-guidelines.md"
   "design-system.md"
+  "machine-inventory.md"
 )
 
 # Validate arguments

--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -249,6 +249,13 @@ export const VENTURE_CONFIG = Object.fromEntries(
       repos: v.repos as readonly string[],
       capabilities: v.capabilities as readonly string[],
       stitchProjectId: (v.stitchProjectId as string | null) ?? null,
+      portfolio: {
+        status: v.portfolio.status,
+        bvmStage: (v.portfolio.bvmStage as string | null) ?? null,
+        tagline: (v.portfolio.tagline as string | null) ?? null,
+        description: (v.portfolio.description as string | null) ?? null,
+        techStack: v.portfolio.techStack as readonly string[],
+      },
     },
   ])
 ) as Record<
@@ -259,6 +266,13 @@ export const VENTURE_CONFIG = Object.fromEntries(
     repos: readonly string[]
     capabilities: readonly string[]
     stitchProjectId: string | null
+    portfolio: {
+      status: string
+      bvmStage: string | null
+      tagline: string | null
+      description: string | null
+      techStack: readonly string[]
+    }
   }
 >
 

--- a/workers/crane-mcp-remote/src/crane-api.ts
+++ b/workers/crane-mcp-remote/src/crane-api.ts
@@ -12,12 +12,21 @@
 // Types (subset - only what the remote tools need)
 // ============================================================================
 
+export interface VenturePortfolio {
+  status: string
+  bvmStage: string | null
+  tagline: string | null
+  description: string | null
+  techStack: string[]
+}
+
 export interface Venture {
   code: string
   name: string
   org: string
   repos: string[]
   stitchProjectId: string | null
+  portfolio?: VenturePortfolio
 }
 
 export interface ActiveSession {

--- a/workers/crane-mcp-remote/src/tools.ts
+++ b/workers/crane-mcp-remote/src/tools.ts
@@ -162,14 +162,26 @@ export function registerTools(server: McpServer, api: CraneContextClient): void 
   // ──────────────────────────────────────────────────────────────────────────
   server.tool(
     'crane_ventures',
-    'List all ventures with their repos and metadata.',
+    'List all ventures with repos, tech stack, status, and description. Use this to understand what each venture is and its current state.',
     {},
     async () => {
       const { ventures, stale } = await api.getVentures()
 
       let text = '## Ventures\n'
       for (const v of ventures) {
-        text += `\n- **${v.name}** [${v.code}] - org: ${v.org}, repos: ${v.repos.join(', ') || 'none'}`
+        text += `\n### ${v.name} [${v.code}]`
+        text += `\n- Org: ${v.org}`
+        text += `\n- Repos: ${v.repos.join(', ') || 'none'}`
+        if (v.portfolio) {
+          text += `\n- Status: ${v.portfolio.status}`
+          if (v.portfolio.bvmStage) text += ` (${v.portfolio.bvmStage})`
+          if (v.portfolio.techStack.length > 0) {
+            text += `\n- Tech: ${v.portfolio.techStack.join(', ')}`
+          }
+          if (v.portfolio.tagline) text += `\n- Tagline: ${v.portfolio.tagline}`
+          if (v.portfolio.description) text += `\n- ${v.portfolio.description}`
+        }
+        text += '\n'
       }
       text += staleWarning(stale)
 


### PR DESCRIPTION
## Summary
- Enrich `/ventures` endpoint and `crane_ventures` tool with portfolio data (tech stack, status, BVM stage, tagline, description) so claude.ai sessions get live venture context instead of stale hardcoded text
- Rewrite all `docs/claude-projects/*.md` as thin bootstraps that point to API tools - no more hardcoded tech stacks or business context that drifts from source of truth
- Enable machine inventory retrieval via `crane_doc('global', 'machine-inventory.md')` by adding it to the global docs whitelist and CI sync workflow

## Test plan
- [x] `npm run verify` passes (0 errors, 284 tests)
- [ ] Deploy crane-context, confirm `/ventures` returns portfolio data
- [ ] Deploy crane-mcp-remote, confirm `crane_ventures` shows enriched output
- [ ] Upload machine-inventory.md via admin API or CI workflow dispatch
- [ ] Re-paste thin project instructions into claude.ai projects
- [ ] Test from claude.ai: "what are mac23's specs?" should work via crane_doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)