### PR TITLE
fix: inject startup prompt for Codex and harden crane_sos with STOP

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1001,6 +1001,66 @@ export function checkMcpSetup(repoPath: string, agent: string): void {
 }
 
 // ============================================================================
+// Startup prompt injection
+// ============================================================================
+
+/**
+ * Plain-English startup prompt for agents that don't support Claude-style
+ * slash commands (Codex, etc). Codex auto-loads project AGENTS.md but most
+ * venture repos don't have one — and even if they did, "auto session start"
+ * instructions in AGENTS.md don't reliably translate into "stop and wait"
+ * behavior. Injecting an explicit startup prompt is the only reliable way
+ * to force the same SOS contract that Claude gets via /sos.
+ */
+const CODEX_STARTUP_PROMPT = `Run these MCP tool calls in order, then STOP and await user instructions:
+
+1. crane_sos (no arguments)
+2. crane_schedule with action="planned-events", from and to set to today's date, type="planned"
+
+Display the briefing returned by crane_sos. Highlight any Resume block or P0 issues.
+
+CRITICAL: Do not start any work after displaying the briefing. Do not explore the codebase, run tests, check git status, view PRs, or take any other action. Wait for the user to tell you what to focus on.`
+
+/**
+ * Decide which startup prompt (if any) to inject as a positional arg to the
+ * agent binary. Returns null when injection should be skipped.
+ *
+ * Skip cases:
+ * - User passed an explicit positional prompt or subcommand (we'd clobber it)
+ * - User invoked headless mode (claude -p / --print)
+ * - Agent has no defined startup prompt (gemini, hermes — left unchanged)
+ */
+export function getStartupPrompt(agent: string, extraArgs: string[]): string | null {
+  // Headless / non-interactive modes — never inject
+  if (extraArgs.includes('-p') || extraArgs.includes('--print')) {
+    return null
+  }
+
+  // User-supplied positional arg (prompt OR subcommand like `codex exec`)
+  // — never override
+  const hasPositional = extraArgs.some((a) => !a.startsWith('-'))
+  if (hasPositional) {
+    return null
+  }
+
+  switch (agent) {
+    case 'claude':
+      // Claude executes /sos as a slash command (.claude/commands/sos.md)
+      return '/sos'
+    case 'codex':
+      // Codex has no slash-command equivalent at the CLI level — pass the
+      // full instructions as the initial prompt.
+      return CODEX_STARTUP_PROMPT
+    default:
+      // gemini and hermes are intentionally not auto-injected here.
+      // gemini supports .gemini/commands/sos.toml but no startup-prompt
+      // mechanism is wired through this launcher yet.
+      // hermes uses subcommand-based invocation (chat/gateway/etc.)
+      return null
+  }
+}
+
+// ============================================================================
 // Agent launcher - direct spawn, no infisical wrapper
 // ============================================================================
 
@@ -1124,12 +1184,14 @@ export function launchAgent(
     }
   }
 
