### PR TITLE
fix(launcher): inject crane-context deny into user-scope Claude settings

### DIFF
--- a/config/claude-deny-rules.json
+++ b/config/claude-deny-rules.json
@@ -1,0 +1,1 @@
+["mcp__claude_ai_crane_context__*"]

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -51,6 +51,7 @@ import {
   setupGeminiMcp,
   setupClaudeMcp,
   ensureClaudeProjectTrust,
+  ensureClaudeUserDenyRules,
   syncClaudeAssets,
   extractPassthroughArgs,
 } from './launch-lib.js'
@@ -642,6 +643,188 @@ describe('ensureClaudeProjectTrust', () => {
     const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
     expect(written.numStartups).toBe(5)
     expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
+  })
+})
+
+describe('ensureClaudeUserDenyRules', () => {
+  const USER_SETTINGS_PATH = join(homedir(), '.claude', 'settings.json')
+  const DENY_RULE = 'mcp__claude_ai_crane_context__*'
+
+  // Set up readFileSync to respond for both the config file and the user settings
+  // file. Any path matcher not supplied falls through to the default `'{}'`.
+  function mockReads(opts: { rules?: unknown; settings?: string | object }): void {
+    vi.mocked(readFileSync).mockImplementation((filePath: unknown) => {
+      const p = String(filePath)
+      if (p.includes('claude-deny-rules.json')) {
+        return opts.rules !== undefined ? JSON.stringify(opts.rules) : JSON.stringify([DENY_RULE])
+      }
+      if (p.includes('.claude/settings.json')) {
+        if (typeof opts.settings === 'string') return opts.settings
+        return JSON.stringify(opts.settings ?? {})
+      }
+      return '{}'
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Silence expected warnings in malformed/bad-type test cases so they don't
+    // clutter the test output. Individual tests that want to inspect warn
+    // behavior can override this spy.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('creates ~/.claude/settings.json with deny rule when file missing', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    mockReads({})
+
+    ensureClaudeUserDenyRules()
+
+    expect(mkdirSync).toHaveBeenCalledWith(join(homedir(), '.claude'), { recursive: true })
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(writeFileSync).mock.calls[0][0]).toBe(USER_SETTINGS_PATH)
+
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.permissions.deny).toEqual([DENY_RULE])
+  })
+
+  it('preserves real-world user settings shape (env, allow list, status line, flags)', () => {
+    const realShape = {
+      env: { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1' },
+      permissions: {
+        allow: [
+          'Bash(*)',
+          'Read',
+          'Edit',
+          'Write',
+          'Glob',
+          'Grep',
+          'WebFetch',
+          'WebSearch',
+          'Skill',
+          'Task',
+          'NotebookEdit',
+          'mcp__crane__*',
+          'mcp__claude_ai_*',
+        ],
+      },
+      statusLine: {
+        type: 'command',
+        command: 'bash /Users/scottdurgan/dev/crane-console/scripts/crane-statusline.sh',
+      },
+      effortLevel: 'high',
+      fastMode: true,
+    }
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({ settings: realShape })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+
+    // All sibling keys preserved verbatim
+    expect(written.env).toEqual(realShape.env)
+    expect(written.statusLine).toEqual(realShape.statusLine)
+    expect(written.effortLevel).toBe('high')
+    expect(written.fastMode).toBe(true)
+
+    // Allow list untouched
+    expect(written.permissions.allow).toEqual(realShape.permissions.allow)
+
+    // Deny rule added
+    expect(written.permissions.deny).toEqual([DENY_RULE])
+  })
+
+  it('skips write when deny rule already present', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({
+      settings: { permissions: { allow: ['mcp__claude_ai_*'], deny: [DENY_RULE] } },
+    })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('skips with warning when settings.json is malformed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({ settings: '{not json' })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'))
+  })
+
+  it('coerces string permissions.deny into an array', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({
+      settings: { permissions: { deny: 'some-preexisting-rule' } },
+    })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.permissions.deny).toEqual(['some-preexisting-rule', DENY_RULE])
+  })
+
+  it('skips with warning when permissions.deny has unexpected type', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({ settings: { permissions: { deny: 42 } } })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unexpected type'))
+  })
+
+  it('wildcard rule supersedes narrower same-namespace entries', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({
+      settings: {
+        permissions: {
+          deny: [
+            'mcp__claude_ai_crane_context__github_search_code',
+            'mcp__claude_ai_crane_context__github_list_issues',
+            'mcp__some_other_server__*',
+          ],
+        },
+      },
+    })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    // Narrower crane_context entries stripped; unrelated deny preserved; wildcard added.
+    expect(written.permissions.deny).toEqual(['mcp__some_other_server__*', DENY_RULE])
+  })
+
+  it('creates permissions object when settings has unrelated top-level keys only', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    mockReads({ settings: { env: { FOO: 'bar' } } })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const written = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(written.env).toEqual({ FOO: 'bar' })
+    expect(written.permissions.deny).toEqual([DENY_RULE])
+  })
+
+  it('is a no-op when config/claude-deny-rules.json is empty or missing', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    // Empty rules list => launcher has nothing to inject
+    mockReads({ rules: [], settings: { permissions: { allow: ['mcp__claude_ai_*'] } } })
+
+    ensureClaudeUserDenyRules()
+
+    expect(writeFileSync).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -669,12 +669,97 @@ export function ensureClaudeProjectTrust(repoPath: string): void {
   console.log(`-> Marked ${basename(repoPath)} as trusted in ~/.claude.json`)
 }
 
+/**
+ * Ensure user-scope ~/.claude/settings.json contains every entry in
+ * config/claude-deny-rules.json under permissions.deny.
+ *
+ * Why user-scope, not per-repo: writing the deny rule into each venture repo's
+ * tracked .claude/settings.json would dirty seven working trees on first launch
+ * after a fleet sync, opening the door to cross-machine commit races and the
+ * mac23-conflict pattern in MEMORY.md. The user-scope file is untracked, applies
+ * across every Claude Code session on the machine, and is the layer Claude Code
+ * itself expects for user-managed permission policy. Deny-wins precedence
+ * guarantees the rule beats any in-repo allow wildcards (docs:
+ * "if a tool is denied at any level, no other level can allow it").
+ *
+ * Idempotent: only writes when a missing rule or a stale narrower entry in the
+ * same namespace needs to be reconciled. Tolerates missing/malformed settings
+ * files (warns and skips instead of clobbering hand edits).
+ */
+export function ensureClaudeUserDenyRules(): void {
+  const claudeDir = join(homedir(), '.claude')
+  const settingsPath = join(claudeDir, 'settings.json')
+  const rules = loadClaudeDenyRules()
+
+  if (rules.length === 0) return
+
+  let settings: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    } catch {
+      console.warn('-> Warning: ~/.claude/settings.json is malformed; skipping deny-rule injection')
+      return
+    }
+  }
+
+  if (!settings.permissions || typeof settings.permissions !== 'object') {
+    settings.permissions = {}
+  }
+  const permissions = settings.permissions as Record<string, unknown>
+
+  // Coerce permissions.deny: missing -> [], string -> [string], otherwise skip+warn.
+  if (permissions.deny === undefined) {
+    permissions.deny = []
+  } else if (typeof permissions.deny === 'string') {
+    permissions.deny = [permissions.deny]
+  } else if (!Array.isArray(permissions.deny)) {
+    console.warn(
+      '-> Warning: ~/.claude/settings.json permissions.deny has unexpected type; skipping'
+    )
+    return
+  }
+
+  let dirty = false
+  for (const rule of rules) {
+    const deny = permissions.deny as string[]
+
+    // A wildcard rule supersedes any narrower same-namespace entry (e.g. adding
+    // `mcp__claude_ai_crane_context__*` strips a stale
+    // `mcp__claude_ai_crane_context__github_search_code`).
+    if (rule.endsWith('__*')) {
+      const prefix = rule.slice(0, -1) // strip trailing *
+      const narrower = deny.filter((d) => d !== rule && d.startsWith(prefix))
+      if (narrower.length > 0) {
+        permissions.deny = deny.filter((d) => !narrower.includes(d))
+        dirty = true
+      }
+    }
+
+    if (!(permissions.deny as string[]).includes(rule)) {
+      ;(permissions.deny as string[]).push(rule)
+      dirty = true
+    }
+  }
+
+  if (!dirty) return
+
+  mkdirSync(claudeDir, { recursive: true })
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
+  console.log('-> Added crane-context deny rule to ~/.claude/settings.json')
+}
+
 export function setupClaudeMcp(repoPath: string): void {
   // Pre-accept the project trust dialog so Claude Code loads .mcp.json on first run.
   // Without this, project-scope MCP servers stay dormant until the user clicks
   // through an interactive prompt — easy to miss, easy to dismiss, and the
   // resulting "no crane MCP" failure is opaque.
   ensureClaudeProjectTrust(repoPath)
+
+  // Maintain the user-scope deny rules that block redundant Claude.ai remote
+  // MCP proxy tools (currently just crane-context, which duplicates our local
+  // mcp__crane__* surface). Writes ~/.claude/settings.json idempotently.
+  ensureClaudeUserDenyRules()
 
   const mcpJson = join(repoPath, '.mcp.json')
   const source = join(CRANE_CONSOLE_ROOT, '.mcp.json')
@@ -760,6 +845,27 @@ function loadSkillExclusions(): Set<string> {
     return new Set(names.map((n) => `${n}.md`))
   } catch {
     return new Set()
+  }
+}
+
+/**
+ * Load launcher-managed Claude Code deny rules from config/claude-deny-rules.json.
+ *
+ * These rules are injected into user-scope ~/.claude/settings.json on every
+ * `crane <venture>` launch by ensureClaudeUserDenyRules(). Adding a new rule
+ * is a one-line config commit, not a launcher code change.
+ *
+ * Graceful fallback: a missing or malformed config file yields an empty list,
+ * making the launcher a no-op rather than crashing.
+ */
+function loadClaudeDenyRules(): string[] {
+  try {
+    const rulesPath = join(CRANE_CONSOLE_ROOT, 'config', 'claude-deny-rules.json')
+    const content = readFileSync(rulesPath, 'utf-8')
+    const rules = JSON.parse(content)
+    return Array.isArray(rules) ? rules.filter((r): r is string => typeof r === 'string') : []
+  } catch {
+    return []
   }
 }
 


