### PR TITLE
feat(truthful-display): branded type + counts endpoint (Track B PR 1/5)

### DIFF
--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -444,6 +444,34 @@ export interface UpdateNotificationStatusResponse {
   notification: Notification
 }
 
+// Plan §B.3: truthful counts endpoint
+export interface NotificationCountsParams {
+  status?: string
+  severity?: string
+  venture?: string
+  repo?: string
+  source?: string
+}
+
+export interface NotificationCountsResponse {
+  total: number
+  by_severity: {
+    critical: number
+    warning: number
+    info: number
+  }
+  by_status: {
+    new: number
+    acked: number
+    resolved: number
+  }
+  window: {
+    retention_days: number
+    filters: NotificationCountsParams
+  }
+  correlation_id?: string
+}
+
 // In-memory cache for session duration
 let venturesCache: Venture[] | null = null
 
@@ -940,6 +968,33 @@ export class CraneApi {
 
     const data = (await response.json()) as { entries: SessionHistoryEntry[] }
     return data.entries
+  }
+
+  /**
+   * Get TRUE notification counts (not paginated). Plan §B.3 - the missing
+   * endpoint that fixes the loudest defect (SOS displaying "10 unresolved"
+   * when DB has 270).
+   */
+  async getNotificationCounts(
+    params: NotificationCountsParams = {}
+  ): Promise<NotificationCountsResponse> {
+    const queryParts: string[] = []
+    if (params.status) queryParts.push(`status=${encodeURIComponent(params.status)}`)
+    if (params.severity) queryParts.push(`severity=${encodeURIComponent(params.severity)}`)
+    if (params.venture) queryParts.push(`venture=${encodeURIComponent(params.venture)}`)
+    if (params.repo) queryParts.push(`repo=${encodeURIComponent(params.repo)}`)
+    if (params.source) queryParts.push(`source=${encodeURIComponent(params.source)}`)
+    const qs = queryParts.length > 0 ? `?${queryParts.join('&')}` : ''
+
+    const response = await fetch(`${this.apiBase}/notifications/counts${qs}`, {
+      headers: { 'X-Relay-Key': this.apiKey },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Notification counts API error: ${response.status}`)
+    }
+
+    return (await response.json()) as NotificationCountsResponse
   }
 
   async listNotifications(

--- a/packages/crane-mcp/src/lib/truthful-display.test.ts
+++ b/packages/crane-mcp/src/lib/truthful-display.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for truthful-display
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  truncate,
+  exact,
+  unknownTotal,
+  formatTruthfulCount,
+  formatHeaderCount,
+  type Truncated,
+} from './truthful-display'
+
+describe('truncate', () => {
+  it('wraps items with the true total', () => {
+    const result = truncate([1, 2, 3], 100)
+    expect(result.shown).toEqual([1, 2, 3])
+    expect(result.total).toBe(100)
+    expect(result.more).toBe(97)
+  })
+
+  it('reports more = 0 when total equals items length', () => {
+    const result = truncate([1, 2, 3], 3)
+    expect(result.more).toBe(0)
+  })
+
+  it('clamps total to items.length when server reports a lower total', () => {
+    // Server bug: should never happen, but if it does we trust the items.
+    const result = truncate([1, 2, 3, 4, 5], 2)
+    expect(result.total).toBe(5)
+    expect(result.more).toBe(0)
+  })
+
+  it('handles empty items', () => {
+    const result = truncate([], 0)
+    expect(result.shown).toEqual([])
+    expect(result.total).toBe(0)
+    expect(result.more).toBe(0)
+  })
+
+  it('handles empty items with non-zero total (filter mismatch)', () => {
+    const result = truncate([], 10)
+    expect(result.total).toBe(10)
+    expect(result.more).toBe(10)
+  })
+})
+
+describe('exact', () => {
+  it('marks items as the complete set', () => {
+    const result = exact([1, 2, 3])
+    expect(result.total).toBe(3)
+    expect(result.more).toBe(0)
+  })
+
+  it('handles empty', () => {
+    const result = exact([])
+    expect(result.total).toBe(0)
+    expect(result.more).toBe(0)
+  })
+})
+
+describe('unknownTotal', () => {
+  it('uses sentinel more=-1', () => {
+    const result = unknownTotal([1, 2, 3])
+    expect(result.shown).toEqual([1, 2, 3])
+    expect(result.total).toBe(3)
+    expect(result.more).toBe(-1)
+  })
+})
+
+describe('formatTruthfulCount', () => {
+  it('renders exact count when more=0', () => {
+    const result = exact([1, 2, 3])
+    expect(formatTruthfulCount(result, 'alerts')).toBe('3 alerts')
+  })
+
+  it('renders truncated count with showing X, +N more', () => {
+    const result = truncate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 270)
+    expect(formatTruthfulCount(result, 'alerts')).toBe('270 alerts (showing 10, +260 more)')
+  })
+
+  it('appends hint to truncated count', () => {
+    const result = truncate([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 270)
+    expect(formatTruthfulCount(result, 'alerts', { hint: 'run crane_notifications' })).toBe(
+      '270 alerts (showing 10, +260 more, run crane_notifications)'
+    )
+  })
+
+  it('renders unknown total with sentinel', () => {
+    const result = unknownTotal([1, 2, 3])
+    expect(formatTruthfulCount(result, 'alerts')).toBe('3 alerts (count unknown)')
+  })
+
+  it('renders unknown total with hint', () => {
+    const result = unknownTotal([1, 2, 3])
+    expect(formatTruthfulCount(result, 'alerts', { hint: 'count endpoint down' })).toBe(
+      '3 alerts (count unknown — count endpoint down)'
+    )
+  })
+
+  it('handles empty exact result', () => {
+    expect(formatTruthfulCount(exact([]), 'alerts')).toBe('0 alerts')
+  })
+
+  it('uses custom verb', () => {
+    const result = truncate([1, 2, 3], 10)
+    expect(formatTruthfulCount(result, 'items', { verb: 'displaying' })).toBe(
+      '10 items (displaying 3, +7 more)'
+    )
+  })
+
+  it('boundary case: 1 of 1', () => {
+    expect(formatTruthfulCount(exact([1]), 'alert')).toBe('1 alert')
+  })
+
+  it('boundary case: 0 of N truncated (filter returned empty slice)', () => {
+    const result = truncate([], 5)
+    expect(formatTruthfulCount(result, 'alerts')).toBe('5 alerts (showing 0, +5 more)')
+  })
+})
+
+describe('formatHeaderCount', () => {
+  it('returns null for empty exact result', () => {
+    expect(formatHeaderCount(exact([]), 'alerts')).toBeNull()
+  })
+
+  it('returns total for non-empty result', () => {
+    expect(formatHeaderCount(truncate([1, 2, 3], 100), 'alerts')).toBe('100 alerts')
+  })
+
+  it('returns floor for unknown total', () => {
+    expect(formatHeaderCount(unknownTotal([1, 2, 3]), 'alerts')).toBe('3+ alerts')
+  })
+})
+
+describe('compile-time brand enforcement', () => {
+  it('Truncated<T> brand prevents accidental .length on items array', () => {
+    // This test exists to document the intended use; the real enforcement
+    // is via TypeScript at compile time. The branded interface has `shown`
+    // (an array) and `total` (a number), so reading `.shown.length` works
+    // but does NOT replace the count - operators must use formatTruthfulCount.
+    const result: Truncated<number> = truncate([1, 2, 3], 100)
+    expect(result.shown.length).toBe(3) // shown count, not total
+    expect(result.total).toBe(100) // true total
+    // Display code that wants the count must use the helper:
+    expect(formatTruthfulCount(result, 'items')).toContain('100')
+  })
+})

--- a/packages/crane-mcp/src/lib/truthful-display.ts
+++ b/packages/crane-mcp/src/lib/truthful-display.ts
@@ -1,0 +1,128 @@
+/**
+ * Truthful Display: branded type for paginated/limited query results.
+ *
+ * Plan §B.2: every operator-facing display must show either the EXACT
+ * total or both `shown` and `total`. Operators must never see `${array.length}`
+ * for an array that came from a paginated query - they cannot distinguish
+ * "the system returned 10 because there are 10" from "the system returned
+ * 10 because that's where the slice ended."
+ *
+ * The `Truncated<T>` brand prevents accidental `.length` reads on paginated
+ * results: the wrapping interface has `shown` (the visible items), `total`
+ * (the true count), and `more` (the difference). Display helpers take a
+ * `Truncated<T>` and produce a string that includes both numbers.
+ *
+ * The branded property `[TruncatedBrand]: true` makes this a nominal type:
+ * a plain `{ shown, total, more }` object cannot be assigned to `Truncated<T>`
+ * without going through `truncate()` or `exact()`. This prevents the most
+ * common foot-gun: hand-constructing a fake "Truncated" with `shown.length`
+ * as the total.
+ */
+
+// Real runtime symbol for the brand. The unique symbol type ensures the
+// branded interface is nominal at compile time, while having a real value
+// means the interface implementation works at runtime.
+const TruncatedBrand: unique symbol = Symbol('Truncated')
+
+/**
+ * A wrapped result from a paginated/limited query. The `shown` array is
+ * the items the operator will see; `total` is the true count of all
+ * matching items in the underlying store; `more` is `total - shown.length`.
+ */
+export interface Truncated<T> {
+  readonly [TruncatedBrand]: true
+  readonly shown: readonly T[]
+  readonly total: number
+  readonly more: number
+}
+
+/**
+ * Wrap items + a true count into a `Truncated<T>`. Use when calling a
+ * paginated API: pass the items returned and the total reported by the
+ * server's count endpoint.
+ *
+ * If `total < items.length` (server told us there are fewer items than
+ * we received), this is a server bug — we trust `items.length` as the
+ * minimum and report it as the total.
+ */
+export function truncate<T>(items: readonly T[], total: number): Truncated<T> {
+  const safeTotal = Math.max(total, items.length)
+  return {
+    [TruncatedBrand]: true,
+    shown: items,
+    total: safeTotal,
+    more: Math.max(0, safeTotal - items.length),
+  } as Truncated<T>
+}
+
+/**
+ * Wrap items as `Truncated<T>` when you KNOW the array is the complete set
+ * (e.g., a fixed-size enum, an in-memory computation, a server response
+ * that returns ALL matches without pagination). Marked as Truncated so
+ * the same display helpers work uniformly.
+ */
+export function exact<T>(items: readonly T[]): Truncated<T> {
+  return {
+    [TruncatedBrand]: true,
+    shown: items,
+    total: items.length,
+    more: 0,
+  } as Truncated<T>
+}
+
+/**
+ * Wrap items as `Truncated<T>` when the true total is unavailable (e.g.,
+ * the count endpoint failed or is not implemented). Renders as
+ * "(at least N) — total unknown" so the operator knows the count is a
+ * floor, not an exact value.
+ */
+export function unknownTotal<T>(items: readonly T[]): Truncated<T> {
+  return {
+    [TruncatedBrand]: true,
+    shown: items,
+    total: items.length,
+    more: -1, // Sentinel: unknown
+  } as Truncated<T>
+}
+
+/**
+ * Format a `Truncated<T>` as a count string. Three rendering modes:
+ *
+ *   exact (shown === total):              "10 alerts"
+ *   truncated (more > 0):                 "270 alerts (showing 10, +260 more — run crane_notifications)"
+ *   unknown total:                        "10 alerts (count unknown — see crane_notifications)"
+ */
+export function formatTruthfulCount<T>(
+  result: Truncated<T>,
+  noun: string,
+  options: { hint?: string; verb?: string } = {}
+): string {
+  const verb = options.verb ?? 'showing'
+
+  // Unknown total
+  if (result.more === -1) {
+    const hint = options.hint ? ` — ${options.hint}` : ''
+    return `${result.shown.length} ${noun} (count unknown${hint})`
+  }
+
+  // Exact (no truncation)
+  if (result.more === 0) {
+    return `${result.total} ${noun}`
+  }
+
+  // Truncated
+  const hint = options.hint ? `, ${options.hint}` : ''
+  return `${result.total} ${noun} (${verb} ${result.shown.length}, +${result.more} more${hint})`
+}
+
+/**
+ * Render a count line that always shows the total, even when truncated.
+ * Useful for headers like "**CI/CD Alerts** — 270 total (12 critical, 45 warning)".
+ *
+ * Returns `null` when there's nothing to show (total === 0).
+ */
+export function formatHeaderCount<T>(result: Truncated<T>, noun: string): string | null {
+  if (result.total === 0 && result.more !== -1) return null
+  if (result.more === -1) return `${result.shown.length}+ ${noun}`
+  return `${result.total} ${noun}`
+}

--- a/workers/crane-context/src/endpoints/notifications.ts
+++ b/workers/crane-context/src/endpoints/notifications.ts
@@ -16,6 +16,8 @@ import {
   listNotifications,
   updateNotificationStatus,
   processGreenEvent,
+  countNotifications,
+  getOldestNotification,
 } from '../notifications'
 import { normalizeGitHubEvent, computeGitHubDedupeHash } from '../notifications-github'
 import { normalizeVercelDeployment, computeVercelDedupeHash } from '../notifications-vercel'
@@ -347,5 +349,86 @@ export async function handleUpdateNotificationStatus(
       ? HTTP_STATUS.CONFLICT
       : HTTP_STATUS.INTERNAL_ERROR
     return errorResponse(message, status, context.correlationId)
+  }
+}
+
+// ============================================================================
+// GET /notifications/counts
+// ============================================================================
+//
+// Plan §B.3: returns true counts (not paginated slices) so the SOS can show
+// "270 alerts (12 critical, 45 warning)" instead of `${array.length}` from a
+// limit:10 query. This is the missing endpoint that fixes defect #1.
+
+export async function handleNotificationCounts(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const url = new URL(request.url)
+    const params = {
+      status: url.searchParams.get('status') || undefined,
+      severity: url.searchParams.get('severity') || undefined,
+      venture: url.searchParams.get('venture') || undefined,
+      repo: url.searchParams.get('repo') || undefined,
+      source: url.searchParams.get('source') || undefined,
+    }
+
+    if (params.status && !NOTIFICATION_STATUSES.includes(params.status as NotificationStatus)) {
+      return validationErrorResponse(
+        [
+          {
+            field: 'status',
+            message: `Invalid status. Expected: ${NOTIFICATION_STATUSES.join(', ')}`,
+          },
+        ],
+        context.correlationId
+      )
+    }
+
+    const result = await countNotifications(env.DB, params)
+    return jsonResponse(
+      { ...result, correlation_id: context.correlationId },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('GET /notifications/counts error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
+  }
+}
+
+// ============================================================================
+// GET /notifications/oldest
+// ============================================================================
+//
+// Plan §B.7: used by the notification-retention-window health check. If the
+// oldest open notification is older than NOTIFICATION_RETENTION_DAYS, the
+// retention filter is broken or the auto-resolver is failing.
+
+export async function handleNotificationOldest(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const url = new URL(request.url)
+    const params = {
+      status: url.searchParams.get('status') || undefined,
+      venture: url.searchParams.get('venture') || undefined,
+      severity: url.searchParams.get('severity') || undefined,
+    }
+
+    const oldest = await getOldestNotification(env.DB, params)
+    return jsonResponse(
+      {
+        notification: oldest,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('GET /notifications/oldest error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
   }
 }

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -67,6 +67,8 @@ import {
   handleIngestNotification,
   handleListNotifications,
   handleUpdateNotificationStatus,
+  handleNotificationCounts,
+  handleNotificationOldest,
 } from './endpoints/notifications'
 import {
   handleListPendingMatches,
@@ -403,6 +405,14 @@ export default {
 
       if (pathname === '/notifications/ingest' && method === 'POST') {
         return await handleIngestNotification(request, env)
+      }
+
+      if (pathname === '/notifications/counts' && method === 'GET') {
+        return await handleNotificationCounts(request, env)
+      }
+
+      if (pathname === '/notifications/oldest' && method === 'GET') {
+        return await handleNotificationOldest(request, env)
       }
 
       if (pathname === '/notifications' && method === 'GET') {

--- a/workers/crane-context/src/notifications.ts
+++ b/workers/crane-context/src/notifications.ts
@@ -776,3 +776,154 @@ export async function countUnresolved(
 
   return counts
 }
+
+// ============================================================================
+// Truthful counts (Track B PR B-1)
+// ============================================================================
+
+/**
+ * Truthful count of notifications matching a filter, broken down by status
+ * and severity. The SOS uses this to display "270 alerts (12 critical, 45 warning)"
+ * instead of `${notifications.length}` from a paginated slice.
+ *
+ * Plan §B.3: this is the missing endpoint that fixes the loudest defect
+ * (defect #1 — SOS displaying "10 unresolved" when DB has 270).
+ */
+export interface CountNotificationsParams {
+  status?: string
+  severity?: string
+  venture?: string
+  repo?: string
+  source?: string
+}
+
+export interface NotificationCountsResult {
+  total: number
+  by_severity: {
+    critical: number
+    warning: number
+    info: number
+  }
+  by_status: {
+    new: number
+    acked: number
+    resolved: number
+  }
+  window: {
+    retention_days: number
+    filters: CountNotificationsParams
+  }
+}
+
+export async function countNotifications(
+  db: D1Database,
+  params: CountNotificationsParams
+): Promise<NotificationCountsResult> {
+  const retentionCutoff = new Date(
+    Date.now() - NOTIFICATION_RETENTION_DAYS * 24 * 60 * 60 * 1000
+  ).toISOString()
+
+  const conditions: string[] = ['created_at > ?']
+  const binds: (string | number)[] = [retentionCutoff]
+
+  if (params.status) {
+    conditions.push('status = ?')
+    binds.push(params.status)
+  }
+  if (params.severity) {
+    conditions.push('severity = ?')
+    binds.push(params.severity)
+  }
+  if (params.venture) {
+    conditions.push('venture = ?')
+    binds.push(params.venture)
+  }
+  if (params.repo) {
+    conditions.push('repo = ?')
+    binds.push(params.repo)
+  }
+  if (params.source) {
+    conditions.push('source = ?')
+    binds.push(params.source)
+  }
+
+  const where = `WHERE ${conditions.join(' AND ')}`
+
+  // Single query that produces both severity and status breakdowns via
+  // GROUP BY. Two grouping queries would be cleaner but D1 round-trips
+  // are expensive; one query with both groupings is faster.
+  const severitySql = `SELECT severity, COUNT(*) as count FROM notifications ${where} GROUP BY severity`
+  const statusSql = `SELECT status, COUNT(*) as count FROM notifications ${where} GROUP BY status`
+
+  const [sevResult, statusResult] = await Promise.all([
+    db
+      .prepare(severitySql)
+      .bind(...binds)
+      .all<{ severity: string; count: number }>(),
+    db
+      .prepare(statusSql)
+      .bind(...binds)
+      .all<{ status: string; count: number }>(),
+  ])
+
+  const by_severity = { critical: 0, warning: 0, info: 0 }
+  let total = 0
+  for (const row of sevResult.results || []) {
+    total += row.count
+    if (row.severity === 'critical') by_severity.critical = row.count
+    if (row.severity === 'warning') by_severity.warning = row.count
+    if (row.severity === 'info') by_severity.info = row.count
+  }
+
+  const by_status = { new: 0, acked: 0, resolved: 0 }
+  for (const row of statusResult.results || []) {
+    if (row.status === 'new') by_status.new = row.count
+    if (row.status === 'acked') by_status.acked = row.count
+    if (row.status === 'resolved') by_status.resolved = row.count
+  }
+
+  return {
+    total,
+    by_severity,
+    by_status,
+    window: {
+      retention_days: NOTIFICATION_RETENTION_DAYS,
+      filters: params,
+    },
+  }
+}
+
+/**
+ * Get the oldest notification matching a filter. Used by the
+ * notification-retention-window health check (plan §B.7) to verify the
+ * retention filter is actually working: if the oldest open notification
+ * is older than NOTIFICATION_RETENTION_DAYS, something is broken.
+ */
+export async function getOldestNotification(
+  db: D1Database,
+  params: CountNotificationsParams
+): Promise<NotificationRecord | null> {
+  const conditions: string[] = []
+  const binds: (string | number)[] = []
+
+  if (params.status) {
+    conditions.push('status = ?')
+    binds.push(params.status)
+  }
+  if (params.venture) {
+    conditions.push('venture = ?')
+    binds.push(params.venture)
+  }
+  if (params.severity) {
+    conditions.push('severity = ?')
+    binds.push(params.severity)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const sql = `SELECT * FROM notifications ${where} ORDER BY created_at ASC LIMIT 1`
+
+  return await db
+    .prepare(sql)
+    .bind(...binds)
+    .first<NotificationRecord>()
+}


### PR DESCRIPTION
Foundation for Track B operator-facing truthfulness. Adds the `Truncated<T>` branded type, `formatTruthfulCount` helper, and the new `/notifications/counts` endpoint that returns true counts (not paginated slices).

**No behavior change yet** — foundation only. Subsequent PRs in Track B use these primitives:
- PR B-2: SOS truthfulness fixes for the 8 confirmed defects
- PR B-3: suspected defect fixes (#9, #10, #11)
- PR B-4: System Health section + 3 v1 health checks
- PR B-5: deploy heartbeats migration + DAL + endpoints + MCP tool

## Validation
- typecheck (both packages): clean
- crane-context tests: 293 passed (unchanged)
- crane-mcp tests: 337 passed (was 316; +21 truthful-display tests)

Plan: `~/.claude/plans/kind-gliding-rossum.md` Track B.