### PR TITLE
fix(fleet-ops-health): stop failing on findings (closes #491)

### DIFF
--- a/.github/workflows/fleet-ops-health.yml
+++ b/.github/workflows/fleet-ops-health.yml
@@ -4,8 +4,13 @@ name: Fleet Ops Health
 #   1. fleet-lint.sh   — static workflow file antipatterns (no API needed)
 #   2. fleet-ops-health.sh — runtime GitHub state via gh api
 #
-# Both fail-loud on findings so the captain sees them in the workflow
-# summary instead of silently rotting.
+# fleet-lint fails the job on antipatterns (script exits 1).
+# fleet-ops-health ingests findings into the fleet_health_findings D1
+# table and lets crane_sos surface them via the Fleet Health section.
+# The job fails only on pipeline errors (script crash, ingest API
+# non-200) — finding count is informational, not a failure signal.
+# This avoids duplicating the alarm channel: SOS Fleet Health is the
+# single source of truth for fleet drift.
 
 on:
   schedule:
@@ -97,10 +102,15 @@ jobs:
           path: fleet-health.json
           retention-days: 90
 
-      - name: Fail on errors
+      - name: Summarize finding count
+        # Informational only — not a failure signal. Findings live in
+        # the fleet_health_findings D1 table (ingested above) and are
+        # surfaced via crane_sos's Fleet Health section. Pipeline errors
+        # (script crash, ingest non-200) already failed the job earlier.
         run: |
           status=$(jq -r '.status' fleet-health.json)
+          finding_count=$(jq -r '.findings | length' fleet-health.json)
+          echo "Fleet health status: $status ($finding_count finding(s))"
           if [ "$status" != "pass" ]; then
-            echo "Fleet health audit failed — see report above"
-            exit 1
+            echo "::notice::Fleet health audit found $finding_count finding(s) — see crane_sos Fleet Health section for details."
           fi


### PR DESCRIPTION
## Summary

Closes venturecrane/crane-console#491. The audit's diagnosis was wrong; the actual fix is a workflow change.

The 9 critical \"Fleet Ops Health\" alerts on \`crane_sos\` were not caused by a missing \`CRANE_ADMIN_KEY\` secret. The secret has been set since 2026-04-09T01:02:43Z, and the most recent failed run logs show:

\`\`\`
Ingested fleet health findings: 1 new, 6 refreshed, 0 auto-resolved
\`\`\`

The ingest step **succeeded**. The job failed at the subsequent **Fail on errors** step, which intentionally exits 1 whenever the fleet has any findings. That design predates the \`fleet_health_findings\` D1 table and the SOS Fleet Health section.

We currently have **two parallel alarm channels for the same data**:

1. **Old path:** workflow exit-1 → crane-watch → critical notification → \`crane_notifications\`
2. **New path:** D1 ingest → \`fleet_health_findings\` → \`crane_sos\` Fleet Health section

The new path is structured, sized, and surfaced at exactly the right time (session start). The old path is noise — it doesn't tell you anything the SOS doesn't already tell you.

## What this PR does

- **Removes** the \`Fail on errors\` step (the spurious failure source).
- **Adds** a \`Summarize finding count\` step that emits a GitHub Actions \`::notice::\` with the finding count instead of failing the job.
- **Updates** the workflow header comment to reflect the new design contract.

## What this PR does NOT change

- \`fleet-lint\` job is unchanged — it still fails on antipatterns via \`fleet-lint.sh --ci\`.
- The secret check (\`if [ -z \"\$CRANE_ADMIN_KEY\" ]; then exit 1\`) is unchanged. Missing secret is still a hard failure.
- The HTTP code check on the ingest call is unchanged. Non-200 from the API is still a hard failure.
- The fleet-ops-health.sh script itself is unchanged. Script crashes still fail the job via \`bash -e\`.

So the workflow still fails-loud on **pipeline errors** (the things you actually want to know about). It just stops failing on **finding counts** (the things the SOS already shows you).

## Where the 9 alerts came from

All 9 alerts came from **4 manual workflow_dispatch runs on Apr 8/9** when someone was setting up \`GH_FLEET_AUDIT_TOKEN\` and \`CRANE_ADMIN_KEY\` (4 runs × 2 alerts each + 1 unrelated d1-backup notify-failure = 9). There have been **zero scheduled runs yet** — the next one is Mon Apr 13 13:00 UTC. The stale alerts will be acked/resolved separately after this PR merges and a verification dispatch run goes green.

## Test plan

- [x] \`npm run verify\` (typecheck + format + lint + tests + canary) passes locally
- [ ] Manual \`workflow_dispatch\` on this branch reports a green run with the \`::notice::\` finding count visible in the summary
- [ ] After merge: ack/resolve the 9 stale alerts via \`crane_notification_update\`
- [ ] Mon Apr 13 13:00 UTC scheduled run goes green

## Side observation (filed separately, not in this PR)

The 9th alert was \`Check \"Notify on failure\" failure on main\` — that's a job inside \`d1-backup.yml\`, not Fleet Ops Health. It's a separate concern. Worth a look but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)