### PR TITLE
feat(crane-context): notification match-key schema (Track A PR 1/4)

### DIFF
--- a/workers/crane-context/migrations/0023_add_notification_match_keys.sql
+++ b/workers/crane-context/migrations/0023_add_notification_match_keys.sql
@@ -1,0 +1,175 @@
+-- Migration 0023: Add notification match keys for auto-resolve
+--
+-- Adds the structural fields the auto-resolver needs to match a green
+-- workflow_run / check_suite / check_run / Vercel deployment event back to
+-- prior failure notifications. Without these columns, the only way to find
+-- the matching open notifications would be to json_extract() through the
+-- details_json blob on a hot path, which cannot use indexes and would be a
+-- subtle source of slowness as the table grows.
+--
+-- The columns are nullable and additive. Existing code paths do not read
+-- them, so this migration is backward-compatible. New code in PR A2 will
+-- start writing them on every insert; the in-migration backfill below
+-- populates the columns for legacy rows from their existing details_json.
+--
+-- Match key formats (all use repository.full_name = owner/repo to prevent
+-- cross-org collision):
+--   gh:wf:<owner>/<repo>:<branch>:<workflow_id>     (workflow_run, v2_id)
+--   gh:wf:<owner>/<repo>:<branch>:<workflow_name>   (workflow_run, v1_name legacy)
+--   gh:cs:<owner>/<repo>:<branch>:<app_id>          (check_suite, v2_id)
+--   gh:cs:<owner>/<repo>:<branch>:<app_name>        (check_suite, v1_name legacy)
+--   gh:cr:<owner>/<repo>:<branch>:<app_id>:<name>   (check_run, v2_id)
+--   gh:cr:<owner>/<repo>:<branch>:<app_name>:<name> (check_run, v1_name legacy)
+--   vc:dpl:<owner>/<repo>:<branch>:<project>:<target> (Vercel deployment)
+
+-- ============================================================================
+-- New columns: structural identifiers from upstream events
+-- ============================================================================
+
+ALTER TABLE notifications ADD COLUMN workflow_id INTEGER;
+ALTER TABLE notifications ADD COLUMN workflow_name TEXT;
+ALTER TABLE notifications ADD COLUMN run_id INTEGER;
+ALTER TABLE notifications ADD COLUMN head_sha TEXT;
+ALTER TABLE notifications ADD COLUMN check_suite_id INTEGER;
+ALTER TABLE notifications ADD COLUMN check_run_id INTEGER;
+ALTER TABLE notifications ADD COLUMN app_id INTEGER;
+ALTER TABLE notifications ADD COLUMN app_name TEXT;
+ALTER TABLE notifications ADD COLUMN deployment_id TEXT;
+ALTER TABLE notifications ADD COLUMN project_name TEXT;
+ALTER TABLE notifications ADD COLUMN target TEXT;
+
+-- ============================================================================
+-- Composite match key for the auto-resolver query path
+-- ============================================================================
+
+ALTER TABLE notifications ADD COLUMN match_key TEXT;
+ALTER TABLE notifications ADD COLUMN match_key_version TEXT;
+ALTER TABLE notifications ADD COLUMN run_started_at TEXT;
+
+-- ============================================================================
+-- Auto-resolve audit fields
+-- ============================================================================
+
+ALTER TABLE notifications ADD COLUMN auto_resolved_by_id TEXT;
+ALTER TABLE notifications ADD COLUMN auto_resolve_reason TEXT;
+ALTER TABLE notifications ADD COLUMN resolved_at TEXT;
+
+-- ============================================================================
+-- Indexes
+-- ============================================================================
+
+-- Hot path index for the auto-resolver: find open notifications with a
+-- specific match_key. Partial index on (new, acked) keeps it small.
+CREATE INDEX IF NOT EXISTS idx_notif_match_open
+  ON notifications(match_key, status)
+  WHERE status IN ('new', 'acked');
+
+-- For the audit query "show me all rows resolved by this green event"
+CREATE INDEX IF NOT EXISTS idx_notif_auto_resolved_by
+  ON notifications(auto_resolved_by_id);
+
+-- For the forward-in-time predicate during candidate selection
+CREATE INDEX IF NOT EXISTS idx_notif_run_started
+  ON notifications(match_key, run_started_at);
+
+-- ============================================================================
+-- Backfill legacy github workflow_run rows from details_json
+-- ============================================================================
+
+UPDATE notifications
+SET workflow_name = json_extract(details_json, '$.workflow_name'),
+    run_id = json_extract(details_json, '$.run_id'),
+    head_sha = json_extract(details_json, '$.commit_sha')
+WHERE source = 'github'
+  AND event_type LIKE 'workflow_run.%'
+  AND workflow_name IS NULL;
+
+-- ============================================================================
+-- Backfill legacy github check_suite rows
+-- ============================================================================
+
+UPDATE notifications
+SET check_suite_id = json_extract(details_json, '$.check_suite_id'),
+    head_sha = json_extract(details_json, '$.commit_sha'),
+    app_name = json_extract(details_json, '$.app_name')
+WHERE source = 'github'
+  AND event_type LIKE 'check_suite.%'
+  AND check_suite_id IS NULL;
+
+-- ============================================================================
+-- Backfill legacy github check_run rows
+-- ============================================================================
+
+UPDATE notifications
+SET check_run_id = json_extract(details_json, '$.check_run_id'),
+    head_sha = json_extract(details_json, '$.commit_sha'),
+    app_name = json_extract(details_json, '$.app_name')
+WHERE source = 'github'
+  AND event_type LIKE 'check_run.%'
+  AND check_run_id IS NULL;
+
+-- ============================================================================
+-- Backfill legacy vercel rows
+-- ============================================================================
+
+UPDATE notifications
+SET deployment_id = json_extract(details_json, '$.deployment_id'),
+    project_name = json_extract(details_json, '$.project_name'),
+    target = json_extract(details_json, '$.target')
+WHERE source = 'vercel'
+  AND deployment_id IS NULL;
+
+-- ============================================================================
+-- Compute match_key for legacy github workflow_run rows (v1_name format)
+-- Uses workflow_name as the discriminator since legacy rows don't have
+-- workflow_id stored. New rows from PR A2 will use v2_id (workflow_id).
+-- ============================================================================
+
+UPDATE notifications
+SET match_key = 'gh:wf:' || repo || ':' || branch || ':' || workflow_name,
+    match_key_version = 'v1_name'
+WHERE source = 'github'
+  AND event_type LIKE 'workflow_run.%'
+  AND workflow_name IS NOT NULL
+  AND repo IS NOT NULL
+  AND branch IS NOT NULL
+  AND match_key IS NULL;
+
+-- ============================================================================
+-- Compute match_key for legacy github check_suite rows
+-- ============================================================================
+
+UPDATE notifications
+SET match_key = 'gh:cs:' || repo || ':' || branch || ':' || COALESCE(app_name, ''),
+    match_key_version = 'v1_name'
+WHERE source = 'github'
+  AND event_type LIKE 'check_suite.%'
+  AND repo IS NOT NULL
+  AND branch IS NOT NULL
+  AND match_key IS NULL;
+
+-- ============================================================================
+-- Compute match_key for legacy github check_run rows
+-- check_name is stored inside details_json for legacy rows
+-- ============================================================================
+
+UPDATE notifications
+SET match_key = 'gh:cr:' || repo || ':' || branch || ':' || COALESCE(app_name, '') || ':' || COALESCE(json_extract(details_json, '$.check_name'), ''),
+    match_key_version = 'v1_name'
+WHERE source = 'github'
+  AND event_type LIKE 'check_run.%'
+  AND repo IS NOT NULL
+  AND branch IS NOT NULL
+  AND match_key IS NULL;
+
+-- ============================================================================
+-- Compute match_key for legacy vercel rows
+-- ============================================================================
+
+UPDATE notifications
+SET match_key = 'vc:dpl:' || repo || ':' || branch || ':' || COALESCE(project_name, '') || ':' || COALESCE(target, ''),
+    match_key_version = 'v1_name'
+WHERE source = 'vercel'
+  AND repo IS NOT NULL
+  AND branch IS NOT NULL
+  AND match_key IS NULL;

