### PR TITLE
feat: add gbp-weekly-post cadence item for SMD Services

### DIFF
--- a/workers/crane-context/migrations/0022_add_gbp_weekly_post.sql
+++ b/workers/crane-context/migrations/0022_add_gbp_weekly_post.sql
@@ -1,0 +1,9 @@
+-- Add weekly GBP post cadence item for SMD Services
+INSERT INTO schedule_items (id, name, title, description, cadence_days, scope, priority, enabled, created_at, updated_at)
+VALUES (
+  'sched_gbp_weekly_post',
+  'gbp-weekly-post',
+  'GBP Weekly Post',
+  'Publish weekly Google Business Profile post. Rotate: problem recognition, what we do, local relevance, credibility. 2-4 sentences, no hashtags, CTA to smd.services/book when relevant.',
+  7, 'ss', 2, 1, datetime('now'), datetime('now')
+);


### PR DESCRIPTION
## Summary

Adds a recurring "GBP Weekly Post" schedule item for SMD Services so the
cadence engine surfaces a weekly reminder to publish a Google Business
Profile post.

| Field | Value |
|---|---|
| name | \`gbp-weekly-post\` |
| title | GBP Weekly Post |
| cadence_days | 7 |
| scope | ss |
| priority | normal (2) |

## Content rotation

Post copy rotates four content angles across weeks:

1. Problem recognition
2. What we do
3. Local relevance
4. Credibility

Each post is 2-4 sentences, no hashtags, with a CTA to
\`smd.services/book\` when relevant.

## Migration is committed but NOT deployed

Per the guardrails on schema/data migrations, this PR only commits the
migration file. **Deploying it to D1 is a separate explicit step** that
should run after merge:

\`\`\`bash
cd workers/crane-context
npm run db:migrate         # staging
npm run db:migrate:prod    # production
\`\`\`

This is an INSERT (data, not destructive schema), but it does create
state in the production cadence registry that the user should approve
before deploying.

## Test plan

- [ ] Merge this PR
- [ ] Run \`npm run db:migrate\` (staging) and verify the row appears in
      the staging \`schedule_items\` table
- [ ] Test the cadence appears in \`crane_schedule(action: 'list', scope: 'ss')\`
      against the staging worker
- [ ] Run \`npm run db:migrate:prod\` (production)
- [ ] Verify \`crane ss\` shows the new cadence item in next SOS briefing