### PR TITLE
feat: add deprecated pattern detection and full content audit

### DIFF
--- a/docs/company/disaster-recovery.md
+++ b/docs/company/disaster-recovery.md
@@ -25,7 +25,7 @@ All fleet machines are destroyed or inaccessible (fire, theft, hardware failure,
 | VCMS knowledge             | crane-context D1          | Covered by D1 backup              |
 | Published packages         | GitHub Packages           | In-place                          |
 | Secrets vault              | Infisical (cloud-hosted)  | Bitwarden has recovery creds      |
-| Docs (this site)           | Vercel                    | Redeploys from GitHub             |
+| Docs (this site)           | Cloudflare Pages          | Redeploys from GitHub             |
 
 ## What Is Lost With the Fleet
 
@@ -55,7 +55,7 @@ Required entries (folder: **`VentureCrane / DR`**):
 | Infisical recovery codes      | Secure Note | If TOTP device lost                             |
 | Infisical Universal Auth (vc) | Secure Note | `CLIENT_ID` + `CLIENT_SECRET` for SSH sessions  |
 | Tailscale (smdurgan) login    | Login + 2FA | Tailnet admin, node authorization               |
-| Vercel login                  | Login + 2FA | Site deployment                                 |
+| Cloudflare login              | Login + 2FA | Site deployment, Workers, D1, Access            |
 | **GH_PRIVATE_KEY_PEM**        | Secure Note | GitHub App signing key — SPF backup (see below) |
 | `CRANE_CONTEXT_KEY` (vc)      | Secure Note | MCP/crane-context auth                          |
 | Domain registrar logins       | Login + 2FA | For any DNS recovery                            |
@@ -246,16 +246,17 @@ Only run this if crane-context D1 was lost or corrupted, not for standard machin
 
 ## Access Control
 
-This page and all of `/company/*` contain confidential operational detail. The Vercel deployment must be configured with password protection for these paths.
+This site contains confidential operational detail and is gated by Cloudflare Access.
 
-**Enable via Vercel Dashboard:**
+**Current setup:**
 
-1. Vercel project `crane-console` → **Settings** → **Deployment Protection**
-2. Enable **Password Protection** (Pro plan feature)
-3. Set password; store in Bitwarden folder `VentureCrane / DR` as `Crane Console Site Password`
-4. Optionally scope via `vercel.json` paths if path-level protection is available on the plan tier
+- **Site URL:** `crane-command.pages.dev`
+- **Auth domain:** `venturecrane.cloudflareaccess.com`
+- **Auth method:** Email OTP (one-time PIN sent to Captain's email)
+- **Session duration:** 24 hours
+- **Configuration:** Cloudflare Dashboard > Zero Trust > Access > Applications > crane-command
 
-If Vercel deployment protection is not sufficient (all-or-nothing), the long-term solution is to convert the Astro site to hybrid/SSR mode with `@astrojs/vercel`, add Edge Middleware, and gate `/company/*` with basic auth using a password from an env var.
+To add a new authorized user, edit the Access policy to include their email address. The Cloudflare Access free tier supports up to 50 users.
 
 ---
 

--- a/docs/company/financial-dashboard.md
+++ b/docs/company/financial-dashboard.md
@@ -34,10 +34,10 @@
 
 ## Banking & Accounts
 
-| Function           | Tool       | Notes                           |
-| ------------------ | ---------- | ------------------------------- |
-| Payment Processing | Stripe     | All ventures                    |
-| Secrets Management | Infisical  | Free tier                       |
-| CI/CD              | GitHub     | Free org                        |
-| Hosting            | Vercel     | Hobby tier                      |
-| Workers/DB         | Cloudflare | Free tier (Workers, D1, R2, KV) |
+| Function           | Tool             | Notes                           |
+| ------------------ | ---------------- | ------------------------------- |
+| Payment Processing | Stripe           | All ventures                    |
+| Secrets Management | Infisical        | Free tier                       |
+| CI/CD              | GitHub           | Free org                        |
+| Hosting            | Cloudflare Pages | Free tier                       |
+| Workers/DB         | Cloudflare       | Free tier (Workers, D1, R2, KV) |

--- a/docs/infra/crane-context-mcp-spec.md
+++ b/docs/infra/crane-context-mcp-spec.md
@@ -639,9 +639,9 @@ echo ""
 
 If MCP implementation fails:
 
-1. **Immediate:** `bash scripts/sos-universal.sh` still works (requires env var set manually)
+1. **Immediate:** The `crane` CLI launcher provides direct MCP connectivity (`crane vc`)
 2. **Short-term:** Revert crane-context worker deployment
-3. **Medium-term:** Wait for Claude Code skill auth fixes
+3. **Medium-term:** The REST endpoints remain operational regardless of MCP status
 
 The REST endpoints (`/sos`, `/eos`) remain operational regardless of MCP status.
 

--- a/docs/process/doc-sync-pipeline.md
+++ b/docs/process/doc-sync-pipeline.md
@@ -18,13 +18,13 @@ docs/**/*.md committed to main ───┤       ▼
                                   │       ▼
                                   │    crane_doc MCP tool (agents read docs)
                                   │
-                                  └──> Vercel build
+                                  └──> GitHub Actions (deploy-site.yml)
                                           │
                                           ▼
                                        sync-docs.mjs (prebuild)
                                           │
                                           ▼
-                                       Starlight site (site/src/content/docs/)
+                                       Cloudflare Pages (crane-command.pages.dev)
 ```
 
 ### Path 1: Git Push to Agent-Readable D1
@@ -33,7 +33,7 @@ Agents read documentation via the `crane_doc` MCP tool, which fetches from crane
 
 ### Path 2: Git Push to Starlight Documentation Site
 
-The Starlight site (hosted on Vercel) runs `sync-docs.mjs` as a prebuild step. This copies markdown files from the repo into the site's content directory with frontmatter injection and template variable replacement.
+The Starlight site (hosted on Cloudflare Pages at `crane-command.pages.dev`) is built and deployed by the `deploy-site.yml` GitHub Actions workflow. The build runs `sync-docs.mjs` to copy markdown files from the repo into the site's content directory with frontmatter injection and template variable replacement.
 
 ## Path 1: GitHub Action to D1
 
@@ -112,7 +112,7 @@ For listing available docs: `GET /docs?venture={code}` returns metadata (without
 
 ### Trigger
 
-The `sync-docs.mjs` script runs as a Vercel prebuild step before `astro build`.
+The `sync-docs.mjs` script runs as a prebuild step in the `deploy-site.yml` GitHub Actions workflow before `astro build`. The workflow triggers on push to `main` when files change under `docs/`, `site/`, or `config/ventures.json`.
 
 ### Directories Synced
 
@@ -135,10 +135,11 @@ For each markdown file:
    - `{{skills:table}}` -- Replaced with an auto-generated table of all skills from `.agents/skills/*/SKILL.md`
 2. **Frontmatter injection** -- If the file lacks YAML frontmatter, a `title` is extracted from the first `# heading` and frontmatter is prepended
 3. **Staleness check** -- Files with more than 2 TBD markers or fewer than 20 lines are flagged in a staleness report
+4. **Deprecated pattern check** -- Files are scanned against a deny-list (`site/deprecated-patterns.json`) for references to deprecated tools, URLs, or scripts. Matches are reported as warnings in the build output.
 
 ### Fail-Fast Guard
 
-If the `docs/` directory does not exist (which happens when Vercel's Root Directory is misconfigured), the script exits immediately with an error message.
+If the `docs/` directory does not exist (which happens when the build runs from the wrong directory), the script exits immediately with an error message.
 
 ## Documentation Audit System
 

--- a/docs/process/eos-sos-process.md
+++ b/docs/process/eos-sos-process.md
@@ -73,10 +73,8 @@ No arguments needed. The agent synthesizes the handoff from conversation history
    - **In Progress:** Unfinished work, partial implementations, pending reviews
    - **Blocked:** Blockers encountered, questions for PM, decisions needed
    - **Next Session:** Recommended focus, logical next steps, follow-ups
-3. **Show for confirmation** - Displays the handoff and asks a single yes/no: "Save to D1?"
-4. **End work day** - Calls the work-day API with `action: "end"`
-5. **Save via MCP** - Calls `crane_handoff` with summary, status (`in_progress`, `blocked`, or `done`), and issue number if applicable
-6. **Confirm** - Reports "Handoff saved to D1. Next session will see this via crane_sos."
+3. **Save via MCP** - Calls `crane_handoff` with summary, status (`in_progress`, `blocked`, or `done`), and issue number if applicable
+4. **Confirm** - Reports "Handoff saved to D1. Next session will see this via crane_sos."
 
 ### Key Principle
 
@@ -115,6 +113,12 @@ The `/update` skill refreshes session metadata:
 - Auto-detects current git branch and commit
 - Updates the Context API with current work context
 - Also refreshes the heartbeat
+
+### Checkpoints
+
+Mid-session snapshots can be saved with `/checkpoint`. Checkpoints capture partial progress without ending the session - useful for long sessions or before risky operations. Each checkpoint gets a unique `cp_<ULID>` ID and auto-incrementing sequence number.
+
+For the full checkpoint protocol (payload structure, size limits, auto-numbering), see [Session Lifecycle](./session-lifecycle.md).
 
 ---
 

--- a/docs/process/mcp-server-architecture.md
+++ b/docs/process/mcp-server-architecture.md
@@ -135,9 +135,7 @@ The local MCP server registers 16 tools. Each tool validates input with Zod sche
 
 ### Observability
 
-| Tool                 | Description                                                   | API Endpoint |
-| -------------------- | ------------------------------------------------------------- | ------------ |
-| `crane_token_report` | Shows estimated token usage by tool, venture, and time period | (local data) |
+Token usage is tracked in-memory by the local crane-mcp server via `logToolTokens()` after each tool call. This data is session-scoped and resets on restart.
 
 ## Complete Tool Inventory (Remote crane-mcp-remote)
 
@@ -193,7 +191,7 @@ The `CraneApi` class in `packages/crane-mcp/src/lib/crane-api.ts` provides typed
 
 ## Token Usage Tracking
 
-The local crane-mcp server includes lightweight token estimation. After each tool call, `logToolTokens()` estimates input and output token counts based on character length (using a ratio of 3.5 chars/token for structured tools, 4.0 for text-heavy tools). Usage data is stored in memory and surfaced via the `crane_token_report` tool.
+The local crane-mcp server includes lightweight token estimation. After each tool call, `logToolTokens()` estimates input and output token counts based on character length (using a ratio of 3.5 chars/token for structured tools, 4.0 for text-heavy tools). Usage data is stored in memory for the duration of the session.
 
 ## crane-context API Overview
 

--- a/docs/process/new-venture-setup-checklist.md
+++ b/docs/process/new-venture-setup-checklist.md
@@ -101,8 +101,8 @@ This creates a repo with:
 ├── .github/workflows/    # CI and security scanning (configured)
 ├── docs/                 # Documentation structure
 │   ├── design/           # Design spec (template auto-populated)
-│   └── wireframes/       # UI wireframe prototypes
-├── scripts/              # sos-universal.sh included
+│   └── design/           # Design spec and Stitch design system
+├── .stitch/              # Stitch design artifacts
 ├── src/                  # Application code
 ├── CLAUDE.md             # Template - customize for your product
 └── package.json          # Basic TypeScript setup
@@ -192,8 +192,8 @@ The GitHub App is named **venturecrane-github** and is registered under the **pe
 
 - [ ] Deploy crane-context: `cd workers/crane-context && npx wrangler deploy`
 
-> **Note:** sos-universal.sh gets venture mappings from the crane-context API.
-> No script changes needed - just update and deploy crane-context.
+> **Note:** The `crane` launcher gets venture mappings from `config/ventures.json`.
+> After adding the venture, deploy crane-context and rebuild crane-mcp.
 
 ### 3.2 Seed Venture Documentation
 
@@ -373,8 +373,8 @@ Copy standard commands from crane-console:
 
 ### 4.3 Scripts
 
-- [ ] Copy `scripts/sos-universal.sh` (updated with venture mapping)
-- [ ] Copy other utility scripts as needed
+- [ ] Verify `crane {code}` launches correctly from the venture repo
+- [ ] Copy utility scripts as needed
 
 ---
 

--- a/docs/runbooks/new-environment-setup.md
+++ b/docs/runbooks/new-environment-setup.md
@@ -305,7 +305,8 @@ pwd  # Verify you're in the right repo
 
 ```bash
 cd ~/dev/crane-console
-bash scripts/sos-universal.sh
+crane vc
+# Then run /sos inside the session
 ```
 
 **Expected Output:**

--- a/docs/standards/golden-path.md
+++ b/docs/standards/golden-path.md
@@ -242,8 +242,8 @@ venture-template/
 ├── docs/
 │   ├── adr/
 │   └── api/
-├── scripts/
-│   └── sos-universal.sh
+├── .stitch/
+│   └── DESIGN.md
 ├── src/
 ├── CLAUDE.md
 ├── README.md

--- a/docs/ventures/vc/website.md
+++ b/docs/ventures/vc/website.md
@@ -78,7 +78,7 @@ All content is AI-drafted and human-reviewed. Published with CC BY 4.0 license f
 
 ## Relationship to Enterprise Docs Site
 
-This site (crane-console.vercel.app) is the **internal** enterprise docs site for agents and the Captain. venturecrane.com is the **external** publication for the practitioner community. They serve different audiences and have different content policies:
+This site (crane-command.pages.dev, gated by Cloudflare Access) is the **internal** enterprise docs site for agents and the Captain. venturecrane.com is the **external** publication for the practitioner community. They serve different audiences and have different content policies:
 
 |                | Enterprise Docs       | venturecrane.com               |
 | -------------- | --------------------- | ------------------------------ |

--- a/site/deprecated-patterns.json
+++ b/site/deprecated-patterns.json
@@ -1,0 +1,32 @@
+[
+  {
+    "pattern": "sos-universal\\.sh",
+    "replacement": "crane launcher (crane vc)",
+    "added": "2026-04-12",
+    "reason": "Shell scripts replaced by MCP-based crane launcher"
+  },
+  {
+    "pattern": "eos-universal\\.sh",
+    "replacement": "crane launcher",
+    "added": "2026-04-12",
+    "reason": "Shell scripts replaced by MCP-based crane launcher"
+  },
+  {
+    "pattern": "crane-console\\.vercel\\.app",
+    "replacement": "crane-command.pages.dev",
+    "added": "2026-04-12",
+    "reason": "Site migrated from Vercel to Cloudflare Pages"
+  },
+  {
+    "pattern": "crane_token_report",
+    "replacement": "(tool removed)",
+    "added": "2026-04-12",
+    "reason": "Dead tool with zero usage, removed in platform audit"
+  },
+  {
+    "pattern": "crane_handoff_update",
+    "replacement": "(tool removed)",
+    "added": "2026-04-12",
+    "reason": "Dead tool with zero usage, removed in platform audit"
+  }
+]

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -54,7 +54,18 @@ const SYNC_DIRS = [
 // Files to exclude from site sync (agent directives that overlap with human-facing docs)
 const EXCLUDE_FILES = [
   'instructions/design-system.md', // Covered by design-system/overview.md and token-taxonomy.md
+  'process/cli-context-integration.md', // Pre-MCP bash integration guide, superseded by crane-cli-launcher.md
+  'process/CONTEXT-WORKER-SETUP.md', // Pre-MCP setup guide, superseded by crane-cli-launcher.md
 ]
+
+// Deprecated patterns - loaded from external config so doc editors can update without touching build code
+const deprecatedPatternsPath = join(siteRoot, 'deprecated-patterns.json')
+const DEPRECATED_PATTERNS = existsSync(deprecatedPatternsPath)
+  ? JSON.parse(readFileSync(deprecatedPatternsPath, 'utf-8')).map((entry) => ({
+      ...entry,
+      regex: new RegExp(entry.pattern, 'gi'),
+    }))
+  : []
 
 // Skills directory for {{skills:table}} token generation
 const SKILLS_DIR = join(siteRoot, '..', '.agents', 'skills')
@@ -282,6 +293,40 @@ function rewriteMarkdownLinks(content, filePath) {
 }
 
 /**
+ * Strip fenced code blocks from content so pattern checks
+ * don't fire on historical references in code examples.
+ */
+function stripCodeFences(content) {
+  return content.replace(/```[\s\S]*?```/g, '')
+}
+
+/**
+ * Check for deprecated pattern matches in content (outside code fences).
+ * Returns array of { pattern, replacement, line } matches.
+ */
+function checkDeprecatedPatterns(content, relPath) {
+  if (DEPRECATED_PATTERNS.length === 0) return []
+
+  const proseContent = stripCodeFences(content)
+  const matches = []
+
+  for (const entry of DEPRECATED_PATTERNS) {
+    if (entry.regex.test(proseContent)) {
+      matches.push({
+        path: relPath,
+        pattern: entry.pattern,
+        replacement: entry.replacement,
+      })
+      // Reset regex lastIndex for next file
+      entry.regex.lastIndex = 0
+    }
+    entry.regex.lastIndex = 0
+  }
+
+  return matches
+}
+
+/**
  * Check content staleness and return a report entry.
  */
 function checkStaleness(content, relPath) {
@@ -306,6 +351,7 @@ for (const dir of SYNC_DIRS) {
 
 let fileCount = 0
 const stalenessReport = []
+const deprecatedReport = []
 
 for (const syncDir of SYNC_DIRS) {
   const sourceDir = join(docsRoot, syncDir)
@@ -333,6 +379,7 @@ for (const syncDir of SYNC_DIRS) {
     writeFileSync(destFile, processed, 'utf-8')
 
     stalenessReport.push(checkStaleness(content, displayPath))
+    deprecatedReport.push(...checkDeprecatedPatterns(content, displayPath))
     fileCount++
   }
 }
@@ -343,7 +390,7 @@ console.log(`Synced ${fileCount} markdown files.`)
 const stalePages = stalenessReport.filter((r) => r.stale)
 const okPages = stalenessReport.filter((r) => !r.stale)
 
-if (stalePages.length > 0) {
+if (stalePages.length > 0 || deprecatedReport.length > 0) {
   console.log('\nSTALENESS REPORT:')
   for (const p of stalePages) {
     console.log(`  WARN  ${p.path} - ${p.tbdCount} TBD, ${p.lineCount} lines`)
@@ -352,4 +399,15 @@ if (stalePages.length > 0) {
     console.log(`  OK    ${p.path}`)
   }
   console.log(`  TOTAL: ${stalePages.length} pages need attention, ${okPages.length} pages OK`)
+}
+
+// Deprecated pattern report
+if (deprecatedReport.length > 0) {
+  console.log('\nDEPRECATED PATTERN REPORT:')
+  for (const m of deprecatedReport) {
+    console.log(
+      `  WARN  ${m.path} - references ${m.pattern.replace(/\\/g, '')} → use ${m.replacement}`
+    )
+  }
+  console.log(`  TOTAL: ${deprecatedReport.length} deprecated references found`)
 }


### PR DESCRIPTION
## Summary
- Adds build-time deprecated pattern detection to sync-docs.mjs - reads from `site/deprecated-patterns.json`, excludes code fences, warns on stale references. Future deprecations = one line added to the JSON.
- Excludes 2 pre-MCP obsolete docs from the site build (cli-context-integration.md, CONTEXT-WORKER-SETUP.md)
- Fixes all Vercel → Cloudflare Pages references across 4 docs (disaster-recovery, doc-sync-pipeline, financial-dashboard, vc/website)
- Removes dead tool references (crane_token_report) from mcp-server-architecture.md
- Replaces deprecated sos-universal.sh references with crane launcher in 4 docs
- Adds checkpoint coverage to eos-sos-process.md

## Test plan
- [x] `npm run verify` passes (806 tests, 0 errors)
- [x] `node scripts/sync-docs.mjs` shows 0 deprecated pattern warnings (all fixed)
- [x] Excluded docs no longer appear in synced output
- [ ] Redeploy to crane-command.pages.dev after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)