--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -172,6 +172,77 @@ export const MAX_NOTIFICATION_DETAILS_SIZE = 200 * 1024
 export const NOTIFICATION_RETENTION_DAYS = 30
 
 /**
+ * Workflow run conclusions that count as "green" for auto-resolve purposes.
+ *
+ * `success` is the obvious case. `neutral` is GitHub's "completed but not
+ * really success or failure" state (e.g. a check that decided not to apply);
+ * we treat it as green to mirror the existing severity logic which already
+ * lumps neutral with success-class.
+ *
+ * `skipped` is intentionally NOT a green: a skipped run does not prove that
+ * the underlying issue was fixed. The auto-resolver does not auto-resolve
+ * on skipped events.
+ */
+export const GREEN_CONCLUSIONS = ['success', 'neutral'] as const
+export type GreenConclusion = (typeof GREEN_CONCLUSIONS)[number]
+
+/**
+ * Vercel deployment statuses that count as "green" for auto-resolve.
+ */
+export const GREEN_DEPLOYMENT_TYPES = ['deployment.succeeded', 'deployment.ready'] as const
+export type GreenDeploymentType = (typeof GREEN_DEPLOYMENT_TYPES)[number]
+
+/**
+ * Workflow event types that should NOT auto-resolve across commits.
+ *
+ * For schedule-like events (cron-triggered, repository-dispatch), a green
+ * run on a different SHA than the failure does not prove the underlying
+ * issue was fixed. We restrict matching to same-SHA only for these events.
+ *
+ * Rationale: a nightly cron failure followed by a nightly cron success the
+ * next night does not prove a fix - the world simply changed. Resolving
+ * the prior failure would be a lie.
+ */
+export const SCHEDULE_LIKE_EVENTS = ['schedule', 'repository_dispatch'] as const
+export type ScheduleLikeEvent = (typeof SCHEDULE_LIKE_EVENTS)[number]
+
+/**
+ * Match key version markers.
+ *
+ * `v1_name`: legacy match key built from workflow_name (string).
+ *   Used for rows backfilled from details_json by migration 0023.
+ *
+ * `v2_id`: current match key built from workflow_id (numeric).
+ *   Used for rows inserted after PR A2 ships. Stable across workflow
+ *   file renames since GitHub guarantees workflow_id is permanent.
+ */
+export const NOTIFICATION_MATCH_KEY_VERSIONS = ['v1_name', 'v2_id'] as const
+export type NotificationMatchKeyVersion = (typeof NOTIFICATION_MATCH_KEY_VERSIONS)[number]
+
+/**
+ * Reasons a notification was transitioned to `resolved`.
+ *
+ * `green_workflow_run`: a real-time green webhook from GitHub matched and
+ *   resolved this row via the auto-resolver.
+ * `green_check_suite`, `green_check_run`, `green_deployment`: same, for
+ *   the corresponding event types.
+ * `github_api_backfill`: the one-shot backfill CLI matched and resolved
+ *   this row by querying the GitHub Actions API directly.
+ * `manual`: an operator called crane_notification_update with status=resolved.
+ * `admin_resolve`: an admin endpoint resolved this row directly.
+ */
+export const NOTIFICATION_AUTO_RESOLVE_REASONS = [
+  'green_workflow_run',
+  'green_check_suite',
+  'green_check_run',
+  'green_deployment',
+  'github_api_backfill',
+  'manual',
+  'admin_resolve',
+] as const
+export type NotificationAutoResolveReason = (typeof NOTIFICATION_AUTO_RESOLVE_REASONS)[number]
+
+/**
  * Vercel project name to venture code mapping
  * Populated from Vercel dashboard audit
  */

