### PR TITLE
feat(deploy-heartbeats): wire GitHub webhook adapters + seed action (Track B PR 5/5)

### DIFF
--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -500,7 +500,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {
             action: {
               type: 'string',
-              enum: ['list', 'suppress', 'unsuppress'],
+              enum: ['list', 'suppress', 'unsuppress', 'seed'],
               description: 'Action (default: list)',
             },
             venture: {
@@ -509,11 +509,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             repo_full_name: {
               type: 'string',
-              description: 'Required for suppress/unsuppress: full owner/repo path',
+              description: 'Required for seed/suppress/unsuppress: full owner/repo path',
             },
             workflow_id: {
               type: 'number',
-              description: 'Required for suppress/unsuppress: GitHub Actions workflow ID',
+              description: 'Required for seed/suppress/unsuppress: GitHub Actions workflow ID',
             },
             branch: {
               type: 'string',
@@ -526,6 +526,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             until: {
               type: 'string',
               description: 'Optional ISO8601 timestamp; suppression auto-expires at that point',
+            },
+            cold_threshold_days: {
+              type: 'number',
+              description: 'For seed: per-row cold threshold in days (default 3)',
             },
           },
           required: ['venture'],

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -1245,6 +1245,27 @@ export class CraneApi {
       throw new Error(`Unsuppress heartbeat failed (${response.status}): ${text}`)
     }
   }
+
+  async seedDeployHeartbeat(params: {
+    venture: string
+    repo_full_name: string
+    workflow_id: number
+    branch?: string
+    cold_threshold_days?: number
+  }): Promise<void> {
+    const response = await fetch(`${this.apiBase}/deploy-heartbeats/seed`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Relay-Key': this.apiKey,
+      },
+      body: JSON.stringify(params),
+    })
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Seed heartbeat failed (${response.status}): ${text}`)
+    }
+  }
 }
 
 function getHostname(): string {

--- a/packages/crane-mcp/src/tools/deploy-heartbeat.ts
+++ b/packages/crane-mcp/src/tools/deploy-heartbeat.ts
@@ -11,24 +11,28 @@ import { getApiBase } from '../lib/config.js'
 
 export const deployHeartbeatInputSchema = z.object({
   action: z
-    .enum(['list', 'suppress', 'unsuppress'])
+    .enum(['list', 'suppress', 'unsuppress', 'seed'])
     .default('list')
     .describe('Action to perform (default: list)'),
   venture: z.string().describe('Venture code (vc, ke, sc, dfg, etc.)'),
   repo_full_name: z
     .string()
     .optional()
-    .describe('Required for suppress/unsuppress: full owner/repo path'),
+    .describe('Required for seed/suppress/unsuppress: full owner/repo path'),
   workflow_id: z
     .number()
     .optional()
-    .describe('Required for suppress/unsuppress: GitHub Actions workflow ID'),
+    .describe('Required for seed/suppress/unsuppress: GitHub Actions workflow ID'),
   branch: z.string().optional().describe('Branch (defaults to main)'),
   reason: z.string().optional().describe('Required for suppress: human-readable reason'),
   until: z
     .string()
     .optional()
     .describe('Optional ISO8601 timestamp; suppression auto-expires at that point'),
+  cold_threshold_days: z
+    .number()
+    .optional()
+    .describe('For seed: per-row cold threshold in days (default 3)'),
 })
 
 export type DeployHeartbeatInput = z.infer<typeof deployHeartbeatInputSchema>
@@ -137,6 +141,33 @@ export async function executeDeployHeartbeat(
       return {
         success: false,
         message: `Suppress failed: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
+  }
+
+  if (input.action === 'seed') {
+    if (!input.repo_full_name || typeof input.workflow_id !== 'number') {
+      return {
+        success: false,
+        message: 'seed requires: repo_full_name, workflow_id',
+      }
+    }
+    try {
+      await api.seedDeployHeartbeat({
+        venture: input.venture,
+        repo_full_name: input.repo_full_name,
+        workflow_id: input.workflow_id,
+        branch: input.branch,
+        cold_threshold_days: input.cold_threshold_days,
+      })
+      return {
+        success: true,
+        message: `Seeded ${input.repo_full_name} workflow ${input.workflow_id} (${input.venture})`,
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: `Seed failed: ${error instanceof Error ? error.message : String(error)}`,
       }
     }
   }

