### PR TITLE
feat: add /platform-audit skill

### DIFF
--- a/.agents/skills/platform-audit/SKILL.md
+++ b/.agents/skills/platform-audit/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: platform-audit
+description: Platform Audit
+---
+
+# /platform-audit - Platform Audit
+
+End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
+
+## Scope
+
+**In scope (the support OS):**
+
+- `workers/` (crane-context, crane-mcp-remote, crane-watch)
+- `packages/` (crane-mcp, crane-test-harness)
+- `.agents/skills/`, `.agents/agents/`, `.claude/settings.json` hooks
+- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` instruction files
+- The MCP tool surface (local + remote)
+- D1 schemas in `workers/crane-context/migrations/`
+- `docs/` tree
+- `crane_docs` uploaded documents (via `crane_doc_audit`)
+- `MEMORY.md` and satellite files
+- `scripts/` shell scripts
+- `.github/workflows/`
+
+**Out of scope:**
+
+- Individual venture product codebases (vc-web, dc-marketing, dfg-console, sc-console, kidexpenses) - those are `/code-review` or `/enterprise-review`.
+- Anything outside the crane-console repo.
+
+## Process
+
+### 1. Recon (inline, cheap)
+
+- `ls` of `workers/`, `packages/`, `scripts/`, `.agents/`, `docs/`, `.github/workflows/`
+- Count skills, migrations, scripts, workflows
+- `git log --oneline -20` for recent activity
+
+### 2. Spawn 6 parallel Explore agents
+
+Launch all six in a single message. Each gets a focused brief and reports under 1500 words. Each must end with kill / fix / keep lists with file paths and line numbers.
+
+| #   | Domain                    | Look for                                                                                                                                                                                                                                           |
+| --- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Workers & packages**    | God files (>500 LOC), dead exports, duplication across workers (esp. GitHub signature validation, HTTP clients, auth), layer violations, `console.log` in production paths, test pathology (over-mocking, test files larger than source)           |
+| 2   | **Skills, agents, hooks** | Skill overlap (lifecycle / review / editorial clusters), AGENTS.md vs GEMINI.md drift, settings.json deny/allow precedence, skill bloat (SKILL.md >10KB), CLAUDE.md content that should be in fetched docs                                         |
+| 3   | **MCP tool surface**      | Schema token cost at session start, action-enum sprawl in single tools (red flag: tool with >5 actions), dead tools (grep for usage), local-vs-remote MCP drift                                                                                    |
+| 4   | **D1 datastores**         | Dead tables (defined in schema, never written), schema sprawl (tables with 25+ columns), missing indices on hot paths, vague `meta_json`/`details_json` columns, migration history smells (drop-and-rebuild patterns, missing baseline migrations) |
+| 5   | **Documentation**         | Stale subdirs (>30 days), contradictions (same fact in 3 places with 3 versions), fragmented bootstrap instructions, `crane_docs` manifest health, `MEMORY.md` sprawl, orphaned handoffs                                                           |
+| 6   | **Scripts & ops**         | Bootstrap script overlap, incomplete migrations (find legacy + new running in parallel), dead scripts (verify with grep), failing GitHub Actions workflows (root cause, not just "it's red")                                                       |
+
+### 3. Synthesize as a senior-engineer report
+
+Required sections:
+
+- **TL;DR** - 3-4 sentences
+- **Critical / fix this week** - 5-10 items max with file:line refs and exact fixes
+- **Inventory** - sized table
+- **Findings by domain** - condensed (don't repeat the deep-dive agent reports verbatim)
+- **Cross-cutting themes** - patterns across domains (incomplete migrations, inline duplication, god files, hardcoded indexes, etc.)
+- **Kill list / Fix list / Invest list**
+- **Risk assessment**
+- **What was deliberately not audited**
+
+### 4. Save the report
+
+Write to `docs/reviews/{YYYY-MM-DD}-platform-audit.md`. Use the actual current date.
+
+### 5. Compare to the prior audit
+
+Find the most recent prior audit: `ls -t docs/reviews/*-platform-audit.md`. If one exists, surface:
+
+- **Still on the list** - items that haven't been addressed (this is the most important section)
+- **New** - sprawl that accumulated since last audit
+- **Resolved** - progress
+
+If no prior audit exists on disk, check branch `audit/platform-audit-skill-and-report` for the original 2026-04-11 report: `git show audit/platform-audit-skill-and-report:docs/reviews/2026-04-11-platform-audit.md`
+
+### 6. Record completion
+
+Log to the Cadence Engine:
+
+```
+crane_schedule(action: "complete", name: "Platform Audit", result: "success", summary: "{grade or headline}", completed_by: "crane-mcp")
+```
+
+### 7. Offer to act on findings
+
+Ask the Captain whether to:
+
+1. File the critical-list items as GitHub issues (with appropriate labels)
+2. Open a PR for the mechanical kill-list deletions
+3. Drill into any specific finding
+
+## Honesty bar
+
+Be unflinching. Name files, line numbers, and specific anti-patterns. Acknowledge what's well-built - but the point is to catch problems early, not to write a flattering report. The Captain wants the version a senior team would deliver in an out-brief.
+
+## Rules
+
+- Must run from crane-console only.
+- All GitHub issues this session target venturecrane/crane-console. Targeting a different repo? STOP.
+- Never write the report to the previous audit's filename - always use today's date.
+- Do NOT execute the kill list automatically. Always ask first.
+- Use `model: "sonnet"` for Explore agents. Reserve opus for the synthesis step.

--- a/workers/crane-context/migrations/0030_add_platform_audit_schedule.sql
+++ b/workers/crane-context/migrations/0030_add_platform_audit_schedule.sql
@@ -1,0 +1,19 @@
+-- Migration 0030: Add Platform Audit to cadence engine
+--
+-- Monthly platform audit for crane-console: sprawl, dead code,
+-- incomplete migrations, accumulated cruft. Scoped to vc since
+-- it audits the crane operating system (not venture products).
+-- Backfill last_completed from the 2026-04-11 inaugural run.
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result, last_result_summary,
+  created_at, updated_at
+) VALUES (
+  'sched_seed_017', 'platform-audit', 'Platform Audit',
+  'End-to-end audit of crane OS: workers, skills, MCP, D1, docs, scripts. Run via /platform-audit.',
+  30, 'vc', 2,
+  '2026-04-11T17:03:04.000Z', 'crane-mcp', 'success', 'Inaugural run. 6 issues filed (#491-#497).',
+  datetime('now'), datetime('now')
+);


### PR DESCRIPTION
## Summary
- Adds `/platform-audit` as a proper skill under `.agents/skills/platform-audit/SKILL.md`
- Promotes the unmerged prototype from `.claude/commands/` (branch `audit/platform-audit-skill-and-report`)
- Spawns 6 parallel Explore agents for deep-dive across workers, skills, MCP, D1, docs, and scripts
- Produces senior-engineer report at `docs/reviews/{date}-platform-audit.md`

## Test plan
- [ ] Verify skill appears in `/sos` briefing skill list on next session
- [ ] Run `/platform-audit` to confirm full 6-agent execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)