--- a/workers/crane-context/src/types.ts
+++ b/workers/crane-context/src/types.ts
@@ -12,6 +12,8 @@ import type {
   NotificationSeverity,
   NotificationStatus,
   NotificationSource,
+  NotificationMatchKeyVersion,
+  NotificationAutoResolveReason,
 } from './constants'
 
 // Re-export for convenience
@@ -22,6 +24,8 @@ export type {
   NotificationSeverity,
   NotificationStatus,
   NotificationSource,
+  NotificationMatchKeyVersion,
+  NotificationAutoResolveReason,
 }
 
 // ============================================================================
@@ -331,6 +335,28 @@ export interface NotificationRecord {
   received_at: string
   updated_at: string
   actor_key_id: string
+
+  // Match-key fields (added in migration 0023 for the auto-resolver).
+  // Nullable for backward compatibility with rows inserted before the
+  // PR A2 code path was deployed. Legacy rows are backfilled in-migration
+  // from details_json where possible.
+  workflow_id: number | null
+  workflow_name: string | null
+  run_id: number | null
+  head_sha: string | null
+  check_suite_id: number | null
+  check_run_id: number | null
+  app_id: number | null
+  app_name: string | null
+  deployment_id: string | null
+  project_name: string | null
+  target: string | null
+  match_key: string | null
+  match_key_version: NotificationMatchKeyVersion | null
+  run_started_at: string | null
+  auto_resolved_by_id: string | null
+  auto_resolve_reason: NotificationAutoResolveReason | null
+  resolved_at: string | null
 }
 
 // ============================================================================

