### PR TITLE
fix: resolve git root via rev-parse instead of cwd in handoff dual-write

### DIFF
--- a/packages/crane-mcp/src/lib/repo-scanner.test.ts
+++ b/packages/crane-mcp/src/lib/repo-scanner.test.ts
@@ -181,6 +181,43 @@ describe('repo-scanner', () => {
     })
   })
 
+  describe('getCurrentRepoRoot', () => {
+    it('returns the git root path when inside a git repo', async () => {
+      const { getCurrentRepoRoot } = await getModule()
+
+      vi.mocked(execSync).mockImplementation((cmd) => {
+        const cmdStr = String(cmd)
+        if (cmdStr.includes('rev-parse --show-toplevel')) {
+          return '/Users/testuser/dev/crane-console\n'
+        }
+        return ''
+      })
+
+      const root = getCurrentRepoRoot()
+      expect(root).toBe('/Users/testuser/dev/crane-console')
+    })
+
+    it('returns null when not inside a git repo', async () => {
+      const { getCurrentRepoRoot } = await getModule()
+
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('fatal: not a git repository')
+      })
+
+      const root = getCurrentRepoRoot()
+      expect(root).toBeNull()
+    })
+
+    it('trims trailing whitespace from git output', async () => {
+      const { getCurrentRepoRoot } = await getModule()
+
+      vi.mocked(execSync).mockImplementation(() => '/Users/testuser/dev/repo  \n  ')
+
+      const root = getCurrentRepoRoot()
+      expect(root).toBe('/Users/testuser/dev/repo')
+    })
+  })
+
   describe('findVentureByRepo', () => {
     it('matches org and repo to venture (case insensitive org)', async () => {
       const { findVentureByRepo } = await getModule()

--- a/packages/crane-mcp/src/lib/repo-scanner.ts
+++ b/packages/crane-mcp/src/lib/repo-scanner.ts
@@ -82,6 +82,27 @@ export function scanLocalRepos(): LocalRepo[] {
 }
 
 /**
+ * Get the absolute path of the current directory's git root.
+ *
+ * Wraps `git rev-parse --show-toplevel`. Returns null if cwd is not inside
+ * a git repository.
+ *
+ * Use this when you need the *filesystem path* of the repo root (e.g., to
+ * write a file at the top of the working tree). Do not use process.cwd() —
+ * the agent's working directory may be a subdirectory of the repo, and
+ * vitest's cwd is the package directory, not the repo root.
+ */
+export function getCurrentRepoRoot(): string | null {
+  try {
+    return execSync('git rev-parse --show-toplevel 2>/dev/null', {
+      encoding: 'utf-8',
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+/**
  * Get current directory's git info
  */
 export function getCurrentRepoInfo(): { org: string; repo: string; branch: string } | null {

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { writeFileSync, mkdirSync } from 'node:fs'
 import { mockVentures } from '../__fixtures__/api-responses.js'
 import { mockRepoInfo } from '../__fixtures__/repo-fixtures.js'
 
@@ -11,10 +12,10 @@ vi.mock('../lib/session-state.js')
 vi.mock('../lib/session-log.js')
 
 // Mock node:fs to prevent the dual-write in executeHandoff() from creating
-// real files in the test working directory. Without this, every test that
-// successfully creates a handoff writes a real `.claude/handoff.md` to
-// vitest's cwd (`packages/crane-mcp/`) and pollutes the working tree with
-// fixture data on every `npm run verify`.
+// real files in the test working directory. Defense in depth — even with
+// the auto-mock of repo-scanner returning undefined for getCurrentRepoRoot,
+// stubbing fs ensures that any test which explicitly sets a repo root
+// can't accidentally hit the real filesystem.
 vi.mock('node:fs', () => ({
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
@@ -433,5 +434,80 @@ describe('handoff tool', () => {
 
     expect(result.success).toBe(false)
     expect(result.message).toContain('Unknown org')
+  })
+
+  describe('dual-write', () => {
+    it('writes the cache to <repo-root>/.claude/handoff.md, not cwd', async () => {
+      const { executeHandoff } = await getModule()
+      const { getCurrentRepoInfo, getCurrentRepoRoot, findVentureByRepo } =
+        await import('../lib/repo-scanner.js')
+      const { getSessionContext } = await import('../lib/session-state.js')
+
+      vi.mocked(getSessionContext).mockReturnValue({
+        sessionId: 'sess_dualwrite',
+        venture: 'vc',
+        repo: 'venturecrane/crane-console',
+      })
+      vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+      vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+      // Critical: simulate the agent running from a subdirectory of the repo.
+      // The dual-write must use the resolved git root, not cwd.
+      vi.mocked(getCurrentRepoRoot).mockReturnValue('/Users/test/dev/crane-console')
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ventures: mockVentures }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        })
+
+      await executeHandoff({ summary: 'test', status: 'done' })
+
+      expect(mkdirSync).toHaveBeenCalledWith('/Users/test/dev/crane-console/.claude', {
+        recursive: true,
+      })
+      expect(writeFileSync).toHaveBeenCalledWith(
+        '/Users/test/dev/crane-console/.claude/handoff.md',
+        expect.stringContaining('# Handoff')
+      )
+    })
+
+    it('skips dual-write gracefully when git root cannot be resolved', async () => {
+      const { executeHandoff } = await getModule()
+      const { getCurrentRepoInfo, getCurrentRepoRoot, findVentureByRepo } =
+        await import('../lib/repo-scanner.js')
+      const { getSessionContext } = await import('../lib/session-state.js')
+
+      vi.mocked(getSessionContext).mockReturnValue({
+        sessionId: 'sess_no_root',
+        venture: 'vc',
+        repo: 'venturecrane/crane-console',
+      })
+      vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+      vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+      // git rev-parse --show-toplevel fails (e.g., not in a git repo at all)
+      vi.mocked(getCurrentRepoRoot).mockReturnValue(null)
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ ventures: mockVentures }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        })
+
+      const result = await executeHandoff({ summary: 'test', status: 'done' })
+
+      // The D1 write should still succeed; the dual-write is best-effort.
+      expect(result.success).toBe(true)
+      // Dual-write must be skipped — no fs calls should fire.
+      expect(mkdirSync).not.toHaveBeenCalled()
+      expect(writeFileSync).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path'
 import { z } from 'zod'
 import { CraneApi } from '../lib/crane-api.js'
 import { getApiBase } from '../lib/config.js'
-import { getCurrentRepoInfo, findVentureByRepo } from '../lib/repo-scanner.js'
+import { getCurrentRepoInfo, getCurrentRepoRoot, findVentureByRepo } from '../lib/repo-scanner.js'
 import { getSessionContext } from '../lib/session-state.js'
 import { getLastActivityTimestamp } from '../lib/session-log.js'
 
@@ -127,8 +127,18 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
 
     // Dual-write: also write .claude/handoff.md as a disposable cache for CC's native /resume.
     // D1 is the authoritative source. This file is gitignored and overwritten on every handoff.
+    //
+    // Resolve the repo root via `git rev-parse --show-toplevel` rather than
+    // process.cwd(). The agent's cwd may be a subdirectory of the repo
+    // (e.g., packages/crane-mcp/) and vitest's cwd is the package dir, not
+    // the repo root. Using cwd would write the cache to the wrong place and
+    // pollute test runs. Skip the dual-write entirely if we can't find the
+    // git root — the D1 write already succeeded and the cache is best-effort.
     try {
-      const repoRoot = process.cwd()
+      const repoRoot = getCurrentRepoRoot()
+      if (!repoRoot) {
+        throw new Error('Not inside a git repository — skipping dual-write')
+      }
       const claudeDir = join(repoRoot, '.claude')
       mkdirSync(claudeDir, { recursive: true })
       const handoffContent =


### PR DESCRIPTION
> **Stacked PR.** This is the second of three fixes to the handoff dual-write
> code path. It is based on \`fix/handoff-test-fs-pollution\` (#420), so the
> diff and CI here will only show this PR's incremental changes once #420
> is merged. Merge order: #420 → this PR → (TBD).

## Summary

The handoff tool's dual-write was using \`process.cwd()\` to resolve the
\`.claude/handoff.md\` destination. This is wrong in two situations:

1. **Subdirectory invocation** — agents often invoke tools from a subdir
   of the repo (e.g., \`packages/crane-mcp/\`). cwd then points at the subdir
   and the dual-write lands at \`<subdir>/.claude/handoff.md\` instead of the
   repo root, where Claude Code's \`/resume\` cannot find it.
2. **Test runs** — vitest's cwd is the package directory, not the repo root.
   Every successful handoff test was writing fixture data to
   \`packages/crane-mcp/.claude/handoff.md\` until #420 mocked \`fs\`.

## Fix

Add a small \`getCurrentRepoRoot()\` helper to \`repo-scanner.ts\` that wraps
\`git rev-parse --show-toplevel\`. \`executeHandoff()\` now resolves the
dual-write destination via this helper, and skips the dual-write
gracefully if the call fails (e.g., not inside a git repo at all). The
D1 write still succeeds independently.

## Why a separate helper?

Adding a \`path\` field to the existing \`getCurrentRepoInfo()\` would have:

- Required updates to \`mockRepoInfo\` and the \`expect(info).toEqual(...)\`
  assertion in \`repo-scanner.test.ts\`
- Forced ~14 callers (preflight, sos, status, context, etc.) to pay an
  extra \`git rev-parse\` execSync cost they don't need

A dedicated helper has minimal blast radius and is opt-in for the single
consumer that actually needs the filesystem path.

## Tests

- 3 new unit tests for \`getCurrentRepoRoot\` (success, null, whitespace trim)
- 2 new integration tests for the dual-write:
  - asserts \`writeFileSync\` is called with \`<resolved-root>/.claude/handoff.md\`,
    not the cwd path
  - asserts the dual-write is skipped when \`getCurrentRepoRoot()\` returns null,
    and that the D1 write still succeeds

All 289 tests pass; \`npm run verify\` clean.

## Out of scope

The third issue identified in the dual-write design review — the silent,
unconditional dual-write contract — is tracked as a separate follow-up.
This PR only fixes the path resolution.