### PR TITLE
fix: switch Stitch MCP to proxy subprocess (claude-code#41664)

### DIFF
--- a/.agents/skills/stitch-ux-brief/SKILL.md
+++ b/.agents/skills/stitch-ux-brief/SKILL.md
@@ -1,0 +1,661 @@
+---
+name: stitch-ux-brief
+description: Stitch UX Brief & Generation
+---
+
+# /stitch-ux-brief - Stitch UX Brief & Generation
+
+Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona), then commissions Stitch to generate three structurally distinct concepts at a single surface + viewport, iterates a winner with the user, expands to the full matrix of surfaces and viewports, and strips default-web gold-plating. Final artifacts land in `.stitch/` in the current venture repo.
+
+Works in any venture console that has a Stitch project configured in `crane-console/config/ventures.json` (field: `stitchProjectId`). If one does not exist, this skill creates it and offers to write it back.
+
+## Arguments
+
+```
+/stitch-ux-brief [target] [--rounds=3] [--generate=true]
+```
+
+- `target` — short name of the surface being designed (e.g., `client-portal`, `signup-flow`, `admin-inbox`). Required. Used for artifact file names.
+- `rounds` — brief review rounds (default **3**). Each round spawns three parallel reviewers; output is synthesized between rounds. Fewer than 3 is not recommended.
+- `generate` — whether to invoke Stitch after brief approval (default **true**). Set `false` to stop after the approved brief and generate later or by hand.
+
+Parse the arguments. If `target` is missing, stop and ask the user what surface they want to brief.
+
+## The methodology, in one paragraph
+
+This skill exists because a UX brief handed to a generative design tool fails in predictable ways: the objectives are pretty but unmeasurable, the tokens are described in vibes instead of hex, the concepts all collapse into card-grid variations, and the generated output comes back padded with marketing chrome. This skill fixes each of those by running the brief through a critical three-reviewer pass (one of them a named customer who talks back), forcing structural divergence in the concept brief ("timeline vs archive vs action-centric, not three visual variations of the same layout"), harnessing Stitch's drift as intentional rather than policing it, and running an explicit strip pass on generated output. Every step has a learning embedded; the skill is the accumulated scar tissue of running this end-to-end.
+
+## Phases
+
+1. Intake — establish target, scope, existing context
+2. Draft brief v1
+3. Three-reviewer passes with synthesis
+4. Decision checkpoints — resolve open questions surfaced by reviewers
+5. Final brief, user-approved, saved to `.stitch/<target>-ux-brief.md`
+6. Stitch project resolution (create or reuse)
+7. Three structurally distinct concepts, one surface × one viewport
+8. Convergence check — user picks winner or hybrid direction
+9. Winner iteration (one targeted edit pass)
+10. Matrix expansion (all remaining surfaces × viewports)
+11. Gold-plating strip pass (batch edit, whitelist preserve)
+12. Artifact consolidation in `.stitch/designs/<target>-vN/`
+
+Each phase ends with a checkpoint. The user can stop at any checkpoint. Do not skip phases.
+
+---
+
+## Phase 1 — Intake
+
+Ask the user these questions if they aren't already answered by the conversation:
+
+1. **Target surface.** What surface are we designing? (e.g., "client portal home dashboard + invoice and proposal deep-link landings").
+2. **Authentication context.** Is the user logged in? Prospect? Public-web visitor? This shapes the "no marketing chrome" framing.
+3. **Customer persona seed.** Give me a realistic archetype — named if possible. Role, revenue range, tech comfort, what they care about. If the user hasn't thought about this, offer to draft one and confirm.
+4. **Any existing brief, PRD, or prior design** to build on? Check for `docs/pm/prd.md`, `docs/design/*`, `.stitch/*-ux-brief.md`, or a prior version of the target.
+
+Scan the repo for context:
+
+- `CLAUDE.md` for venture positioning / tone rules
+- `src/styles/globals.css` or `**/globals.css` for design tokens (hex values, type families)
+- `tailwind.config.*` for palette and type scale
+- Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
+- `.stitch/DESIGN.md` if present (established design system for the venture)
+
+Display an **Intake Summary** table:
+
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| Target         | _e.g., `client-portal`_                       |
+| Authentication | _logged-in / prospect / public_               |
+| Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief    | _path or "none"_                              |
+| Tokens source  | _path to globals.css or config_               |
+| Venture code   | _resolved from `crane_ventures`_              |
+| Stitch project | _ID or "will create"_                         |
+
+Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
+
+Wait for confirmation.
+
+---
+
+## Phase 2 — Draft v1
+
+Write a v1 brief to `.stitch/<target>-ux-brief.md` (create the directory if needed). Use this structure:
+
+```markdown
+# <Title> — UX Redesign Brief (v1)
+
+## Context
+
+<2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
+
+## Scope of this Stitch pass
+
+<surfaces + viewports to be generated>
+
+## Visit modes
+
+<5-ish modes: action responder, status checker, etc. Be specific to this surface>
+
+## Objectives, ranked
+
+1. ... 2. ... 3. ... 4. ... 5. ...
+
+## Entry points (with email context)
+
+<each entry point, with the subject line and CTA from the email that triggers it>
+
+## Design principles
+
+<3-5 principles that constrain Stitch without dictating layout>
+
+## Three concepts requested (structurally distinct, not visual variations)
+
+A — <axis>
+B — <axis>
+C — <axis>
+
+## Worked example (fidelity reference)
+
+<one concept × one surface × one viewport, with inline type specs>
+
+## Above-fold specs for B and C
+
+<matching A's format>
+
+## What must be preserved
+
+<typography, palette, shape, voice>
+
+## What is open
+
+<layout, hierarchy, flow — full creative freedom>
+
+## Anti-patterns (do not produce)
+
+<bullet list of explicit no-gos>
+
+## Mobile spec
+
+<390×844, thumb zone, tap target, no hover, no horizontal scroll>
+
+## Desktop spec
+
+<1280px, right-rail placement, eye-level action>
+
+## Contact affordance spec
+
+<primary channel, fallback, SLA — operational commitment, not copy>
+
+## Copy samples (tone calibration)
+
+<5-6 lines showing the voice in concrete context>
+
+## Error states (must design)
+
+<per-surface error list — each includes named human + next step>
+
+## Activity timeline schema
+
+<if the surface has time-series data, define the event shape>
+
+## Money rule
+
+<dollar figures only, never bars or percentages, if applicable>
+
+## Photo placeholder rule
+
+<harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
+
+## Accessibility floor
+
+<WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
+
+## Success criteria
+
+**Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
+
+Secondary: <2-4 testable criteria>
+
+## Follow-ups (scheduled, not gaps)
+
+<real priorities scheduled after this pass, each with a target window>
+
+## Data available
+
+<data fields the design can use; ask for flag if design needs data we don't capture>
+
+## Constraints
+
+<stack, viewports, scope limits>
+
+## Approver
+
+<name — Stitch output reviewed before any iteration>
+
+## Appendix: Hard design tokens
+
+### Color
+
+<hex block — use exact values from globals.css or tailwind config>
+
+### Typography
+
+<family, weights, sizes, line-heights, tracking>
+
+### Spacing and shape
+
+<rounded, padding, rhythm, tap target, breakpoints>
+```
+
+Write the brief. Then present the draft to the user and proceed to Phase 3.
+
+---
+
+## Phase 3 — Three-reviewer passes
+
+Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via the Task tool using `subagent_type: general-purpose`. The three reviewers are:
+
+### Product manager reviewer
+
+**Role prompt preamble:**
+
+> You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
+
+**Focus:**
+
+- Are user objectives correctly framed and ranked?
+- Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
+- Are success criteria measurable? Name the primary metric.
+- Is scope bounded for a realistic first pass?
+- Does the data inventory match what the design is being asked to do?
+- Business logic edge cases: multi-contact reality, partial payments, SOW revisions, out-of-portal artifacts
+- Is "reach a human" spec'd as an affordance or left as a phrase?
+- Are empty/error states required? Accessibility floor? Approver named?
+- Is the deliverable list realistic for a first Stitch pass, or unbounded?
+
+### UX designer reviewer
+
+**Role prompt preamble:**
+
+> You are a senior UX designer with deep experience using AI design tools — Stitch, v0, Magic Patterns, Figma Make. You know what makes them produce generic output vs considered work.
+
+**Focus:**
+
+- Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent runs across concepts. Require hex.
+- Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
+- Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
+- Is information hierarchy clear? What dominates, what recedes?
+- Are anti-patterns named? Are placeholder instructions strong enough to prevent real-face drift?
+- Predict what Stitch will produce as-is, including what's likely to go wrong.
+
+### Customer persona reviewer
+
+**Role prompt preamble (customize per surface):**
+
+> You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
+
+**Focus:**
+
+- Does this sound like real me, or like someone who's never talked to someone in my role?
+- What's patronizing? Soft? Over-explained?
+- What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
+- What would I actually do on this surface vs what they think I'd do?
+
+**Persona discipline:**
+
+- Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
+- Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
+
+### Round structure
+
+**Round 1:** Each reviewer critiques v1 from their role. Output format:
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Specific changes I'd make
+<concrete rewrites with proposed wording>
+
+## What's missing
+<things the brief does not address that it needs to>
+```
+
+Persona reviewer uses a different format — see their prompt above. They talk first, then summarize in three sections: got right / got wrong / still missing.
+
+**Between rounds:** Synthesize the feedback into a delta. Apply clear fixes directly to the brief. Surface disagreements or decisions that require user input as **open questions** — these become Phase 4 checkpoints.
+
+**Round 2:** Reviewers see v2 plus a summary of what changed from v1. They critique v2 specifically — what's still weak, what new issues emerged, what v2 got wrong in addressing Round 1 feedback.
+
+**Round 3:** Final polish pass. Reviewers are asked whether v3 is ready to ship. Format tightens to:
+
+```
+## Ready for Stitch? (Yes / Yes with caveats / No)
+## Any remaining critical issues?
+## Any last surgical edits?
+```
+
+**IMPORTANT**: All three reviewers in a round must be launched in a single Task tool message to run in parallel.
+
+---
+
+## Phase 4 — Decision checkpoints
+
+After each round, surface any decisions the reviewers flagged that require user judgment. Common examples:
+
+- An SLA promise in copy — is it an operational commitment or just marketing?
+- A user mode that was named but doesn't get its own surface — fold it into another mode, or design for it?
+- A concept that has an internal contradiction on a specific viewport — which way does it resolve?
+
+Present decisions as a short numbered list with your recommendation and rationale. Do NOT present 10 decisions — filter to the ones that will actually change the brief.
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 5 — Final brief saved
+
+Apply the last round's fixes and the user's decisions. Save the final brief to `.stitch/<target>-ux-brief.md`. Present the user a summary of:
+
+- Total rounds run
+- Major things that shifted v1 → final
+- Open decisions resolved
+- The final brief is ready to hand to Stitch
+
+Ask: **"Ready to generate? Or pause here?"**
+
+If `--generate=false` or the user pauses, stop. The brief is the deliverable.
+
+---
+
+## Phase 6 — Stitch project resolution
+
+Determine the venture code from the current repo (e.g., `ss-console` → `ss`).
+
+**Resolve project ID:**
+
+1. Call `crane_ventures` MCP tool. Find the venture. Read `stitchProjectId`.
+2. If it's a non-null string: use it.
+3. If it's `null`: tell the user no Stitch project exists for this venture, and ask if you should create one.
+
+**To create:**
+
+```
+Create a Stitch project titled "<Venture Name> — <Target>" and capture the returned project ID.
+```
+
+Use `mcp__stitch__create_project` if available. If the Stitch MCP errors with `Incompatible auth server: does not support dynamic client registration` or similar (known transient state), fall back to the curl pattern:
+
+```bash
+KEY=$(infisical secrets get STITCH_API_KEY --path /vc --env prod --plain)
+curl -sS -X POST https://stitch.googleapis.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Goog-Api-Key: $KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_project","arguments":{"title":"<title>"}}}'
+```
+
+Extract the project ID from `result.structuredContent.name` (format: `projects/<id>`).
+
+**Write the ID back:** Edit `crane-console/config/ventures.json` — find the venture entry by `code`, set `stitchProjectId` to the new ID.
+
+---
+
+## Phase 7 — Three structurally distinct concepts
+
+Generate three concepts at the **primary surface × mobile viewport only**. This is the convergence check — you verify the concepts actually diverge before spending on a full matrix.
+
+For each concept, write a prompt file to `/tmp/stitch-prompt-<concept>.txt`. The prompt template:
+
+```
+<Concept letter and axis> — <viewport description, e.g., "Mobile home dashboard for client portal at 390×844">
+
+<Paragraph explaining the concept's structural philosophy. What does it prioritize? What IS the page?>
+
+DESIGN SYSTEM (REQUIRED):
+- Platform: Web, mobile-first, 390x844 viewport only (or desktop 1280px)
+- Palette: <hex values from the brief's Appendix>
+- Typography: <families, weights, sizes>
+- Shape: <rounding, pills>
+- Density: <rhythm, tap targets, hover rules>
+- Tone: <voice rules — no hype, no AI copy, etc>
+- COLOR RULE (intentional): <any harnessed drift — e.g., "muted indigo family for metadata, not neutral slate">
+
+PAGE STRUCTURE:
+
+1. <Minimal header spec>
+2. <Dominant element — the concept's defining feature>
+3. <Supporting elements>
+4. <Consultant/contact block spec>
+5. <What is explicitly absent>
+
+Anti-patterns: <per-surface anti-patterns — not a generic list>
+
+Mood: <one sentence that captures the intent>
+```
+
+Fire all three generations in parallel (three Bash calls in one message, each with its own timeout of 330000ms for 5-minute Stitch generation).
+
+**JSON-RPC payload:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <n>,
+  "method": "tools/call",
+  "params": {
+    "name": "generate_screen_from_text",
+    "arguments": {
+      "projectId": "<resolved ID>",
+      "prompt": "<contents of prompt file>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Save each response to `/tmp/stitch-screen-<concept>.json`. Extract:
+
+- Screen ID: `result.structuredContent.outputComponents[design].screens[0].id`
+- Title: `result.structuredContent.outputComponents[design].screens[0].title`
+- HTML URL: `result.structuredContent.outputComponents[design].screens[0].htmlCode.downloadUrl`
+- PNG URL: `result.structuredContent.outputComponents[design].screens[0].screenshot.downloadUrl`
+- Description: any `outputComponents[text]` entry
+
+Download HTML and PNG for each to `.stitch/designs/<target>-v1/concept-<letter>.{html,png}`.
+
+---
+
+## Phase 8 — Convergence check
+
+View the three PNGs. Compare.
+
+**Question to answer, rigorously:** Are the three concepts structurally distinct, or have they collapsed into visual variations of the same layout?
+
+Signal of structural divergence:
+
+- Height ratios differ noticeably (e.g., one concept is ~60% the height of the others)
+- Information hierarchy differs (what dominates the viewport is genuinely different)
+- The "what IS the page?" answer differs per concept
+
+Signal of collapse:
+
+- All three are the same layout with different colors or card treatments
+- The heights are within 10% of each other
+- The dominant element is the same across all three
+
+If collapse: the brief failed to force divergence. Iterate the concept prompts with harder axis constraints, regenerate. Do not proceed until divergence is real.
+
+If divergence is good:
+
+Write a review to the user:
+
+```
+## Concept A — <axis>
+<summary of what it does, what worked, what didn't>
+
+## Concept B — <axis>
+<same>
+
+## Concept C — <axis>
+<same>
+
+## My read
+<lean toward one or a hybrid, with reasoning>
+```
+
+Ask the user: **"Which concept wins, or which hybrid do you want? Or do you want to re-commission the concepts with a different axis?"**
+
+Wait for the user's answer.
+
+---
+
+## Phase 9 — Winner iteration
+
+Once the user picks (single concept or hybrid), write an **edit** prompt that targets the existing screen(s) via `edit_screens`. The edit should:
+
+- Explicitly preserve everything that works (action dominance, consultant block, etc.)
+- Explicitly add the hybrid elements from other concepts
+- Not redesign from scratch
+
+Use `mcp__stitch__edit_screens` if MCP works, otherwise the curl equivalent:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "edit_screens",
+    "arguments": {
+      "projectId": "<id>",
+      "selectedScreenIds": ["<winner screen ID>"],
+      "prompt": "<edit prompt>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Download the updated preview. Present to user. Confirm the iteration landed before expanding.
+
+---
+
+## Phase 10 — Matrix expansion
+
+Generate the remaining surfaces × viewports for the winning concept.
+
+Typical matrix:
+
+- Remaining surfaces (2 at minimum — e.g., deep-link invoice landing, deep-link proposal landing) × 2 viewports (mobile, desktop) = 4 new screens
+- Plus the desktop variant of the primary surface = 1 more
+
+Total = usually 5 new screens beyond the winning mobile primary.
+
+For each, write a prompt file following the template from Phase 7. **Key move**: include the winning concept's DNA in each prompt. If the winner is "C-hybrid" (action-centric with a timeline below), make sure every surface in the matrix follows that DNA, not a fresh Stitch reading of the brief.
+
+Fire all generations in parallel (5 Bash calls in one message, each timeout 330000ms).
+
+Extract, download, save to `.stitch/designs/<target>-v1/<surface>-<viewport>.{html,png}`.
+
+---
+
+## Phase 11 — Gold-plating strip pass
+
+Stitch reliably adds default-web chrome that doesn't belong on an authenticated surface:
+
+- Global navigation tabs ("Dashboard | Documents | Billing")
+- Testimonial pull quotes and italicized customer-voice paragraphs
+- Copyright footers and legal link rows (Privacy | Terms | Contact)
+- Marketing CTAs ("Schedule a call", "Book a demo")
+- Hero imagery and decorative illustrations
+- Duplicated bottom-sticky action bars
+
+Run a **batch edit** across all generated screens with a hardened strip directive. `edit_screens` supports an array of `selectedScreenIds` — pass all of them in one call.
+
+**Strip directive template (customize per run):**
+
+```
+CONTEXT RESET: This is an authenticated <surface type> surface. The person viewing this is already logged in. <Describe their relationship to the product — existing customer, signed prospect, etc.>. This is NOT a marketing page. NOT a public website. NOT a landing page with a conversion goal. It is a working surface.
+
+Your job: remove everything that was added as gold-plating or default web chrome, and touch nothing else. Do NOT redesign. Do NOT rebalance layouts. Do NOT reword preserved copy. Only remove.
+
+REMOVE IF PRESENT:
+1. Global navigation tabs or menus
+2. Testimonial paragraphs, pull quotes, italicized client-voice sentences
+3. Copyright lines
+4. Legal link rows
+5. Marketing CTAs not in the original prompt
+6. Hero imagery, illustrations, decorative graphics
+7. Promotional banners, announcement bars, status indicators unrelated to the current task
+8. Stickied bottom bars duplicating a visible primary action
+
+PRESERVE EXACTLY:
+<Whitelist every element that should remain — the primary action, the amount display, every named section, the consultant block, all inline artifacts, the minimal header, every link that was explicit in the original prompt>
+
+REPLACEMENT RULE: Do not replace what you remove. If removing creates empty space, leave it empty. The page ends where content ends.
+
+BIAS: when in doubt, remove.
+```
+
+**Learning (hard-won):** the strip bias "when in doubt, remove" over-strips if you don't whitelist explicit preserves. Include the whitelist every time.
+
+Download updated previews. Compare pre-strip and post-strip heights — a 15-30% reduction is expected when cruft was present. More than 40% means something legitimate was stripped.
+
+Present the stripped set to the user. Note any over-strips (elements from the original brief that got removed). Decide: accept the cruft loss, targeted re-add, or accept the over-strip as the new baseline.
+
+---
+
+## Phase 12 — Artifact consolidation
+
+Final state on disk:
+
+```
+<repo>/.stitch/
+├── <target>-ux-brief.md             # Final brief
+└── designs/
+    └── <target>-v1/
+        ├── concept-A.html           # Concepts from Phase 7
+        ├── concept-A.png
+        ├── concept-B.html
+        ├── concept-B.png
+        ├── concept-C.html
+        ├── concept-C.png
+        ├── <winner>-iterated.html   # Phase 9
+        ├── <winner>-iterated.png
+        ├── <surface>-<viewport>.html   # Matrix expansion from Phase 10
+        ├── <surface>-<viewport>.png
+        └── <surface>-<viewport>-stripped.html  # Phase 11 outputs
+```
+
+Write a short log to `.stitch/designs/<target>-v1/RUN-LOG.md` capturing:
+
+- Date
+- Target surface
+- Rounds run
+- Winning concept
+- Decisions made by the user
+- Known drifts / over-strips
+- Next follow-ups
+
+Update `crane-console/config/ventures.json` with the `stitchProjectId` if it was created during this run.
+
+Tell the user:
+
+- How many screens were produced
+- Where they live
+- What's next (implementation, additional surfaces, another round of polish)
+
+---
+
+## Embedded learnings (tune these into every run)
+
+1. **Personify the customer reviewer.** A named individual with real specifics produces sharper critique than a demographic. The persona should push back on the brief's description of them — that's usually where the brief is patronizing.
+
+2. **Structural divergence must be commissioned explicitly.** "Three structurally distinct concepts — timeline-centric, archive-centric, action-centric" works. "Three concepts" collapses into variations.
+
+3. **Tokens as hex, not vibes.** "Muted violet" is three different colors to three Stitch runs. Always include hex values from the venture's actual stylesheet.
+
+4. **Mobile-first as constraint, not slogan.** Specify viewport (390×844), thumb zone (bottom 40%), tap target (44px), no-hover rule, no-horizontal-scroll rule. These are the constraints; "design mobile-first" alone is a wish.
+
+5. **Harness drift, don't police it.** If Stitch's first pass does something unintended but coherent (muted-indigo dates instead of neutral slate), codify it in subsequent prompts rather than fighting it. The first-pass output is a design proposal you can accept into the spec.
+
+6. **Anti-patterns need an affirmative frame.** "No nav tabs, no testimonials" is weaker than "This is an authenticated portal, not a marketing page. Chrome is strictly limited to what's listed below." Affirmative framing is what makes the strip pass work.
+
+7. **Strip passes need whitelisted preserves.** Removal bias without a preserve whitelist over-strips. Always list every preserved element explicitly before stripping.
+
+8. **Placeholder instructions are weak.** "Neutral portrait placeholder with caption 'consultant photo'" is routinely ignored — Stitch defaults to real faces. Either spec a solid shape ("solid indigo circle with initials") or a clearly abstract graphic ("geometric avatar, no face").
+
+9. **Scope to 3 surfaces × 2 viewports.** A first Stitch pass generating more than ~6-8 screens is unreviewable. Converge on a concept first, then expand.
+
+10. **Batch edits for consistency.** `edit_screens` supports arrays. One directive across many screens is cheaper and more consistent than per-screen edits.
+
+11. **Desktop is an expansion, not a redesign.** Spec the right-rail pattern explicitly ("~340px wide, 160-200px from top, sticky, at eye level"). Otherwise Stitch improvises a desktop design that diverges from the mobile concept.
+
+12. **MCP fallbacks matter.** The Stitch MCP occasionally enters a state where it reports connected but every call fails with an OAuth error. The endpoint works with the API key via direct HTTP. Always include the curl fallback path so a broken MCP doesn't block the run.
+
+---
+
+## Dependencies and conventions
+
+- **Stitch project ID** resolved via `crane_ventures` MCP tool. Writes back to `crane-console/config/ventures.json`.
+- **API key** stored in Infisical at `/vc` (prod env, key `STITCH_API_KEY`). Never echo the value.
+- **Artifact directory** is `.stitch/designs/<target>-v<n>/` — use versioned subfolders so prior runs are preserved.
+- **Brief filename** is `.stitch/<target>-ux-brief.md`.
+- **Run log** is `.stitch/designs/<target>-v<n>/RUN-LOG.md`.
+
+---
+
+## Versioning
+
+When iterating a target that already has `.stitch/<target>-ux-brief.md` and `.stitch/designs/<target>-v1/`:
+
+- The new run creates `<target>-v2/`, `<target>-v3/`, etc.
+- The brief overwrites (with the prior version moved to `.stitch/<target>-ux-brief-v1.md` if substantive changes).
+- The run log records "v2 vs v1: what changed and why."

--- a/.claude/commands/stitch-ux-brief.md
+++ b/.claude/commands/stitch-ux-brief.md
@@ -1,0 +1,656 @@
+# /stitch-ux-brief - Stitch UX Brief & Generation
+
+Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona), then commissions Stitch to generate three structurally distinct concepts at a single surface + viewport, iterates a winner with the user, expands to the full matrix of surfaces and viewports, and strips default-web gold-plating. Final artifacts land in `.stitch/` in the current venture repo.
+
+Works in any venture console that has a Stitch project configured in `crane-console/config/ventures.json` (field: `stitchProjectId`). If one does not exist, this skill creates it and offers to write it back.
+
+## Arguments
+
+```
+/stitch-ux-brief [target] [--rounds=3] [--generate=true]
+```
+
+- `target` — short name of the surface being designed (e.g., `client-portal`, `signup-flow`, `admin-inbox`). Required. Used for artifact file names.
+- `rounds` — brief review rounds (default **3**). Each round spawns three parallel reviewers; output is synthesized between rounds. Fewer than 3 is not recommended.
+- `generate` — whether to invoke Stitch after brief approval (default **true**). Set `false` to stop after the approved brief and generate later or by hand.
+
+Parse the arguments. If `target` is missing, stop and ask the user what surface they want to brief.
+
+## The methodology, in one paragraph
+
+This skill exists because a UX brief handed to a generative design tool fails in predictable ways: the objectives are pretty but unmeasurable, the tokens are described in vibes instead of hex, the concepts all collapse into card-grid variations, and the generated output comes back padded with marketing chrome. This skill fixes each of those by running the brief through a critical three-reviewer pass (one of them a named customer who talks back), forcing structural divergence in the concept brief ("timeline vs archive vs action-centric, not three visual variations of the same layout"), harnessing Stitch's drift as intentional rather than policing it, and running an explicit strip pass on generated output. Every step has a learning embedded; the skill is the accumulated scar tissue of running this end-to-end.
+
+## Phases
+
+1. Intake — establish target, scope, existing context
+2. Draft brief v1
+3. Three-reviewer passes with synthesis
+4. Decision checkpoints — resolve open questions surfaced by reviewers
+5. Final brief, user-approved, saved to `.stitch/<target>-ux-brief.md`
+6. Stitch project resolution (create or reuse)
+7. Three structurally distinct concepts, one surface × one viewport
+8. Convergence check — user picks winner or hybrid direction
+9. Winner iteration (one targeted edit pass)
+10. Matrix expansion (all remaining surfaces × viewports)
+11. Gold-plating strip pass (batch edit, whitelist preserve)
+12. Artifact consolidation in `.stitch/designs/<target>-vN/`
+
+Each phase ends with a checkpoint. The user can stop at any checkpoint. Do not skip phases.
+
+---
+
+## Phase 1 — Intake
+
+Ask the user these questions if they aren't already answered by the conversation:
+
+1. **Target surface.** What surface are we designing? (e.g., "client portal home dashboard + invoice and proposal deep-link landings").
+2. **Authentication context.** Is the user logged in? Prospect? Public-web visitor? This shapes the "no marketing chrome" framing.
+3. **Customer persona seed.** Give me a realistic archetype — named if possible. Role, revenue range, tech comfort, what they care about. If the user hasn't thought about this, offer to draft one and confirm.
+4. **Any existing brief, PRD, or prior design** to build on? Check for `docs/pm/prd.md`, `docs/design/*`, `.stitch/*-ux-brief.md`, or a prior version of the target.
+
+Scan the repo for context:
+
+- `CLAUDE.md` for venture positioning / tone rules
+- `src/styles/globals.css` or `**/globals.css` for design tokens (hex values, type families)
+- `tailwind.config.*` for palette and type scale
+- Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
+- `.stitch/DESIGN.md` if present (established design system for the venture)
+
+Display an **Intake Summary** table:
+
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| Target         | _e.g., `client-portal`_                       |
+| Authentication | _logged-in / prospect / public_               |
+| Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief    | _path or "none"_                              |
+| Tokens source  | _path to globals.css or config_               |
+| Venture code   | _resolved from `crane_ventures`_              |
+| Stitch project | _ID or "will create"_                         |
+
+Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
+
+Wait for confirmation.
+
+---
+
+## Phase 2 — Draft v1
+
+Write a v1 brief to `.stitch/<target>-ux-brief.md` (create the directory if needed). Use this structure:
+
+```markdown
+# <Title> — UX Redesign Brief (v1)
+
+## Context
+
+<2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
+
+## Scope of this Stitch pass
+
+<surfaces + viewports to be generated>
+
+## Visit modes
+
+<5-ish modes: action responder, status checker, etc. Be specific to this surface>
+
+## Objectives, ranked
+
+1. ... 2. ... 3. ... 4. ... 5. ...
+
+## Entry points (with email context)
+
+<each entry point, with the subject line and CTA from the email that triggers it>
+
+## Design principles
+
+<3-5 principles that constrain Stitch without dictating layout>
+
+## Three concepts requested (structurally distinct, not visual variations)
+
+A — <axis>
+B — <axis>
+C — <axis>
+
+## Worked example (fidelity reference)
+
+<one concept × one surface × one viewport, with inline type specs>
+
+## Above-fold specs for B and C
+
+<matching A's format>
+
+## What must be preserved
+
+<typography, palette, shape, voice>
+
+## What is open
+
+<layout, hierarchy, flow — full creative freedom>
+
+## Anti-patterns (do not produce)
+
+<bullet list of explicit no-gos>
+
+## Mobile spec
+
+<390×844, thumb zone, tap target, no hover, no horizontal scroll>
+
+## Desktop spec
+
+<1280px, right-rail placement, eye-level action>
+
+## Contact affordance spec
+
+<primary channel, fallback, SLA — operational commitment, not copy>
+
+## Copy samples (tone calibration)
+
+<5-6 lines showing the voice in concrete context>
+
+## Error states (must design)
+
+<per-surface error list — each includes named human + next step>
+
+## Activity timeline schema
+
+<if the surface has time-series data, define the event shape>
+
+## Money rule
+
+<dollar figures only, never bars or percentages, if applicable>
+
+## Photo placeholder rule
+
+<harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
+
+## Accessibility floor
+
+<WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
+
+## Success criteria
+
+**Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
+
+Secondary: <2-4 testable criteria>
+
+## Follow-ups (scheduled, not gaps)
+
+<real priorities scheduled after this pass, each with a target window>
+
+## Data available
+
+<data fields the design can use; ask for flag if design needs data we don't capture>
+
+## Constraints
+
+<stack, viewports, scope limits>
+
+## Approver
+
+<name — Stitch output reviewed before any iteration>
+
+## Appendix: Hard design tokens
+
+### Color
+
+<hex block — use exact values from globals.css or tailwind config>
+
+### Typography
+
+<family, weights, sizes, line-heights, tracking>
+
+### Spacing and shape
+
+<rounded, padding, rhythm, tap target, breakpoints>
+```
+
+Write the brief. Then present the draft to the user and proceed to Phase 3.
+
+---
+
+## Phase 3 — Three-reviewer passes
+
+Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via the Task tool using `subagent_type: general-purpose`. The three reviewers are:
+
+### Product manager reviewer
+
+**Role prompt preamble:**
+
+> You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
+
+**Focus:**
+
+- Are user objectives correctly framed and ranked?
+- Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
+- Are success criteria measurable? Name the primary metric.
+- Is scope bounded for a realistic first pass?
+- Does the data inventory match what the design is being asked to do?
+- Business logic edge cases: multi-contact reality, partial payments, SOW revisions, out-of-portal artifacts
+- Is "reach a human" spec'd as an affordance or left as a phrase?
+- Are empty/error states required? Accessibility floor? Approver named?
+- Is the deliverable list realistic for a first Stitch pass, or unbounded?
+
+### UX designer reviewer
+
+**Role prompt preamble:**
+
+> You are a senior UX designer with deep experience using AI design tools — Stitch, v0, Magic Patterns, Figma Make. You know what makes them produce generic output vs considered work.
+
+**Focus:**
+
+- Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent runs across concepts. Require hex.
+- Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
+- Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
+- Is information hierarchy clear? What dominates, what recedes?
+- Are anti-patterns named? Are placeholder instructions strong enough to prevent real-face drift?
+- Predict what Stitch will produce as-is, including what's likely to go wrong.
+
+### Customer persona reviewer
+
+**Role prompt preamble (customize per surface):**
+
+> You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
+
+**Focus:**
+
+- Does this sound like real me, or like someone who's never talked to someone in my role?
+- What's patronizing? Soft? Over-explained?
+- What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
+- What would I actually do on this surface vs what they think I'd do?
+
+**Persona discipline:**
+
+- Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
+- Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
+
+### Round structure
+
+**Round 1:** Each reviewer critiques v1 from their role. Output format:
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Specific changes I'd make
+<concrete rewrites with proposed wording>
+
+## What's missing
+<things the brief does not address that it needs to>
+```
+
+Persona reviewer uses a different format — see their prompt above. They talk first, then summarize in three sections: got right / got wrong / still missing.
+
+**Between rounds:** Synthesize the feedback into a delta. Apply clear fixes directly to the brief. Surface disagreements or decisions that require user input as **open questions** — these become Phase 4 checkpoints.
+
+**Round 2:** Reviewers see v2 plus a summary of what changed from v1. They critique v2 specifically — what's still weak, what new issues emerged, what v2 got wrong in addressing Round 1 feedback.
+
+**Round 3:** Final polish pass. Reviewers are asked whether v3 is ready to ship. Format tightens to:
+
+```
+## Ready for Stitch? (Yes / Yes with caveats / No)
+## Any remaining critical issues?
+## Any last surgical edits?
+```
+
+**IMPORTANT**: All three reviewers in a round must be launched in a single Task tool message to run in parallel.
+
+---
+
+## Phase 4 — Decision checkpoints
+
+After each round, surface any decisions the reviewers flagged that require user judgment. Common examples:
+
+- An SLA promise in copy — is it an operational commitment or just marketing?
+- A user mode that was named but doesn't get its own surface — fold it into another mode, or design for it?
+- A concept that has an internal contradiction on a specific viewport — which way does it resolve?
+
+Present decisions as a short numbered list with your recommendation and rationale. Do NOT present 10 decisions — filter to the ones that will actually change the brief.
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 5 — Final brief saved
+
+Apply the last round's fixes and the user's decisions. Save the final brief to `.stitch/<target>-ux-brief.md`. Present the user a summary of:
+
+- Total rounds run
+- Major things that shifted v1 → final
+- Open decisions resolved
+- The final brief is ready to hand to Stitch
+
+Ask: **"Ready to generate? Or pause here?"**
+
+If `--generate=false` or the user pauses, stop. The brief is the deliverable.
+
+---
+
+## Phase 6 — Stitch project resolution
+
+Determine the venture code from the current repo (e.g., `ss-console` → `ss`).
+
+**Resolve project ID:**
+
+1. Call `crane_ventures` MCP tool. Find the venture. Read `stitchProjectId`.
+2. If it's a non-null string: use it.
+3. If it's `null`: tell the user no Stitch project exists for this venture, and ask if you should create one.
+
+**To create:**
+
+```
+Create a Stitch project titled "<Venture Name> — <Target>" and capture the returned project ID.
+```
+
+Use `mcp__stitch__create_project` if available. If the Stitch MCP errors with `Incompatible auth server: does not support dynamic client registration` or similar (known transient state), fall back to the curl pattern:
+
+```bash
+KEY=$(infisical secrets get STITCH_API_KEY --path /vc --env prod --plain)
+curl -sS -X POST https://stitch.googleapis.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Goog-Api-Key: $KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_project","arguments":{"title":"<title>"}}}'
+```
+
+Extract the project ID from `result.structuredContent.name` (format: `projects/<id>`).
+
+**Write the ID back:** Edit `crane-console/config/ventures.json` — find the venture entry by `code`, set `stitchProjectId` to the new ID.
+
+---
+
+## Phase 7 — Three structurally distinct concepts
+
+Generate three concepts at the **primary surface × mobile viewport only**. This is the convergence check — you verify the concepts actually diverge before spending on a full matrix.
+
+For each concept, write a prompt file to `/tmp/stitch-prompt-<concept>.txt`. The prompt template:
+
+```
+<Concept letter and axis> — <viewport description, e.g., "Mobile home dashboard for client portal at 390×844">
+
+<Paragraph explaining the concept's structural philosophy. What does it prioritize? What IS the page?>
+
+DESIGN SYSTEM (REQUIRED):
+- Platform: Web, mobile-first, 390x844 viewport only (or desktop 1280px)
+- Palette: <hex values from the brief's Appendix>
+- Typography: <families, weights, sizes>
+- Shape: <rounding, pills>
+- Density: <rhythm, tap targets, hover rules>
+- Tone: <voice rules — no hype, no AI copy, etc>
+- COLOR RULE (intentional): <any harnessed drift — e.g., "muted indigo family for metadata, not neutral slate">
+
+PAGE STRUCTURE:
+
+1. <Minimal header spec>
+2. <Dominant element — the concept's defining feature>
+3. <Supporting elements>
+4. <Consultant/contact block spec>
+5. <What is explicitly absent>
+
+Anti-patterns: <per-surface anti-patterns — not a generic list>
+
+Mood: <one sentence that captures the intent>
+```
+
+Fire all three generations in parallel (three Bash calls in one message, each with its own timeout of 330000ms for 5-minute Stitch generation).
+
+**JSON-RPC payload:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <n>,
+  "method": "tools/call",
+  "params": {
+    "name": "generate_screen_from_text",
+    "arguments": {
+      "projectId": "<resolved ID>",
+      "prompt": "<contents of prompt file>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Save each response to `/tmp/stitch-screen-<concept>.json`. Extract:
+
+- Screen ID: `result.structuredContent.outputComponents[design].screens[0].id`
+- Title: `result.structuredContent.outputComponents[design].screens[0].title`
+- HTML URL: `result.structuredContent.outputComponents[design].screens[0].htmlCode.downloadUrl`
+- PNG URL: `result.structuredContent.outputComponents[design].screens[0].screenshot.downloadUrl`
+- Description: any `outputComponents[text]` entry
+
+Download HTML and PNG for each to `.stitch/designs/<target>-v1/concept-<letter>.{html,png}`.
+
+---
+
+## Phase 8 — Convergence check
+
+View the three PNGs. Compare.
+
+**Question to answer, rigorously:** Are the three concepts structurally distinct, or have they collapsed into visual variations of the same layout?
+
+Signal of structural divergence:
+
+- Height ratios differ noticeably (e.g., one concept is ~60% the height of the others)
+- Information hierarchy differs (what dominates the viewport is genuinely different)
+- The "what IS the page?" answer differs per concept
+
+Signal of collapse:
+
+- All three are the same layout with different colors or card treatments
+- The heights are within 10% of each other
+- The dominant element is the same across all three
+
+If collapse: the brief failed to force divergence. Iterate the concept prompts with harder axis constraints, regenerate. Do not proceed until divergence is real.
+
+If divergence is good:
+
+Write a review to the user:
+
+```
+## Concept A — <axis>
+<summary of what it does, what worked, what didn't>
+
+## Concept B — <axis>
+<same>
+
+## Concept C — <axis>
+<same>
+
+## My read
+<lean toward one or a hybrid, with reasoning>
+```
+
+Ask the user: **"Which concept wins, or which hybrid do you want? Or do you want to re-commission the concepts with a different axis?"**
+
+Wait for the user's answer.
+
+---
+
+## Phase 9 — Winner iteration
+
+Once the user picks (single concept or hybrid), write an **edit** prompt that targets the existing screen(s) via `edit_screens`. The edit should:
+
+- Explicitly preserve everything that works (action dominance, consultant block, etc.)
+- Explicitly add the hybrid elements from other concepts
+- Not redesign from scratch
+
+Use `mcp__stitch__edit_screens` if MCP works, otherwise the curl equivalent:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "edit_screens",
+    "arguments": {
+      "projectId": "<id>",
+      "selectedScreenIds": ["<winner screen ID>"],
+      "prompt": "<edit prompt>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Download the updated preview. Present to user. Confirm the iteration landed before expanding.
+
+---
+
+## Phase 10 — Matrix expansion
+
+Generate the remaining surfaces × viewports for the winning concept.
+
+Typical matrix:
+
+- Remaining surfaces (2 at minimum — e.g., deep-link invoice landing, deep-link proposal landing) × 2 viewports (mobile, desktop) = 4 new screens
+- Plus the desktop variant of the primary surface = 1 more
+
+Total = usually 5 new screens beyond the winning mobile primary.
+
+For each, write a prompt file following the template from Phase 7. **Key move**: include the winning concept's DNA in each prompt. If the winner is "C-hybrid" (action-centric with a timeline below), make sure every surface in the matrix follows that DNA, not a fresh Stitch reading of the brief.
+
+Fire all generations in parallel (5 Bash calls in one message, each timeout 330000ms).
+
+Extract, download, save to `.stitch/designs/<target>-v1/<surface>-<viewport>.{html,png}`.
+
+---
+
+## Phase 11 — Gold-plating strip pass
+
+Stitch reliably adds default-web chrome that doesn't belong on an authenticated surface:
+
+- Global navigation tabs ("Dashboard | Documents | Billing")
+- Testimonial pull quotes and italicized customer-voice paragraphs
+- Copyright footers and legal link rows (Privacy | Terms | Contact)
+- Marketing CTAs ("Schedule a call", "Book a demo")
+- Hero imagery and decorative illustrations
+- Duplicated bottom-sticky action bars
+
+Run a **batch edit** across all generated screens with a hardened strip directive. `edit_screens` supports an array of `selectedScreenIds` — pass all of them in one call.
+
+**Strip directive template (customize per run):**
+
+```
+CONTEXT RESET: This is an authenticated <surface type> surface. The person viewing this is already logged in. <Describe their relationship to the product — existing customer, signed prospect, etc.>. This is NOT a marketing page. NOT a public website. NOT a landing page with a conversion goal. It is a working surface.
+
+Your job: remove everything that was added as gold-plating or default web chrome, and touch nothing else. Do NOT redesign. Do NOT rebalance layouts. Do NOT reword preserved copy. Only remove.
+
+REMOVE IF PRESENT:
+1. Global navigation tabs or menus
+2. Testimonial paragraphs, pull quotes, italicized client-voice sentences
+3. Copyright lines
+4. Legal link rows
+5. Marketing CTAs not in the original prompt
+6. Hero imagery, illustrations, decorative graphics
+7. Promotional banners, announcement bars, status indicators unrelated to the current task
+8. Stickied bottom bars duplicating a visible primary action
+
+PRESERVE EXACTLY:
+<Whitelist every element that should remain — the primary action, the amount display, every named section, the consultant block, all inline artifacts, the minimal header, every link that was explicit in the original prompt>
+
+REPLACEMENT RULE: Do not replace what you remove. If removing creates empty space, leave it empty. The page ends where content ends.
+
+BIAS: when in doubt, remove.
+```
+
+**Learning (hard-won):** the strip bias "when in doubt, remove" over-strips if you don't whitelist explicit preserves. Include the whitelist every time.
+
+Download updated previews. Compare pre-strip and post-strip heights — a 15-30% reduction is expected when cruft was present. More than 40% means something legitimate was stripped.
+
+Present the stripped set to the user. Note any over-strips (elements from the original brief that got removed). Decide: accept the cruft loss, targeted re-add, or accept the over-strip as the new baseline.
+
+---
+
+## Phase 12 — Artifact consolidation
+
+Final state on disk:
+
+```
+<repo>/.stitch/
+├── <target>-ux-brief.md             # Final brief
+└── designs/
+    └── <target>-v1/
+        ├── concept-A.html           # Concepts from Phase 7
+        ├── concept-A.png
+        ├── concept-B.html
+        ├── concept-B.png
+        ├── concept-C.html
+        ├── concept-C.png
+        ├── <winner>-iterated.html   # Phase 9
+        ├── <winner>-iterated.png
+        ├── <surface>-<viewport>.html   # Matrix expansion from Phase 10
+        ├── <surface>-<viewport>.png
+        └── <surface>-<viewport>-stripped.html  # Phase 11 outputs
+```
+
+Write a short log to `.stitch/designs/<target>-v1/RUN-LOG.md` capturing:
+
+- Date
+- Target surface
+- Rounds run
+- Winning concept
+- Decisions made by the user
+- Known drifts / over-strips
+- Next follow-ups
+
+Update `crane-console/config/ventures.json` with the `stitchProjectId` if it was created during this run.
+
+Tell the user:
+
+- How many screens were produced
+- Where they live
+- What's next (implementation, additional surfaces, another round of polish)
+
+---
+
+## Embedded learnings (tune these into every run)
+
+1. **Personify the customer reviewer.** A named individual with real specifics produces sharper critique than a demographic. The persona should push back on the brief's description of them — that's usually where the brief is patronizing.
+
+2. **Structural divergence must be commissioned explicitly.** "Three structurally distinct concepts — timeline-centric, archive-centric, action-centric" works. "Three concepts" collapses into variations.
+
+3. **Tokens as hex, not vibes.** "Muted violet" is three different colors to three Stitch runs. Always include hex values from the venture's actual stylesheet.
+
+4. **Mobile-first as constraint, not slogan.** Specify viewport (390×844), thumb zone (bottom 40%), tap target (44px), no-hover rule, no-horizontal-scroll rule. These are the constraints; "design mobile-first" alone is a wish.
+
+5. **Harness drift, don't police it.** If Stitch's first pass does something unintended but coherent (muted-indigo dates instead of neutral slate), codify it in subsequent prompts rather than fighting it. The first-pass output is a design proposal you can accept into the spec.
+
+6. **Anti-patterns need an affirmative frame.** "No nav tabs, no testimonials" is weaker than "This is an authenticated portal, not a marketing page. Chrome is strictly limited to what's listed below." Affirmative framing is what makes the strip pass work.
+
+7. **Strip passes need whitelisted preserves.** Removal bias without a preserve whitelist over-strips. Always list every preserved element explicitly before stripping.
+
+8. **Placeholder instructions are weak.** "Neutral portrait placeholder with caption 'consultant photo'" is routinely ignored — Stitch defaults to real faces. Either spec a solid shape ("solid indigo circle with initials") or a clearly abstract graphic ("geometric avatar, no face").
+
+9. **Scope to 3 surfaces × 2 viewports.** A first Stitch pass generating more than ~6-8 screens is unreviewable. Converge on a concept first, then expand.
+
+10. **Batch edits for consistency.** `edit_screens` supports arrays. One directive across many screens is cheaper and more consistent than per-screen edits.
+
+11. **Desktop is an expansion, not a redesign.** Spec the right-rail pattern explicitly ("~340px wide, 160-200px from top, sticky, at eye level"). Otherwise Stitch improvises a desktop design that diverges from the mobile concept.
+
+12. **MCP fallbacks matter.** The Stitch MCP occasionally enters a state where it reports connected but every call fails with an OAuth error. The endpoint works with the API key via direct HTTP. Always include the curl fallback path so a broken MCP doesn't block the run.
+
+---
+
+## Dependencies and conventions
+
+- **Stitch project ID** resolved via `crane_ventures` MCP tool. Writes back to `crane-console/config/ventures.json`.
+- **API key** stored in Infisical at `/vc` (prod env, key `STITCH_API_KEY`). Never echo the value.
+- **Artifact directory** is `.stitch/designs/<target>-v<n>/` — use versioned subfolders so prior runs are preserved.
+- **Brief filename** is `.stitch/<target>-ux-brief.md`.
+- **Run log** is `.stitch/designs/<target>-v<n>/RUN-LOG.md`.
+
+---
+
+## Versioning
+
+When iterating a target that already has `.stitch/<target>-ux-brief.md` and `.stitch/designs/<target>-v1/`:
+
+- The new run creates `<target>-v2/`, `<target>-v3/`, etc.
+- The brief overwrites (with the prior version moved to `.stitch/<target>-ux-brief-v1.md` if substantive changes).
+- The run log records "v2 vs v1: what changed and why."

--- a/.gemini/commands/stitch-ux-brief.toml
+++ b/.gemini/commands/stitch-ux-brief.toml
@@ -1,0 +1,620 @@
+description = "Stitch UX Brief & Generation"
+
+prompt = """
+
+Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona), then commissions Stitch to generate three structurally distinct concepts at a single surface + viewport, iterates a winner with the user, expands to the full matrix of surfaces and viewports, and strips default-web gold-plating. Final artifacts land in `.stitch/` in the current venture repo.
+
+Works in any venture console that has a Stitch project configured in `crane-console/config/ventures.json` (field: `stitchProjectId`). If one does not exist, this skill creates it and offers to write it back.
+
+## Arguments
+
+```
+/stitch-ux-brief [target] [--rounds=3] [--generate=true]
+```
+
+- `target` — short name of the surface being designed (e.g., `client-portal`, `signup-flow`, `admin-inbox`). Required. Used for artifact file names.
+- `rounds` — brief review rounds (default **3**). Each round spawns three parallel reviewers; output is synthesized between rounds. Fewer than 3 is not recommended.
+- `generate` — whether to invoke Stitch after brief approval (default **true**). Set `false` to stop after the approved brief and generate later or by hand.
+
+Parse the arguments. If `target` is missing, stop and ask the user what surface they want to brief.
+
+## The methodology, in one paragraph
+
+This skill exists because a UX brief handed to a generative design tool fails in predictable ways: the objectives are pretty but unmeasurable, the tokens are described in vibes instead of hex, the concepts all collapse into card-grid variations, and the generated output comes back padded with marketing chrome. This skill fixes each of those by running the brief through a critical three-reviewer pass (one of them a named customer who talks back), forcing structural divergence in the concept brief ("timeline vs archive vs action-centric, not three visual variations of the same layout"), harnessing Stitch's drift as intentional rather than policing it, and running an explicit strip pass on generated output. Every step has a learning embedded; the skill is the accumulated scar tissue of running this end-to-end.
+
+## Phases
+
+1. Intake — establish target, scope, existing context
+2. Draft brief v1
+3. Three-reviewer passes with synthesis
+4. Decision checkpoints — resolve open questions surfaced by reviewers
+5. Final brief, user-approved, saved to `.stitch/<target>-ux-brief.md`
+6. Stitch project resolution (create or reuse)
+7. Three structurally distinct concepts, one surface × one viewport
+8. Convergence check — user picks winner or hybrid direction
+9. Winner iteration (one targeted edit pass)
+10. Matrix expansion (all remaining surfaces × viewports)
+11. Gold-plating strip pass (batch edit, whitelist preserve)
+12. Artifact consolidation in `.stitch/designs/<target>-vN/`
+
+Each phase ends with a checkpoint. The user can stop at any checkpoint. Do not skip phases.
+
+---
+
+## Phase 1 — Intake
+
+Ask the user these questions if they aren't already answered by the conversation:
+
+1. **Target surface.** What surface are we designing? (e.g., "client portal home dashboard + invoice and proposal deep-link landings").
+2. **Authentication context.** Is the user logged in? Prospect? Public-web visitor? This shapes the "no marketing chrome" framing.
+3. **Customer persona seed.** Give me a realistic archetype — named if possible. Role, revenue range, tech comfort, what they care about. If the user hasn't thought about this, offer to draft one and confirm.
+4. **Any existing brief, PRD, or prior design** to build on? Check for `docs/pm/prd.md`, `docs/design/*`, `.stitch/*-ux-brief.md`, or a prior version of the target.
+
+Scan the repo for context:
+
+- `CLAUDE.md` for venture positioning / tone rules
+- `src/styles/globals.css` or `**/globals.css` for design tokens (hex values, type families)
+- `tailwind.config.*` for palette and type scale
+- Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
+- `.stitch/DESIGN.md` if present (established design system for the venture)
+
+Display an **Intake Summary** table:
+
+| Field | Value |
+| --- | --- |
+| Target | _e.g., `client-portal`_ |
+| Authentication | _logged-in / prospect / public_ |
+| Persona | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief | _path or "none"_ |
+| Tokens source | _path to globals.css or config_ |
+| Venture code | _resolved from `crane_ventures`_ |
+| Stitch project | _ID or "will create"_ |
+
+Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
+
+Wait for confirmation.
+
+---
+
+## Phase 2 — Draft v1
+
+Write a v1 brief to `.stitch/<target>-ux-brief.md` (create the directory if needed). Use this structure:
+
+```markdown
+# <Title> — UX Redesign Brief (v1)
+
+## Context
+<2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
+
+## Scope of this Stitch pass
+<surfaces + viewports to be generated>
+
+## Visit modes
+<5-ish modes: action responder, status checker, etc. Be specific to this surface>
+
+## Objectives, ranked
+1. ... 2. ... 3. ... 4. ... 5. ...
+
+## Entry points (with email context)
+<each entry point, with the subject line and CTA from the email that triggers it>
+
+## Design principles
+<3-5 principles that constrain Stitch without dictating layout>
+
+## Three concepts requested (structurally distinct, not visual variations)
+A — <axis>
+B — <axis>
+C — <axis>
+
+## Worked example (fidelity reference)
+<one concept × one surface × one viewport, with inline type specs>
+
+## Above-fold specs for B and C
+<matching A's format>
+
+## What must be preserved
+<typography, palette, shape, voice>
+
+## What is open
+<layout, hierarchy, flow — full creative freedom>
+
+## Anti-patterns (do not produce)
+<bullet list of explicit no-gos>
+
+## Mobile spec
+<390×844, thumb zone, tap target, no hover, no horizontal scroll>
+
+## Desktop spec
+<1280px, right-rail placement, eye-level action>
+
+## Contact affordance spec
+<primary channel, fallback, SLA — operational commitment, not copy>
+
+## Copy samples (tone calibration)
+<5-6 lines showing the voice in concrete context>
+
+## Error states (must design)
+<per-surface error list — each includes named human + next step>
+
+## Activity timeline schema
+<if the surface has time-series data, define the event shape>
+
+## Money rule
+<dollar figures only, never bars or percentages, if applicable>
+
+## Photo placeholder rule
+<harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
+
+## Accessibility floor
+<WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
+
+## Success criteria
+**Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
+
+Secondary: <2-4 testable criteria>
+
+## Follow-ups (scheduled, not gaps)
+<real priorities scheduled after this pass, each with a target window>
+
+## Data available
+<data fields the design can use; ask for flag if design needs data we don't capture>
+
+## Constraints
+<stack, viewports, scope limits>
+
+## Approver
+<name — Stitch output reviewed before any iteration>
+
+## Appendix: Hard design tokens
+### Color
+<hex block — use exact values from globals.css or tailwind config>
+### Typography
+<family, weights, sizes, line-heights, tracking>
+### Spacing and shape
+<rounded, padding, rhythm, tap target, breakpoints>
+```
+
+Write the brief. Then present the draft to the user and proceed to Phase 3.
+
+---
+
+## Phase 3 — Three-reviewer passes
+
+Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via the Task tool using `subagent_type: general-purpose`. The three reviewers are:
+
+### Product manager reviewer
+
+**Role prompt preamble:**
+
+> You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
+
+**Focus:**
+- Are user objectives correctly framed and ranked?
+- Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
+- Are success criteria measurable? Name the primary metric.
+- Is scope bounded for a realistic first pass?
+- Does the data inventory match what the design is being asked to do?
+- Business logic edge cases: multi-contact reality, partial payments, SOW revisions, out-of-portal artifacts
+- Is "reach a human" spec'd as an affordance or left as a phrase?
+- Are empty/error states required? Accessibility floor? Approver named?
+- Is the deliverable list realistic for a first Stitch pass, or unbounded?
+
+### UX designer reviewer
+
+**Role prompt preamble:**
+
+> You are a senior UX designer with deep experience using AI design tools — Stitch, v0, Magic Patterns, Figma Make. You know what makes them produce generic output vs considered work.
+
+**Focus:**
+- Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent runs across concepts. Require hex.
+- Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
+- Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
+- Is information hierarchy clear? What dominates, what recedes?
+- Are anti-patterns named? Are placeholder instructions strong enough to prevent real-face drift?
+- Predict what Stitch will produce as-is, including what's likely to go wrong.
+
+### Customer persona reviewer
+
+**Role prompt preamble (customize per surface):**
+
+> You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
+
+**Focus:**
+- Does this sound like real me, or like someone who's never talked to someone in my role?
+- What's patronizing? Soft? Over-explained?
+- What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
+- What would I actually do on this surface vs what they think I'd do?
+
+**Persona discipline:**
+- Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
+- Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
+
+### Round structure
+
+**Round 1:** Each reviewer critiques v1 from their role. Output format:
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Specific changes I'd make
+<concrete rewrites with proposed wording>
+
+## What's missing
+<things the brief does not address that it needs to>
+```
+
+Persona reviewer uses a different format — see their prompt above. They talk first, then summarize in three sections: got right / got wrong / still missing.
+
+**Between rounds:** Synthesize the feedback into a delta. Apply clear fixes directly to the brief. Surface disagreements or decisions that require user input as **open questions** — these become Phase 4 checkpoints.
+
+**Round 2:** Reviewers see v2 plus a summary of what changed from v1. They critique v2 specifically — what's still weak, what new issues emerged, what v2 got wrong in addressing Round 1 feedback.
+
+**Round 3:** Final polish pass. Reviewers are asked whether v3 is ready to ship. Format tightens to:
+
+```
+## Ready for Stitch? (Yes / Yes with caveats / No)
+## Any remaining critical issues?
+## Any last surgical edits?
+```
+
+**IMPORTANT**: All three reviewers in a round must be launched in a single Task tool message to run in parallel.
+
+---
+
+## Phase 4 — Decision checkpoints
+
+After each round, surface any decisions the reviewers flagged that require user judgment. Common examples:
+
+- An SLA promise in copy — is it an operational commitment or just marketing?
+- A user mode that was named but doesn't get its own surface — fold it into another mode, or design for it?
+- A concept that has an internal contradiction on a specific viewport — which way does it resolve?
+
+Present decisions as a short numbered list with your recommendation and rationale. Do NOT present 10 decisions — filter to the ones that will actually change the brief.
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 5 — Final brief saved
+
+Apply the last round's fixes and the user's decisions. Save the final brief to `.stitch/<target>-ux-brief.md`. Present the user a summary of:
+
+- Total rounds run
+- Major things that shifted v1 → final
+- Open decisions resolved
+- The final brief is ready to hand to Stitch
+
+Ask: **"Ready to generate? Or pause here?"**
+
+If `--generate=false` or the user pauses, stop. The brief is the deliverable.
+
+---
+
+## Phase 6 — Stitch project resolution
+
+Determine the venture code from the current repo (e.g., `ss-console` → `ss`).
+
+**Resolve project ID:**
+
+1. Call `crane_ventures` MCP tool. Find the venture. Read `stitchProjectId`.
+2. If it's a non-null string: use it.
+3. If it's `null`: tell the user no Stitch project exists for this venture, and ask if you should create one.
+
+**To create:**
+
+```
+Create a Stitch project titled "<Venture Name> — <Target>" and capture the returned project ID.
+```
+
+Use `mcp__stitch__create_project` if available. If the Stitch MCP errors with `Incompatible auth server: does not support dynamic client registration` or similar (known transient state), fall back to the curl pattern:
+
+```bash
+KEY=$(infisical secrets get STITCH_API_KEY --path /vc --env prod --plain)
+curl -sS -X POST https://stitch.googleapis.com/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "X-Goog-Api-Key: $KEY" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_project","arguments":{"title":"<title>"}}}'
+```
+
+Extract the project ID from `result.structuredContent.name` (format: `projects/<id>`).
+
+**Write the ID back:** Edit `crane-console/config/ventures.json` — find the venture entry by `code`, set `stitchProjectId` to the new ID.
+
+---
+
+## Phase 7 — Three structurally distinct concepts
+
+Generate three concepts at the **primary surface × mobile viewport only**. This is the convergence check — you verify the concepts actually diverge before spending on a full matrix.
+
+For each concept, write a prompt file to `/tmp/stitch-prompt-<concept>.txt`. The prompt template:
+
+```
+<Concept letter and axis> — <viewport description, e.g., "Mobile home dashboard for client portal at 390×844">
+
+<Paragraph explaining the concept's structural philosophy. What does it prioritize? What IS the page?>
+
+DESIGN SYSTEM (REQUIRED):
+- Platform: Web, mobile-first, 390x844 viewport only (or desktop 1280px)
+- Palette: <hex values from the brief's Appendix>
+- Typography: <families, weights, sizes>
+- Shape: <rounding, pills>
+- Density: <rhythm, tap targets, hover rules>
+- Tone: <voice rules — no hype, no AI copy, etc>
+- COLOR RULE (intentional): <any harnessed drift — e.g., "muted indigo family for metadata, not neutral slate">
+
+PAGE STRUCTURE:
+
+1. <Minimal header spec>
+2. <Dominant element — the concept's defining feature>
+3. <Supporting elements>
+4. <Consultant/contact block spec>
+5. <What is explicitly absent>
+
+Anti-patterns: <per-surface anti-patterns — not a generic list>
+
+Mood: <one sentence that captures the intent>
+```
+
+Fire all three generations in parallel (three Bash calls in one message, each with its own timeout of 330000ms for 5-minute Stitch generation).
+
+**JSON-RPC payload:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <n>,
+  "method": "tools/call",
+  "params": {
+    "name": "generate_screen_from_text",
+    "arguments": {
+      "projectId": "<resolved ID>",
+      "prompt": "<contents of prompt file>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Save each response to `/tmp/stitch-screen-<concept>.json`. Extract:
+
+- Screen ID: `result.structuredContent.outputComponents[design].screens[0].id`
+- Title: `result.structuredContent.outputComponents[design].screens[0].title`
+- HTML URL: `result.structuredContent.outputComponents[design].screens[0].htmlCode.downloadUrl`
+- PNG URL: `result.structuredContent.outputComponents[design].screens[0].screenshot.downloadUrl`
+- Description: any `outputComponents[text]` entry
+
+Download HTML and PNG for each to `.stitch/designs/<target>-v1/concept-<letter>.{html,png}`.
+
+---
+
+## Phase 8 — Convergence check
+
+View the three PNGs. Compare.
+
+**Question to answer, rigorously:** Are the three concepts structurally distinct, or have they collapsed into visual variations of the same layout?
+
+Signal of structural divergence:
+- Height ratios differ noticeably (e.g., one concept is ~60% the height of the others)
+- Information hierarchy differs (what dominates the viewport is genuinely different)
+- The "what IS the page?" answer differs per concept
+
+Signal of collapse:
+- All three are the same layout with different colors or card treatments
+- The heights are within 10% of each other
+- The dominant element is the same across all three
+
+If collapse: the brief failed to force divergence. Iterate the concept prompts with harder axis constraints, regenerate. Do not proceed until divergence is real.
+
+If divergence is good:
+
+Write a review to the user:
+
+```
+## Concept A — <axis>
+<summary of what it does, what worked, what didn't>
+
+## Concept B — <axis>
+<same>
+
+## Concept C — <axis>
+<same>
+
+## My read
+<lean toward one or a hybrid, with reasoning>
+```
+
+Ask the user: **"Which concept wins, or which hybrid do you want? Or do you want to re-commission the concepts with a different axis?"**
+
+Wait for the user's answer.
+
+---
+
+## Phase 9 — Winner iteration
+
+Once the user picks (single concept or hybrid), write an **edit** prompt that targets the existing screen(s) via `edit_screens`. The edit should:
+
+- Explicitly preserve everything that works (action dominance, consultant block, etc.)
+- Explicitly add the hybrid elements from other concepts
+- Not redesign from scratch
+
+Use `mcp__stitch__edit_screens` if MCP works, otherwise the curl equivalent:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "tools/call",
+  "params": {
+    "name": "edit_screens",
+    "arguments": {
+      "projectId": "<id>",
+      "selectedScreenIds": ["<winner screen ID>"],
+      "prompt": "<edit prompt>",
+      "deviceType": "MOBILE"
+    }
+  }
+}
+```
+
+Download the updated preview. Present to user. Confirm the iteration landed before expanding.
+
+---
+
+## Phase 10 — Matrix expansion
+
+Generate the remaining surfaces × viewports for the winning concept.
+
+Typical matrix:
+- Remaining surfaces (2 at minimum — e.g., deep-link invoice landing, deep-link proposal landing) × 2 viewports (mobile, desktop) = 4 new screens
+- Plus the desktop variant of the primary surface = 1 more
+
+Total = usually 5 new screens beyond the winning mobile primary.
+
+For each, write a prompt file following the template from Phase 7. **Key move**: include the winning concept's DNA in each prompt. If the winner is "C-hybrid" (action-centric with a timeline below), make sure every surface in the matrix follows that DNA, not a fresh Stitch reading of the brief.
+
+Fire all generations in parallel (5 Bash calls in one message, each timeout 330000ms).
+
+Extract, download, save to `.stitch/designs/<target>-v1/<surface>-<viewport>.{html,png}`.
+
+---
+
+## Phase 11 — Gold-plating strip pass
+
+Stitch reliably adds default-web chrome that doesn't belong on an authenticated surface:
+
+- Global navigation tabs ("Dashboard | Documents | Billing")
+- Testimonial pull quotes and italicized customer-voice paragraphs
+- Copyright footers and legal link rows (Privacy | Terms | Contact)
+- Marketing CTAs ("Schedule a call", "Book a demo")
+- Hero imagery and decorative illustrations
+- Duplicated bottom-sticky action bars
+
+Run a **batch edit** across all generated screens with a hardened strip directive. `edit_screens` supports an array of `selectedScreenIds` — pass all of them in one call.
+
+**Strip directive template (customize per run):**
+
+```
+CONTEXT RESET: This is an authenticated <surface type> surface. The person viewing this is already logged in. <Describe their relationship to the product — existing customer, signed prospect, etc.>. This is NOT a marketing page. NOT a public website. NOT a landing page with a conversion goal. It is a working surface.
+
+Your job: remove everything that was added as gold-plating or default web chrome, and touch nothing else. Do NOT redesign. Do NOT rebalance layouts. Do NOT reword preserved copy. Only remove.
+
+REMOVE IF PRESENT:
+1. Global navigation tabs or menus
+2. Testimonial paragraphs, pull quotes, italicized client-voice sentences
+3. Copyright lines
+4. Legal link rows
+5. Marketing CTAs not in the original prompt
+6. Hero imagery, illustrations, decorative graphics
+7. Promotional banners, announcement bars, status indicators unrelated to the current task
+8. Stickied bottom bars duplicating a visible primary action
+
+PRESERVE EXACTLY:
+<Whitelist every element that should remain — the primary action, the amount display, every named section, the consultant block, all inline artifacts, the minimal header, every link that was explicit in the original prompt>
+
+REPLACEMENT RULE: Do not replace what you remove. If removing creates empty space, leave it empty. The page ends where content ends.
+
+BIAS: when in doubt, remove.
+```
+
+**Learning (hard-won):** the strip bias "when in doubt, remove" over-strips if you don't whitelist explicit preserves. Include the whitelist every time.
+
+Download updated previews. Compare pre-strip and post-strip heights — a 15-30% reduction is expected when cruft was present. More than 40% means something legitimate was stripped.
+
+Present the stripped set to the user. Note any over-strips (elements from the original brief that got removed). Decide: accept the cruft loss, targeted re-add, or accept the over-strip as the new baseline.
+
+---
+
+## Phase 12 — Artifact consolidation
+
+Final state on disk:
+
+```
+<repo>/.stitch/
+├── <target>-ux-brief.md             # Final brief
+└── designs/
+    └── <target>-v1/
+        ├── concept-A.html           # Concepts from Phase 7
+        ├── concept-A.png
+        ├── concept-B.html
+        ├── concept-B.png
+        ├── concept-C.html
+        ├── concept-C.png
+        ├── <winner>-iterated.html   # Phase 9
+        ├── <winner>-iterated.png
+        ├── <surface>-<viewport>.html   # Matrix expansion from Phase 10
+        ├── <surface>-<viewport>.png
+        └── <surface>-<viewport>-stripped.html  # Phase 11 outputs
+```
+
+Write a short log to `.stitch/designs/<target>-v1/RUN-LOG.md` capturing:
+
+- Date
+- Target surface
+- Rounds run
+- Winning concept
+- Decisions made by the user
+- Known drifts / over-strips
+- Next follow-ups
+
+Update `crane-console/config/ventures.json` with the `stitchProjectId` if it was created during this run.
+
+Tell the user:
+
+- How many screens were produced
+- Where they live
+- What's next (implementation, additional surfaces, another round of polish)
+
+---
+
+## Embedded learnings (tune these into every run)
+
+1. **Personify the customer reviewer.** A named individual with real specifics produces sharper critique than a demographic. The persona should push back on the brief's description of them — that's usually where the brief is patronizing.
+
+2. **Structural divergence must be commissioned explicitly.** "Three structurally distinct concepts — timeline-centric, archive-centric, action-centric" works. "Three concepts" collapses into variations.
+
+3. **Tokens as hex, not vibes.** "Muted violet" is three different colors to three Stitch runs. Always include hex values from the venture's actual stylesheet.
+
+4. **Mobile-first as constraint, not slogan.** Specify viewport (390×844), thumb zone (bottom 40%), tap target (44px), no-hover rule, no-horizontal-scroll rule. These are the constraints; "design mobile-first" alone is a wish.
+
+5. **Harness drift, don't police it.** If Stitch's first pass does something unintended but coherent (muted-indigo dates instead of neutral slate), codify it in subsequent prompts rather than fighting it. The first-pass output is a design proposal you can accept into the spec.
+
+6. **Anti-patterns need an affirmative frame.** "No nav tabs, no testimonials" is weaker than "This is an authenticated portal, not a marketing page. Chrome is strictly limited to what's listed below." Affirmative framing is what makes the strip pass work.
+
+7. **Strip passes need whitelisted preserves.** Removal bias without a preserve whitelist over-strips. Always list every preserved element explicitly before stripping.
+
+8. **Placeholder instructions are weak.** "Neutral portrait placeholder with caption 'consultant photo'" is routinely ignored — Stitch defaults to real faces. Either spec a solid shape ("solid indigo circle with initials") or a clearly abstract graphic ("geometric avatar, no face").
+
+9. **Scope to 3 surfaces × 2 viewports.** A first Stitch pass generating more than ~6-8 screens is unreviewable. Converge on a concept first, then expand.
+
+10. **Batch edits for consistency.** `edit_screens` supports arrays. One directive across many screens is cheaper and more consistent than per-screen edits.
+
+11. **Desktop is an expansion, not a redesign.** Spec the right-rail pattern explicitly ("~340px wide, 160-200px from top, sticky, at eye level"). Otherwise Stitch improvises a desktop design that diverges from the mobile concept.
+
+12. **MCP fallbacks matter.** The Stitch MCP occasionally enters a state where it reports connected but every call fails with an OAuth error. The endpoint works with the API key via direct HTTP. Always include the curl fallback path so a broken MCP doesn't block the run.
+
+---
+
+## Dependencies and conventions
+
+- **Stitch project ID** resolved via `crane_ventures` MCP tool. Writes back to `crane-console/config/ventures.json`.
+- **API key** stored in Infisical at `/vc` (prod env, key `STITCH_API_KEY`). Never echo the value.
+- **Artifact directory** is `.stitch/designs/<target>-v<n>/` — use versioned subfolders so prior runs are preserved.
+- **Brief filename** is `.stitch/<target>-ux-brief.md`.
+- **Run log** is `.stitch/designs/<target>-v<n>/RUN-LOG.md`.
+
+---
+
+## Versioning
+
+When iterating a target that already has `.stitch/<target>-ux-brief.md` and `.stitch/designs/<target>-v1/`:
+
+- The new run creates `<target>-v2/`, `<target>-v3/`, etc.
+- The brief overwrites (with the prior version moved to `.stitch/<target>-ux-brief-v1.md` if substantive changes).
+- The run log records "v2 vs v1: what changed and why."
+"""

--- a/config/ventures.json
+++ b/config/ventures.json
@@ -109,7 +109,7 @@
       "org": "venturecrane",
       "repos": ["ss-console"],
       "capabilities": ["has_api", "has_database"],
-      "stitchProjectId": null,
+      "stitchProjectId": "17873719980790683333",
       "portfolio": {
         "status": "building",
         "bvmStage": "PROTOTYPE",

--- a/docs/instructions/wireframe-guidelines.md
+++ b/docs/instructions/wireframe-guidelines.md
@@ -94,28 +94,32 @@ Once Dev marks issue `status:in-progress`, the wireframe is frozen. Any PM chang
 
 ### Authentication
 
-Stitch is a **remote HTTP MCP server** at `https://stitch.googleapis.com/mcp`. Auth is via API key header - no local subprocess, no gcloud, no OAuth tokens to expire.
+Stitch is registered as a **local proxy subprocess** (`npx @_davideast/stitch-mcp proxy`) authenticated via `STITCH_API_KEY` env var. This is **Option 1** in the Stitch docs (https://davideast.github.io/stitch-mcp/connect-your-agent/) and the only option that works with Claude Code today.
 
-- `STITCH_API_KEY` — stored in Infisical `/vc` (shared secret, propagated to all ventures)
-- No per-machine gcloud setup required
+**Why not direct HTTP?** Claude Code ignores the `headers` block on HTTP-transport MCP servers and attempts OAuth Dynamic Client Registration against the endpoint. Stitch doesn't support DCR, so every tool call fails with `Incompatible auth server: does not support dynamic client registration`. Upstream bug: [anthropics/claude-code#41664](https://github.com/anthropics/claude-code/issues/41664). We spent a day cycling through workarounds before settling on the docs-prescribed option — **do not reintroduce the HTTP transport until #41664 is fixed.**
 
-**Per-machine setup** (one-time):
+**Setup — nothing per-machine:**
+
+The `crane` launcher owns Stitch registration. Just launch with `--stitch`:
 
 ```bash
-claude mcp add stitch --transport http https://stitch.googleapis.com/mcp \
-  -H "X-Goog-Api-Key: <key-from-infisical>" -s user
+crane <venture> --stitch
 ```
+
+The launcher pulls `STITCH_API_KEY` from Infisical `/vc`, registers stitch at project scope via `claude mcp add stitch -e STITCH_API_KEY=<key> -s project -- npx -y @_davideast/stitch-mcp@<pinned> proxy`, and removes it on session exit.
+
+**Never hardcode `stitch` in `.mcp.json`.** The launcher strips any pre-existing stitch entry on launch — direct-HTTP artifacts cause the OAuth bug above, and stale subprocess entries pin outdated versions or collide with the add/remove cycle. Single source of truth: launcher + `STITCH_API_KEY` in Infisical.
 
 **If Stitch tools fail to connect:**
 
-1. Verify the API key: `infisical secrets get STITCH_API_KEY --path /vc --env prod`
-2. Verify MCP registration: `claude mcp list` should show `stitch` as connected
-3. If missing, re-run the setup command above with the current key from Infisical
-4. Docs: https://stitch.withgoogle.com/docs/mcp/setup
+1. Confirm the session was launched with `--stitch`: `claude mcp list` should show `stitch` registered with an `npx` command.
+2. Verify the API key is in Infisical: `infisical secrets get STITCH_API_KEY --path /vc --env prod`
+3. Check `.mcp.json` doesn't have a rogue `stitch` block. If it does, delete it and relaunch.
+4. Stitch docs: https://davideast.github.io/stitch-mcp/connect-your-agent/
 
-### MCP Tools (Fleet-Managed)
+### MCP Tools (Launcher-Managed)
 
-The `stitch` MCP server is registered fleet-wide via `.mcp.json`. Available tools:
+Stitch is gated behind `crane <venture> --stitch` and registered at project scope for that session only. Available tools:
 
 | Tool               | Purpose                                         |
 | ------------------ | ----------------------------------------------- |

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -457,6 +457,40 @@ describe('setupClaudeMcp', () => {
     expect(targetWritten.mcpServers.stitch).toBeUndefined()
   })
 
+  it('removes direct-HTTP stitch entry from target (claude-code#41664 bug class)', () => {
+    // Direct HTTP registration trips Claude Code's OAuth DCR bug — even with a
+    // valid API key header, tool calls fail. Launcher owns stitch registration
+    // via the proxy subprocess, so any pre-existing HTTP entry must be stripped.
+    const targetConfig = {
+      mcpServers: {
+        crane: { command: 'crane-mcp', args: [], env: {} },
+        stitch: {
+          type: 'http',
+          url: 'https://stitch.googleapis.com/mcp',
+          headers: { 'X-Goog-Api-Key': 'AQ.Ab8fake' },
+        },
+      },
+    }
+
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockImplementation((filePath: string) => {
+      if (String(filePath) === CLAUDE_CONFIG_PATH) return TRUSTED_CLAUDE_CONFIG
+      if (String(filePath).includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [{ code: 'vc' }, { code: 'ke' }, { code: 'sc' }, { code: 'dfg' }],
+        })
+      }
+      if (String(filePath).includes('crane-console')) return JSON.stringify(SOURCE_CONFIG)
+      return JSON.stringify(targetConfig)
+    })
+
+    setupClaudeMcp('/fake/repo')
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    const targetWritten = JSON.parse(vi.mocked(writeFileSync).mock.calls[0][1] as string)
+    expect(targetWritten.mcpServers.stitch).toBeUndefined()
+  })
+
   it('skips write when source and target already match', () => {
     vi.mocked(existsSync).mockReturnValue(true)
     vi.mocked(readFileSync).mockImplementation((filePath: string) => {

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -26,10 +26,13 @@ import { API_BASE_PRODUCTION, getCraneEnv, getStagingInfisicalPath } from '../li
 import { scanLocalRepos, LocalRepo } from '../lib/repo-scanner.js'
 import { prepareSSHAuth } from './ssh-auth.js'
 
-/** Stitch remote MCP endpoint. Stitch is a remote HTTP MCP server — no local
- *  subprocess needed. Auth is via API key header (STITCH_API_KEY from Infisical).
- *  Docs: https://stitch.withgoogle.com/docs/mcp/setup */
-const STITCH_MCP_URL = 'https://stitch.googleapis.com/mcp'
+/** Stitch MCP is registered as a local proxy subprocess (`npx @_davideast/stitch-mcp
+ *  proxy`) authenticated via STITCH_API_KEY env var. This is Option 1 of the Stitch
+ *  docs (https://davideast.github.io/stitch-mcp/connect-your-agent/) and the only
+ *  option that works with Claude Code — direct HTTP transport trips Claude Code's
+ *  OAuth dynamic-client-registration path and fails against stitch.googleapis.com
+ *  (see anthropics/claude-code#41664). Do NOT reintroduce direct HTTP. */
+const STITCH_MCP_PACKAGE = '@_davideast/stitch-mcp@0.5.3'
 
 // Resolve crane-console root relative to this script
 // Compiled path: packages/crane-mcp/dist/cli/launch-lib.js -> 4 levels up
@@ -777,14 +780,17 @@ export function setupClaudeMcp(repoPath: string): void {
     return
   }
 
-  // Stitch is now a remote HTTP MCP server — no local subprocess needed.
-  // The user-level config (~/.claude.json) handles the API key header.
-  // Remove any legacy subprocess stitch entry from .mcp.json so it doesn't conflict.
+  // Stitch is registered dynamically by the launcher when --stitch is passed
+  // (via `claude mcp add stitch ... -s project`). It must NEVER live in
+  // checked-in .mcp.json — stale direct-HTTP entries trip Claude Code's OAuth
+  // DCR bug (anthropics/claude-code#41664), and stale subprocess entries can
+  // pin an outdated package version or conflict with the launcher's add/remove
+  // cycle. Strip any pre-existing stitch entry on launch, regardless of shape.
   const servers = (sourceConfig.mcpServers ?? {}) as Record<string, Record<string, unknown>>
-  if (servers.stitch && (servers.stitch as Record<string, unknown>).command) {
+  if (servers.stitch) {
     delete servers.stitch
     writeFileSync(source, JSON.stringify(sourceConfig, null, 2) + '\n')
-    console.log('-> Removed legacy Stitch subprocess from .mcp.json (now remote HTTP)')
+    console.log('-> Removed stale Stitch entry from .mcp.json (launcher owns registration)')
   }
 
   const sourceServers = (sourceConfig.mcpServers ?? {}) as Record<string, unknown>
@@ -819,8 +825,9 @@ export function setupClaudeMcp(repoPath: string): void {
     }
   }
 
-  // Remove legacy Stitch subprocess from target (now remote HTTP, configured per-user)
-  if (targetServers.stitch && (targetServers.stitch as Record<string, unknown>).command) {
+  // Strip any pre-existing stitch entry from target .mcp.json — launcher owns
+  // stitch registration (see STITCH_MCP_PACKAGE comment).
+  if (targetServers.stitch) {
     delete targetServers.stitch
     dirty = true
   }
@@ -976,8 +983,8 @@ export function setupGeminiMcp(repoPath: string): void {
     dirty = true
   }
 
-  // --- Stitch: remove legacy subprocess entry (now remote HTTP, configured per-user) ---
-  if (mcpServers.stitch && (mcpServers.stitch as Record<string, unknown>).command) {
+  // --- Stitch: strip any pre-existing entry. Launcher owns registration. ---
+  if (mcpServers.stitch) {
     delete mcpServers.stitch
     dirty = true
   }
@@ -1055,8 +1062,8 @@ export function setupCodexMcp(): void {
     updated = true
   }
 
-  // Stitch is now a remote HTTP MCP server — no Codex config needed.
-  // Remove legacy subprocess entry if present.
+  // Stitch is Claude-only. If a Codex config picked up a stale stitch block
+  // from an earlier era, strip it.
   if (content.includes('[mcp_servers.stitch]')) {
     content = content.replace(/\[mcp_servers\.stitch][^[]*/, '')
     updated = true
@@ -1334,7 +1341,11 @@ export function launchAgent(
     ENABLE_TOOL_SEARCH: 'false',
   }
 
-  // Inject Stitch MCP when --stitch is passed (project-scope, writes to gitignored settings.local.json)
+  // Inject Stitch MCP when --stitch is passed. We register the local proxy
+  // subprocess (Option 1 in Stitch's docs) because Claude Code ignores pre-shared
+  // headers on HTTP-transport MCP servers and attempts OAuth dynamic client
+  // registration, which Stitch doesn't support. See the comment on
+  // STITCH_MCP_PACKAGE for details.
   if (enableStitch && agent === 'claude') {
     const stitchApiKey = secrets.STITCH_API_KEY || process.env.STITCH_API_KEY
     if (stitchApiKey) {
@@ -1345,17 +1356,19 @@ export function launchAgent(
             'mcp',
             'add',
             'stitch',
-            '--transport',
-            'http',
-            STITCH_MCP_URL,
-            '-H',
-            `X-Goog-Api-Key: ${stitchApiKey}`,
+            '-e',
+            `STITCH_API_KEY=${stitchApiKey}`,
             '-s',
             'project',
+            '--',
+            'npx',
+            '-y',
+            STITCH_MCP_PACKAGE,
+            'proxy',
           ],
           { cwd: venture.localPath!, stdio: debug ? 'inherit' : 'pipe' }
         )
-        console.log('-> Stitch MCP enabled for this session')
+        console.log('-> Stitch MCP enabled for this session (proxy subprocess)')
       } catch {
         console.warn('-> Warning: failed to add Stitch MCP')
       }


### PR DESCRIPTION
## Summary

- **Root cause:** Claude Code ignores the `headers` block on HTTP-transport MCP servers and attempts OAuth Dynamic Client Registration. Stitch doesn't support DCR, so every tool call fails with `Incompatible auth server: does not support dynamic client registration`. Upstream bug: [anthropics/claude-code#41664](https://github.com/anthropics/claude-code/issues/41664).
- **Fix:** Switch the launcher to Option 1 of [Stitch's official setup docs](https://davideast.github.io/stitch-mcp/connect-your-agent/) — local proxy subprocess (`npx @_davideast/stitch-mcp proxy`) with `STITCH_API_KEY` passed as an env var. No OAuth, no gcloud, no token expiry, no Claude Code bug.
- **Hardening:** Strip any pre-existing `stitch` entry from `.mcp.json` unconditionally on every launch. Stale direct-HTTP entries were the vector for this bug class; stale subprocess entries pin outdated package versions. Launcher owns Stitch registration. Nothing in `.mcp.json` ever.

## Why this PR exists

PR #395 moved us from the proxy subprocess to direct HTTP + API key header. That looked cleaner on paper but runs straight into claude-code#41664. We spent a full day cycling through workarounds (API-key rotations, project-scope vs user-scope, `--stitch` gating tweaks) before an agent finally read the actual Stitch docs and found that Option 1 — the proxy subprocess with an API key env var — is the only Claude Code option that works today.

This PR settles it. Do not reintroduce the HTTP transport until #41664 is fixed upstream.

## Changes

- `packages/crane-mcp/src/cli/launch-lib.ts`:
  - Replaced `STITCH_MCP_URL` constant with `STITCH_MCP_PACKAGE = '@_davideast/stitch-mcp@0.5.3'` (pinned).
  - `claude mcp add stitch ...` now registers the proxy subprocess with `-e STITCH_API_KEY=<key>` at project scope.
  - Three cleanup blocks (source `.mcp.json`, target `.mcp.json`, enterprise MCP config) changed from "remove command-based stitch" to "remove any stitch entry." Launcher owns registration.
- `packages/crane-mcp/src/cli/launch-lib.test.ts`: added a regression test for the HTTP-transport entry removal (the new bug class).
- `docs/instructions/wireframe-guidelines.md`: rewrote the Auth section with the correct setup (just `crane <venture> --stitch`), a warning against hardcoding stitch in `.mcp.json`, and links to the Stitch docs + claude-code#41664 so the next agent finds the answer quickly.

## Follow-up (separate repos, separate PRs)

- `ss-console/.mcp.json` has a hardcoded stitch block (`AIzaSy...` key) — needs to be deleted.
- `smd-console/.mcp.json` has a hardcoded stitch block (`AQ.Ab8...` key) — needs to be deleted.

Both will be auto-stripped on next `crane ... --stitch` launch via the cleanup code in this PR, but a direct PR per repo is cleaner.

## Test plan

- [x] `npm run verify` (typecheck + format + lint + tests) passes locally
- [ ] After merge: launch `crane vc --stitch` on at least one fleet machine and confirm `claude mcp list` shows stitch registered as an `npx` subprocess, and `mcp__stitch__list_projects` returns real project data
- [ ] Confirm exit cleanup still runs (stitch removed from `.mcp.json` after session ends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)