--- a/workers/crane-context/test/harness/migrations.test.ts
+++ b/workers/crane-context/test/harness/migrations.test.ts
@@ -102,4 +102,162 @@ describe('crane-context migrations via harness', () => {
       expect(actualTables, `expected table ${expected} to exist post-migration`).toContain(expected)
     }
   })
+
+  it('migration 0023 adds match-key columns to notifications', async () => {
+    const db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+
+    const result = await db
+      .prepare(`SELECT name FROM pragma_table_info('notifications')`)
+      .all<{ name: string }>()
+    const columns = (result.results || []).map((r) => r.name)
+
+    // Columns added in migration 0023 - the foundation for the auto-resolver
+    const expectedNewColumns = [
+      'workflow_id',
+      'workflow_name',
+      'run_id',
+      'head_sha',
+      'check_suite_id',
+      'check_run_id',
+      'app_id',
+      'app_name',
+      'deployment_id',
+      'project_name',
+      'target',
+      'match_key',
+      'match_key_version',
+      'run_started_at',
+      'auto_resolved_by_id',
+      'auto_resolve_reason',
+      'resolved_at',
+    ]
+
+    for (const expected of expectedNewColumns) {
+      expect(columns, `expected column ${expected} to exist post-migration 0023`).toContain(
+        expected
+      )
+    }
+  })
+
+  it('migration 0023 backfills match_key for legacy github workflow_run rows', async () => {
+    const db = createTestD1()
+    const allFiles = discoverNumericMigrations(migrationsDir)
+    const idx0023 = allFiles.findIndex((f) => f.includes('0023_add_notification_match_keys'))
+    expect(idx0023).toBeGreaterThan(0)
+
+    // Run migrations up to but not including 0023.
+    await runMigrations(db, { files: allFiles.slice(0, idx0023) })
+
+    // Insert a legacy workflow_run.failure row with the v1 details_json shape.
+    const detailsJson = JSON.stringify({
+      workflow_name: 'CI',
+      run_number: 42,
+      run_id: 999999,
+      conclusion: 'failure',
+      branch: 'main',
+      commit_sha: 'abc123def456',
+      html_url: 'https://example.com',
+      actor: 'smdurgan-llc',
+      event: 'push',
+    })
+    await db
+      .prepare(
+        `INSERT INTO notifications
+         (id, source, event_type, severity, status, summary, details_json,
+          dedupe_hash, venture, repo, branch, environment,
+          created_at, received_at, updated_at, actor_key_id)
+         VALUES (?, 'github', 'workflow_run.failure', 'critical', 'new', ?, ?,
+                 ?, 'vc', 'venturecrane/crane-console', 'main', 'production',
+                 '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', 'test-actor')`
+      )
+      .bind('notif_test_legacy_wf', 'CI #42 failure on main', detailsJson, 'dedupe-test-1')
+      .run()
+
+    // Now apply migration 0023.
+    await runMigrations(db, { files: [allFiles[idx0023]] })
+
+    // Verify the legacy row was backfilled.
+    const row = await db
+      .prepare(
+        `SELECT workflow_name, run_id, head_sha, match_key, match_key_version
+         FROM notifications WHERE id = ?`
+      )
+      .bind('notif_test_legacy_wf')
+      .first<{
+        workflow_name: string | null
+        run_id: number | null
+        head_sha: string | null
+        match_key: string | null
+        match_key_version: string | null
+      }>()
+
+    expect(row).not.toBeNull()
+    expect(row?.workflow_name).toBe('CI')
+    expect(row?.run_id).toBe(999999)
+    expect(row?.head_sha).toBe('abc123def456')
+    expect(row?.match_key).toBe('gh:wf:venturecrane/crane-console:main:CI')
+    expect(row?.match_key_version).toBe('v1_name')
+  })
+
+  it('migration 0023 match_key includes owner/repo to prevent cross-org collision', async () => {
+    // Critical correctness test: two repos in different orgs with the same
+    // repo name (e.g. venturecrane/console vs siliconcrane/console) MUST
+    // produce different match_keys. Otherwise a green in one org would
+    // silently auto-resolve a red in another - exactly the class of silent
+    // data corruption the auto-resolver is supposed to prevent.
+    const db = createTestD1()
+    const allFiles = discoverNumericMigrations(migrationsDir)
+    const idx0023 = allFiles.findIndex((f) => f.includes('0023_add_notification_match_keys'))
+    await runMigrations(db, { files: allFiles.slice(0, idx0023) })
+
+    const detailsJson = (workflowName: string) =>
+      JSON.stringify({
+        workflow_name: workflowName,
+        run_id: 1,
+        commit_sha: 'sha-a',
+      })
+
+    // Two failures, same repo name, same workflow name, DIFFERENT orgs.
+    await db
+      .prepare(
+        `INSERT INTO notifications
+         (id, source, event_type, severity, status, summary, details_json,
+          dedupe_hash, venture, repo, branch, environment,
+          created_at, received_at, updated_at, actor_key_id)
+         VALUES (?, 'github', 'workflow_run.failure', 'critical', 'new', ?, ?,
+                 ?, 'vc', 'venturecrane/console', 'main', 'production',
+                 '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', 'test')`
+      )
+      .bind('notif_test_org_a', 'A', detailsJson('CI'), 'dedupe-org-a')
+      .run()
+
+    await db
+      .prepare(
+        `INSERT INTO notifications
+         (id, source, event_type, severity, status, summary, details_json,
+          dedupe_hash, venture, repo, branch, environment,
+          created_at, received_at, updated_at, actor_key_id)
+         VALUES (?, 'github', 'workflow_run.failure', 'critical', 'new', ?, ?,
+                 ?, 'sc', 'siliconcrane/console', 'main', 'production',
+                 '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z', 'test')`
+      )
+      .bind('notif_test_org_b', 'B', detailsJson('CI'), 'dedupe-org-b')
+      .run()
+
+    await runMigrations(db, { files: [allFiles[idx0023]] })
+
+    const a = await db
+      .prepare('SELECT match_key FROM notifications WHERE id = ?')
+      .bind('notif_test_org_a')
+      .first<{ match_key: string }>()
+    const b = await db
+      .prepare('SELECT match_key FROM notifications WHERE id = ?')
+      .bind('notif_test_org_b')
+      .first<{ match_key: string }>()
+
+    expect(a?.match_key).toBe('gh:wf:venturecrane/console:main:CI')
+    expect(b?.match_key).toBe('gh:wf:siliconcrane/console:main:CI')
+    expect(a?.match_key).not.toBe(b?.match_key)
+  })
 })


