### PR TITLE
chore: move ss venture from smdservices to venturecrane org

### DIFF
--- a/config/ventures.json
+++ b/config/ventures.json
@@ -101,16 +101,16 @@
     {
       "code": "ss",
       "name": "SMD Services",
-      "org": "smdservices",
+      "org": "venturecrane",
       "repos": ["ss-console"],
-      "capabilities": [],
+      "capabilities": ["has_api", "has_database"],
       "stitchProjectId": null,
       "portfolio": {
         "status": "building",
         "bvmStage": "PROTOTYPE",
         "tagline": "Operations consulting for Phoenix-area small businesses",
         "description": "SMD Services helps 5-50 employee businesses fix the operational chaos that keeps owners working until 9pm. Fixed-price engagements covering process documentation, lead management, financial visibility, and workflow automation.",
-        "techStack": [],
+        "techStack": ["Astro", "Cloudflare Pages", "D1"],
         "url": null,
         "showInPortfolio": false
       }

--- a/docs/process/new-venture-setup-checklist.md
+++ b/docs/process/new-venture-setup-checklist.md
@@ -657,7 +657,7 @@ ls ~/dev/{product}-console/.infisical.json && echo "PASS: local clone with .infi
 | Durgan Field Guide | `dfg` | durganfieldguide | dfg-console   |
 | Kid Expenses       | `ke`  | kidexpenses      | ke-console    |
 | SMD Ventures       | `smd` | smd-ventures     | smd-console   |
-| SMD Services       | `ss`  | smdservices      | ss-console    |
+| SMD Services       | `ss`  | venturecrane     | ss-console    |
 | Draft Crane        | `dc`  | draftcrane       | dc-console    |
 
 ---

--- a/packages/crane-mcp/src/cli/launch.test.ts
+++ b/packages/crane-mcp/src/cli/launch.test.ts
@@ -480,7 +480,7 @@ describe('launchAgent', () => {
     const venture = {
       code: 'ss',
       name: 'SMD Services',
-      org: 'smdservices',
+      org: 'venturecrane',
       repos: ['ss-console'],
       localPath: '/fake/ss-console',
     }

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -128,12 +128,12 @@ else
         *venturecrane/dc-console*|*dc-console*)
           SCOPE="dc"
           ;;
-        *smdservices/ss-console*|*ss-console*)
+        *venturecrane/ss-console*|*ss-console*)
           SCOPE="ss"
           ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc}-console, smdservices/ss-console"
+          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc,ss}-console"
           exit 1
           ;;
       esac


### PR DESCRIPTION
## Summary

Transferred \`ss-console\` from the \`smdservices\` GitHub org to \`venturecrane\` via GitHub repo transfer. SS was the only venture sitting outside the venturecrane umbrella, which created friction for any cross-repo or shared-package operation (e.g. installing \`@venturecrane/crane-test-harness\` from GitHub Packages required special PAT setup that no other venture needed).

The transfer is complete on the GitHub side. This PR updates the crane-console references that pointed at the old location.

## Why

While shipping the SS-side harness adoption PR (venturecrane/ss-console#182), the cross-org \`npm ci\` failed because the smdservices repo's \`GITHUB_TOKEN\` couldn't read packages from the venturecrane org. There were three paths to fix:

1. Change the harness package visibility to public — blocked by org admin policy on venturecrane.
2. Link ss-console as a permitted repo — only available within the same org as the package.
3. Generate a fine-grained PAT with cross-org \`read:packages\`, store as a secret, update workflows.

All three were workarounds for the underlying problem: SS being in a separate org for no clear reason. Captain decision: fix the root cause. Move SS into venturecrane, and every shared-package / cross-repo operation works for SS the same way it does for every other venture.

## What's NOT in this PR

- \`workers/crane-watch/wrangler.toml\` \`GH_INSTALLATIONS_JSON\` still references the smdservices installation (#118744407). The GitHub App is still installed on that org and removing the entry would break webhook handling if anything fires from there. Decommissioning the smdservices org / installation is a separate cleanup task.
- \`MEMORY.md\` installation IDs reference list — same reason.
- \`docs/process/new-venture-setup-checklist.md\` has stale rows for OTHER ventures (sc → siliconcrane, dfg → durganfieldguide, ke → kidexpenses) that document old per-venture orgs. Those are stale documentation, separate doc cleanup.

## Test plan

- [x] \`npm run typecheck\` clean across all packages
- [x] crane-mcp tests pass (296 tests including the updated \`launch.test.ts\` fixture)
- [ ] CI green on this branch

## Related

- venturecrane/ss-console#182 — SS-side harness adoption PR (transferred from smdservices/ss-console#182). Blocked on this PR landing so package linking and CI auth pick up the new org.
- venturecrane/crane-console#433 — harness package itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)