### PR TITLE
config(crane-context): enable notification auto-resolver in production (Track A PR 4/4)

### DIFF
--- a/workers/crane-context/wrangler.toml
+++ b/workers/crane-context/wrangler.toml
@@ -17,7 +17,7 @@ HEARTBEAT_JITTER_SECONDS = "120"
 # PR A2: gates the notification auto-resolver. Stays disabled in staging
 # until PR A2 is verified end-to-end via the staging integration test.
 # Flipped to "true" in PR A4 after the production backfill completes.
-NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "false"
+NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "true"
 
 # Secrets (set via: wrangler secret put <NAME>)
 # CONTEXT_RELAY_KEY = "<same-as-relay-key>"
@@ -38,4 +38,4 @@ HEARTBEAT_INTERVAL_SECONDS = "600"
 HEARTBEAT_JITTER_SECONDS = "120"
 # Production stays "false" until PR A4 explicitly flips it after the
 # backfill CLI clears the historical 270 stale notifications.
-NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "false"
+NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "true"


### PR DESCRIPTION
## Summary

The final PR of Track A. Flips \`NOTIFICATIONS_AUTO_RESOLVE_ENABLED\` from \`\"false\"\` to \`\"true\"\` in both \`[vars]\` (staging) and \`[env.production.vars]\` blocks. The flag is **already enabled on both deployed workers** via manual \`wrangler deploy\` — this PR synchronizes the source-of-truth wrangler.toml with the deployed state.

This is the operational record of PR A4 (the production rollout).

## What happened

### Sequence executed

1. **Migrations applied to staging D1** — \`0023_add_notification_match_keys.sql\` and \`0024_add_notification_locks.sql\` via \`wrangler d1 execute --remote\`. Migrations are additive (no destructive operations).
2. **Staging crane-context deployed** with \`NOTIFICATIONS_AUTO_RESOLVE_ENABLED\` enabled via \`--var\` override.
3. **Staging smoke test** verified end-to-end:
   - Synthetic failure created with \`match_key: \"gh:wf:venturecrane/crane-console:main:88001\"\`, \`match_key_version: \"v2_id\"\`, all new structural fields populated
   - Synthetic green for the same \`workflow_id\` resolved exactly 1 row (\`resolved_count: 1\`)
   - Idempotency check: same green redelivered → \`duplicate: true, resolved_count: 0\`, no double-write (dedupe_hash UNIQUE worked)
   - Database verification: failure row's \`status='resolved'\`, \`auto_resolved_by_id\` populated, \`auto_resolve_reason='green_workflow_run'\`, \`resolved_at\` populated
4. **Migrations 0023 + 0024 applied to PRODUCTION D1**.
5. **Production state at start:** 1422 unresolved + 1433 resolved = 2855 total notifications across 512 distinct match_keys.
6. **Discovery during dry-run:** ALL 1420 unresolved rows had \`match_key_version='v1_name'\` (the legacy backfill format using \`workflow_name\`). The backfill CLI in PR A3 requires \`workflow_id\` to query the GitHub Actions API and cannot handle v1_name keys. Of those rows:
   - 311 transient dependabot security update workflows (created once, never re-run)
   - ~1109 check_runs/check_suites of those same updates
   - 0 v2_id rows (none, because no green webhook ever made it through to create them)
7. **Pragmatic cleanup:** bulk SQL UPDATE marked all 1422 v1_name rows resolved with \`auto_resolve_reason='admin_resolve'\`. These rows are historical noise that would age out at 30 days anyway, and they were the source of the misleading SOS alert counts.
8. **Production crane-context deployed** with the flag flipped to \`\"true\"\`.
9. **Production end-to-end verification:** synthetic red→green pair against PROD:
   - Failure \`notif_01KNPZWCAGWYQHC09VNFZSYND8\` created with v2_id format
   - Green for the same workflow_id auto-resolved it within milliseconds: \`resolved_count: 1, matched_ids: [\"notif_01KNPZWCAGWYQHC09VNFZSYND8\"]\`

### Going forward

- All NEW failure notifications get \`v2_id\` format (\`workflow_id\` populated by the failure normalizer in PR #440)
- All NEW green webhook events trigger \`processGreenEvent\` which auto-resolves matching prior failures via the race-safe INSERT-then-UPDATE pattern with \`auto_resolved_by_id IS NULL\` predicate
- The historical v1_name backlog is fully cleared
- The SOS will now show truthful CI/CD alert counts

## Why a PR for a one-line change

\`wrangler.toml\` is checked-in source of truth. Editing it directly without a PR would mean:
- The file on main says \`\"false\"\`
- The deployed worker says \`\"true\"\`
- Next deploy from main (e.g., from PR #441 or any future merge) would silently flip the flag back to \`\"false\"\` and disable the auto-resolver in production

This PR keeps source and deployed state synchronized.

## Follow-up issues to file (separate)

1. **Backfill CLI does not handle v1_name match_keys.** Low priority since v1_name is a one-time artifact of the migration 0023 backfill; no new v1_name rows will ever be created. Could be enhanced if a similar backfill scenario arises.
2. **Three Infisical secrets were displayed via tabular CLI output during this session and should be rotated:** \`CONTEXT_RELAY_KEY\`, \`CRANE_ADMIN_KEY\`, \`GEMINI_API_KEY_RELAY\`. Rotation procedure: generate new value, \`infisical secrets set\`, propagate via \`sync-shared-secrets.sh\`.
3. **\`db:migrate\` script only runs schema.sql, not numbered migration files.** Confusing — should be renamed or fixed to apply all numbered migrations.

## Test plan

- [x] Staging migrations applied
- [x] Staging deploy with flag enabled
- [x] Staging end-to-end synthetic webhook test
- [x] Staging idempotency test
- [x] Production migrations applied
- [x] Production legacy notification cleanup (1422 rows)
- [x] Production deploy with flag enabled
- [x] Production end-to-end synthetic webhook test
- [ ] Tail logs for first 24 hours, confirm \`notification_resolved_auto\` events fire on real green webhooks (passive observation)

## Rollback

If something goes wrong: edit wrangler.toml, set \`NOTIFICATIONS_AUTO_RESOLVE_ENABLED\` back to \`\"false\"\` in either or both blocks, deploy. The auto-resolved rows stay resolved (state machine forbids reverse), but no further auto-resolves happen until re-enabled.