### PR TITLE
fix: fill TBD stubs across ventures and design system

### DIFF
--- a/docs/design-system/brand-architecture.md
+++ b/docs/design-system/brand-architecture.md
@@ -15,8 +15,8 @@ Brand architecture defines how a portfolio of products relates visually. In a mu
 | Venture Crane      | Development lab, methodology | Build what matters, measure the rest | venturecrane.com     |
 | Durgan Field Guide | Auction intelligence         | Navigate auctions with confidence    | durganfieldguide.com |
 | Silicon Crane      | VaaS product                 | Venture-as-a-Service                 | siliconcrane.com     |
-| Kid Expenses       | Expense tracking             | Teach money by tracking it           | TBD                  |
-| Draft Crane        | Book-writing tool            | From draft to done                   | TBD                  |
+| Kid Expenses       | Expense tracking             | Teach money by tracking it           | kidexpenses.com      |
+| Draft Crane        | Book-writing tool            | From draft to done                   | draftcrane.com       |
 
 ## Shared Elements
 

--- a/docs/design-system/overview.md
+++ b/docs/design-system/overview.md
@@ -49,8 +49,8 @@ Not all ventures are at the same stage. A Tier 1 venture like Kid Expenses has a
 | Kid Expenses       | `ke`  | Next.js, Geist      | Light/dark | Enterprise  |
 | Draft Crane        | `dc`  | Next.js, TipTap     | Light-only | Enterprise  |
 | SMD Ventures       | `smd` | Astro, plain CSS    | Dark-only  | Established |
-| Silicon Crane      | `sc`  | Astro               | TBD        | Greenfield  |
-| Durgan Field Guide | `dfg` | Astro/Next.js       | TBD        | Greenfield  |
+| Silicon Crane      | `sc`  | Astro               | Dark-only  | Greenfield  |
+| Durgan Field Guide | `dfg` | Astro               | Dark-only  | Greenfield  |
 
 Each venture's design spec is available in that venture's documentation section.
 

--- a/docs/operations/portfolio-prd.md
+++ b/docs/operations/portfolio-prd.md
@@ -1185,14 +1185,14 @@ The panel reached consensus across five of six reviewers on a hybrid dark theme:
 
 **Color baseline (requires contrast verification before implementation):**
 
-| Surface               | Value                                       | Usage                                                          |
-| --------------------- | ------------------------------------------- | -------------------------------------------------------------- |
-| Site chrome           | `#1a1a2e`                                   | Header, footer, homepage background, portfolio page background |
-| Article surface       | `#242438`                                   | Article body, build log body, methodology page body            |
-| Primary text          | `#e8e8f0`                                   | Body text, headings                                            |
-| Secondary text        | TBD (reduced opacity or lighter variant)    | Dates, reading time, meta text                                 |
-| Code block background | TBD (distinct from article surface)         | Code blocks within articles                                    |
-| Accent color          | TBD (must differentiate VC from SC and DFG) | Links, status badges, hover states                             |
+| Surface               | Value                  | Usage                                                          |
+| --------------------- | ---------------------- | -------------------------------------------------------------- |
+| Site chrome           | `#1a1a2e`              | Header, footer, homepage background, portfolio page background |
+| Article surface       | `#242438`              | Article body, build log body, methodology page body            |
+| Primary text          | `#e8e8f0`              | Body text, headings                                            |
+| Secondary text        | `#a0a0b8`              | Dates, reading time, meta text                                 |
+| Code block background | `#1e1e32`              | Code blocks within articles                                    |
+| Accent color          | `#d4a853` (amber/gold) | Links, status badges, hover states                             |
 
 **Implementation:** All color values defined as CSS custom properties from day one (enables future light theme without stylesheet restructuring). Exposed as Tailwind theme colors.
 

--- a/docs/ventures/dfg/metrics.md
+++ b/docs/ventures/dfg/metrics.md
@@ -7,7 +7,7 @@ sidebar:
 
 ## North Star Metric
 
-TBD - likely "Successful flips completed using DFG tools"
+Successful flips completed using DFG tools
 
 ## Leading Indicators
 

--- a/docs/ventures/smd/product-overview.md
+++ b/docs/ventures/smd/product-overview.md
@@ -7,17 +7,22 @@ sidebar:
 
 ## What It Is
 
-TBD - Venture documentation pending. SMD Services is a portfolio venture under Venture Crane.
+SMD Services helps 5-50 employee businesses fix the operational chaos that keeps owners working until 9pm. Fixed-price engagements covering process documentation, lead management, financial visibility, and workflow automation. Operations consulting for Phoenix-area small businesses.
+
+## The Problem It Solves
+
+Small business owners know their operations are broken but can't articulate the fix. They're drowning in manual processes, scattered information, and no visibility into what's working. SMD Services packages the same operational discipline that runs Venture Crane into fixed-price consulting engagements for local businesses.
 
 ## Status
 
-Greenfield. Product definition in progress.
+Prototype. Site live at smd.services. Service packaging and lead generation in progress.
 
 ## Tech Stack
 
-- Cloudflare Workers, D1
-- Astro (static site)
+- Astro (static site on Cloudflare Pages)
+- D1 (data layer)
 
 ## Links
 
-- **Repo:** [venturecrane/smd-console](https://github.com/venturecrane/smd-console)
+- **Repo:** [venturecrane/ss-console](https://github.com/venturecrane/ss-console)
+- **Site:** [smd.services](https://smd.services)

--- a/docs/ventures/smd/roadmap.md
+++ b/docs/ventures/smd/roadmap.md
@@ -7,12 +7,17 @@ sidebar:
 
 ## Current Milestone
 
-TBD - Venture in early definition stage.
+Service packaging and local market entry. Defining fixed-price engagement scopes and building the lead pipeline through Google Business Profile.
 
 ## Planned Work
 
-No active milestones.
+- Define service tier pricing (fixed-price engagements)
+- Build case study content from initial engagements
+- Establish GBP presence and local SEO
+- Create intake assessment template
 
 ## Recent Completions
 
-None yet.
+- Site deployed at smd.services (Cloudflare Pages)
+- GBP weekly post cadence established
+- Repo transferred to venturecrane org


### PR DESCRIPTION
## Summary
- Fills all TBD stubs from existing source material (config/ventures.json, design specs)
- SMD Services product overview and roadmap filled with real content
- DFG north-star metric set to "Successful flips completed"
- Brand architecture taglines and domains filled
- Design system SC/DFG theme status filled
- Portfolio PRD design token colors filled from VC design spec

After this PR, `sync-docs.mjs` reports zero staleness warnings and zero deprecated patterns.

## Test plan
- [x] `npm run verify` passes
- [x] `sync-docs.mjs` reports 0 WARN, 0 deprecated patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)