-  // Auto-inject /sos for interactive Claude sessions (no -p flag, no existing prompt)
-  if (agent === 'claude' && !extraArgs.includes('-p') && !extraArgs.includes('--print')) {
-    const hasPrompt = extraArgs.some((a) => !a.startsWith('-'))
-    if (!hasPrompt) {
-      extraArgs.push('/sos')
-    }
+  // Auto-inject startup prompt for interactive sessions.
+  // Without this, agents launch bare and their first response to any user
+  // message becomes a free-form action — Codex in particular will start
+  // exploring the codebase, running tests, and resuming "blocked work" rather
+  // than retrieving venture context and waiting for instructions.
+  const startupPrompt = getStartupPrompt(agent, extraArgs)
+  if (startupPrompt !== null) {
+    extraArgs.push(startupPrompt)
   }
 
   // Hermes-specific env and arg translation

--- a/packages/crane-mcp/src/cli/launch.test.ts
+++ b/packages/crane-mcp/src/cli/launch.test.ts
@@ -59,6 +59,7 @@ import {
   stripAgentFlags,
   fetchSecrets,
   ensureFreshBuild,
+  getStartupPrompt,
   INFISICAL_PATHS,
   KNOWN_AGENTS,
 } from './launch-lib.js'
@@ -146,6 +147,52 @@ describe('INFISICAL_PATHS', () => {
     }
     // Known ventures are present
     expect(INFISICAL_PATHS['vc']).toBe('/vc')
+  })
+})
+
+describe('getStartupPrompt', () => {
+  it('returns /sos for claude with no positional args', () => {
+    expect(getStartupPrompt('claude', [])).toBe('/sos')
+  })
+
+  it('returns CODEX_STARTUP_PROMPT for codex with no positional args', () => {
+    const prompt = getStartupPrompt('codex', [])
+    expect(prompt).not.toBeNull()
+    expect(prompt).toContain('crane_sos')
+    expect(prompt).toContain('STOP')
+    expect(prompt).toContain('Wait for the user')
+  })
+
+  it('returns null for gemini (intentional - no startup prompt wired)', () => {
+    expect(getStartupPrompt('gemini', [])).toBeNull()
+  })
+
+  it('returns null for hermes (uses subcommand invocation)', () => {
+    expect(getStartupPrompt('hermes', [])).toBeNull()
+  })
+
+  it('returns null when claude is in headless mode (-p)', () => {
+    expect(getStartupPrompt('claude', ['-p', 'do thing'])).toBeNull()
+  })
+
+  it('returns null when claude is in headless mode (--print)', () => {
+    expect(getStartupPrompt('claude', ['--print', 'do thing'])).toBeNull()
+  })
+
+  it('returns null when codex is in headless mode (-p)', () => {
+    expect(getStartupPrompt('codex', ['-p', 'do thing'])).toBeNull()
+  })
+
+  it('returns null when user passed an explicit positional prompt to claude', () => {
+    expect(getStartupPrompt('claude', ['investigate the bug'])).toBeNull()
+  })
+
+  it('returns null when user passed an explicit positional prompt to codex', () => {
+    expect(getStartupPrompt('codex', ['investigate the bug'])).toBeNull()
+  })
+
+  it('returns null when user invoked a codex subcommand (e.g. exec)', () => {
+    expect(getStartupPrompt('codex', ['exec', 'do thing'])).toBeNull()
   })
 })
 
@@ -412,6 +459,46 @@ describe('launchAgent', () => {
 
     // Verify spawn was NOT called with 'infisical'
     expect(spawn).not.toHaveBeenCalledWith('infisical', expect.any(Array), expect.any(Object))
+
+    process.chdir = origChdir
+  })
+
+  it('spawns codex with startup prompt injected as positional arg', async () => {
+    const { launchAgent } = await import('./launch-lib.js')
+    const { execSync } = await import('child_process')
+
+    vi.mocked(execSync).mockImplementation(() => Buffer.from('/usr/local/bin/codex'))
+
+    const mockOutput = JSON.stringify([{ key: 'CRANE_CONTEXT_KEY', value: 'test-key' }])
+    vi.mocked(spawnSync).mockReturnValue({
+      status: 0,
+      stdout: mockOutput,
+      stderr: '',
+      error: undefined,
+    } as any)
+
+    const venture = {
+      code: 'ss',
+      name: 'SMD Services',
+      org: 'smdservices',
+      repos: ['ss-console'],
+      localPath: '/fake/ss-console',
+    }
+
+    const origChdir = process.chdir
+    process.chdir = vi.fn() as any
+
+    launchAgent(venture, 'codex', false)
+
+    // Codex must be launched with the startup prompt as a positional arg.
+    // Without this, codex sits idle and the user's first message gets
+    // interpreted as a free-form work directive.
+    const spawnCall = vi.mocked(spawn).mock.calls.at(-1)!
+    expect(spawnCall[0]).toBe('codex')
+    const spawnArgs = spawnCall[1] as string[]
+    expect(spawnArgs.length).toBe(1)
+    expect(spawnArgs[0]).toContain('crane_sos')
+    expect(spawnArgs[0]).toContain('STOP')
 
     process.chdir = origChdir
   })

--- a/packages/crane-mcp/src/tools/sos.test.ts
+++ b/packages/crane-mcp/src/tools/sos.test.ts
@@ -854,6 +854,36 @@ describe('sos tool', () => {
     expect(result.message).toContain('Scope discipline')
   })
 
