### PR TITLE
release: bump @venturecrane/crane-test-harness to 0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5184,7 +5184,7 @@
     },
     "packages/crane-test-harness": {
       "name": "@venturecrane/crane-test-harness",
-      "version": "0.1.0-rc.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241230.0",

--- a/packages/crane-test-harness/package.json
+++ b/packages/crane-test-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/crane-test-harness",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0",
   "description": "In-process HTTP test harness for Cloudflare Workers + D1 ventures",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps the harness package version from \`0.1.0-rc.1\` to \`0.1.0\` (final release). The rc.1 prerelease has been validated by both day-one adopters:

- **crane-context** (in-monorepo, via #433) — 209 unit + harness tests + 2 Miniflare canary tests, all green
- **ss-console** (cross-repo, via venturecrane/ss-console#182) — 6 new cross-org regression tests passing against the rc, plus 875 existing source-grep tests unaffected

Tagging this commit as \`crane-test-harness-v0.1.0\` will trigger the publish workflow to publish the final 0.1.0 to GitHub Packages with the 'latest' dist-tag.

## Test plan

- [x] \`npm install\` clean after version bump
- [x] \`npm run build -w @venturecrane/crane-test-harness\` clean
- [ ] CI green
- [ ] Tag pushed → publish workflow runs → 0.1.0 visible on GH Packages
- [ ] SS PR bumps to ^0.1.0 and merges

## Related

- venturecrane/crane-console#433 — harness package + first in-monorepo adopter (merged)
- venturecrane/crane-console#434 — SS org transfer (merged)
- venturecrane/ss-console#182 — SS-side adoption PR, blocked on this release publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)