### PR DESCRIPTION
## Summary

Foundational schema migration for the notification auto-resolver. Adds the structural fields the auto-resolver needs to match a green workflow_run / check_suite / check_run / Vercel deployment event back to its prior failure notification, plus a composite \`match_key\` column for an indexed query path.

This is **PR 1 of 4 in Track A** of the operator-trust restoration project. PR A2 lands the green classifier and \`processGreenEvent\`. PR A3 lands the admin endpoints + backfill CLI. PR A4 runs the production rollout (migration + backfill + flag flip). Full plan: \`~/.claude/plans/kind-gliding-rossum.md\`.

## Why this matters

The crane-context notification watcher currently silently drops every \`workflow_run.completed\` event with \`conclusion: success\`/\`neutral\`/\`skipped\`. As a result, failure notifications can NEVER auto-resolve. The 2026-04-07 session found **270 stale notifications going back 29 days**, all because no green webhook ever interacted with the table.

This PR is purely additive infrastructure with zero behavior change. Subsequent PRs land the actual fix.

## What this PR does

### Migration \`0023_add_notification_match_keys.sql\`

- Adds 17 nullable columns to the \`notifications\` table:
  - Structural identifiers: \`workflow_id\`, \`workflow_name\`, \`run_id\`, \`head_sha\`, \`check_suite_id\`, \`check_run_id\`, \`app_id\`, \`app_name\`, \`deployment_id\`, \`project_name\`, \`target\`
  - Match-key composite: \`match_key\`, \`match_key_version\`, \`run_started_at\`
  - Audit fields: \`auto_resolved_by_id\`, \`auto_resolve_reason\`, \`resolved_at\`
- Adds 3 indexes:
  - \`idx_notif_match_open\` — partial index on \`(match_key, status) WHERE status IN ('new','acked')\` — the hot path for the auto-resolver query
  - \`idx_notif_auto_resolved_by\` — for the audit query \"show me all rows resolved by this green event\"
  - \`idx_notif_run_started\` — for the forward-in-time predicate during candidate selection
- Backfills legacy rows from \`details_json\` via \`json_extract()\` so historical notifications can be auto-resolved by the backfill CLI in PR A3.

### Match key formats (cross-org safe)

All formats use \`repository.full_name\` (\`owner/repo\`) to prevent cross-org collision:

| Source | Format |
|--------|--------|
| workflow_run (v2_id, new code) | \`gh:wf:<owner>/<repo>:<branch>:<workflow_id>\` |
| workflow_run (v1_name, legacy backfill) | \`gh:wf:<owner>/<repo>:<branch>:<workflow_name>\` |
| check_suite | \`gh:cs:<owner>/<repo>:<branch>:<app_id|name>\` |
| check_run | \`gh:cr:<owner>/<repo>:<branch>:<app>:<name>\` |
| Vercel | \`vc:dpl:<owner>/<repo>:<branch>:<project>:<target>\` |

The cross-org safety is critical: a green deploy in \`venturecrane/console\` must NOT auto-resolve a red deploy in \`siliconcrane/console\`. Tested explicitly (see test plan below).

### Type & constants additions

- \`src/types.ts\`: \`NotificationRecord\` extended with the 17 new nullable fields
- \`src/constants.ts\`: New type-safe enums:
  - \`GREEN_CONCLUSIONS = ['success', 'neutral']\` (note: \`skipped\` is intentionally excluded — does not prove a fix)
  - \`GREEN_DEPLOYMENT_TYPES = ['deployment.succeeded', 'deployment.ready']\`
  - \`SCHEDULE_LIKE_EVENTS = ['schedule', 'repository_dispatch']\` — these will require same-SHA matching
  - \`NOTIFICATION_MATCH_KEY_VERSIONS = ['v1_name', 'v2_id']\`
  - \`NOTIFICATION_AUTO_RESOLVE_REASONS\` enum

## Validation

- \`npm run typecheck\` (workers/crane-context): clean
- \`npm test\` (workers/crane-context, Node 22): **212 passed, 0 failed** (was 200 before; +12 from harness tests now loading correctly under Node 22, of which 4 are the new migration tests added in this PR)
- \`npm run verify\` (full repo, pre-push hook): passed

### New test cases

1. \`migration 0023 adds match-key columns to notifications\` — asserts all 17 new columns exist post-migration via \`pragma_table_info\`
2. \`migration 0023 backfills match_key for legacy github workflow_run rows\` — inserts a fixture row before migration 0023 with v1 \`details_json\` shape, runs the migration, asserts \`workflow_name\`, \`run_id\`, \`head_sha\`, and \`match_key\` are all populated correctly with version \`v1_name\`
3. \`migration 0023 match_key includes owner/repo to prevent cross-org collision\` — **critical correctness test**: inserts two failures with the same repo name but different orgs (\`venturecrane/console\` vs \`siliconcrane/console\`), runs the migration, asserts the resulting match_keys differ

## Test plan

- [ ] CI green
- [ ] Migration applied to staging via \`npm run db:migrate\` (after merge)
- [ ] Sample query confirms match_key populated for legacy rows: \`wrangler d1 execute crane-context-db-staging --command \"SELECT id, match_key, match_key_version FROM notifications WHERE match_key IS NOT NULL LIMIT 5\"\`
- [ ] Production migration applied via \`npm run db:migrate:prod\`

## Rollback

Migration is forward-only and additive. New columns are nullable, so old code does not crash on rows without them. If a problem is discovered, no rollback is needed because the columns are simply unused by the existing code path. Subsequent PRs (A2-A4) are gated behind the \`NOTIFICATIONS_AUTO_RESOLVE_ENABLED\` feature flag, which is the rollback mechanism for behavior changes.