--- a/workers/crane-context/src/deploy-heartbeats-github.ts
+++ b/workers/crane-context/src/deploy-heartbeats-github.ts
@@ -1,0 +1,184 @@
+/**
+ * GitHub-payload adapter for deploy heartbeats.
+ *
+ * Plan §B.6. Translates raw GitHub webhook payloads (push, workflow_run)
+ * into the typed observations the deploy_heartbeats DAL accepts.
+ *
+ * Lives in crane-context (NOT crane-watch) so the venture lookup uses the
+ * same `VENTURE_CONFIG` source of truth that the rest of the worker reads.
+ * Crane-watch just forwards the raw payload.
+ */
+
+import { VENTURE_CONFIG } from './constants'
+import type { CommitObservation, RunObservation } from './deploy-heartbeats'
+
+/**
+ * Resolve a venture code from a `repository.full_name` string. Returns
+ * `null` if no venture in the config owns this repo. Caller should
+ * gracefully ignore unknown repos rather than 500 — webhooks for
+ * archived/orphaned repos still arrive and shouldn't blow up.
+ */
+export function ventureForRepo(repoFullName: string): string | null {
+  const slash = repoFullName.indexOf('/')
+  if (slash < 1) return null
+  const org = repoFullName.slice(0, slash)
+  const repo = repoFullName.slice(slash + 1)
+
+  for (const [code, cfg] of Object.entries(VENTURE_CONFIG)) {
+    if (cfg.org !== org) continue
+    if (cfg.repos.includes(repo)) return code
+  }
+  return null
+}
+
+/**
+ * Per-venture-class default cold thresholds (Plan §B.6). Stored as code
+ * defaults until per-venture overrides land in `config/ventures.json`.
+ *
+ *   - content/marketing (vc-web, dfg, dc-marketing): 2 days
+ *   - infrastructure (crane-console, crane-relay): 7 days
+ *   - everything else (app consoles): 3 days
+ */
+const CONTENT_REPOS = new Set([
+  'venturecrane/vc-web',
+  'venturecrane/dfg-marketing',
+  'venturecrane/dc-marketing',
+])
+const INFRA_REPOS = new Set(['venturecrane/crane-console', 'venturecrane/crane-relay'])
+
+export function defaultColdThresholdDays(repoFullName: string): number {
+  if (CONTENT_REPOS.has(repoFullName)) return 2
+  if (INFRA_REPOS.has(repoFullName)) return 7
+  return 3
+}
+
+// ============================================================================
+// Push event → CommitObservation[]
+// ============================================================================
+
+interface GitHubPushPayload {
+  ref?: string
+  after?: string
+  head_commit?: { id?: string; timestamp?: string }
+  repository?: { full_name?: string }
+  // Push events don't carry a workflow_id — see note below.
+}
+
+export interface PushAdapterResult {
+  venture: string
+  repo_full_name: string
+  branch: string
+  commit_at: string
+  commit_sha: string
+}
+
+/**
+ * Convert a GitHub `push` payload into the fields needed to record a
+ * commit observation. Returns `null` for unknown ventures, non-default-branch
+ * pushes (deploy-heartbeats only tracks main), or malformed payloads.
+ *
+ * Note: a push event tells us a commit exists but does NOT tell us which
+ * workflow_id will run on it. The caller must therefore call recordCommit
+ * for EACH workflow_id discovered for the repo (via the reconciliation
+ * cron's discoverWorkflows action). The fan-out is intentional: we want
+ * each workflow's heartbeat to advance independently.
+ */
+export function adaptPushPayload(payload: unknown): PushAdapterResult | null {
+  if (!payload || typeof payload !== 'object') return null
+  const p = payload as GitHubPushPayload
+
+  const repoFullName = p.repository?.full_name
+  if (!repoFullName) return null
+
+  const venture = ventureForRepo(repoFullName)
+  if (!venture) return null
+
+  // Only track default branch (main). Feature branches don't need a
+  // deploy heartbeat — they're WIP, not "should-have-deployed" signals.
+  const ref = p.ref ?? ''
+  const branch = ref.replace(/^refs\/heads\//, '')
+  if (branch !== 'main') return null
+
+  const commitSha = p.after || p.head_commit?.id
+  const commitAt = p.head_commit?.timestamp
+  if (!commitSha || !commitAt) return null
+
+  return {
+    venture,
+    repo_full_name: repoFullName,
+    branch,
+    commit_at: commitAt,
+    commit_sha: commitSha,
+  }
+}
+
+// ============================================================================
+// workflow_run event → RunObservation
+// ============================================================================
+
+interface GitHubWorkflowRunPayload {
+  action?: string
+  workflow_run?: {
+    id?: number
+    workflow_id?: number
+    head_sha?: string
+    head_branch?: string
+    status?: string
+    conclusion?: string | null
+    created_at?: string
+    updated_at?: string
+    run_started_at?: string
+  }
+  repository?: { full_name?: string }
+}
+
+/**
+ * Convert a GitHub `workflow_run.completed` payload into a RunObservation.
+ * Returns `null` for unknown ventures, non-default-branch runs, in-progress
+ * runs (we only care about completed), or malformed payloads.
+ *
+ * Returns the OBSERVATION typed for `recordRun()`. The caller is responsible
+ * for invoking `recordRun(db, obs)` and handling errors.
+ */
+export function adaptWorkflowRunPayload(payload: unknown): RunObservation | null {
+  if (!payload || typeof payload !== 'object') return null
+  const p = payload as GitHubWorkflowRunPayload
+
+  // Only act on `completed` deliveries — `requested` and `in_progress` carry
+  // null conclusions and would create stale heartbeat rows.
+  if (p.action !== 'completed') return null
+
+  const run = p.workflow_run
+  if (!run) return null
+
+  const repoFullName = p.repository?.full_name
+  if (!repoFullName) return null
+
+  const venture = ventureForRepo(repoFullName)
+  if (!venture) return null
+
+  // Track only default-branch runs. Feature-branch runs don't update the
+  // deploy heartbeat — they're not "did the deploy succeed" signals.
+  const branch = run.head_branch ?? ''
+  if (branch !== 'main') return null
+
+  if (typeof run.workflow_id !== 'number' || typeof run.id !== 'number') return null
+  if (!run.conclusion) return null
+
+  // Prefer run_started_at, fall back to updated_at, then created_at.
+  const runAt = run.run_started_at ?? run.updated_at ?? run.created_at
+  if (!runAt) return null
+
+  return {
+    venture,
+    repo_full_name: repoFullName,
+    workflow_id: run.workflow_id,
+    branch,
+    run_id: run.id,
+    run_at: runAt,
+    conclusion: run.conclusion,
+    head_sha: run.head_sha ?? null,
+  }
+}
+
+export type CommitObservationFromPush = PushAdapterResult & Pick<CommitObservation, 'workflow_id'>

--- a/workers/crane-context/src/deploy-heartbeats.ts
+++ b/workers/crane-context/src/deploy-heartbeats.ts
@@ -369,6 +369,48 @@ export async function unsuppressHeartbeat(
 }
 
 /**
+ * Seed an empty heartbeat row for a (venture, repo, workflow_id, branch).
+ * Used by the manual seeding flow before reconciliation cron exists, and
+ * by the cron itself once it ships. Idempotent — second seed is a no-op.
+ *
+ * The row is created with no commit or run state. Subsequent push and
+ * workflow_run webhooks fill in the actual data.
+ */
+export async function seedHeartbeat(
+  db: D1Database,
+  params: {
+    venture: string
+    repo_full_name: string
+    workflow_id: number
+    branch?: string
+    cold_threshold_days?: number
+  }
+): Promise<void> {
+  const branch = params.branch ?? 'main'
+  const now = nowIso()
+  await db
+    .prepare(
+      `
+      INSERT INTO deploy_heartbeats (
+        venture, repo_full_name, workflow_id, branch,
+        cold_threshold_days, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(venture, repo_full_name, workflow_id, branch) DO NOTHING
+      `
+    )
+    .bind(
+      params.venture,
+      params.repo_full_name,
+      params.workflow_id,
+      branch,
+      params.cold_threshold_days ?? 3,
+      now,
+      now
+    )
+    .run()
+}
+
+/**
  * Set the cold threshold for a heartbeat. Called by the discovery
  * action that reads `config/ventures.json deploy_cold_threshold_days`
  * and applies the per-venture-class default.

--- a/workers/crane-context/src/endpoints/deploy-heartbeats.ts
+++ b/workers/crane-context/src/endpoints/deploy-heartbeats.ts
@@ -25,8 +25,14 @@ import {
   suppressHeartbeat,
   unsuppressHeartbeat,
   setColdThreshold,
+  seedHeartbeat,
   isHeartbeatCold,
 } from '../deploy-heartbeats'
+import {
+  adaptPushPayload,
+  adaptWorkflowRunPayload,
+  defaultColdThresholdDays,
+} from '../deploy-heartbeats-github'
 
 // ============================================================================
 // GET /deploy-heartbeats
@@ -306,6 +312,186 @@ export async function handleSetColdThreshold(request: Request, env: Env): Promis
     )
   } catch (error) {
     console.error('POST /deploy-heartbeats/threshold error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
+  }
+}
+
+// ============================================================================
+// POST /deploy-heartbeats/seed
+// ============================================================================
+//
+// Seed an empty heartbeat row so subsequent push events have something to
+// update. Used during initial rollout (before reconciliation cron exists)
+// and by the cron itself once it ships. Idempotent.
+
+interface SeedBody {
+  venture: string
+  repo_full_name: string
+  workflow_id: number
+  branch?: string
+  cold_threshold_days?: number
+}
+
+export async function handleSeedHeartbeat(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const body = (await request.json()) as SeedBody
+    if (!body.venture || !body.repo_full_name || typeof body.workflow_id !== 'number') {
+      return validationErrorResponse(
+        [{ field: 'body', message: 'Required: venture, repo_full_name, workflow_id' }],
+        context.correlationId
+      )
+    }
+    await seedHeartbeat(env.DB, body)
+    return jsonResponse(
+      { ok: true, correlation_id: context.correlationId },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /deploy-heartbeats/seed error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
+  }
+}
+
+// ============================================================================
+// POST /deploy-heartbeats/observe-github-workflow-run
+// ============================================================================
+//
+// Plan §B.6. Accepts a raw GitHub `workflow_run` webhook payload from
+// crane-watch and converts it via the adapter into a typed run observation
+// before recording. The adapter handles venture lookup, default-branch
+// filtering, completed-only filtering, and field extraction. Unknown
+// ventures and feature-branch runs return 200 ignored — never an error.
+
+export async function handleObserveGithubWorkflowRun(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const payload = (await request.json()) as unknown
+    const obs = adaptWorkflowRunPayload(payload)
+
+    if (!obs) {
+      return jsonResponse(
+        { ignored: true, reason: 'not_actionable', correlation_id: context.correlationId },
+        HTTP_STATUS.OK,
+        context.correlationId
+      )
+    }
+
+    await recordRun(env.DB, obs, defaultColdThresholdDays(obs.repo_full_name))
+
+    return jsonResponse(
+      {
+        ok: true,
+        venture: obs.venture,
+        repo_full_name: obs.repo_full_name,
+        workflow_id: obs.workflow_id,
+        run_id: obs.run_id,
+        conclusion: obs.conclusion,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /deploy-heartbeats/observe-github-workflow-run error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
+  }
+}
+
+// ============================================================================
+// POST /deploy-heartbeats/observe-github-push
+// ============================================================================
+//
+// Accepts a raw GitHub `push` webhook payload. Records the commit against
+// EVERY workflow_id already discovered for the repo+branch. The
+// reconciliation cron is responsible for seeding workflow_ids initially;
+// pushes only update existing rows. This means a brand-new repo's first
+// commit doesn't create heartbeat rows — that's intentional, since we'd
+// have no idea which workflows to track until the cron discovers them.
+
+export async function handleObserveGithubPush(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const payload = (await request.json()) as unknown
+    const adapted = adaptPushPayload(payload)
+
+    if (!adapted) {
+      return jsonResponse(
+        { ignored: true, reason: 'not_actionable', correlation_id: context.correlationId },
+        HTTP_STATUS.OK,
+        context.correlationId
+      )
+    }
+
+    // Update last_main_commit_at for every existing heartbeat row that
+    // matches (venture, repo, branch). The DAL's recordCommit upserts on
+    // the composite key — we have to fan out across the rows that already
+    // exist for this repo+branch (one per workflow_id discovered by the cron).
+    const existing = await env.DB.prepare(
+      `SELECT workflow_id FROM deploy_heartbeats
+       WHERE venture = ? AND repo_full_name = ? AND branch = ?`
+    )
+      .bind(adapted.venture, adapted.repo_full_name, adapted.branch)
+      .all<{ workflow_id: number }>()
+
+    const workflows = (existing.results || []) as { workflow_id: number }[]
+
+    if (workflows.length === 0) {
+      // No tracked workflows yet for this repo. The reconciliation cron
+      // will pick up the commit on its next run; until then, we have
+      // nothing to update. Return 200 with a clear reason so the caller
+      // can log it without treating it as an error.
+      return jsonResponse(
+        {
+          ignored: true,
+          reason: 'no_workflows_tracked',
+          venture: adapted.venture,
+          repo_full_name: adapted.repo_full_name,
+          correlation_id: context.correlationId,
+        },
+        HTTP_STATUS.OK,
+        context.correlationId
+      )
+    }
+
+    for (const { workflow_id } of workflows) {
+      await recordCommit(
+        env.DB,
+        {
+          venture: adapted.venture,
+          repo_full_name: adapted.repo_full_name,
+          workflow_id,
+          branch: adapted.branch,
+          commit_at: adapted.commit_at,
+          commit_sha: adapted.commit_sha,
+        },
+        defaultColdThresholdDays(adapted.repo_full_name)
+      )
+    }
+
+    return jsonResponse(
+      {
+        ok: true,
+        venture: adapted.venture,
+        repo_full_name: adapted.repo_full_name,
+        workflows_updated: workflows.length,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /deploy-heartbeats/observe-github-push error:', error)
     return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
   }
 }

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -84,6 +84,9 @@ import {
   handleSuppressHeartbeat,
   handleUnsuppressHeartbeat,
   handleSetColdThreshold,
+  handleSeedHeartbeat,
+  handleObserveGithubWorkflowRun,
+  handleObserveGithubPush,
 } from './endpoints/deploy-heartbeats'
 import { handleMcpRequest } from './mcp'
 import { errorResponse } from './utils'
@@ -459,6 +462,18 @@ export default {
 
       if (pathname === '/deploy-heartbeats/threshold' && method === 'POST') {
         return await handleSetColdThreshold(request, env)
+      }
+
+      if (pathname === '/deploy-heartbeats/observe-github-workflow-run' && method === 'POST') {
+        return await handleObserveGithubWorkflowRun(request, env)
+      }
+
+      if (pathname === '/deploy-heartbeats/observe-github-push' && method === 'POST') {
+        return await handleObserveGithubPush(request, env)
+      }
+
+      if (pathname === '/deploy-heartbeats/seed' && method === 'POST') {
+        return await handleSeedHeartbeat(request, env)
       }
 
       // ========================================================================

--- a/workers/crane-context/test/deploy-heartbeats-github.test.ts
+++ b/workers/crane-context/test/deploy-heartbeats-github.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for deploy-heartbeats GitHub payload adapters (Plan §B.6).
+ *
+ * These adapters live in crane-context (not crane-watch) so they can use
+ * the canonical VENTURE_CONFIG. The tests verify:
+ *   - venture lookup from repository.full_name
+ *   - per-venture-class default cold thresholds
+ *   - default-branch filtering (main only)
+ *   - completed-only filtering for workflow_run
+ *   - graceful null returns for unknown / malformed payloads
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  ventureForRepo,
+  defaultColdThresholdDays,
+  adaptPushPayload,
+  adaptWorkflowRunPayload,
+} from '../src/deploy-heartbeats-github'
+
+// ============================================================================
+// ventureForRepo
+// ============================================================================
+
+describe('ventureForRepo', () => {
+  it('returns the venture code for a known repo', () => {
+    expect(ventureForRepo('venturecrane/crane-console')).toBe('vc')
+  })
+
+  it('returns null for unknown org', () => {
+    expect(ventureForRepo('thirdparty/some-repo')).toBe(null)
+  })
+
+  it('returns null for unknown repo in known org', () => {
+    expect(ventureForRepo('venturecrane/random-fork')).toBe(null)
+  })
+
+  it('returns null for malformed input', () => {
+    expect(ventureForRepo('no-slash')).toBe(null)
+    expect(ventureForRepo('')).toBe(null)
+    expect(ventureForRepo('/leading-slash')).toBe(null)
+  })
+
+  it('does not cross-org collide (different orgs, same repo name)', () => {
+    // Cross-org test: a repo named 'console' in two different orgs must
+    // resolve independently. This is the same defense-in-depth as the
+    // notification match_key cross-org test.
+    expect(ventureForRepo('venturecrane/crane-console')).toBe('vc')
+    expect(ventureForRepo('siliconcrane/crane-console')).toBe(null)
+  })
+})
+
+// ============================================================================
+// defaultColdThresholdDays
+// ============================================================================
+
+describe('defaultColdThresholdDays', () => {
+  it('returns 7 days for infrastructure repos (crane-console)', () => {
+    expect(defaultColdThresholdDays('venturecrane/crane-console')).toBe(7)
+  })
+
+  it('returns 2 days for content/marketing repos', () => {
+    expect(defaultColdThresholdDays('venturecrane/vc-web')).toBe(2)
+    expect(defaultColdThresholdDays('venturecrane/dc-marketing')).toBe(2)
+  })
+
+  it('returns 3 days for app/console repos by default', () => {
+    expect(defaultColdThresholdDays('venturecrane/ke-console')).toBe(3)
+    expect(defaultColdThresholdDays('venturecrane/sc-console')).toBe(3)
+  })
+
+  it('returns 3 days for unknown repos (safe default)', () => {
+    expect(defaultColdThresholdDays('thirdparty/unknown')).toBe(3)
+  })
+})
+
+// ============================================================================
+// adaptPushPayload
+// ============================================================================
+
+describe('adaptPushPayload', () => {
+  it('extracts venture, branch, sha, and timestamp from a main-branch push', () => {
+    const result = adaptPushPayload({
+      ref: 'refs/heads/main',
+      after: 'abc123',
+      head_commit: {
+        id: 'abc123',
+        timestamp: '2026-04-08T10:00:00Z',
+      },
+      repository: { full_name: 'venturecrane/crane-console' },
+    })
+    expect(result).toEqual({
+      venture: 'vc',
+      repo_full_name: 'venturecrane/crane-console',
+      branch: 'main',
+      commit_at: '2026-04-08T10:00:00Z',
+      commit_sha: 'abc123',
+    })
+  })
+
+  it('returns null for non-default-branch pushes (we only track main)', () => {
+    expect(
+      adaptPushPayload({
+        ref: 'refs/heads/feature/foo',
+        after: 'sha',
+        head_commit: { id: 'sha', timestamp: '2026-04-08T10:00:00Z' },
+        repository: { full_name: 'venturecrane/crane-console' },
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for unknown repos (gracefully ignored)', () => {
+    expect(
+      adaptPushPayload({
+        ref: 'refs/heads/main',
+        after: 'sha',
+        head_commit: { id: 'sha', timestamp: '2026-04-08T10:00:00Z' },
+        repository: { full_name: 'thirdparty/random' },
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for missing fields', () => {
+    expect(adaptPushPayload(null)).toBeNull()
+    expect(adaptPushPayload({})).toBeNull()
+    expect(
+      adaptPushPayload({
+        ref: 'refs/heads/main',
+        repository: { full_name: 'venturecrane/crane-console' },
+        // missing head_commit + after
+      })
+    ).toBeNull()
+  })
+})
+
+// ============================================================================
+// adaptWorkflowRunPayload
+// ============================================================================
+
+describe('adaptWorkflowRunPayload', () => {
+  function makeRun(overrides: Record<string, unknown> = {}) {
+    return {
+      action: 'completed',
+      workflow_run: {
+        id: 100,
+        workflow_id: 12345,
+        head_sha: 'abc123',
+        head_branch: 'main',
+        status: 'completed',
+        conclusion: 'success',
+        run_started_at: '2026-04-08T10:00:00Z',
+        ...overrides,
+      },
+      repository: { full_name: 'venturecrane/crane-console' },
+    }
+  }
+
+  it('extracts a typed RunObservation from a completed success run', () => {
+    const result = adaptWorkflowRunPayload(makeRun())
+    expect(result).toEqual({
+      venture: 'vc',
+      repo_full_name: 'venturecrane/crane-console',
+      workflow_id: 12345,
+      branch: 'main',
+      run_id: 100,
+      run_at: '2026-04-08T10:00:00Z',
+      conclusion: 'success',
+      head_sha: 'abc123',
+    })
+  })
+
+  it('preserves the failure conclusion (so the heartbeat advances consecutive_failures)', () => {
+    const result = adaptWorkflowRunPayload(makeRun({ conclusion: 'failure' }))
+    expect(result?.conclusion).toBe('failure')
+  })
+
+  it('returns null for non-completed actions (in_progress / requested)', () => {
+    expect(adaptWorkflowRunPayload({ ...makeRun(), action: 'in_progress' })).toBeNull()
+    expect(adaptWorkflowRunPayload({ ...makeRun(), action: 'requested' })).toBeNull()
+  })
+
+  it('returns null for non-default-branch runs', () => {
+    expect(
+      adaptWorkflowRunPayload({
+        ...makeRun(),
+        workflow_run: { ...makeRun().workflow_run, head_branch: 'feature/foo' },
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for unknown ventures', () => {
+    expect(
+      adaptWorkflowRunPayload({
+        ...makeRun(),
+        repository: { full_name: 'thirdparty/random' },
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for missing workflow_id (legacy webhook payloads)', () => {
+    expect(
+      adaptWorkflowRunPayload({
+        ...makeRun(),
+        workflow_run: { ...makeRun().workflow_run, workflow_id: undefined },
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for missing conclusion', () => {
+    expect(
+      adaptWorkflowRunPayload({
+        ...makeRun(),
+        workflow_run: { ...makeRun().workflow_run, conclusion: null },
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to updated_at when run_started_at is missing', () => {
+    const result = adaptWorkflowRunPayload({
+      ...makeRun(),
+      workflow_run: {
+        ...makeRun().workflow_run,
+        run_started_at: undefined,
+        updated_at: '2026-04-08T11:30:00Z',
+      },
+    })
+    expect(result?.run_at).toBe('2026-04-08T11:30:00Z')
+  })
+})

--- a/workers/crane-watch/src/index.ts
+++ b/workers/crane-watch/src/index.ts
@@ -822,7 +822,20 @@ async function handleGitHubWebhook(
   if (eventType && CI_EVENT_TYPES.includes(eventType)) {
     const deliveryId = req.headers.get('X-GitHub-Delivery') || crypto.randomUUID()
     ctx.waitUntil(forwardToNotifications(env, 'github', eventType, deliveryId, payload))
+    // Also feed the deploy-heartbeats observer for workflow_run events.
+    // The two pipelines are independent — the heartbeats endpoint is
+    // tolerant of unknown ventures and non-default branches.
+    if (eventType === 'workflow_run') {
+      ctx.waitUntil(forwardToDeployHeartbeats(env, 'workflow-run', payload))
+    }
     return new Response('OK - CI event forwarded', { status: 200 })
+  }
+
+  // Push events feed the deploy-heartbeats commit-without-deploy detector.
+  // We don't forward to notifications for pushes — only to heartbeats.
+  if (eventType === 'push') {
+    ctx.waitUntil(forwardToDeployHeartbeats(env, 'push', payload))
+    return new Response('OK - push event forwarded', { status: 200 })
   }
 
   // Only handle issues events
@@ -1102,6 +1115,67 @@ async function forwardToNotifications(
     }
   } catch (err) {
     console.error('Notification forwarding error:', err)
+  }
+}
+
+// ============================================================================
+// DEPLOY HEARTBEAT FORWARDING
+// ============================================================================
+//
+// Forwards `push` and `workflow_run.completed` events to the deploy-heartbeats
+// observer endpoints in crane-context. The two pipelines are independent of
+// notification forwarding: a push event has no notification side-effect, and
+// a workflow_run produces both a notification (failure path) AND a heartbeat
+// observation (success or failure).
+//
+// The endpoint is tolerant of unknown ventures and non-default branches —
+// it returns 200 with `ignored: true` rather than erroring.
+
+async function forwardToDeployHeartbeats(
+  env: Env,
+  kind: 'push' | 'workflow-run',
+  payload: unknown
+): Promise<void> {
+  const relayKey = env.CONTEXT_RELAY_KEY
+  if (!relayKey) {
+    console.error('CONTEXT_RELAY_KEY not configured, skipping heartbeat forwarding')
+    return
+  }
+
+  const fetcher = env.CRANE_CONTEXT || null
+  const contextUrl = env.CRANE_CONTEXT_URL
+  if (!fetcher && !contextUrl) {
+    console.error(
+      'Neither CRANE_CONTEXT service binding nor CRANE_CONTEXT_URL configured, skipping heartbeat forwarding'
+    )
+    return
+  }
+
+  const path =
+    kind === 'push'
+      ? '/deploy-heartbeats/observe-github-push'
+      : '/deploy-heartbeats/observe-github-workflow-run'
+
+  try {
+    const requestInit: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Relay-Key': relayKey,
+      },
+      body: JSON.stringify(payload),
+    }
+
+    const response = fetcher
+      ? await fetcher.fetch(`https://crane-context${path}`, requestInit)
+      : await fetch(`${contextUrl}${path}`, requestInit)
+
+    if (!response.ok) {
+      const text = await response.text()
+      console.error(`Heartbeat forwarding (${kind}) failed: ${response.status} ${text}`)
+    }
+  } catch (err) {
+    console.error(`Heartbeat forwarding (${kind}) error:`, err)
   }
 }
 


### PR DESCRIPTION
## Summary

Plan §B.6 (continued from #450). Closes the data-layer loop: real GitHub `push` and `workflow_run.completed` webhooks now feed the `deploy_heartbeats` table directly via crane-watch, and operators can seed initial workflow rows via the new `seed` action.

## What this completes

After #450 the deploy_heartbeats schema, DAL, and observe-* endpoints were live, but no production webhook traffic flowed into them yet. This PR turns the data layer on.

After this lands:

1. Operators run `crane_deploy_heartbeat(action: \"seed\", venture: \"vc\", repo_full_name: \"venturecrane/crane-console\", workflow_id: 12345)` once per workflow they want tracked.
2. Subsequent `push` events on main update `last_main_commit_*` for every seeded row (fan-out across all workflows for that repo+branch).
3. Subsequent `workflow_run.completed` events update `last_run_*` and, on success, advance `last_success_*`.
4. The System Health `deploy-pipeline-heartbeat` check from #446 surfaces any pipeline that goes cold.

## Worker (crane-context)

- **`src/deploy-heartbeats-github.ts`** (new): pure adapters that translate raw GitHub payloads into typed observations, handle venture lookup via `VENTURE_CONFIG`, default-branch filtering, and per-venture-class default thresholds.
- **`src/deploy-heartbeats.ts`**: new `seedHeartbeat()` — idempotent INSERT...ON CONFLICT DO NOTHING.
- **`src/endpoints/deploy-heartbeats.ts`**: 3 new routes — `observe-github-workflow-run`, `observe-github-push`, `seed`.

## Worker (crane-watch)

- New `forwardToDeployHeartbeats()` helper (same pattern as `forwardToNotifications`).
- `workflow_run` events now forward to BOTH notifications AND deploy-heartbeats (independent pipelines).
- New branch for `push` events that forwards only to deploy-heartbeats.

## API client + MCP tool

- `seedDeployHeartbeat({...})` on `CraneApi`.
- `crane_deploy_heartbeat(action: \"seed\", ...)` MCP action.

## Tests

- 21 new unit tests in `test/deploy-heartbeats-github.test.ts`:
  - 5 for `ventureForRepo` (incl. cross-org collision safety)
  - 4 for `defaultColdThresholdDays`
  - 4 for `adaptPushPayload`
  - 8 for `adaptWorkflowRunPayload`
- All 331 worker tests pass (was 310, +21)
- All crane-mcp tests pass
- Full `npm run verify` is green

## Rollout

1. Merge → triggers automatic deploy of crane-context + crane-watch.
2. For each venture's primary deploy workflow, seed:
   ```
   crane_deploy_heartbeat(action: \"seed\", venture: \"vc\",
     repo_full_name: \"venturecrane/crane-console\", workflow_id: <id>)
   ```
3. Push a synthetic commit and verify `crane_deploy_heartbeat(venture: \"vc\")` shows `last_main_commit_*` populated within seconds.
4. The System Health section in `/sos vc` should reflect the real cold-pipeline state.

## Plan reference

- v2 plan: \`/Users/scottdurgan/.claude/plans/kind-gliding-rossum.md\` §B.6
- This PR completes the deploy-heartbeats sub-track of Track B.

## Not in this PR (deferred follow-ups)

- **Reconciliation cron** (`cron: \"0 */6 * * *\"`) that walks the GitHub API for all enabled workflows and upserts. Seed action is the manual fallback.
- **Threshold backtest script** (`scripts/backtest-cold-thresholds.sh`).
- **Per-venture override in config/ventures.json** — thresholds are currently a code default in `defaultColdThresholdDays()`. Captain decision required to add `deploy_cold_threshold_days` to the venture schema.
- **`discoverWorkflows` admin action** that auto-seeds rows from a GitHub API listing.

These are non-blocking — the data layer ships with manual seed and real-time webhook updates, which is enough to verify the system end-to-end in production before adding the failsafe cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)