### PR TITLE
fix(crane-context): add session_id format validation to /eos, /update, /heartbeat

### DIFF
--- a/workers/crane-context/src/endpoints/sessions.ts
+++ b/workers/crane-context/src/endpoints/sessions.ts
@@ -27,6 +27,7 @@ import {
   isValidAgent,
   isValidVenture,
   isValidRepo,
+  isValidSessionId,
 } from '../utils'
 import { HTTP_STATUS, MAX_REQUEST_BODY_SIZE, KNOWLEDGE_BASE_TAGS, VENTURES } from '../constants'
 import { fetchDocsForVenture, fetchDocsMetadata } from '../docs'
@@ -450,10 +451,14 @@ export async function handleEndOfSession(request: Request, env: Env): Promise<Re
 
     const body = (await request.json()) as EndOfSessionBody
 
-    // Basic validation
-    if (!body.session_id || typeof body.session_id !== 'string') {
+    // Validate required fields with format checks
+    if (
+      !body.session_id ||
+      typeof body.session_id !== 'string' ||
+      !isValidSessionId(body.session_id)
+    ) {
       return validationErrorResponse(
-        [{ field: 'session_id', message: 'Required string field' }],
+        [{ field: 'session_id', message: 'Required, must match pattern: sess_<ULID>' }],
         context.correlationId
       )
     }
@@ -603,10 +608,14 @@ export async function handleUpdate(request: Request, env: Env): Promise<Response
     // 2. Parse and validate request body
     const body = (await request.json()) as UpdateBody
 
-    // Basic validation
-    if (!body.session_id || typeof body.session_id !== 'string') {
+    // Validate required fields with format checks
+    if (
+      !body.session_id ||
+      typeof body.session_id !== 'string' ||
+      !isValidSessionId(body.session_id)
+    ) {
       return validationErrorResponse(
-        [{ field: 'session_id', message: 'Required string field' }],
+        [{ field: 'session_id', message: 'Required, must match pattern: sess_<ULID>' }],
         context.correlationId
       )
     }
@@ -710,10 +719,14 @@ export async function handleHeartbeat(request: Request, env: Env): Promise<Respo
     // 2. Parse and validate request body
     const body = (await request.json()) as HeartbeatBody
 
-    // Basic validation
-    if (!body.session_id || typeof body.session_id !== 'string') {
+    // Validate required fields with format checks
+    if (
+      !body.session_id ||
+      typeof body.session_id !== 'string' ||
+      !isValidSessionId(body.session_id)
+    ) {
       return validationErrorResponse(
-        [{ field: 'session_id', message: 'Required string field' }],
+        [{ field: 'session_id', message: 'Required, must match pattern: sess_<ULID>' }],
         context.correlationId
       )
     }

--- a/workers/crane-context/src/utils.ts
+++ b/workers/crane-context/src/utils.ts
@@ -434,6 +434,14 @@ export function isValidAgent(agent: string): boolean {
 }
 
 /**
+ * Validate session ID format
+ * Must match: sess_<26-char ULID>
+ */
+export function isValidSessionId(id: string): boolean {
+  return /^sess_[0-9A-HJKMNP-TV-Z]{26}$/.test(id)
+}
+
+/**
  * Calculate size of string in bytes
  *
  * @param str - String to measure


### PR DESCRIPTION
## Summary

- Add `isValidSessionId()` validator enforcing the `sess_<26-char ULID>` pattern
- Wire it into `/eos`, `/update`, and `/heartbeat` handlers (previously only checked non-empty string)
- Rejects malformed session IDs at the validation layer instead of letting them through to the DB lookup

## Test plan

- [ ] `npm run verify` passes
- [ ] Existing 343 crane-context tests pass (no regressions)
- [ ] Canary test passes (workerd-safe - no eval/new Function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)