### PR TITLE
fix(launcher): auto-accept Claude project trust dialog for venture repos

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -50,6 +50,7 @@ import { homedir } from 'os'
 import {
   setupGeminiMcp,
   setupClaudeMcp,
+  ensureClaudeProjectTrust,
   syncClaudeAssets,
   extractPassthroughArgs,
 } from './launch-lib.js'
@@ -365,6 +366,15 @@ describe('setupClaudeMcp', () => {
     },
   }
 
+  // ensureClaudeProjectTrust is exercised in its own describe block. For these
+  // tests we want to isolate the .mcp.json sync behavior, so we make
+  // ~/.claude.json appear "already trusted" — that path becomes a no-op write
+  // and won't pollute writeFileSync assertions.
+  const CLAUDE_CONFIG_PATH = join(homedir(), '.claude.json')
+  const TRUSTED_CLAUDE_CONFIG = JSON.stringify({
+    projects: { '/fake/repo': { hasTrustDialogAccepted: true } },
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -398,6 +408,7 @@ describe('setupClaudeMcp', () => {
 
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return TRUSTED_CLAUDE_CONFIG
       if (String(filePath).includes('ventures.json')) {
         return JSON.stringify({
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
@@ -427,6 +438,7 @@ describe('setupClaudeMcp', () => {
 
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return TRUSTED_CLAUDE_CONFIG
       if (String(filePath).includes('ventures.json')) {
         return JSON.stringify({
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
@@ -447,6 +459,7 @@ describe('setupClaudeMcp', () => {
   it('skips write when source and target already match', () => {
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return TRUSTED_CLAUDE_CONFIG
       if (String(filePath).includes('ventures.json')) {
         return JSON.stringify({
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
@@ -489,6 +502,7 @@ describe('setupClaudeMcp', () => {
 
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return TRUSTED_CLAUDE_CONFIG
       if (String(filePath).includes('ventures.json')) {
         return JSON.stringify({
           ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
@@ -502,6 +516,132 @@ describe('setupClaudeMcp', () => {
 
     // Source and target match on crane, custom preserved. No writes needed.
     expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('marks the project trusted via ensureClaudeProjectTrust', () => {
+    // ~/.claude.json starts WITHOUT the project entry. The .mcp.json side
+    // already matches source so the only expected write is the trust patch.
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return JSON.stringify({ projects: {} })
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      return JSON.stringify(SOURCE_CONFIG)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const [path, body] = vi.mocked(writeFileSync).mock.calls[0]
+    expect(path).toBe(CLAUDE_CONFIG_PATH)
+    const written = JSON.parse(body as string)
+    expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
+  })
+})
+
+describe('ensureClaudeProjectTrust', () => {
+  const CLAUDE_CONFIG_PATH = join(homedir(), '.claude.json')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips silently when ~/.claude.json does not exist', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) !== CLAUDE_CONFIG_PATH)
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('skips silently when ~/.claude.json is malformed', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) === CLAUDE_CONFIG_PATH)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return '{not valid json'
+      return '{}'
+    })
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('adds the project entry with hasTrustDialogAccepted when missing', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) === CLAUDE_CONFIG_PATH)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) {
+        return JSON.stringify({ projects: {} })
+      }
+      return '{}'
+    })
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
+  })
+
+  it('flips hasTrustDialogAccepted to true while preserving other project fields', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) === CLAUDE_CONFIG_PATH)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) {
+        return JSON.stringify({
+          projects: {
+            '/fake/repo': {
+              hasTrustDialogAccepted: false,
+              allowedTools: ['Bash'],
+              mcpContextUris: [],
+            },
+          },
+        })
+      }
+      return '{}'
+    })
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
+    expect(written.projects['/fake/repo'].allowedTools).toEqual(['Bash'])
+    expect(written.projects['/fake/repo'].mcpContextUris).toEqual([])
+  })
+
+  it('is a no-op when the project is already trusted', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) === CLAUDE_CONFIG_PATH)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) {
+        return JSON.stringify({
+          projects: { '/fake/repo': { hasTrustDialogAccepted: true } },
+        })
+      }
+      return '{}'
+    })
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('creates projects map when ~/.claude.json has no projects key', () => {
+    vi.mocked(existsSync).mockImplementation((p: string) => String(p) === CLAUDE_CONFIG_PATH)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) {
+        return JSON.stringify({ numStartups: 5 })
+      }
+      return '{}'
+    })
+
+    ensureClaudeProjectTrust('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.numStartups).toBe(5)
+    expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -615,7 +615,67 @@ export function checkMcpBinary(): void {
   }
 }
 
+/**
+ * Ensure the venture project is marked trusted in ~/.claude.json so Claude Code
+ * loads its project-scope .mcp.json automatically.
+ *
+ * Background: Claude Code only starts servers from a project's .mcp.json after
+ * the user accepts the project trust dialog (which sets `hasTrustDialogAccepted`
+ * on the project entry in ~/.claude.json). On a fresh venture clone on a fresh
+ * fleet machine, the dialog has never been accepted, so `crane-mcp` silently
+ * fails to start and the agent reports "no MCP tools available" with no clear
+ * cause. Crane-managed venture repos are trusted by definition — the user
+ * explicitly opted in by running `crane <venture>` — so we stamp the flag
+ * directly, the same way the launcher already auto-configures Gemini and Codex.
+ *
+ * Idempotent: only writes when the flag actually changes. Tolerates a missing
+ * or malformed ~/.claude.json (skips silently — claude's first interactive
+ * launch will create it).
+ */
+export function ensureClaudeProjectTrust(repoPath: string): void {
+  const claudeConfigPath = join(homedir(), '.claude.json')
+
+  if (!existsSync(claudeConfigPath)) {
+    // Claude has never been onboarded on this machine; nothing to patch.
+    // The first interactive `claude` launch will create the file and prompt.
+    return
+  }
+
+  let config: Record<string, unknown>
+  try {
+    config = JSON.parse(readFileSync(claudeConfigPath, 'utf-8'))
+  } catch {
+    // Malformed user config — refuse to clobber, fall back to interactive prompt.
+    console.warn('-> Warning: ~/.claude.json is malformed; skipping project trust patch')
+    return
+  }
+
+  if (!config.projects || typeof config.projects !== 'object') {
+    config.projects = {}
+  }
+  const projects = config.projects as Record<string, Record<string, unknown>>
+
+  const existing = projects[repoPath]
+  if (existing && existing.hasTrustDialogAccepted === true) {
+    return // already trusted, no-op
+  }
+
+  projects[repoPath] = {
+    ...(existing ?? {}),
+    hasTrustDialogAccepted: true,
+  }
+
+  writeFileSync(claudeConfigPath, JSON.stringify(config, null, 2) + '\n')
+  console.log(`-> Marked ${basename(repoPath)} as trusted in ~/.claude.json`)
+}
+
 export function setupClaudeMcp(repoPath: string): void {
+  // Pre-accept the project trust dialog so Claude Code loads .mcp.json on first run.
+  // Without this, project-scope MCP servers stay dormant until the user clicks
+  // through an interactive prompt — easy to miss, easy to dismiss, and the
+  // resulting "no crane MCP" failure is opaque.
+  ensureClaudeProjectTrust(repoPath)
+
   const mcpJson = join(repoPath, '.mcp.json')
   const source = join(CRANE_CONSOLE_ROOT, '.mcp.json')
 


### PR DESCRIPTION
## Summary
- Adds `ensureClaudeProjectTrust(repoPath)` to the crane launcher and calls it from `setupClaudeMcp`. The launcher already auto-configures Gemini and Codex MCP — Claude was the holdout, and the missing piece quietly broke MCP on every fresh venture clone on every fresh fleet machine.
- Without `hasTrustDialogAccepted: true` in `~/.claude.json`, Claude Code refuses to start any server listed in a project's `.mcp.json`, so `crane-mcp` never launches and the agent reports *"no MCP tools available"* with no surfaced cause.
- The new helper is idempotent, tolerates a missing or malformed `~/.claude.json`, and only writes when the flag actually changes — no surprise mutation of unrelated user state.

## Why this is safe
- Crane-managed venture repos are trusted by definition: the user opted in by running `crane <venture>`.
- The function only flips one boolean on one project entry. It preserves any other fields already on that entry (`allowedTools`, `mcpServers`, `mcpContextUris`, etc.).
- If `~/.claude.json` is missing, it skips silently — claude's first interactive launch will create it.
- If `~/.claude.json` is malformed, it warns and skips rather than clobbering.

## Repro (today, on mac23)
1. `crane ss` → claude launches in `~/dev/ss-console`
2. `/sos` → agent reports crane MCP unconnected
3. Inspect `~/.claude.json`: `projects['/Users/scottdurgan/dev/ss-console'].hasTrustDialogAccepted === false`
4. Same `.mcp.json`, same launcher, same `crane-mcp` binary on PATH — only the missing trust flag was blocking server startup.

After this PR, the next `crane ss` on mac23 stamps the flag and the MCP server starts on first launch.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run format` clean
- [x] `packages/crane-mcp` test suite: 35/35 pass (5 new `ensureClaudeProjectTrust` cases + 1 new `setupClaudeMcp` integration case)
- [x] Existing `setupClaudeMcp` tests updated to mock `~/.claude.json` so they continue to assert only `.mcp.json` sync behavior
- [x] Manual: pre-push `npm run verify` passes end-to-end on Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)