### PR DESCRIPTION
## Summary

- PR #488 added `mcp__claude_ai_crane_context__*` to `crane-console/.claude/settings.json` to block the redundant Claude.ai remote MCP proxy tools, but that deny is project-scoped and never applied to any other venture repo. Agents running in `ss-console`, `dc-console`, `dfg-console`, `ke-console`, `sc-console`, `smd-console`, or `vc-web` still hit per-tool permission prompts for `github_search_code`, `github_list_issues`, etc.
- Fix moves the deny-rule maintenance into the launcher and writes it to **user-scope** `~/.claude/settings.json` (untracked, machine-local) on every `crane <venture>` launch. Deny-wins precedence (per Claude Code docs: "if a tool is denied at any level, no other level can allow it") guarantees the rule beats the `mcp__claude_ai_*` allow wildcards that three venture repos already have committed.
- New `config/claude-deny-rules.json` holds the canonical list, mirroring `config/skill-exclusions.json`. Future additions become one-line config commits with no launcher code change.

## Why user-scope instead of per-repo

The original plan was to write the deny to each venture's committed `.claude/settings.json`, mirroring `setupGeminiMcp`. A `/critique` pass flagged three load-bearing risks with that approach:
1. First launch after fleet sync would dirty seven working trees and invite the `mac23` cross-machine commit-race pattern in `MEMORY.md`.
2. Three repos have `mcp__claude_ai_*` allow wildcards, making deny-wins semantics a load-bearing assumption that wasn't verified.
3. Deny list would need to live in launcher TypeScript, not a config file.