+  it('ends with explicit STOP directive to re-anchor non-Claude agents', async () => {
+    const { executeSos } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getP0Issues } = await import('../lib/github.js')
+
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+    vi.mocked(getP0Issues).mockReturnValue({ success: true, issues: [] })
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: mockVentures }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSosResponse,
+      })
+
+    const result = await executeSos({})
+
+    expect(result.status).toBe('valid')
+    // STOP directive must be the final line so it can't be missed by an agent
+    // that scans only the tail of the response.
+    expect(result.message).toContain('**STOP.')
+    expect(result.message).toContain('Do not start any work')
+    expect(result.message?.trimEnd().endsWith('user responds with their focus.**')).toBe(true)
+  })
+
   it('omits Alerts section when no P0 issues and no active sessions', async () => {
     const { executeSos } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -781,7 +781,15 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
   if (!isFleet) {
     message += `Full documentation index: \`crane_doc_audit()\`\n\n`
   }
-  message += `**What would you like to focus on?**`
+  message += `**What would you like to focus on?**\n\n`
+
+  // Explicit stop directive — re-anchors any agent (Codex, Gemini, etc.) that
+  // calls this tool without going through Claude's /sos slash command. Without
+  // this line, agents that don't natively pause after tool calls will continue
+  // straight into autonomous exploration of whatever the user said before SOS
+  // ran. Keep this as the final line of the response so it can't be missed.
+  message += `---\n\n`
+  message += `**STOP. Do not start any work, explore the codebase, run commands, view PRs, or take any other action until the user responds with their focus.**`
 
   // SOD budget check: warn if over 8KB
   const SOS_BUDGET = 8_192


### PR DESCRIPTION
## Summary

When launched via `crane <code> --codex`, Codex was launching bare with no
startup ritual. The user's first message — even something as innocuous as
`done. login successful` after a vercel MCP login — was getting interpreted
as a free-form work directive, sending Codex into autonomous exploration
(reading `.claude/handoff.md` from the prior Claude session, running tests,
viewing PRs, polling mergeability) instead of just retrieving venture context
and waiting for instructions.

Root cause: the launcher's auto-inject `/sos` block at
`packages/crane-mcp/src/cli/launch-lib.ts` was gated to `agent === 'claude'`,
so non-Claude agents got no startup prompt at all.

## Fix

Two complementary changes:

**1. Generalize startup-prompt injection in the launcher** via a new
`getStartupPrompt(agent, extraArgs)` helper.
- Claude still gets `/sos` (existing slash-command behavior).
- Codex gets a plain-English prompt that tells it to call `crane_sos`,
  display the briefing, and STOP.
- Headless modes (`-p`, `--print`) and explicit positional args / subcommands
  (`codex exec ...`) are skipped — never clobbered.
- Gemini and Hermes are intentionally left unchanged (Gemini has its own
  `.gemini/commands/sos.toml` mechanism; Hermes uses subcommand-based
  invocation).

**2. Harden the `crane_sos` tool response itself** by appending an explicit
STOP directive as the final line of the message. This re-anchors any agent
that calls the tool — through the launcher, through `AGENTS.md`, or directly
mid-session — even if the wrapping prompt is misinterpreted. Defense in depth.

## Why both?

These are complementary, not alternatives:
- Fix #1 (launcher) ensures Codex *calls* `crane_sos` on startup.
- Fix #2 (tool output) ensures Codex *stops after* calling it.

Without #1, Codex never calls the tool. Without #2, even if Codex calls it,
nothing in the response text tells it to wait — the existing
"What would you like to focus on?" line was being read as conversational
filler rather than a directive.

## Test plan

- [x] `npm run verify` — typecheck, format, lint, test, build all clean
  (296 tests passed, 0 lint errors, 0 type errors)
- [x] New unit tests for `getStartupPrompt` covering: claude/codex/gemini/hermes
  branches, headless mode, explicit positional prompts, codex subcommands
- [x] New end-to-end test asserting `launchAgent(venture, 'codex', ...)` spawns
  `codex` with the startup prompt as a positional arg
- [x] New test asserting the `crane_sos` message ends with the STOP directive
- [ ] Manual verification: `crane ss --codex` should now show a venture
  briefing and pause for input, instead of going agentic on the first reply

## Out of scope

- Gemini startup prompt injection — Gemini already has
  `.gemini/commands/sos.toml`, and wiring CLI-level injection for it is a
  separate change with its own headless-mode considerations.
- Per-venture `AGENTS.md` files — relying on Codex auto-loading `AGENTS.md`
  from each venture cwd has the same maintenance problem this fix avoids
  (one source of truth in the launcher vs N files across ventures).