### PR TITLE
fix(d1-backup): workspace-relative paths for artifact upload

### DIFF
--- a/.github/workflows/d1-backup.yml
+++ b/.github/workflows/d1-backup.yml
@@ -38,22 +38,21 @@ jobs:
         working-directory: ${{ matrix.working-directory }}
 
       - name: Export D1 database
-        working-directory: ${{ matrix.working-directory }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          OUT="../../backup-${{ matrix.database }}-$(date -u +%Y%m%dT%H%M%SZ).sql"
-          npx wrangler d1 export DB ${{ matrix.env_flag }} --output="$OUT" --remote
+          mkdir -p backups
+          STEM="backup-${{ matrix.database }}-$(date -u +%Y%m%dT%H%M%SZ)"
+          OUT="backups/${STEM}.sql"
+          (cd "${{ matrix.working-directory }}" && \
+            npx wrangler d1 export DB ${{ matrix.env_flag }} \
+              --output="${GITHUB_WORKSPACE}/${OUT}" --remote)
           ls -lh "$OUT"
+          sha256sum "$OUT" | tee "${OUT}.sha256"
           echo "BACKUP_FILE=$OUT" >> "$GITHUB_ENV"
-          # Strip leading ../../
-          echo "BACKUP_NAME=$(basename "$OUT")" >> "$GITHUB_ENV"
-
-      - name: Compute checksum
-        run: |
-          sha256sum "${{ env.BACKUP_FILE }}" | tee "${{ env.BACKUP_FILE }}.sha256"
+          echo "BACKUP_NAME=$STEM" >> "$GITHUB_ENV"
 
       - name: Upload backup artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Fix path handling in \`.github/workflows/d1-backup.yml\` — actions/upload-artifact rejects \`..\` segments
- Export SQL to \`\$GITHUB_WORKSPACE/backups/\` instead of a relative path out of the worker directory

## Why

First manual run of the workflow (introduced in #448) failed with:

\`\`\`
##[error]Invalid pattern '../../backup-crane-context-db-staging-...sql'.
Relative pathing '.' and '..' is not allowed.
\`\`\`

Run: https://github.com/venturecrane/crane-console/actions/runs/24152248852

## Test plan

- [ ] Manual dispatch of \`D1 Nightly Backup\` workflow succeeds for both databases
- [ ] Artifacts appear with SQL + SHA-256 checksum files

🤖 Generated with [Claude Code](https://claude.com/claude-code)