### PR TITLE
fix: mock node:fs in handoff.test.ts to prevent test pollution

### DIFF
--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -10,6 +10,16 @@ vi.mock('../lib/repo-scanner.js')
 vi.mock('../lib/session-state.js')
 vi.mock('../lib/session-log.js')
 
+// Mock node:fs to prevent the dual-write in executeHandoff() from creating
+// real files in the test working directory. Without this, every test that
+// successfully creates a handoff writes a real `.claude/handoff.md` to
+// vitest's cwd (`packages/crane-mcp/`) and pollutes the working tree with
+// fixture data on every `npm run verify`.
+vi.mock('node:fs', () => ({
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}))
+
 const getModule = async () => {
   vi.resetModules()
   return import('./handoff.js')


### PR DESCRIPTION
## Summary

`handoff.test.ts` was not mocking `node:fs`, which caused
`executeHandoff()`'s "dual-write" code path to write **real**
`.claude/handoff.md` files to vitest's working directory on every
`npm run verify` run.

## Root cause

`executeHandoff()` does a dual-write at \`packages/crane-mcp/src/tools/handoff.ts:128-143\`:

\`\`\`js
// Dual-write: also write .claude/handoff.md as a disposable cache for CC's native /resume.
const repoRoot = process.cwd()
const claudeDir = join(repoRoot, '.claude')
mkdirSync(claudeDir, { recursive: true })
...
writeFileSync(join(claudeDir, 'handoff.md'), handoffContent)
\`\`\`

handoff.test.ts mocked \`repo-scanner\`, \`session-state\`, and \`session-log\`
but not \`node:fs\`. Every successful handoff test was therefore writing a
real file to vitest's cwd (\`packages/crane-mcp/.claude/handoff.md\`).

## How it was discovered

A "Draft Crane" handoff appeared in the working tree on a day when nobody
had touched the dc venture. The fixture data ("Cross-venture work on Draft
Crane", session id \`sess_cross\`) didn't match any real session, and the
mtime matched a recent \`npm run verify\` run.

The polluting test was \`creates handoff with venture override, bypassing
repo mismatch\` (handoff.test.ts:324) — it exercises the cross-venture
override path with a fake dc venture and writes the resulting handoff
through the unmocked \`writeFileSync\`.

## Fix

Add a single \`vi.mock('node:fs', ...)\` declaration with no-op stubs for
\`writeFileSync\` and \`mkdirSync\` near the existing module mocks. The
handoff tests don't assert on dual-write behavior, so stubbing both
functions to no-ops is sufficient.

## Verification

- [x] \`npx vitest run src/tools/handoff.test.ts\` — all 13 tests pass
- [x] \`npm run verify\` — all 284 tests pass, typecheck/format/lint clean
- [x] \`ls packages/crane-mcp/.claude\` after verify — directory does not exist

## Related issues

This is one of three issues identified with the handoff dual-write code
path. The remaining two are tracked as follow-ups:

- **\`executeHandoff\` uses cwd-relative paths** — \`process.cwd()\` is the
  wrong way to resolve the repo root. The dual-write should use the git
  root from \`getCurrentRepoInfo()\` (or similar) so it doesn't write to
  the wrong place when the agent's cwd is a subdirectory.
- **The dual-write is silent and unconditional** — there's no logging,
  no opt-out, and no contract documenting where the file lands or who
  reads it. Worth a design review.