### PR TITLE
fix(fleet): extend PATH in fleet-exec.sh for non-interactive SSH dispatch

### DIFF
--- a/scripts/fleet-exec.sh
+++ b/scripts/fleet-exec.sh
@@ -9,6 +9,33 @@
 
 set -euo pipefail
 
+# Extend PATH for non-interactive SSH dispatch.
+#
+# The dispatcher invokes us via `ssh <host> bash $HOME/.../fleet-exec.sh ...`
+# which is a non-login non-interactive bash session. Neither ~/.bashrc nor
+# ~/.zshrc is sourced, so the inherited PATH is whatever sshd's default
+# Environment provides — typically `/usr/local/bin:/usr/bin:/bin:/usr/sbin:
+# /sbin:/snap/bin` and nothing else.
+#
+# `claude` (and sometimes `crane` / `node`) is commonly installed in
+# user-local locations that are NOT on the default sshd PATH:
+#
+#   ~/.local/bin             — official claude installer (macOS + Linux)
+#   ~/.npm-global/bin        — npm with user-local prefix (think pattern)
+#   /opt/homebrew/bin        — Apple Silicon Homebrew (mac23 pattern)
+#   /usr/local/bin           — Intel Homebrew, common Linux installs
+#
+# Without this prepend, `nohup crane "$VENTURE"` below would either fail
+# with "crane: command not found" or succeed and then crash inside the
+# launcher with "claude is not installed or not in PATH". Both error modes
+# happen silently from the dispatcher's perspective and the task ends up
+# in a "crashed - no result.json" state with no obvious cause.
+#
+# This is the SAME PATH augmentation a login shell would build via the
+# user's rc files. We do it explicitly here to avoid the side effects of
+# sourcing arbitrary rc files (custom prompts, aliases, etc.).
+export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 TASK_ID="${1:?task_id required}"
 VENTURE="${2:?venture required}"
 REPO="${3:?repo (org/repo) required}"


### PR DESCRIPTION
## Summary

Today's Track C wave 2 fleet dispatch surfaced a real bug in `fleet-exec.sh`: it relies on the SSH default PATH to find `claude`, but `claude` is commonly installed in user-local locations (`~/.local/bin`, `~/.npm-global/bin`) that aren't on sshd's default Environment PATH.

Result: the dispatch silently crashed on **think** (claude at `~/.npm-global/bin/claude`) and **mac23** (claude at `~/.local/bin/claude`), even though both machines had claude installed and the user expected them to work.

## Root cause

`fleet-exec.sh` runs as `ssh <host> bash <path>` which is **non-login non-interactive bash**. Neither `~/.bashrc` nor `~/.zshrc` is sourced, so the inherited PATH is whatever sshd's default Environment provides — typically just `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/snap/bin`.

The four common claude install locations on a fleet machine:

| Path | Source | Affected machine |
|---|---|---|
| `~/.local/bin/claude` | Official claude installer | mac23 |
| `~/.npm-global/bin/claude` | npm with user-local prefix | think |
| `/usr/local/bin/claude` | Intel Homebrew, common Linux | mini ✓ (worked) |
| `/usr/bin/claude` | apt, Linux package manager | mbp27 ✓ (worked) |

Both failure modes were silent from the dispatcher's perspective: tasks landed in "crashed - no result.json" with the actual `claude is not installed or not in PATH` error buried in the per-task output log.

## Fix

Prepend the four common user-local bin locations to PATH at the top of `fleet-exec.sh`:

```bash
export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
```

This is the same PATH augmentation a login shell builds via the user's rc files. Doing it explicitly avoids the side effects of sourcing arbitrary rc files (custom prompts, aliases, network calls, etc.).

## Verification

- Read `scripts/fleet-exec.sh` — only adds the export line, no other changes.
- The exact PATH locations were enumerated by SSHing into each machine and inspecting where `claude` actually resolves (via `which`, `command -v`, `find`, and `readlink`).
- After this lands, the same dispatch wave that crashed on think and mac23 should succeed on the next retry.

## Test plan

- [x] `npm run verify` is green (script-only change, no TS)
- [ ] After merge: pull on each fleet machine via `git -C ~/dev/crane-console pull`
- [ ] Re-dispatch the wave (`crane_fleet_dispatch` for sc-console#97 to think, smd-console#9 to mac23) and verify the tasks reach `running` state instead of crashing immediately

## Follow-ups

- Add a fleet-dispatch preflight check (`crane_preflight --machine think`) that verifies `claude` and `crane` are resolvable BEFORE dispatching, with a clear "missing on $machine" error instead of silent crash.
- Add `claude` install verification to `scripts/bootstrap-machine.sh`.
- These will be filed as separate issues against crane-console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)