### PR TITLE
fix: remove dead handoff dual-write to .claude/handoff.md

### DIFF
--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -3,8 +3,6 @@
  */
 
 import { hostname } from 'node:os'
-import { writeFileSync, mkdirSync } from 'node:fs'
-import { join } from 'node:path'
 import { z } from 'zod'
 import { CraneApi } from '../lib/crane-api.js'
 import { getApiBase } from '../lib/config.js'
@@ -124,26 +122,6 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
       issue_number: input.issue_number,
       last_activity_at: lastActivityAt,
     })
-
-    // Dual-write: also write .claude/handoff.md as a disposable cache for CC's native /resume.
-    // D1 is the authoritative source. This file is gitignored and overwritten on every handoff.
-    try {
-      const repoRoot = process.cwd()
-      const claudeDir = join(repoRoot, '.claude')
-      mkdirSync(claudeDir, { recursive: true })
-      const handoffContent =
-        `# Handoff\n\n` +
-        `**Venture:** ${venture.name}\n` +
-        `**Status:** ${input.status}\n` +
-        `**Session:** ${session.sessionId}\n` +
-        `**Agent:** ${getAgentName()}\n` +
-        `**Date:** ${new Date().toISOString()}\n` +
-        (input.issue_number ? `**Issue:** #${input.issue_number}\n` : '') +
-        `\n## Summary\n\n${input.summary}\n`
-      writeFileSync(join(claudeDir, 'handoff.md'), handoffContent)
-    } catch {
-      // Dual-write is best-effort. D1 write already succeeded.
-    }
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

The handoff tool's "dual-write" code path wrote \`<repo-root>/.claude/handoff.md\`
on every handoff, with a comment claiming it was "a disposable cache for
CC's native /resume." A repo-wide audit revealed this is **dead code**:

- **No reader exists.** Nothing in this codebase reads \`.claude/handoff.md\`.
  The only references are the writer (handoff.ts), the test of the writer,
  \`.gitignore\` (excluding it from VCS), and the /ship skill across
  \`.claude\` / \`.gemini\` / \`.agents\` (excluding it from staging).

- **The /resume claim doesn't hold up.** Claude Code's \`/resume\` reads from
  \`~/.claude/projects/<project-hash>/sessions/\`, not from \`.claude/handoff.md\`
  in the repo. The dual-write may have been written under an old assumption,
  but no current Claude Code version reads it.

- **D1 is the authoritative source.** \`crane_sos\` already pulls recent
  handoffs from D1 via \`api.queryHandoffs()\` to render the Resume block.
  The local file added nothing.

The /ship workflow's explicit exclusion of this file across three skill
files is itself evidence that it had been a known nuisance.

## How this was discovered

A phantom "Draft Crane" handoff appeared in the working tree on a day when
nobody had touched the dc venture. Root-cause analysis revealed it was
test fixture pollution from \`handoff.test.ts\` writing through an unmocked
\`writeFileSync\`. That investigation led to a deeper question: who actually
reads this file at all? Answer: nobody.

## Fix

Delete the dual-write block (~17 lines) and the now-unused \`node:fs\` and
\`node:path\` imports. No test or behavior changes — \`handoff.test.ts\` didn't
assert on the dual-write at all, and 284 tests pass unchanged.

\`\`\`
1 file changed, 22 deletions(-)
\`\`\`

## Notes

- \`.claude/handoff.md\` remains in \`.gitignore\` and the /ship exclusion lists
  as defensive entries. They cost nothing and protect against any stale
  files left over on developer machines from before this change.
- Stale \`.claude/handoff.md\` files on developer machines will simply sit
  there, never updated, never read. They can be deleted manually as part
  of routine cleanup.

## Supersedes

This PR makes two earlier in-flight PRs unnecessary:

- **#420** (mock node:fs in handoff.test.ts) — no longer needed since
  handoff.ts no longer touches the filesystem
- **#421** (resolve git root via rev-parse) — no longer needed since the
  dual-write is gone, so cwd-vs-rev-parse is moot

Both PRs should be closed once this lands.

## Test plan

- [x] \`npm run verify\` — typecheck, format, lint, test, build all clean
- [x] 284 tests pass (same baseline as main, confirming no test was
      asserting on the dual-write)
- [x] \`grep -rn writeFileSync.*handoff\` confirms no remaining writers
      outside the build output (\`dist/\`)