### PR TITLE
fix(launcher): restore Claude.ai MCP integrations with targeted deny

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,5 @@
-{}
+{
+  "permissions": {
+    "deny": ["mcp__claude_ai_crane_context__*"]
+  }
+}

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1207,11 +1207,10 @@ export function launchAgent(
     CRANE_VENTURE_NAME: venture.name,
     CRANE_REPO: repoName,
     MCP_TIMEOUT: process.env.MCP_TIMEOUT ?? '30000',
-    // Disable Claude.ai remote MCP integrations in CLI sessions.
-    // The local crane MCP + gh CLI cover everything agents need.
-    // Without this, remote servers like crane-context expose redundant
-    // GitHub tools that bloat context and mislead agents.
-    ENABLE_CLAUDEAI_MCP_SERVERS: 'false',
+    // Claude.ai remote MCP integrations are left enabled so that
+    // non-crane integrations (Google Calendar, Notion, etc.) remain
+    // available. Redundant crane-context tools are blocked by deny
+    // rules in .claude/settings.json instead of a blanket kill switch.
     // Force Claude Code to load all MCP tool schemas eagerly. By default
     // (Claude Code 2.1.x) MCP tools are auto-deferred when their schemas
     // exceed ~10% of the context window — they show up in a deferred-tool


### PR DESCRIPTION
## Summary
- Remove blanket `ENABLE_CLAUDEAI_MCP_SERVERS=false` from the crane launcher; it killed Google Calendar, Notion, and every other Claude.ai remote integration, not just the crane-context GitHub proxy it was meant to block
- Replace with a targeted deny rule in `.claude/settings.json` for `mcp__claude_ai_crane_context__*` (the only integration that was actually redundant with local crane MCP)
- Restores `/calendar-sync` end-to-end - Google Calendar events can be created again from CLI sessions

## Root cause
`#396` (March 30) added the blanket kill switch to stop agents reaching for redundant crane-context GitHub tools through the Claude.ai remote path. The env var disables ALL Claude.ai integrations as a single binary switch. Since March 30, `/calendar-sync` has been creating D1 actual event records but never linking them to GCal because `gcal_create_event` was unreachable.

## Test plan
- [x] `npm run verify` passes
- [ ] Launch a fresh `crane vc` session, confirm Google Calendar tools appear in tool list
- [ ] Run `/calendar-sync`, confirm pending D1 records (2026-04-06 through 2026-04-09) get GCal events created and linked
- [ ] Confirm the original #396 motivation still holds: agents should not see redundant crane-context tools from Claude.ai (deny rule covers this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)