### PR TITLE
chore: gitignore .vercel link state and nested .claude handoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ workers/crane-context/manual-test-log.md
 .worktrees/
 
 # Disposable handoff cache (D1 is authoritative, this is for CC's /resume)
-.claude/handoff.md
+# Match at any depth — workspace packages have their own .claude/handoff.md
+**/.claude/handoff.md
+
+# Vercel CLI per-developer link state (vercel link writes here)
+.vercel/


### PR DESCRIPTION
## Summary

Two small `.gitignore` hygiene fixes that surfaced while cleaning up an
unrelated working tree:

1. **Add `.vercel/`** — Vercel CLI's `vercel link` command writes per-developer
   project link state (`.vercel/project.json`, `.vercel/README.txt`) into the
   repo root. Vercel itself recommends gitignoring this directory. It was
   showing up as untracked across developer machines.

2. **Fix `.claude/handoff.md` pattern** — the existing pattern contained a
   slash, which makes git treat it as rooted at the .gitignore directory
   (`<repo-root>/.claude/handoff.md` only). Workspace packages with their
   own Claude Code state, like `packages/crane-mcp/.claude/handoff.md`, were
   not being matched. Changed to `**/.claude/handoff.md` so it matches at
   any depth.

## Verification

```
$ git check-ignore -v .vercel/project.json packages/crane-mcp/.claude/handoff.md
.gitignore:22:.vercel/                 .vercel/project.json
.gitignore:19:**/.claude/handoff.md    packages/crane-mcp/.claude/handoff.md
```

Both patterns now match.

## Test plan

- [x] `git check-ignore -v` confirms both files are matched
- [x] `git status` no longer shows `.vercel/` or nested `.claude/` directories
- [ ] Other developers should also see these gone after pulling