### PR TITLE
feat: migrate crane-command site from Vercel to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,39 @@
+name: Deploy Crane Command
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'site/**'
+      - 'config/ventures.json'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-site
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & Deploy Site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: cd site && npm ci
+
+      - name: Build site
+        run: cd site && node scripts/sync-docs.mjs && npx astro build
+
+      - name: Deploy to Cloudflare Pages
+        run: npx wrangler pages deploy site/dist --project-name crane-command
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/company/financial-dashboard.md
+++ b/docs/company/financial-dashboard.md
@@ -8,6 +8,7 @@
 | Durgan Field Guide | —             | ~$500          | —   | Active      |
 | Silicon Crane      | $0            | Minimal        | —   | Pre-revenue |
 | Kid Expenses       | $0            | Minimal        | —   | Pre-revenue |
+| SMD Services       | $0            | Minimal        | —   | Pre-revenue |
 | Draft Crane        | $0            | Minimal        | —   | Pre-revenue |
 
 ## Revenue Streams
@@ -18,6 +19,7 @@
 | Subscriptions | DFG           | Recurring | Planned |
 | Sprint fees   | Silicon Crane | Project   | Planned |
 | Subscriptions | Kid Expenses  | Recurring | Planned |
+| Consulting    | SMD Services  | Project   | Planned |
 | Subscriptions | Draft Crane   | Recurring | Planned |
 
 ## Expense Categories

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -103,13 +103,13 @@ For ventures using Google Stitch for UI generation, a `DESIGN.md` file provides 
 
 ### File Placement Rules
 
-| File                 | Location                          | Repo                      |
-| -------------------- | --------------------------------- | ------------------------- |
-| `design-spec.md`     | `docs/ventures/{code}/`           | crane-console (canonical) |
-| `design-spec.md`     | `docs/design/`                    | venture repo (local copy) |
-| `.stitch/DESIGN.md`  | `.stitch/DESIGN.md`               | venture repo only         |
-| Stitch screens       | `.stitch/designs/`                | venture repo only         |
-| Committed wireframes | `docs/wireframes/{issue-number}/` | venture repo only         |
+| File                | Location                | Repo                      |
+| ------------------- | ----------------------- | ------------------------- |
+| `design-spec.md`    | `docs/ventures/{code}/` | crane-console (canonical) |
+| `design-spec.md`    | `docs/design/`          | venture repo (local copy) |
+| `.stitch/DESIGN.md` | `.stitch/DESIGN.md`     | venture repo only         |
+| Stitch screens      | `.stitch/designs/`      | venture repo only         |
+| Generated designs   | `.stitch/designs/`      | venture repo only         |
 
 ## Stitch Workflow Steps
 

--- a/docs/operations/operating-cadence.md
+++ b/docs/operations/operating-cadence.md
@@ -1,0 +1,89 @@
+# Operating Cadence
+
+The franchise routine. What it looks like to operate the Venture Crane enterprise day to day, week to week, and month to month. This is written for the Captain - the person directing the agent team and making Go/Kill decisions.
+
+## The Daily Cycle
+
+Every working session follows the same three-phase pattern:
+
+### 1. Start of Session (SOS)
+
+The Captain launches a session with `/sos`. The system loads:
+
+- Active venture context (repo, branch, environment)
+- Pending handoffs from previous sessions
+- Overdue cadence items
+- P0 issues and alerts
+- Resume block (what was in progress when the last session ended)
+
+The Captain reviews the briefing and decides what to focus on. The system suggests - the Captain directs.
+
+### 2. Sprint Work
+
+The Captain directs agents through the session's work. This could be:
+
+- Building features on a venture product
+- Running cadence items (reviews, audits, health checks)
+- Investigating and fixing issues
+- Content production and editorial review
+- Infrastructure maintenance
+
+Multi-agent teams can be spawned for parallel work. Fleet machines can be dispatched for independent tasks. The Captain's job is directing, not doing - setting priorities, reviewing output, making decisions.
+
+### 3. End of Session (EOS)
+
+Every session ends with `/eos`. The system automatically saves:
+
+- What was accomplished
+- What's still in progress
+- Blockers and open questions
+- Context for the next session to resume from
+
+Handoffs are the continuity mechanism. They ensure no context is lost between sessions, regardless of which machine or agent picks up next.
+
+## Weekly Cadence
+
+| Item                    | Scope       | Purpose                                               |
+| ----------------------- | ----------- | ----------------------------------------------------- |
+| Weekly Plan             | CRANE       | Set priorities for the week via `/work-plan`          |
+| Portfolio Review        | VC          | Review venture stages, metrics, and Go/Kill decisions |
+| GBP Weekly Post         | SS          | SMD Services Google Business Profile content          |
+| Code Reviews            | Per venture | Codebase health check on active ventures              |
+| Secrets Rotation Review | CRANE       | Verify no expired or compromised credentials          |
+
+The Weekly Plan is the Captain's primary steering mechanism. It sets which ventures get attention, what cadence items to execute, and what the week's deliverables are. Run `/work-plan` at the start of each week.
+
+## Monthly Cadence
+
+| Item                 | Scope | Purpose                                                             |
+| -------------------- | ----- | ------------------------------------------------------------------- |
+| Platform Audit       | CRANE | Senior-engineer audit of the operating system via `/platform-audit` |
+| Context Refresh      | CRANE | Refresh enterprise documentation and D1 context                     |
+| Enterprise Review    | CRANE | Cross-venture codebase audit                                        |
+| Fleet Health Check   | CRANE | Verify all fleet machines are operational and current               |
+| Command Sync         | CRANE | Sync slash commands across fleet machines                           |
+| Dependency Freshness | CRANE | Check for outdated dependencies across all repos                    |
+| Design System Review | CRANE | Review design token consistency and venture compliance              |
+| Financial Review     | —     | Review the Financial Dashboard, update actuals, assess burn rate    |
+
+The Platform Audit is the most important monthly item. It catches sprawl, dead code, and accumulated technical debt before they compound. The audit produces a graded report with kill/fix/invest lists.
+
+## Quarterly Cadence
+
+- **Strategic Planning Review**: Revisit capital allocation principles, portfolio evaluation, and risk register
+- **Venture Stage Assessment**: Formal Go/Kill/Pivot decision for each venture based on metrics
+- **Infrastructure Review**: Evaluate platform costs, capacity, and consolidation opportunities
+
+## The Captain's Role
+
+The Captain is not a developer, writer, or operator in the traditional sense. The Captain is the director of an AI agent team. The role is:
+
+**Decide, don't do.** Set priorities. Choose which ventures get attention. Make Go/Kill calls. The agents execute.
+
+**Review, don't write.** Read agent output. Approve PRs. Validate that work matches intent. Course-correct when it doesn't.
+
+**Systematize, don't improvise.** If something works, document it. If a process is manual, automate it. The franchise prototype grows by capturing what works into repeatable systems.
+
+**Kill fast.** The hardest part of the role. When a venture isn't working, shut it down. Don't prop up failing ventures with good-venture profits. Archive and move on.
+
+This operating cadence IS the franchise routine. If a new Captain took over tomorrow, they would follow this same cycle - SOS, sprint, EOS, weekly plan, monthly audit, quarterly review - and the enterprise would continue to operate.