User-scope sidesteps all three: one untracked file per machine, applies regardless of CWD, deny-wins is verified by the docs (`deny → ask → allow`, first match wins, cross-level deny is absolute), and the deny list externalizes cleanly.

## Changes

- **`config/claude-deny-rules.json`** (new) — initial list: `["mcp__claude_ai_crane_context__*"]`.
- **`packages/crane-mcp/src/cli/launch-lib.ts`**
  - `loadClaudeDenyRules()` private helper with graceful empty-list fallback for missing/malformed config.
  - `ensureClaudeUserDenyRules()` exported helper merges every entry into `~/.claude/settings.json` under `permissions.deny`. Preserves all sibling keys (`env`, `statusLine`, `effortLevel`, `fastMode`, `permissions.allow`). Coerces string deny to array, skips on non-array non-string with a warning, and wildcard rules supersede pre-existing narrower entries in the same namespace to keep the list tidy.
  - `setupClaudeMcp()` calls `ensureClaudeUserDenyRules()` immediately after `ensureClaudeProjectTrust()` so every launch self-heals the rule and is silent after the first run.
- **`packages/crane-mcp/src/cli/launch-lib.test.ts`** — 9 new cases: fresh-file creation, real-world shape preservation (env + allow list + status line + flags), idempotence, malformed settings, string coercion, unexpected-type bailout, wildcard superseding narrower entries, missing `permissions` key, and empty-config no-op.

## Test plan

- [x] `npm run verify` green (392 crane-mcp + 36 test-harness + 343 crane-context + 65 crane-watch + 25 crane-mcp-remote + 2 canary)
- [x] 9 new `ensureClaudeUserDenyRules` unit tests pass
- [x] Existing `setupClaudeMcp` and `ensureClaudeProjectTrust` tests still pass (new call is a no-op in those mocks because `loadClaudeDenyRules` returns `[]` when the mocked `readFileSync` serves non-rule content)
- [ ] Manual: launch `crane ss` in a fresh shell, confirm log line `-> Added crane-context deny rule to ~/.claude/settings.json`, inspect the written file to verify existing fields preserved
- [ ] Manual: second `crane ss` launch emits no log, no file modification
- [ ] Manual: in the session, agent calling `mcp__claude_ai_crane_context__github_search_code` is rejected silently (no permission prompt)
- [ ] Manual: `mcp__claude_ai_Google_Calendar__gcal_list_events` still works in the same session
- [ ] Manual: `git status` clean in all eight venture repos
- [ ] Post-merge: on one other fleet machine (mac23), run `crane vc`, confirm first launch writes the rule there

## Follow-ups (not in this PR)

- After confirming the user-scope deny works in production, the redundant project-scope deny in `crane-console/.claude/settings.json` from #488 can be removed in a cleanup PR.
- The MCP wildcard matching boundary (whether `mcp__claude_ai_*` matches across the `__` server/tool segment boundary) is not explicitly documented; the user-visible evidence in this project suggests it does NOT. Worth filing a docs-feedback item with code.claude.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)