### PR TITLE
fix(crane-mcp): debounced session heartbeat refresh (fixes /eos 409s on long sessions)

### DIFF
--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from './tools/notifications.js'
 import { deployHeartbeatInputSchema, executeDeployHeartbeat } from './tools/deploy-heartbeat.js'
 import { logTokenUsage, generateTokenReport } from './lib/token-tracker.js'
+import { refreshSessionHeartbeatIfNeeded, startHeartbeatTimer } from './lib/heartbeat-refresh.js'
 
 const server = new Server(
   {
@@ -579,6 +580,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params
   const startMs = Date.now()
 
+  // Keep the current session alive during tool-heavy work. Debounced
+  // to ~10 min, fire-and-forget, never blocks or fails the tool call.
+  // Safe to call on every tool (including crane_sos/crane_preflight)
+  // because it is a no-op when session context is empty.
+  refreshSessionHeartbeatIfNeeded()
+
   try {
     switch (name) {
       case 'crane_preflight': {
@@ -760,6 +767,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport()
   await server.connect(transport)
+
+  // Install the background heartbeat timer. This covers the edge case
+  // where MCP tool calls go sparse for 10+ minutes (long bash runs,
+  // test suites, sub-agent delegation). The timer is .unref()'d so it
+  // does not prevent process exit when stdin closes.
+  startHeartbeatTimer()
+
   console.error('crane-mcp server started')
 }
 

--- a/packages/crane-mcp/src/lib/crane-api.test.ts
+++ b/packages/crane-mcp/src/lib/crane-api.test.ts
@@ -139,6 +139,93 @@ describe('crane-api', () => {
     })
   })
 
+  describe('CraneApi.refreshHeartbeat', () => {
+    it('POSTs to /heartbeat with session_id and resolves on 200', async () => {
+      const { CraneApi } = await getModule()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          session_id: 'sess_abc',
+          last_heartbeat_at: '2026-04-11T00:10:00Z',
+        }),
+      })
+
+      const api = new CraneApi('test-api-key', PROD_URL)
+      await expect(api.refreshHeartbeat('sess_abc')).resolves.toBeUndefined()
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${PROD_URL}/heartbeat`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-Relay-Key': 'test-api-key',
+          }),
+        })
+      )
+
+      const callArgs = mockFetch.mock.calls[0]
+      const body = JSON.parse(callArgs[1].body)
+      expect(body).toEqual({ session_id: 'sess_abc' })
+    })
+
+    it('throws SessionNotActiveError with parsed status on 409', async () => {
+      const { CraneApi, SessionNotActiveError } = await getModule()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: 'Session is not active',
+          details: {
+            session_id: 'sess_abc',
+            status: 'abandoned',
+          },
+        }),
+      })
+
+      const api = new CraneApi('test-api-key', PROD_URL)
+      const promise = api.refreshHeartbeat('sess_abc')
+
+      await expect(promise).rejects.toBeInstanceOf(SessionNotActiveError)
+      await expect(promise).rejects.toThrow('Session not active: abandoned')
+    })
+
+    it('throws SessionNotActiveError with "unknown" when 409 body is malformed', async () => {
+      const { CraneApi, SessionNotActiveError } = await getModule()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => {
+          throw new Error('invalid json')
+        },
+      })
+
+      const api = new CraneApi('test-api-key', PROD_URL)
+      await expect(api.refreshHeartbeat('sess_abc')).rejects.toMatchObject({
+        name: 'SessionNotActiveError',
+        sessionStatus: 'unknown',
+      })
+    })
+
+    it('throws a generic error on 5xx', async () => {
+      const { CraneApi } = await getModule()
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+
+      const api = new CraneApi('test-api-key', PROD_URL)
+      await expect(api.refreshHeartbeat('sess_abc')).rejects.toThrow(
+        'Heartbeat refresh failed (500)'
+      )
+    })
+  })
+
   describe('CraneApi.getDoc', () => {
     it('fetches doc successfully', async () => {
       const { CraneApi } = await getModule()

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -4,6 +4,20 @@
 
 import { hostname as osHostname } from 'node:os'
 
+/**
+ * Thrown by CraneApi.refreshHeartbeat() when the server returns 409
+ * with a non-active session status (abandoned, ended, superseded).
+ *
+ * The caller should treat this as a permanent failure for this session
+ * and stop further refresh attempts — not a transient error to retry.
+ */
+export class SessionNotActiveError extends Error {
+  constructor(public readonly sessionStatus: string) {
+    super(`Session not active: ${sessionStatus}`)
+    this.name = 'SessionNotActiveError'
+  }
+}
+
 export interface Venture {
   code: string
   name: string
@@ -659,6 +673,46 @@ export class CraneApi {
     }
 
     return (await response.json()) as SosResponse
+  }
+
+  /**
+   * Refresh the session heartbeat. Called by the client-side debounced
+   * refresh loop in heartbeat-refresh.ts to keep long sessions alive
+   * during tool-heavy work or idle bash runs.
+   *
+   * Throws SessionNotActiveError on 409 so the caller can clearSession()
+   * and halt further attempts against a dead session. Throws a generic
+   * Error on any other non-2xx response.
+   */
+  async refreshHeartbeat(sessionId: string): Promise<void> {
+    const response = await fetch(`${this.apiBase}/heartbeat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Relay-Key': this.apiKey,
+      },
+      body: JSON.stringify({ session_id: sessionId }),
+    })
+
+    if (response.status === 409) {
+      // Server tells us the session is not in 'active' status. Parse
+      // the body to surface the specific status (abandoned/ended/etc.)
+      // and throw a typed error so the debounce loop can react.
+      let status = 'unknown'
+      try {
+        const body = (await response.json()) as { details?: { status?: string } }
+        if (body?.details?.status) {
+          status = body.details.status
+        }
+      } catch {
+        // Body was not JSON or malformed; fall through with 'unknown'
+      }
+      throw new SessionNotActiveError(status)
+    }
+
+    if (!response.ok) {
+      throw new Error(`Heartbeat refresh failed (${response.status})`)
+    }
   }
 
   async getDocAudit(

--- a/packages/crane-mcp/src/lib/heartbeat-refresh.test.ts
+++ b/packages/crane-mcp/src/lib/heartbeat-refresh.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for heartbeat-refresh.ts
+ *
+ * Verifies both the on-dispatch refresh path and the background timer
+ * path keep the session alive against a 45-minute server-side staleness
+ * threshold without thundering-herd retries on failure.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+import { CraneApi, SessionNotActiveError } from './crane-api.js'
+import {
+  HEARTBEAT_REFRESH_INTERVAL_MS,
+  clearSession,
+  getSessionContext,
+  setSession,
+} from './session-state.js'
+import { refreshSessionHeartbeatIfNeeded, startHeartbeatTimer } from './heartbeat-refresh.js'
+
+// Mirrors STALE_AFTER_MINUTES in workers/crane-context/src/constants.ts.
+// The liveness simulations (tests 10 & 11) assert the debounce cadence
+// keeps the simulated server last_heartbeat_at within this window.
+const SERVER_STALE_THRESHOLD_MS = 45 * 60 * 1000
+
+describe('heartbeat-refresh', () => {
+  let refreshSpy: MockInstance<[string], Promise<void>>
+  let originalContextKey: string | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-11T00:00:00Z'))
+
+    originalContextKey = process.env.CRANE_CONTEXT_KEY
+    process.env.CRANE_CONTEXT_KEY = 'test-relay-key'
+
+    clearSession()
+
+    refreshSpy = vi.spyOn(CraneApi.prototype, 'refreshHeartbeat').mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    refreshSpy.mockRestore()
+    if (originalContextKey === undefined) {
+      delete process.env.CRANE_CONTEXT_KEY
+    } else {
+      process.env.CRANE_CONTEXT_KEY = originalContextKey
+    }
+    clearSession()
+    vi.useRealTimers()
+  })
+
+  describe('refreshSessionHeartbeatIfNeeded', () => {
+    it('is a no-op when no session is set', () => {
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when CRANE_CONTEXT_KEY is unset', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      // Advance past the debounce window so the getSessionContext check passes
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+
+      delete process.env.CRANE_CONTEXT_KEY
+      refreshSessionHeartbeatIfNeeded()
+
+      expect(refreshSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not refresh immediately after setSession (server already has fresh heartbeat from /sos)', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      refreshSessionHeartbeatIfNeeded()
+
+      // setSession marks an implicit attempt at T=0 because /sos just
+      // updated the server-side heartbeat. A client-side refresh would
+      // be redundant for ~10 min.
+      expect(refreshSpy).not.toHaveBeenCalled()
+    })
+
+    it('fires a refresh once the debounce window elapses', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+      refreshSessionHeartbeatIfNeeded()
+
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+      expect(refreshSpy).toHaveBeenCalledWith('sess_1')
+    })
+
+    it('debounces repeat calls within the refresh window', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+
+      // First refresh fires at T = debounce + 1
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+      // Rapid follow-ups are debounced
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(30_000) // 30s between calls
+        refreshSessionHeartbeatIfNeeded()
+      }
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+      // After another full window, refresh fires again
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS)
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('clears session on permanent 409 SessionNotActiveError', async () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+
+      refreshSpy.mockRejectedValueOnce(new SessionNotActiveError('abandoned'))
+
+      refreshSessionHeartbeatIfNeeded()
+
+      // Flush the promise chain so .catch() can run clearSession()
+      await vi.runAllTicks()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(getSessionContext()).toBeNull()
+
+      // Subsequent calls are no-ops because the session is cleared
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('preserves session on transient (non-409) errors but respects debounce', async () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+
+      refreshSpy.mockRejectedValueOnce(new Error('network timeout'))
+      refreshSessionHeartbeatIfNeeded()
+
+      // Flush microtasks
+      await vi.runAllTicks()
+      await Promise.resolve()
+
+      // Session is preserved
+      expect(getSessionContext()).not.toBeNull()
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+      // Immediate retry is debounced — no thundering herd
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+      // Next attempt fires after a full debounce window
+      vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+      refreshSessionHeartbeatIfNeeded()
+      expect(refreshSpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('never emits an unhandledRejection, even when the underlying promise rejects', async () => {
+      const unhandled: unknown[] = []
+      const handler = (reason: unknown) => {
+        unhandled.push(reason)
+      }
+      process.on('unhandledRejection', handler)
+
+      try {
+        setSession('sess_1', 'vc', 'venturecrane/crane-console')
+        vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS + 1)
+
+        refreshSpy.mockRejectedValueOnce(new Error('boom'))
+        refreshSessionHeartbeatIfNeeded()
+
+        // Flush microtasks so any pending rejection has a chance to
+        // propagate. If our .catch() handler is wired correctly, none will.
+        await vi.runAllTicks()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off('unhandledRejection', handler)
+      }
+    })
+  })
+
+  describe('startHeartbeatTimer', () => {
+    it('installs an interval at HEARTBEAT_REFRESH_INTERVAL_MS and calls .unref()', () => {
+      const timer = startHeartbeatTimer()
+      try {
+        // Node timers carry an unref marker; easiest way to observe is
+        // via a spy before the call, but we at minimum verify the timer
+        // exists and fires at the expected interval.
+        expect(timer).toBeDefined()
+      } finally {
+        clearInterval(timer)
+      }
+    })
+
+    it('timer ticks trigger refreshSessionHeartbeatIfNeeded', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      const timer = startHeartbeatTimer()
+      try {
+        // At T = HEARTBEAT_REFRESH_INTERVAL_MS, the timer fires but the
+        // debounce check sees (now - setSession-time) == interval exactly,
+        // which is enough to trigger (>= comparison). Refresh fires once.
+        vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS)
+        expect(refreshSpy).toHaveBeenCalledTimes(1)
+
+        // Next tick 10 min later fires again
+        vi.advanceTimersByTime(HEARTBEAT_REFRESH_INTERVAL_MS)
+        expect(refreshSpy).toHaveBeenCalledTimes(2)
+      } finally {
+        clearInterval(timer)
+      }
+    })
+  })
+
+  describe('end-to-end liveness simulation', () => {
+    it('on-dispatch path keeps session live over 60 min with tool calls every 90 s', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      const sessionStart = Date.now()
+
+      // Track the timestamp of every successful refresh — this is what
+      // the server would record as last_heartbeat_at.
+      let serverLastHeartbeatAt = sessionStart // /sos just set it
+
+      refreshSpy.mockImplementation(async (_sessionId: string) => {
+        serverLastHeartbeatAt = Date.now()
+      })
+
+      // Simulate 60 min of work with a tool call every 90 s.
+      const sessionDurationMs = 60 * 60 * 1000
+      const toolCallIntervalMs = 90 * 1000
+
+      for (let t = 0; t < sessionDurationMs; t += toolCallIntervalMs) {
+        vi.advanceTimersByTime(toolCallIntervalMs)
+        refreshSessionHeartbeatIfNeeded()
+
+        // CRITICAL: at every step, assert the simulated server would NOT
+        // consider this session stale. This is the real property we care
+        // about — not "N heartbeats fired", but "session stays alive".
+        const timeSinceServerHeartbeat = Date.now() - serverLastHeartbeatAt
+        expect(timeSinceServerHeartbeat).toBeLessThan(SERVER_STALE_THRESHOLD_MS)
+      }
+
+      // Over 60 min with a 10-min debounce, we expect ~6 refresh calls.
+      expect(refreshSpy.mock.calls.length).toBeGreaterThanOrEqual(5)
+      expect(refreshSpy.mock.calls.length).toBeLessThanOrEqual(7)
+    })
+
+    it('background timer alone keeps session live over 60 min with zero tool calls', () => {
+      setSession('sess_1', 'vc', 'venturecrane/crane-console')
+      const sessionStart = Date.now()
+
+      let serverLastHeartbeatAt = sessionStart
+
+      refreshSpy.mockImplementation(async (_sessionId: string) => {
+        serverLastHeartbeatAt = Date.now()
+      })
+
+      const timer = startHeartbeatTimer()
+      try {
+        // Let the timer drive liveness for 60 min, with ZERO explicit
+        // refreshSessionHeartbeatIfNeeded() calls from the "dispatch path".
+        // Advance in 1-minute increments so we can assert the liveness
+        // invariant at every step.
+        for (let minute = 0; minute < 60; minute++) {
+          vi.advanceTimersByTime(60 * 1000)
+          const timeSinceServerHeartbeat = Date.now() - serverLastHeartbeatAt
+          expect(timeSinceServerHeartbeat).toBeLessThan(SERVER_STALE_THRESHOLD_MS)
+        }
+
+        // Timer should have fired ~6 times at the 10-min interval.
+        expect(refreshSpy.mock.calls.length).toBeGreaterThanOrEqual(5)
+        expect(refreshSpy.mock.calls.length).toBeLessThanOrEqual(7)
+      } finally {
+        clearInterval(timer)
+      }
+    })
+  })
+})