--- a/docs/planning/index.md
+++ b/docs/planning/index.md
@@ -6,10 +6,8 @@ sidebar:
 
 # Planning
 
-Weekly plans and milestone tracking. Managed by the `crane_plan` MCP tool.
+Weekly plans and milestone tracking. Managed by the `crane_schedule` cadence engine.
 
-## Contents
+## How It Works
 
-- [Weekly Plan](WEEKLY_PLAN.md) - Current weekly priorities and focus areas
-
-To refresh the weekly plan, run `/work-plan`.
+The weekly plan is generated and tracked through the cadence engine (`crane_schedule` MCP tool). To create or refresh the weekly plan, run `/work-plan`.

--- a/docs/process/mcp-server-architecture.md
+++ b/docs/process/mcp-server-architecture.md
@@ -96,7 +96,7 @@ The local MCP server registers 16 tools. Each tool validates input with Zod sche
 | Tool           | Description                                                          | API Endpoint        |
 | -------------- | -------------------------------------------------------------------- | ------------------- |
 | `crane_status` | Full GitHub issue breakdown: P0, ready, in-progress, blocked, triage | (GitHub API via gh) |
-| `crane_plan`   | Reads weekly plan from `docs/planning/WEEKLY_PLAN.md`                | (local filesystem)  |
+| `crane_plan`   | Reads weekly plan from the cadence engine (`crane_schedule`)         | (local state)       |
 
 ### Venture & Documentation
 

--- a/docs/process/team-workflow.md
+++ b/docs/process/team-workflow.md
@@ -240,8 +240,8 @@ Since PM writes ACs and tests them:
 2. Claude generates interactive HTML/CSS prototype using venture design tokens
 3. PM iterates via prompt refinement until wireframe matches intent
 4. PM verifies wireframe renders correctly (open in browser, test mobile viewport, confirm interactive states work)
-5. PM commits wireframe to `/docs/wireframes/{issue-number}/`
-6. PM adds wireframe link to Agent Brief section of the issue
+5. PM commits design artifacts to `.stitch/designs/` in the venture repo
+6. PM adds design reference to Agent Brief section of the issue
 
 **Freeze rule:** Once Dev marks issue `status:in-progress`, the wireframe is frozen. PM changes require Captain approval.
 

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -25,10 +25,10 @@ const siteRoot = join(__dirname, '..')
 const docsRoot = join(siteRoot, '..', 'docs')
 const contentDocsDir = join(siteRoot, 'src', 'content', 'docs')
 
-// Fail fast if docs directory is missing (catches Vercel Root Directory misconfiguration)
+// Fail fast if docs directory is missing (build must run from the site/ subdirectory)
 if (!existsSync(docsRoot)) {
   console.error(`ERROR: docs directory not found at ${docsRoot}`)
-  console.error('Ensure the Vercel Root Directory is set to "site/" in project settings.')
+  console.error('Ensure the build runs from the site/ subdirectory of the crane-console repo.')
   process.exit(1)
 }
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "astro"
-}


### PR DESCRIPTION
## Summary
- Migrates the crane-command operations manual from Vercel (no auth on Hobby tier) to Cloudflare Pages, aligning with the enterprise standard (all 5 venture sites already on Pages)
- Adds GitHub Actions workflow for auto-deploy on push to main when docs/, site/, or config/ventures.json change
- Fixes broken links and stale references from the platform audit kill-list (deleted wireframes dir, WEEKLY_PLAN.md, crane_plan docs)
- Adds SMD Services to the Financial Dashboard
- Adds Operating Cadence page - the E-Myth franchise routine documenting the Captain's daily/weekly/monthly operating cycle

Closes #458

## Test plan
- [x] `npm run verify` passes (806 tests, 0 errors)
- [ ] Captain configures Cloudflare Access on `crane-command.pages.dev` before first deploy
- [ ] `wrangler pages deploy` succeeds after Access is confirmed
- [ ] Site prompts for auth, then serves all pages correctly
- [ ] Captain deletes Vercel project after migration confirmed
- [ ] GitHub Actions deploy workflow triggers on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)