--- a/packages/crane-mcp/src/lib/heartbeat-refresh.ts
+++ b/packages/crane-mcp/src/lib/heartbeat-refresh.ts
@@ -1,0 +1,108 @@
+/**
+ * Client-side session heartbeat refresh.
+ *
+ * Keeps long sessions alive against the crane-context server's 45-minute
+ * staleness threshold (STALE_AFTER_MINUTES in workers/crane-context/src/constants.ts).
+ *
+ * Two code paths call refreshSessionHeartbeatIfNeeded:
+ *
+ * 1. The MCP tool dispatch handler in src/index.ts — runs before every
+ *    tool call, naturally keeps the session alive during active work.
+ *
+ * 2. A background setInterval timer installed by startHeartbeatTimer() —
+ *    fires every 10 min regardless of tool activity, covering the edge
+ *    case where tool calls go sparse (long bash runs, test suites,
+ *    sub-agent delegation where no MCP calls happen for 10+ minutes).
+ *
+ * Both paths share debounce state in session-state.ts, so only one
+ * network call fires per debounce window regardless of which path
+ * triggered it.
+ */
+
+import { CraneApi, SessionNotActiveError } from './crane-api.js'
+import { getApiBase } from './config.js'
+import {
+  HEARTBEAT_REFRESH_INTERVAL_MS,
+  clearSession,
+  getSessionContext,
+  markHeartbeatAttempted,
+  shouldRefreshHeartbeat,
+} from './session-state.js'
+
+/**
+ * Attempt to refresh the current session's heartbeat if:
+ *   (a) there is an active session in memory, and
+ *   (b) the debounce window has elapsed since the last attempt.
+ *
+ * Fire-and-forget: never throws, never blocks, never returns a promise
+ * the caller has to await. The internal promise chain always has both
+ * .then() and .catch() handlers attached before it escapes the function
+ * scope, so rejections cannot become unhandledRejection events.
+ *
+ * On permanent failure (409 SessionNotActiveError), calls clearSession()
+ * to halt further attempts against a dead session. This prevents a
+ * thundering herd of heartbeat requests when a sub-agent or team worker
+ * has already abandoned the parent session.
+ */
+export function refreshSessionHeartbeatIfNeeded(): void {
+  const ctx = getSessionContext()
+  if (!ctx) return
+
+  if (!shouldRefreshHeartbeat()) return
+
+  const apiKey = process.env.CRANE_CONTEXT_KEY
+  if (!apiKey) return
+
+  // Mark the attempt BEFORE the network call fires. This prevents
+  // synchronous repeat calls within the debounce window (either from
+  // the on-dispatch path or from a concurrent timer tick) from
+  // stacking up refresh requests.
+  markHeartbeatAttempted()
+
+  const api = new CraneApi(apiKey, getApiBase())
+
+  // The promise is not awaited, but both handlers are attached before
+  // it leaves this function scope — so a rejection cannot become an
+  // unhandledRejection event.
+  api
+    .refreshHeartbeat(ctx.sessionId)
+    .then(() => {
+      // No additional state to update — the attempt marker is already set.
+    })
+    .catch((err: unknown) => {
+      if (err instanceof SessionNotActiveError) {
+        // The server says this session is not active. Stop trying.
+        // The next /sos will create a fresh session.
+        clearSession()
+        if (process.env.CRANE_DEBUG) {
+          console.error(
+            `[crane-mcp] heartbeat refresh: session marked ${err.sessionStatus}, clearing local state`
+          )
+        }
+        return
+      }
+      // Transient error (network, 500, etc.). The attempt marker is
+      // still set, so we will not retry until the next debounce window.
+      // The background timer will naturally provide the next attempt.
+      if (process.env.CRANE_DEBUG) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[crane-mcp] heartbeat refresh failed (transient): ${message}`)
+      }
+    })
+}
+
+/**
+ * Install a background interval that fires refreshSessionHeartbeatIfNeeded()
+ * every HEARTBEAT_REFRESH_INTERVAL_MS milliseconds.
+ *
+ * The timer handle is .unref()'d so it does not keep the Node.js event
+ * loop alive when stdin closes — crane-mcp must exit cleanly when the
+ * Claude Code parent process terminates.
+ *
+ * Returns the timer handle so tests can clearInterval() it in cleanup.
+ */
+export function startHeartbeatTimer(): NodeJS.Timeout {
+  const timer = setInterval(refreshSessionHeartbeatIfNeeded, HEARTBEAT_REFRESH_INTERVAL_MS)
+  timer.unref()
+  return timer
+}

--- a/packages/crane-mcp/src/lib/session-state.ts
+++ b/packages/crane-mcp/src/lib/session-state.ts
@@ -9,10 +9,22 @@ export interface SessionContext {
   repo: string
 }
 
+/**
+ * Debounce interval for heartbeat refresh calls. Matches the server's
+ * HEARTBEAT_INTERVAL_SECONDS (600s in workers/crane-context/src/constants.ts)
+ * and gives a 3x safety margin under the 45-minute staleness threshold.
+ */
+export const HEARTBEAT_REFRESH_INTERVAL_MS = 10 * 60 * 1000
+
 let sessionContext: SessionContext | null = null
+let lastHeartbeatAttemptAt: number = 0
 
 export function setSession(id: string, venture: string, repo: string): void {
   sessionContext = { sessionId: id, venture, repo }
+  // A fresh /sos already set last_heartbeat_at server-side, so we do
+  // not need another client-side refresh until the debounce window
+  // elapses. Record the implicit "attempt" at setSession time.
+  lastHeartbeatAttemptAt = Date.now()
 }
 
 export function getSessionContext(): SessionContext | null {
@@ -21,4 +33,28 @@ export function getSessionContext(): SessionContext | null {
 
 export function clearSession(): void {
   sessionContext = null
+  lastHeartbeatAttemptAt = 0
+}
+
+/**
+ * Debounce check: has enough time passed since the last heartbeat attempt
+ * (success or failure) to justify another refresh?
+ *
+ * Keyed on attempts, not successes, so persistent failures cannot cause
+ * a thundering-herd retry on every MCP tool call. The tradeoff: if a
+ * heartbeat fails, we will not retry until the debounce window elapses.
+ * That is acceptable because the background timer in heartbeat-refresh.ts
+ * provides the redundant attempt path.
+ */
+export function shouldRefreshHeartbeat(): boolean {
+  return Date.now() - lastHeartbeatAttemptAt >= HEARTBEAT_REFRESH_INTERVAL_MS
+}
+
+/**
+ * Record that a heartbeat refresh was attempted. Called before the
+ * network call fires so synchronous repeat calls within the debounce
+ * window are correctly skipped.
+ */
+export function markHeartbeatAttempted(): void {
+  lastHeartbeatAttemptAt = Date.now()
 }


### PR DESCRIPTION
## Summary

Long AI-agent work sessions routinely fail at \`/eos\` with \`HTTP 409 Session is not active (status: abandoned)\`. Root cause: nothing refreshes \`last_heartbeat_at\` between \`/sos\` and \`/eos\`. The crane-context worker uses a 45-minute staleness threshold, but MCP tool calls (\`POST /mcp\`) do not touch the heartbeat — only \`/sos\`, \`/heartbeat\`, and \`/update\` do, and nothing calls those during normal work.

This PR adds a two-path client-side heartbeat refresh inside \`crane-mcp\`, sharing a single debounced helper.

## What changed

### New module: \`packages/crane-mcp/src/lib/heartbeat-refresh.ts\`

Two entry points sharing one implementation:

1. **\`refreshSessionHeartbeatIfNeeded()\`** — called at the top of \`CallToolRequestSchema\` handler in \`src/index.ts\`, so any MCP tool call naturally keeps the session alive during active work.
2. **\`startHeartbeatTimer()\`** — installed once at crane-mcp server startup via \`main()\`. Calls \`setInterval()\` every 10 minutes and \`.unref()\`'s the handle so it does not prevent process exit. Covers the edge case where tool calls go sparse for 10+ minutes (long bash runs, test suites, sub-agent delegation).

Both paths share debounce state keyed on **attempts, not successes**, so persistent failures cannot cause thundering-herd retries. On permanent 409 (\`SessionNotActiveError\` with \`status=abandoned/ended\`), the helper calls \`clearSession()\` to halt further attempts against a dead session. Fire-and-forget semantics with both \`.then()\` and \`.catch()\` handlers attached before the promise escapes the function scope (no unhandled rejections).

### \`packages/crane-mcp/src/lib/session-state.ts\`

Adds \`shouldRefreshHeartbeat()\` and \`markHeartbeatAttempted()\` helpers plus \`HEARTBEAT_REFRESH_INTERVAL_MS = 10 * 60 * 1000\`. \`setSession()\` initializes the attempt marker to \`Date.now()\` (since \`/sos\` just set the server-side heartbeat). \`clearSession()\` resets it to 0.

### \`packages/crane-mcp/src/lib/crane-api.ts\`

New \`refreshHeartbeat(sessionId)\` method + typed \`SessionNotActiveError\` class. The method \`POST\`s to \`/heartbeat\` with \`X-Relay-Key\` and parses the 409 response body to surface the specific status. No server-side changes — the endpoint already exists.

### \`packages/crane-mcp/src/index.ts\`

Two small additions: (1) call \`refreshSessionHeartbeatIfNeeded()\` at the top of the tool dispatch handler; (2) call \`startHeartbeatTimer()\` in \`main()\` right after \`server.connect(transport)\`. No changes to individual tool cases.

## Design decisions (from the approved plan)

- **Client-side, not server-side:** multiple \`crane-mcp\` processes on the same host share an actor key, so the server cannot safely pick which session to refresh. Each \`crane-mcp\` process already knows its own session in memory via the existing \`session-state.ts\` singleton.
- **Debounce on attempts:** prevents retry stampedes. If a refresh fails, we wait the full 10-minute window before the next attempt. The background timer provides the redundant path in case the on-dispatch path misses.
- **10-minute debounce:** matches the server's \`HEARTBEAT_INTERVAL_SECONDS = 600\`. 3x safety margin under the 45-minute staleness threshold. At most ~6 extra network calls/hour during active work, zero when idle.
- **Does NOT change \`STALE_AFTER_MINUTES\`:** 45 min is fine once the mechanism is fixed.
- **No server changes, no migrations, no hooks, no filesystem persistence.**

## Known behavior change

Team workers and sub-agents that call \`/sos\` mid-session will now **resume** the parent session (because it stays fresh) rather than forking a new one. This is arguably closer to the design intent of \`findOrCreateSession\` (sessions are \`(agent, venture, repo, track)\`-keyed identities, not per-process instances).

**Regression risk:** if a future team worker calls \`/eos\`, the parent's subsequent \`/eos\` would 409 with \`status=ended\` instead of \`status=abandoned\`. Today's team workers don't do this. If observed after shipping, the signature is visible in \`crane_notifications\` and the rollback is trivial (revert this PR and pursue the proper fix — team worker \`track\` differentiation — as a follow-up).

## Tests

**New file:** \`packages/crane-mcp/src/lib/heartbeat-refresh.test.ts\` — **12 tests** including two critical end-to-end liveness simulations:

- **Test 11:** Simulates a 60-minute session with tool calls every 90 seconds. At every step, asserts that \`Date.now() - simulatedServerLastHeartbeatAt < 45 * 60 * 1000\`. This proves the debounce cadence is actually sufficient to keep the session live, not just that \"N heartbeats fired\".
- **Test 12:** Same but with **zero tool calls** — only the background timer fires. Proves the timer path alone keeps the session alive.
- Plus 10 tests covering: no-op when session null, no-op when \`CRANE_CONTEXT_KEY\` unset, debounce within window, refresh after window, clearSession on permanent 409, preserve session on transient errors, no unhandledRejection canary, background timer install, timer ticks trigger refresh.

**Edits:** \`packages/crane-mcp/src/lib/crane-api.test.ts\` — **4 new tests** for \`refreshHeartbeat()\` covering happy path, 409 with parsed status, 409 with malformed body, and 5xx.

**\`npm run verify\` passes:** 383 crane-mcp tests (was 367), 36 crane-test-harness, 343 crane-context, 65 crane-watch, 25 crane-mcp-remote, 2 canary. Zero new lint errors.

## Follow-ups to file as separate issues

1. **Server-side defense-in-depth** — refresh heartbeat inside \`workers/crane-context/src/mcp.ts handleMcpRequest()\` based on actor identity. Benefits any non-crane-mcp MCP client in the future.
2. **\`last_activity_at\` orphan column cleanup** — either use it in the staleness check or drop it.
3. **Team worker session isolation** — pass a distinct \`track\` parameter to \`/sos\` when spawning team workers.
4. **Staleness telemetry** — counter in \`markSessionAbandoned()\` so we can observe how often sessions still go stale after this fix ships.
5. **Permanent-failure observability** — debug log/metric when \`clearSession()\` is called due to 409.

## Test plan

- [x] \`npm test -w @venturecrane/crane-mcp\` — passes
- [x] \`npm run verify\` (typecheck + format + lint + tests + canary + builds) — passes
- [x] End-to-end liveness unit simulations (tests 11 & 12) assert real liveness invariant at every step
- [ ] **Stage 3 live staging verification** (per plan) — temporarily set \`CONTEXT_SESSION_STALE_MINUTES=5\` in staging, run a Claude Code session against staging, observe \`POST /heartbeat\` requests in the tail log, verify \`/eos\` succeeds after the 5-min window has elapsed with tool calls, then repeat for the idle-bash scenario, then the permanent-failure scenario. Revert staging config. **To be done before merge.**
- [ ] Stage 4 production observation — after merge, confirm a deliberately long session (~90 min) completes \`/eos\` against the original session, and watch \`crane_notifications\` for 7 days for regression signatures.

## Source

Written from the approved plan after a Devil's Advocate \`/critique\` round that identified 5 issues; 4 were adopted in the final plan and 1 was already handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)