### PR TITLE
feat: version-control global skills + sync to fleet

### DIFF
--- a/.agents/skills/nav-spec/README.md
+++ b/.agents/skills/nav-spec/README.md
@@ -1,0 +1,54 @@
+# nav-spec
+
+Companion to `stitch-design` and `stitch-ux-brief`. Eliminates navigation drift across Stitch-generated screens and live code by authoring and enforcing a per-venture `NAVIGATION.md`.
+
+## What it does
+
+- Authors `.stitch/NAVIGATION.md` — IA, surface-class taxonomy (by auth model), archetype × chrome contracts, mobile↔desktop transforms, states, transitions, a11y floor, anti-patterns
+- Audits drift between shipped code and generated artifacts
+- Feeds a NAV CONTRACT block into every Stitch generation prompt via the patched `stitch-design` pipeline
+- Validates generated HTML against a deterministic rubric post-generation; fails loud on violations
+
+## Who this is for
+
+Ventures using the Stitch MCP server to generate design artifacts that also ship to production (Astro + Tailwind). One spec per venture; shared skill across the portfolio.
+
+## When to run
+
+| Moment                                        | Command                                        |
+| --------------------------------------------- | ---------------------------------------------- |
+| First time for a venture                      | `/nav-spec` (invokes author workflow)          |
+| Quarterly review                              | `/nav-spec --audit`                            |
+| After adding a new surface class or archetype | `/nav-spec --revise`                           |
+| After Stitch model version change             | `/nav-spec --phase-0` (re-run compliance test) |
+
+## Dependencies
+
+- Stitch MCP connected (curl fallback supported when MCP is in its intermittent OAuth-broken state)
+- Venture has `stitchProjectId` set in `crane-console/config/ventures.json`
+- `STITCH_API_KEY` in Infisical at `/vc` path (for curl fallback)
+- `.stitch/DESIGN.md` recommended but not required
+
+## Relationship to other skills
+
+- **stitch-design** reads `.stitch/NAVIGATION.md` and injects NAV CONTRACT into every generation prompt. Graceful-degradation: if no spec present, behaves as today.
+- **stitch-ux-brief** reads `.stitch/NAVIGATION.md` in Phase 1; injects NAV CONTRACT into Phase 7 concept prompts; generates strip-directive forbidden-list from the spec's anti-patterns in Phase 11.
+- **react-components** (future) will read the same spec to produce Astro components aligned with the chrome contracts.
+
+## Key files
+
+- `SKILL.md` — entry point and overview
+- `workflows/author.md` — primary nine-phase workflow (intake → drift audit → draft → 3-reviewer pass → decisions → save → integration-check → adversarial verification → write-back)
+- `workflows/audit.md` — standalone drift audit
+- `workflows/revise.md` — update existing spec
+- `workflows/phase-0-compliance-test.md` — empirical injection-compliance measurement
+- `workflows/validate-navigation.md` — post-generation validator rubric
+- `references/` — archetype catalog, chrome contracts, anti-patterns, injection template, classification rubric
+- `examples/` — gold-standard NAVIGATION.md and audit/compliance report formats
+
+## Philosophy
+
+1. **Authoring is probabilistic; enforcement is deterministic.** Injection is the fast path; the validator is the truth.
+2. **Ground specs in shipped code.** The Implementation reviewer's job is to flag any contract that would require a component refactor — the user chooses to align the spec or flag the refactor.
+3. **Four surface classes, by auth model.** `public`, `token-auth`, `session-auth-client`, `session-auth-admin`. The subdomain is secondary.
+4. **The spec prevents drift on unseen screens.** Self-consistency tests are necessary but not sufficient. The adversarial verification phase is the real gate.

--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: nav-spec
+description: Authors and enforces `.stitch/NAVIGATION.md` — the per-venture navigation specification that eliminates chrome drift across Stitch-generated screens and live code. Companion to `stitch-design` and `stitch-ux-brief`.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+  - Agent
+---
+
+# Nav Spec Authority
+
+You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture, then enforce it across every subsequent Stitch generation. You have seen what happens when navigation is left "open" per surface: three portal pages, three different headers, no back affordance where it matters, a token-auth landing that looks like a marketing page. Your output is the thing that stops that.
+
+## Core responsibilities
+
+1. **Spec authoring** — produce `.stitch/NAVIGATION.md`: IA, surface-class taxonomy (by auth model), archetype × chrome contracts, mobile↔desktop transforms, states, transitions, a11y floor, anti-patterns, four surface-class override appendices.
+2. **Drift audit** — scan shipped code (`src/pages/`, `src/layouts/`, `src/components/`) and generated artifacts (`.stitch/designs/`) to ground the spec in reality; surface inconsistencies.
+3. **Consumption wiring** — the spec feeds `stitch-design`'s pipeline and `stitch-ux-brief`'s Phase 7 concept template as injected NAV CONTRACT blocks, and drives the post-generation `validate-navigation` step.
+4. **Validator enforcement** — every Stitch generation's HTML is checked against the forbidden/required chrome list; violations fail loud with specific fixes.
+
+## Workflows
+
+| User intent                             | Workflow                                                           | Primary output                                |
+| :-------------------------------------- | :----------------------------------------------------------------- | :-------------------------------------------- |
+| "Create NAVIGATION.md for this venture" | [author.md](workflows/author.md)                                   | `.stitch/NAVIGATION.md`                       |
+| "Audit nav drift only"                  | [audit.md](workflows/audit.md)                                     | In-memory drift report                        |
+| "Update NAVIGATION.md"                  | [revise.md](workflows/revise.md)                                   | `.stitch/NAVIGATION.md` (bumped spec-version) |
+| "Re-run Phase 0 compliance test"        | [phase-0-compliance-test.md](workflows/phase-0-compliance-test.md) | `examples/phase-0-compliance-report.md`       |
+| "Validate a generated screen"           | [validate-navigation.md](workflows/validate-navigation.md)         | Violation report; fails or passes             |
+
+## Fail-fast preconditions
+
+Before any workflow except `audit`:
+
+1. Resolve the venture's Stitch project ID via the `crane_ventures` MCP tool. Match the current repo to a venture code, read `stitchProjectId`. If null: stop. Tell the user: "No Stitch project configured. Add `stitchProjectId` for this venture in `crane-console/config/ventures.json` first." No fallback discovery.
+2. Check for `.stitch/DESIGN.md`. If absent, warn: "No design system doc present. NAVIGATION.md references tokens from DESIGN.md; consider running `stitch-design` generate-design-md workflow first." Proceed with a hex inventory pulled from `src/styles/*` or Tailwind config.
+3. Check for `.stitch/NAVIGATION.md`. If present, this is a revise operation (route to `revise.md`); if absent, this is an author operation (route to `author.md`).
+
+## Surface-class taxonomy (authoritative)
+
+Surface classes are modeled by auth model, not by subdomain:
+
+| Class                 | Auth                         | Examples (ss-console)                                                               |
+| --------------------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| `public`              | None                         | Marketing home, scorecard, blog, contact                                            |
+| `token-auth`          | Signed URL token, no account | Proposal landings (`/portal/proposals/[token]`), invoice landings (`/invoice/[id]`) |
+| `session-auth-client` | Cookie session               | `/portal/home`, `/portal/invoices/[id]`, `/portal/quotes/[id]`                      |
+| `session-auth-admin`  | Cookie session, admin role   | `/admin/*`                                                                          |
+
+The subdomain is a secondary attribute. A public page on `portal.*` is still `public` chrome-wise.
+
+## Archetype taxonomy (authoritative)
+
+| Archetype   | Examples                          | Nav contract summary                                                         |
+| ----------- | --------------------------------- | ---------------------------------------------------------------------------- |
+| `dashboard` | Portal home, admin home           | No back. No breadcrumbs. Minimal header.                                     |
+| `list`      | All invoices, all proposals       | Back to dashboard. No breadcrumbs.                                           |
+| `detail`    | Invoice #1042, proposal view      | Back to parent list. No breadcrumbs on portal; breadcrumbs allowed on admin. |
+| `form`      | New invoice, edit profile         | Cancel + Save. No breadcrumbs. Explicit dirty-state guard.                   |
+| `wizard`    | New engagement intake, onboarding | Progress indicator (N of M). Cancel to parent. Previous + Next.              |
+| `empty`     | Empty list state                  | Back. Instruction to add first item.                                         |
+| `error`     | 404, 500, 401                     | Back to safety (home for authenticated, apex for public).                    |
+| `modal`     | Confirm dialog, filter picker     | Esc closes. Click-outside closes. Focus returns to trigger.                  |
+| `drawer`    | Side panel for secondary actions  | Same close rules as modal. Never contains primary navigation.                |
+
+Full contracts in [references/archetype-catalog.md](references/archetype-catalog.md).
+
+## Classification (deterministic, required)
+
+Every `stitch-design` or `stitch-ux-brief` invocation targeting a specific screen must carry explicit classification tags:
+
+```
+surface=<public|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer>
+viewport=<mobile|desktop>
+```
+
+The pipeline fails fast if any tag is missing or unrecognized. Natural-language inference is explicitly disabled. Manual lookup aid: [references/classification-rubric.md](references/classification-rubric.md).
+
+## Injection mechanism
+
+At prompt-enhancement time, `stitch-design` reads `.stitch/NAVIGATION.md`, looks up the matching `{surface-class, archetype}` block, concatenates shared sections (a11y, states, anti-patterns) with the surface-class appendix, and injects a NAV CONTRACT block between DESIGN SYSTEM and PAGE STRUCTURE. Canonical format: [references/injection-snippet-template.md](references/injection-snippet-template.md). Size budget: ≤600 tokens.
+
+Post-generation, the `validate-navigation` step parses the returned HTML and runs a fixed violation rubric. Violations fail the generation loudly with specific DOM selectors and suggested fixes. The validator is mandatory, not optional — injection compliance measured in Phase 0 is strong at the categorical level but leaks cosmetic/semantic violations (see `examples/phase-0-compliance-report.md`).
+
+## References
+
+- [archetype-catalog.md](references/archetype-catalog.md) — 9 archetypes × nav contracts
+- [chrome-component-contracts.md](references/chrome-component-contracts.md) — DOM + Tailwind for every chrome piece
+- [anti-patterns.md](references/anti-patterns.md) — what to never render and why
+- [injection-snippet-template.md](references/injection-snippet-template.md) — canonical NAV CONTRACT block with placeholders
+- [classification-rubric.md](references/classification-rubric.md) — surface × archetype decision rules
+
+## Examples
+
+- [examples/NAVIGATION.md](examples/NAVIGATION.md) — gold-standard from ss-console
+- [examples/drift-audit-report.md](examples/drift-audit-report.md) — audit format
+- [examples/phase-0-compliance-report.md](examples/phase-0-compliance-report.md) — compliance measurement format and ss-console's own results
+
+## Best practices
+
+- **Ground the spec in live code first, then constrain.** Drift audit (phase 2) runs before spec drafting for a reason: prescribing a contract that fights the shipped codebase creates design/implementation drift, which is the same problem in a different location. The Implementation reviewer in phase 4 exists to prevent this.
+- **Four surface classes, not three.** Token-auth is its own animal. Folding it into "portal" or "public" silently produces wrong chrome for proposal/invoice landings.
+- **The validator is the enforcement layer.** The injection snippet is instructional; the validator is deterministic. When in conflict, trust the validator.
+- **Spec-version bumps are per release, not per edit.** Additive changes (new archetype, new forbidden pattern) can land without a bump. Structural changes (taxonomy redefinition, rule inversion) must bump.
+- **A11y is not a separate concern.** It lives in the same DOM/class layer as the chrome contracts. The Implementation reviewer covers it; do not create a separate a11y appendix.

--- a/.agents/skills/nav-spec/examples/NAVIGATION.md
+++ b/.agents/skills/nav-spec/examples/NAVIGATION.md
@@ -1,0 +1,783 @@
+---
+spec-version: 1-pending
+design-md-sha: absent
+stitch-project-id: '17873719980790683333'
+phase-0-compliance:
+  categorical: '97%'
+  strict: '87%'
+  date: '2026-04-15'
+enforcement: 'injection-first + required validator (nav-spec/validate.py)'
+approval-state: 'pending retrofit PR (see Section 11)'
+---
+
+# SMD Services — Navigation Specification
+
+Single source of truth for navigation chrome across `smd.services`, `admin.smd.services`, and `portal.smd.services`. Every Stitch-generated screen and every new shipped component must conform. Deviations require a spec-version bump, not a one-off exception.
+
+Companion skill: `~/.agents/skills/nav-spec/`. Spec is consumed by `stitch-design` (via NAV CONTRACT injection) and `stitch-ux-brief` (Phase 7 concept template, Phase 11 strip directive). Post-generation enforcement via `nav-spec/validate.py`.
+
+**v1 status:** spec is authored; approval is held on the refactor checklist in Section 11. Validator is in injection-first + belt-and-suspenders mode per Phase 0 compliance evidence (see `nav-spec/examples/phase-0-compliance-report.md`).
+
+---
+
+## 1. Information architecture
+
+### Sitemap (by subdomain)
+
+**`smd.services`** (marketing and auth entry — served from apex)
+
+- `/` — marketing home (public, dashboard archetype)
+- `/contact` — contact form (public, form)
+- `/book` — booking flow (public, form)
+- `/book/manage/` — query-param redirect handler; renders an inline "invalid link" fallback when no token (public, error)
+- `/book/manage/[token]` — **token-auth**, manage existing booking (token-auth, detail)
+- `/get-started` — onboarding CTA page (public, dashboard)
+- `/scorecard` — self-serve assessment (public, wizard)
+- `/contact` — contact form (public, form)
+- `/404` — shared not-found page (renders in all subdomain contexts; see "Cross-subdomain 404" in Section 7)
+- `/auth/login` — admin OAuth entry (**auth-gate**, form)
+- `/auth/portal-login` — client magic-link request (**auth-gate**, form)
+- `/auth/verify` — magic-link verification (**auth-gate**, transient)
+
+**`admin.smd.services`**
+
+- `/admin` — dashboard (session-auth-admin, dashboard)
+- `/admin/entities` — client list (session-auth-admin, list)
+- `/admin/entities/[id]` — client detail (session-auth-admin, detail)
+- `/admin/entities/[id]/quotes/[quoteId]` — quote detail, nested (session-auth-admin, detail)
+- `/admin/engagements/[id]` — engagement detail (session-auth-admin, detail) — no `/admin/engagements` list; parent is the client detail
+- `/admin/assessments/[id]` — assessment detail (session-auth-admin, detail) — no list; parent is the client detail
+- `/admin/follow-ups` — follow-ups list (session-auth-admin, list)
+- `/admin/analytics` — analytics dashboard (session-auth-admin, dashboard)
+- `/admin/settings/google-connect` — integration settings (session-auth-admin, form)
+
+**`portal.smd.services`**
+
+- `/portal` — dashboard (session-auth-client, dashboard)
+- `/portal/invoices` — list (session-auth-client, list)
+- `/portal/invoices/[id]` — detail (session-auth-client, detail)
+- `/portal/quotes` — list (session-auth-client, list)
+- `/portal/quotes/[id]` — detail (session-auth-client, detail)
+- `/portal/documents` — index (session-auth-client, list)
+- `/portal/engagement` — current engagement summary (session-auth-client, detail)
+
+**Dev-only (exempt from spec enforcement)**
+
+- `/dev/portal-components`, `/dev/portal-states` — internal component preview harnesses, noindex, not Stitch generation targets
+
+### Auth boundary table
+
+| Surface class         | Auth model                                                   | Base URL                                                                        | Session cookie                                        | Redirect on logout                                |
+| --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------- |
+| `public`              | None                                                         | `smd.services/*` (default marketing)                                            | None                                                  | n/a                                               |
+| `auth-gate`           | Anonymous; surface exists to produce or consume a credential | `smd.services/auth/*`                                                           | None pre-submit; session set on post-success redirect | n/a — surface IS the redirect target after logout |
+| `token-auth`          | Signed URL token in path segment                             | `/book/manage/[token]` (and any future `/proposal/[token]`, `/invoice/[token]`) | None                                                  | n/a — link expiry replaces logout                 |
+| `session-auth-client` | Client cookie session (portal user)                          | `portal.smd.services/*`                                                         | `__Host-portal_session`                               | `smd.services/auth/portal-login`                  |
+| `session-auth-admin`  | Admin cookie session (operator)                              | `admin.smd.services/*`                                                          | `__Host-admin_session`                                | `smd.services/auth/login`                         |
+
+### Deep-link inventory
+
+Every URL reachable from outside the app (email, SMS, saved bookmark):
+
+- `/` and public marketing — organic traffic
+- `/book/manage/[token]` — emailed after booking confirmation (signed token, session-less)
+- `/portal` and `/portal/*` — arrived via `/auth/portal-login` after a magic-link email
+- `/admin` — arrived via `/auth/login` (Google OAuth)
+
+Portal detail pages (`/portal/invoices/[id]`, `/portal/quotes/[id]`) always require session auth in the current architecture. If token-auth landings for these ship later, they must route through a distinct URL (e.g., `portal.smd.services/proposal/[token]`) and render `token-auth` chrome per Appendix B — **not** portal chrome. See "Surface-class selection when subdomain is ambiguous" in Section 2.
+
+---
+
+## 2. Surface-class taxonomy
+
+Classes are modeled by **auth model**, not subdomain. Subdomain is a secondary attribute; two surface classes can coexist on one subdomain (e.g., `portal.smd.services` can host `session-auth-client` dashboards and `token-auth` proposal landings under distinct URL paths).
+
+| Class                 | One-line definition                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `public`              | No authentication. Addressed to a stranger or first-time visitor. Marketing, contact, scorecard.      |
+| `auth-gate`           | Anonymous; surface exists solely to produce or consume an auth credential. Minimal chrome. `noindex`. |
+| `token-auth`          | Signed URL token grants access without an account. User arrived via an emailed link; token expires.   |
+| `session-auth-client` | Authenticated client with a portal cookie session. Low-privilege; views their own records.            |
+| `session-auth-admin`  | Authenticated operator with an admin cookie session. High-privilege; views all records.               |
+
+### Surface-class selection when subdomain is ambiguous
+
+If the same subdomain hosts multiple surface classes (e.g., a future `portal.smd.services/proposal/[token]`), disambiguation:
+
+1. **Presence of a valid session cookie** is the primary signal. If present → session-auth-client (or admin on admin subdomain). If absent but a URL token is valid → token-auth.
+2. **Token-auth on an authenticated subdomain must render distinct chrome** so an authenticated user who refreshes the tab can tell the session expired. Use a visible "Viewing via secure link" badge in the header band plus the Appendix B token-auth chrome (not Appendix C portal chrome).
+3. **Middleware enforcement:** `src/middleware.ts` must carve out token-auth paths before session-auth checks; otherwise the middleware redirects token-auth users to login.
+
+---
+
+## 3. Screen archetype taxonomy
+
+10 archetypes. 9 interactive + 1 transient. See `~/.agents/skills/nav-spec/references/archetype-catalog.md` for full per-archetype contracts.
+
+| Archetype   | Allowed surface classes            | Back                                   | Breadcrumbs                  |
+| ----------- | ---------------------------------- | -------------------------------------- | ---------------------------- |
+| `dashboard` | session-auth-\*, public (landing)  | no                                     | no                           |
+| `list`      | session-auth-\*                    | yes → parent                           | session-auth-admin: 2 levels |
+| `detail`    | all five                           | yes → parent                           | session-auth-admin: 3 levels |
+| `form`      | session-auth-\*, public, auth-gate | cancel+save OR submit-only (auth-gate) | no                           |
+| `wizard`    | session-auth-\*, public            | prev/next                              | no                           |
+| `empty`     | session-auth-\*, token-auth        | inherit                                | inherit                      |
+| `error`     | all five                           | no                                     | no                           |
+| `modal`     | session-auth-\*, token-auth        | close                                  | no                           |
+| `drawer`    | session-auth-\*, token-auth        | close                                  | no                           |
+| `transient` | auth-gate                          | n/a                                    | n/a                          |
+
+`transient` is new: a server-side processing surface with no user-facing chrome (renders only a fallback if the redirect fails). Used by `/auth/verify`.
+
+---
+
+## 4. Chrome component contracts (defaults)
+
+Chrome pieces default to shapes in `~/.agents/skills/nav-spec/references/chrome-component-contracts.md`. Surface-class appendices override.
+
+### Default header band
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <!-- left: per surface class -->
+    <!-- right: per surface class -->
+  </div>
+</header>
+```
+
+**Height class placement:** `h-14 md:h-16` MUST be on the `<header>` element, not on an inner wrapper. The validator checks the `<header>`'s class list only. Inner-div `py-*` produces a different computed height and fails validation.
+
+**Width wrapper:** `max-w-5xl mx-auto` lives on the inner `<div>`, inside `<header>`. The outer `<header>` is full-bleed so the bottom border spans the viewport.
+
+### Token acceptance forms
+
+The spec uses literal hex (`#e2e8f0`) in examples. The validator and the Stitch injection accept these equivalent forms for every token:
+
+| Token        | Literal hex | CSS variable                  | Tailwind named color |
+| ------------ | ----------- | ----------------------------- | -------------------- |
+| Border       | `#e2e8f0`   | `var(--color-border)`         | `slate-200`          |
+| Text default | `#475569`   | `var(--color-text-secondary)` | `slate-600`          |
+| Text bold    | `#0f172a`   | `var(--color-text-primary)`   | `slate-900`          |
+| Primary      | `#1e40af`   | `var(--color-primary)`        | `blue-800`           |
+| Focus ring   | `#3b82f6`   | `var(--color-action)`         | `blue-500`           |
+
+Astro components should prefer the CSS-var form. Stitch generations emit literal hex. Validator accepts any.
+
+### Default back affordance (detail archetypes)
+
+```html
+<a href="<canonical-parent-url>" aria-label="<parent-label>" class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded-lg">
+  <span class="material-symbols-outlined">chevron_left</span>
+  <span class="text-[13px] font-medium"><parent-label></span>
+</a>
+```
+
+Positioned inside `<main>`, above content, never inside `<header>`.
+
+### Breadcrumbs
+
+Admin only, depth ≥ 2.
+
+### Skip-to-main link (all surfaces, no exceptions)
+
+```html
+<a
+  href="#main"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] bg-white px-4 py-2 rounded-lg border border-[#e2e8f0] text-[#1e40af] font-medium"
+>
+  Skip to main content
+</a>
+```
+
+First element in `<body>`, before `<header>`. `<main id="main">` is the target.
+
+---
+
+## 5. Mobile ↔ desktop transforms
+
+**Single breakpoint for chrome:** `md:` (768px). Content layouts may use `sm:` / `lg:` / `xl:`; **chrome never does, with one named exception (right-rail sticky).**
+
+### Transforms per chrome piece
+
+| Chrome                                 | Mobile (<768)                                                         | Desktop (≥768)                                |
+| -------------------------------------- | --------------------------------------------------------------------- | --------------------------------------------- |
+| Header height                          | `h-14` (56px) on `<header>`                                           | `md:h-16` (64px) on `<header>`                |
+| Header padding x                       | `px-4` on inner div                                                   | `md:px-6` on inner div                        |
+| Header max-width                       | full bleed (no wrapper constraint below md)                           | `md:max-w-5xl md:mx-auto` on inner div        |
+| Back affordance                        | in-flow, left of content, inside `<main>`                             | same                                          |
+| Admin nav tabs (Appendix D)            | `hidden`, collapsed into user menu                                    | `md:flex`, inline                             |
+| Admin user menu trigger (Appendix D)   | icon button, right of header                                          | `md:hidden` (email + Sign out visible inline) |
+| ActionCard (portal detail, Appendix C) | **above** `<main>` content                                            | inside right rail                             |
+| Right rail (portal detail, dashboard)  | stacks below (collapsed)                                              | `md:` (see below)                             |
+| Breadcrumbs                            | segment truncation at 24ch                                            | full labels                                   |
+| Safe-area bottom                       | `pb-[max(1rem,env(safe-area-inset-bottom))]` on `<main>` or container | n/a                                           |
+
+### Right-rail stickiness (named exception)
+
+The right rail is the **only** chrome piece that may use `lg:` classes. Live shipped portal code uses `md:` for the rail, and the spec ratifies this after reviewing the evidence:
+
+- Permitted class pattern on `<aside>` elements inside `<main>`: `md:w-[340px] md:sticky md:top-20 md:self-start`
+- Forbidden on all other chrome elements: `sm:`, `lg:`, `xl:` classes anywhere in `<header>`, `<footer>`, nav elements, or back affordances.
+
+Rail top offset is `md:top-20` (80px), which clears the 64px sticky header + 16px buffer. If header height changes, rail offset must update in lockstep.
+
+---
+
+## 6. State conventions
+
+Pulled from `src/styles/global.css`. Hex values authoritative.
+
+| State                        | Hex                         | CSS var                  | Tailwind name (equivalent) |
+| ---------------------------- | --------------------------- | ------------------------ | -------------------------- |
+| Primary / active link        | `#1e40af`                   | `--color-primary`        | `blue-800`                 |
+| Primary hover                | `#1e3a8a`                   | `--color-primary-hover`  | `blue-900`                 |
+| Default text                 | `#475569`                   | `--color-text-secondary` | `slate-600`                |
+| Bold text / hover on default | `#0f172a`                   | `--color-text-primary`   | `slate-900`                |
+| Disabled text                | `#94a3b8`                   | `--color-text-muted`     | `slate-400`                |
+| Border                       | `#e2e8f0`                   | `--color-border`         | `slate-200`                |
+| Focus ring                   | `#3b82f6` @ 2px, 2px offset | `--color-action`         | `blue-500`                 |
+| Error                        | `#ef4444`                   | `--color-error`          | `red-500`                  |
+| Success / paid               | `#10b981`                   | `--color-complete`       | `emerald-500`              |
+| Attention                    | `#f59e0b`                   | `--color-attention`      | `amber-500`                |
+| Meta (timeline dates)        | `#6366f1`                   | `--color-meta`           | `indigo-500`               |
+
+### Touch-state parity (critical for mobile)
+
+Every `hover:` utility on an interactive element MUST be paired with a matching `focus-visible:` utility (keyboard users) AND an `active:` utility (pressed state on touch). Without `active:`, touch devices exhibit "stuck hover" — a tapped element stays in hover state until another element is tapped.
+
+**Canonical interactive-element class pattern:**
+
+```
+text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2
+```
+
+Apply this pattern to every chrome link, button, and CTA.
+
+### Tap target enforcement
+
+Tap target minimum: 44×44px. Every interactive chrome element declares an explicit `min-h-11 min-w-11` (or `w-11 h-11` for icon-only, or `min-h-11` + negative horizontal margins when the ink is text). This is load-bearing; do not omit.
+
+### aria-current
+
+Active nav item carries `aria-current="page"` and the active hex. The validator checks for this on any rendered nav.
+
+---
+
+## 7. Transition contracts
+
+### Back-target resolution
+
+All back buttons and cancel buttons resolve to a **hardcoded canonical URL string**. Never `#`, `javascript:`, or `history.back()`. Token-auth leaves (which have no parent) have **no back button** at all.
+
+### Canonical parents (authoritative; every shipped dynamic route enumerated)
+
+| From                                    | Back target            | Label                                              |
+| --------------------------------------- | ---------------------- | -------------------------------------------------- |
+| `/portal/invoices/[id]`                 | `/portal/invoices`     | "All invoices"                                     |
+| `/portal/quotes/[id]`                   | `/portal/quotes`       | "All quotes"                                       |
+| `/portal/engagement`                    | `/portal`              | "Home"                                             |
+| `/portal/documents/[id]` (future)       | `/portal/documents`    | "All documents"                                    |
+| `/admin/entities/[id]`                  | `/admin/entities`      | "All clients"                                      |
+| `/admin/entities/[id]/quotes/[quoteId]` | `/admin/entities/[id]` | "<Client name>"                                    |
+| `/admin/engagements/[id]`               | `/admin/entities/[id]` | "<Client name>" (engagement is scoped to a client) |
+| `/admin/assessments/[id]`               | `/admin/entities/[id]` | "<Client name>" (same pattern)                     |
+| `/admin/settings/google-connect`        | `/admin`               | "Dashboard"                                        |
+| `/admin/follow-ups`                     | `/admin`               | "Dashboard"                                        |
+| `/admin/analytics`                      | `/admin`               | "Dashboard"                                        |
+| `/contact` submit/cancel                | `/`                    | "Home"                                             |
+| `/book` cancel                          | `/`                    | "Home"                                             |
+| `/get-started`                          | `/`                    | "Home"                                             |
+| `/scorecard`                            | `/`                    | "Home"                                             |
+
+No fallback row. Every new dynamic route must add a row during spec revision.
+
+### Modal / drawer close
+
+Esc closes. Click-outside (scrim) closes. X button closes. Focus returns to the triggering element.
+
+### Cross-auth-boundary transitions (full enumeration)
+
+| From                | To                            | Mechanism                                                                 | Clears cookie?                 |
+| ------------------- | ----------------------------- | ------------------------------------------------------------------------- | ------------------------------ |
+| public              | auth-gate (`/auth/*`)         | `<a href="smd.services/auth/...">` (same origin)                          | no                             |
+| auth-gate           | session-auth-client           | 302 to `portal.smd.services/portal` + Set-Cookie                          | sets `__Host-portal_session`   |
+| auth-gate           | session-auth-admin            | 302 to `admin.smd.services/admin` + Set-Cookie                            | sets `__Host-admin_session`    |
+| session-auth-client | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/portal-login` | clears `__Host-portal_session` |
+| session-auth-admin  | auth-gate (logout)            | form POST to `/api/auth/logout` → 302 to `smd.services/auth/login`        | clears `__Host-admin_session`  |
+| session-auth-\*     | public (marketing link click) | `<a>` with target subdomain origin                                        | no                             |
+| session-auth-admin  | session-auth-client           | not supported; operator must log out and re-login                         | n/a                            |
+| token-auth          | anywhere (via link click)     | `<a>` with explicit origin; token does not follow                         | n/a                            |
+
+All cross-subdomain transitions are **full page loads**; no client-side routing across origins.
+
+### Post-login redirects (also table rows above)
+
+- Client magic-link verify success → 302 `portal.smd.services/portal`
+- Admin OAuth success → 302 `admin.smd.services/admin`
+- Any auth-gate failure → 302 back to same auth-gate page with `?error=<code>`
+
+### Cross-subdomain 404
+
+`src/pages/404.astro` is a shared not-found page that renders in all three subdomain contexts. Current implementation has no layout, so it ships chrome-less — which is actually acceptable per the spec's `error` archetype rules (minimal header, back-to-safety link). Target link resolves by subdomain:
+
+- On `smd.services` → `/`
+- On `portal.smd.services` → `/portal`
+- On `admin.smd.services` → `/admin`
+
+Middleware detects host and sets `Astro.locals.homeUrl`; 404 page reads it for the back-to-safety link.
+
+---
+
+## 8. Anti-patterns (forbidden by default)
+
+See `~/.agents/skills/nav-spec/references/anti-patterns.md` for rationale.
+
+| Anti-pattern                                       | Forbidden by default on                            | Exceptions                            |
+| -------------------------------------------------- | -------------------------------------------------- | ------------------------------------- |
+| Global nav tabs in header                          | public, session-auth-client, token-auth, auth-gate | Admin (see Appendix D.2)              |
+| Sidebar / hamburger / drawer as primary nav        | all                                                | none                                  |
+| Bottom-tab nav on mobile                           | all                                                | none                                  |
+| Sticky-bottom action bar on viewport               | all                                                | See escape hatches below              |
+| Footer                                             | auth-gate, session-auth-\*, token-auth             | Public (Appendix A)                   |
+| Marketing CTAs on auth surface                     | session-auth-\*, token-auth, auth-gate             | none                                  |
+| Testimonials / pull quotes                         | all                                                | Public marketing (explicit in prompt) |
+| Hero imagery on auth surface                       | session-auth-\*, token-auth, auth-gate             | Public marketing (explicit)           |
+| Real-face photo placeholders                       | all                                                | none; see consultant-block rule below |
+| Breadcrumbs on non-admin                           | public, auth-gate, session-auth-client, token-auth | Admin only                            |
+| `<nav aria-label="Breadcrumb">` around single link | all                                                | none                                  |
+| `fixed top-0` on header                            | all                                                | none; always `sticky top-0`           |
+| `backdrop-blur-*` / translucent header bg          | session-auth-\*, token-auth, auth-gate             | Public hero bands (explicit)          |
+| Icon before client name in header                  | session-auth-\*, token-auth                        | none                                  |
+| Back `href="#"` / `javascript:` / `history.back()` | all                                                | none                                  |
+
+### Sticky-bottom escape hatches (for long forms on mobile)
+
+Sticky-bottom action bars that stick to the viewport (`fixed bottom-0`, `sticky bottom-0` with a `fixed` ancestor) are **forbidden**. For long forms or wizards where the primary CTA would fall below the fold on 390×844:
+
+1. **Primary CTA at the natural end of `<main>`** (inside document flow). Preferred.
+2. **Wizard split** — break the form into steps so each step's CTA fits above the fold. Required for forms ≥ 6 fields on mobile.
+3. **Duplicate CTA at top and bottom of `<main>`** (both in document flow). Acceptable for public-facing forms (contact, book) where the form length is outside the designer's control.
+4. **`sticky bottom-0` scoped to a scrollable container inside `<main>`** — permitted only inside `modal` and `drawer` archetypes. Not a header-level escape.
+
+### Consultant block photo placeholder
+
+Defers to `.stitch/portal-ux-brief.md § Photo placeholder rule`. Current rule: **neutral SVG silhouette**, never initials, never real photos. The spec in Section 4 and `chrome-component-contracts.md` is superseded by the portal-ux-brief on this specific element.
+
+---
+
+## 9. Accessibility floor
+
+- **Landmarks on every page:** `<header role="banner">`, `<main role="main" id="main">`, `<footer role="contentinfo">` (public only).
+- **Skip-to-main link** first in `<body>` (no exceptions; see Section 4).
+- **Keyboard order matches visual order.** No positive `tabindex` values.
+- **Focus rings** on keyboard focus only (`focus-visible:`); no always-on rings.
+- **aria-label** on every icon-only button, link, or control.
+- **`aria-current="page"`** on the active nav item if any nav is rendered.
+- **Tap target** ≥ 44×44px on touch surfaces. Enforce via `min-h-11` or `w-11 h-11`.
+- **Touch-state parity** (Section 6) — `hover:` paired with `focus-visible:` and `active:`.
+- **Safe-area insets (mobile):** pages whose last interactive element is near the bottom apply `pb-[max(1rem,env(safe-area-inset-bottom))]` to `<main>` or the page container. Public footers apply the inset inside `<footer>`.
+- **Contrast:** body text `#475569` on `#ffffff` = 8.6:1, bold `#0f172a` = 19.0:1 (WCAG 2.2 AAA).
+- **No autoplay media, no carousels on auth surfaces.**
+
+---
+
+## 10. Content rules
+
+- **Nav labels**: sentence case ("Text Scott", "All invoices"). Not Title Case. Not ALL CAPS.
+- **Mobile breadcrumb truncation**: each segment caps at 24ch via `truncate max-w-[24ch]`. Full label on desktop.
+- **Icon + label pairing**: icon-only buttons must have `aria-label`; icon + visible-text buttons must not duplicate the label as `aria-label` (redundant to screen readers).
+- **Status pills**: sentence case ("Paid", "Due Friday"). Colors via state-token table. Never three attention colors in one view (use exactly one attention color per surface).
+- **Date format in chrome**: "Apr 18" (short) in back labels / breadcrumbs; never "04/18" or ISO format.
+- **Contact channel labels**: "Email Scott", "Text Scott", "Call Scott" (sentence case, action verb + name).
+
+---
+
+## 11. Refactor checklist (prerequisites for v1 approval)
+
+Per user decision, v1 of this spec is held until the following retrofits land. All are spec-conformance refactors against shipped code; none change user-visible behavior materially.
+
+### Blocking (v1 held until complete)
+
+| #   | File / Scope                                                                 | Change                                                                                                                        | Est. LOC          |
+| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| 1   | New `src/components/SkipToMain.astro`                                        | Create reusable component per Section 4 contract                                                                              | 10                |
+| 2   | Every layout + every page outside a layout                                   | Insert `<SkipToMain />` as first child of `<body>`                                                                            | ~15 insertions    |
+| 3   | Every `<main>` element                                                       | Add `id="main"`                                                                                                               | ~15               |
+| 4   | `src/components/Nav.astro`                                                   | Move `h-16` from inner div to `<header>`; add mobile `h-14`                                                                   | 3                 |
+| 5   | `src/components/portal/PortalHeader.astro`                                   | Replace `py-4` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`                                                     | 3                 |
+| 6   | `src/layouts/AdminLayout.astro`                                              | Replace `py-3` with `h-14 md:h-16` on `<header>`; add `sticky top-0 z-50`; add mobile user-menu transform per D.1-mobile      | ~40               |
+| 7   | `src/pages/portal/invoices/[id].astro`, `src/pages/portal/quotes/[id].astro` | Add back affordance inside `<main>` per canonical-parents table                                                               | ~6 per file = 12  |
+| 8   | `src/layouts/AdminLayout.astro`                                              | Breadcrumb separator: replace text `/` with `<span aria-hidden="true" class="material-symbols-outlined">chevron_right</span>` | 3                 |
+| 9   | `~/.agents/skills/nav-spec/validate.py`                                      | Guard R6b with `surface != "session-auth-admin"`; expand token regex to accept CSS-var, slate-N, and literal hex forms        | 10                |
+| 10  | Portal + Token-auth headers                                                  | Implement three-icon contact control (email/SMS/phone) per Appendix B/C                                                       | ~15 per component |
+
+**Total estimated scope:** ~120 LOC across ~10 files.
+
+### Non-blocking (v2 follow-ups, tracked separately)
+
+- Right-rail offset update when admin + portal headers become sticky — may require QA visual check of `md:top-20` being correct across all detail pages
+- `<aside>` semantic audit for right-rail elements (ensure `<aside>` not `<div>`)
+- `.stitch/designs/portal-v1/` artifact regeneration under the new spec (optional; existing artifacts are historical)
+- `/privacy` and `/terms` marketing pages — currently linked from Appendix A footer but not shipped; either create minimal pages or remove links from footer
+
+Once all 10 blocking items are merged, bump front matter to `spec-version: 1` (remove `-pending` suffix) and mark approval state as `approved`.
+
+---
+
+# Appendix A — `public` (marketing)
+
+Base URL: `smd.services`. Visitor is a stranger or first-time prospect; goal is clear communication of offering.
+
+## A.1 Chrome allowed
+
+### Header
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <a
+      href="/"
+      class="text-lg font-bold tracking-tight text-[#0f172a] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded"
+      >SMD Services</a
+    >
+    <div class="flex items-center gap-5">
+      <a
+        href="/contact"
+        class="text-sm font-medium text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 min-h-11 px-2 -mx-2 inline-flex items-center rounded"
+        >Contact</a
+      >
+      <a
+        href="/book"
+        class="inline-flex items-center bg-[#1e40af] hover:bg-[#1e3a8a] active:bg-[#1e3a8a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 px-5 py-2 rounded font-medium text-white min-h-11"
+        >Book a Call</a
+      >
+    </div>
+  </div>
+</header>
+```
+
+**Delta vs default header:** logo wordmark (only surface class where a logo appears) + one text link + one CTA button.
+
+### Footer (public only)
+
+```html
+<footer role="contentinfo" class="bg-white border-t border-[#e2e8f0] mt-16">
+  <div
+    class="max-w-5xl mx-auto px-4 md:px-6 py-8 pb-[max(2rem,env(safe-area-inset-bottom))] flex flex-col md:flex-row justify-between gap-4 text-[13px] text-[#475569]"
+  >
+    <span>© 2026 SMDurgan LLC. All rights reserved.</span>
+    <nav aria-label="Legal" class="flex gap-4">
+      <a
+        href="/contact"
+        class="hover:text-[#0f172a] active:text-[#0f172a] min-h-11 inline-flex items-center"
+        >Contact</a
+      >
+    </nav>
+  </div>
+</footer>
+```
+
+**`/privacy` and `/terms` are not shipped as of v1.** Footer omits them until pages exist. Re-add when ready (tracked in non-blocking follow-ups).
+
+### Hero imagery
+
+Allowed on `/`, `/get-started`, `/scorecard` — must be explicitly specified in the page prompt. Stock headshots forbidden (validator R9).
+
+## A.2 Chrome forbidden on public
+
+Universal anti-patterns from Section 8, plus:
+
+- Sidebar / hamburger / drawer as primary nav
+- Bottom-tab nav
+- Sticky-bottom action bar (the header CTA is sufficient for marketing)
+- Testimonials on non-`/` pages
+- `backdrop-blur-*` / translucent header bg (marketing can use solid hero bands; header is always solid white)
+
+## A.3 Archetype-specific notes
+
+- `dashboard` = the marketing home `/`. The public landing.
+- `form` = `/contact`, `/book`. Cancel returns to `/`.
+- `wizard` = `/scorecard`, `/get-started`. Multi-step with progress indicator in header band.
+- `error` = `/404` (on `smd.services` context). Back-to-safety returns to `/`.
+
+---
+
+# Appendix B — `token-auth`
+
+Base URL examples: `smd.services/book/manage/[token]`. Future: `portal.smd.services/proposal/[token]`, `portal.smd.services/invoice/[token]`. No account; token encodes identity.
+
+## B.1 Chrome allowed
+
+### Header (three-icon contact control, per user rule: "clients know what they want")
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between gap-4 px-4 md:px-6">
+    <p class="text-[13px] leading-[18px] font-medium text-[#475569] truncate"><recipient name or "Your booking"></p>
+    <div class="flex items-center gap-1">
+      <a href="mailto:<email>" aria-label="Email Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+      </a>
+      <a href="sms:<phone>" aria-label="Text Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">sms</span>
+      </a>
+      <a href="tel:<phone>" aria-label="Call Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">call</span>
+      </a>
+    </div>
+  </div>
+</header>
+```
+
+**Delta vs default:** no logo; recipient name left; **three contact channels on the right** (email / SMS / phone), each 44×44, each with `aria-label`. Client picks the channel that works for them; every channel works on every device. `<mailto:>`, `<sms:>`, and `<tel:>` handle fallbacks automatically per OS/browser.
+
+### Back affordance
+
+**Absent.** Token-auth pages are leaf surfaces; user arrived from a link.
+
+## B.2 Chrome forbidden on token-auth
+
+Universal anti-patterns from Section 8. Additionally:
+
+- Links to authenticated surfaces (`/portal`, `/admin`) — user has no session
+- "Sign up" / "Create account" CTAs — not the job of token-auth
+
+## B.3 Archetype-specific notes
+
+- `detail` — primary; managing a booking, viewing a proposal/invoice
+- `form` — reschedule via token; submit-only (no cancel affordance — user closes tab)
+- `empty`, `error` — the three-icon contact control is the only recovery path
+
+---
+
+# Appendix C — `session-auth-client` (portal)
+
+Base URL: `portal.smd.services`. Authenticated client viewing their own records. The working surface this spec's rigor was tuned against.
+
+## C.1 Chrome allowed
+
+### Header (three-icon contact control)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between gap-4 px-4 md:px-6">
+    <p class="text-[13px] leading-[18px] font-medium tracking-[0.01em] text-[#475569] truncate"><client name></p>
+    <div class="flex items-center gap-1">
+      <a href="mailto:<email>" aria-label="Email Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+      </a>
+      <a href="sms:<phone>" aria-label="Text Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">sms</span>
+      </a>
+      <a href="tel:<phone>" aria-label="Call Scott" class="inline-flex items-center justify-center w-11 h-11 rounded-lg text-[#475569] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2">
+        <span class="material-symbols-outlined" aria-hidden="true">call</span>
+      </a>
+      <slot /> <!-- host page may pass Sign out form -->
+    </div>
+  </div>
+</header>
+```
+
+Shipped component: `src/components/portal/PortalHeader.astro`. Refactor item #5 in Section 11 aligns shipped component to this contract.
+
+### Back affordance (detail archetypes)
+
+Default contract from Section 4. Positioned inside `<main>` above content.
+
+### Right rail (detail + dashboard, `md:` and up)
+
+```html
+<aside class="w-full md:w-[340px] md:sticky md:top-20 md:self-start space-y-6">
+  <!-- ActionCard, ConsultantBlock, related links -->
+</aside>
+```
+
+Width 340px ratifies live shipped portal code. `md:top-20` (80px) clears the 64px sticky header + 16px buffer.
+
+### Mobile stack order (detail archetype)
+
+On mobile (<`md:`), the ActionCard moves **above** `<main>` content — the primary CTA must be above the fold. Order: `<header>` → `<main>` → back button → **ActionCard** → main content body → ConsultantBlock → related links.
+
+On desktop (`md:` and up), ActionCard lives in the right rail.
+
+### ConsultantBlock
+
+Shipped component: `src/components/portal/ConsultantBlock.astro`. Photo placeholder treatment is the **SVG silhouette** defined in `.stitch/portal-ux-brief.md § Photo placeholder rule`. The nav-spec defers to the UX brief on this element specifically (do not substitute initials).
+
+## C.2 Chrome forbidden on session-auth-client
+
+Universal anti-patterns. Especially:
+
+- **Breadcrumbs** — never; portal is shallow (≤2 levels)
+- **Global nav tabs** — portal is narrow; no tab bar
+- **Sticky-bottom action bar** — primary action is in ActionCard above the fold
+- **Logo in header** — client name identifies context
+
+## C.3 Archetype-specific notes
+
+- `dashboard` = `/portal`. No back. Two-column on `md:`. ActionCard above timeline on mobile.
+- `list` = `/portal/invoices`, `/portal/quotes`, `/portal/documents`. Back → `/portal`. Filter bar below header.
+- `detail` = `/portal/*/[id]`. Back → canonical parent. ActionCard above main on mobile, in right rail on `md:`.
+- `form` — rare on portal; none currently live. Cancel → origin.
+- `empty` — inside list views; no CTA (user doesn't create these records).
+- `error` — three-icon contact control is the recovery.
+
+---
+
+# Appendix D — `session-auth-admin`
+
+Base URL: `admin.smd.services`. Operator (Scott). High-privilege. Broader IA than portal; nav tabs allowed as a ratified exception.
+
+## D.1 Chrome allowed
+
+### Desktop header (`md:` and up)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16 hidden md:block">
+  <div class="max-w-5xl mx-auto h-full flex items-center justify-between px-4 md:px-6">
+    <div class="flex items-center gap-3">
+      <a href="/admin" class="text-lg font-bold text-[#0f172a] hover:text-[#1e40af] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded">SMD Services</a>
+      <span class="text-xs bg-[#f1f5f9] text-[#475569] px-2 py-0.5 rounded">Admin</span>
+    </div>
+    <div class="flex items-center gap-4">
+      <!-- nav tabs per D.2, rendered hidden md:flex -->
+      <span class="text-sm text-[#94a3b8]" aria-hidden="true">|</span>
+      <span class="text-sm text-[#475569]"><operator email></span>
+      <form method="POST" action="/api/auth/logout">
+        <button type="submit" class="text-sm text-[#475569] hover:text-[#0f172a] active:text-[#0f172a] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 min-h-11 px-2 -mx-2 rounded">Sign out</button>
+      </form>
+    </div>
+  </div>
+</header>
+```
+
+### Mobile header (<`md:`)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:hidden">
+  <div class="h-full flex items-center justify-between px-4">
+    <div class="flex items-center gap-3">
+      <a href="/admin" class="text-lg font-bold text-[#0f172a] active:text-[#1e40af] focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 rounded">SMD Services</a>
+      <span class="text-xs bg-[#f1f5f9] text-[#475569] px-2 py-0.5 rounded">Admin</span>
+    </div>
+    <details class="relative">
+      <summary aria-label="Open menu" class="list-none w-11 h-11 flex items-center justify-center rounded-lg hover:bg-[#f1f5f9] active:bg-[#f1f5f9] focus-visible:ring-2 focus-visible:ring-[#3b82f6] cursor-pointer">
+        <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+      </summary>
+      <div class="absolute right-0 top-12 w-64 bg-white border border-[#e2e8f0] rounded-lg shadow-lg p-2 z-50">
+        <nav aria-label="Primary" class="flex flex-col">
+          <a href="/admin" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Dashboard</a>
+          <a href="/admin/entities" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Entities</a>
+          <a href="/admin/follow-ups" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Follow-ups</a>
+          <a href="/admin/analytics" class="block px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Analytics</a>
+        </nav>
+        <hr class="my-2 border-[#e2e8f0]">
+        <p class="px-3 py-1.5 text-xs text-[#475569]"><operator email></p>
+        <form method="POST" action="/api/auth/logout">
+          <button type="submit" class="w-full text-left px-3 py-2.5 text-sm rounded hover:bg-[#f1f5f9] active:bg-[#f1f5f9]">Sign out</button>
+        </form>
+      </div>
+    </details>
+  </div>
+</header>
+```
+
+Below `md:`, tabs + email + Sign out collapse into a `<details>` menu triggered by an icon button. This is a **ratified menu-trigger pattern** (not a general hamburger) — it exists specifically to collapse the admin-only tab bar below `md:`. The pattern is scoped to admin; no other surface class gets a menu trigger.
+
+### D.2 Admin nav tabs (ratified exception)
+
+```html
+<nav aria-label="Primary" class="hidden md:flex items-center gap-4">
+  <a href="/admin" aria-current={active ? "page" : undefined}
+     class={`text-sm transition-colors min-h-11 inline-flex items-center px-2 -mx-2 rounded focus-visible:ring-2 focus-visible:ring-[#3b82f6] focus-visible:ring-offset-2 ${active ? "text-[#1e40af] font-medium" : "text-[#475569] hover:text-[#0f172a] active:text-[#0f172a]"}`}>
+    Dashboard
+  </a>
+  <!-- Entities, Follow-ups, Analytics — same pattern -->
+</nav>
+```
+
+Rationale for exception: admin has 4 top-level sections with distinct IA (Entities, Follow-ups, Analytics, plus Dashboard). Tab bar is clearest IA for a single-operator surface. Cap at 5 tabs; if a 6th appears, revisit via `/nav-spec --revise`.
+
+### D.3 Breadcrumbs
+
+Admin is the only surface class rendering breadcrumbs. Live `AdminLayout.astro` ships an optional breadcrumb prop; keep it. Format per `chrome-component-contracts.md` (use `<chevron_right aria-hidden="true">`, not `/` text).
+
+Depth caps:
+
+- `list`: 2 levels
+- `detail`: 3 levels
+
+### D.4 Back vs breadcrumbs
+
+If the page has breadcrumbs, it does **not** also have a back button. If no breadcrumbs (e.g., admin dashboard), no back either — the nav tabs/menu is the navigation.
+
+## D.5 Chrome forbidden on session-auth-admin
+
+Universal anti-patterns, **except** nav tabs (D.2 exception) and the mobile `<details>` menu (D.1 exception). Additionally:
+
+- Sidebar (permanent) — no
+- Right rail — no (data-dense; 3-column is cramped)
+- Footer — no (authenticated)
+- Marketing CTAs, testimonials, hero imagery — obviously forbidden
+
+## D.6 Archetype-specific notes
+
+- `dashboard` = `/admin`. Grid of metric cards.
+- `list` = `/admin/entities`, `/admin/follow-ups`. Filter bar. 2-level breadcrumbs acceptable.
+- `detail` = `/admin/*/[id]`. 3-level breadcrumbs. No back button (breadcrumbs carry the affordance).
+- `form` = `/admin/settings/*`, `/admin/*/[id]/edit`. Cancel + Save. 2-level breadcrumbs.
+
+---
+
+# Appendix E — `auth-gate`
+
+Base URLs: `smd.services/auth/login`, `/auth/verify`, `/auth/portal-login`. Anonymous surface; exists to produce or consume an auth credential. All pages in this class carry `<meta name="robots" content="noindex, nofollow">`.
+
+## E.1 Chrome allowed
+
+### Header (wordmark only)
+
+```html
+<header role="banner" class="sticky top-0 z-50 bg-white border-b border-[#e2e8f0] h-14 md:h-16">
+  <div class="max-w-sm md:max-w-md mx-auto h-full flex items-center justify-center px-4">
+    <span class="text-lg font-bold tracking-tight text-[#0f172a]">SMD Services</span>
+  </div>
+</header>
+```
+
+**Delta vs default:** wordmark centered (not linked — no destination is safe from an auth-gate); no Contact, no Book a Call, no nav, no contact icons. Narrower max-width to focus the form.
+
+### No footer, no back affordance
+
+Auth-gate has no parent destination and no legal chrome. Post-success redirects happen server-side (Section 7's cross-auth-boundary table).
+
+## E.2 Chrome forbidden
+
+Universal anti-patterns. Additionally:
+
+- Contact link / Book a Call CTA — wrong audience; users are trying to sign in
+- Footer with legal links — if legal is required by an OAuth consent screen, it's rendered by the OAuth provider, not by this surface
+- Links to authenticated surfaces — session doesn't exist yet
+- Links to marketing pages — distracting mid-auth
+
+## E.3 Archetype-specific notes
+
+- `form` — `/auth/login` (admin OAuth), `/auth/portal-login` (client magic-link). Submit-only (no cancel). Errors render inline via `?error=` query param.
+- `transient` — `/auth/verify`. Server-side processing + redirect. Renders a fallback error only if the redirect fails. No header required (server sends a bare HTML document with a `<noscript>` fallback link).
+
+## E.4 Post-auth transitions
+
+Enumerated in Section 7 cross-auth-boundary table. Summary:
+
+- Admin OAuth success → 302 `admin.smd.services/admin`
+- Client magic-link verify success → 302 `portal.smd.services/portal`
+- Any failure → 302 back to same auth-gate with `?error=<code>`
+
+---
+
+## Revision history
+
+| spec-version | Date       | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Approver |
+| ------------ | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| 1-pending    | 2026-04-15 | Initial spec authored via `/nav-spec`. Grounded in Phase 0 compliance run (categorical 97%, strict 87%) and drift audit of shipped code. Approves: admin nav tabs as documented exception (D.2), admin mobile `<details>` menu (D.1-mobile), ratified live portal right-rail `md:` + 340px + `md:top-20`, SVG silhouette for ConsultantBlock (defers to portal-ux-brief), three-icon contact control in portal and token-auth headers (per user: "clients know what they want"). Introduces `auth-gate` surface class (Appendix E) for `/auth/*` pages and `transient` archetype for `/auth/verify`. Approval held pending 10 retrofit items in Section 11. | _(held)_ |

--- a/.agents/skills/nav-spec/examples/drift-audit-report.md
+++ b/.agents/skills/nav-spec/examples/drift-audit-report.md
@@ -1,0 +1,51 @@
+# Drift audit — ss-console — 2026-04-15
+
+spec-version checked against: _no spec yet (pre-authoring)_
+
+## Live code matrix
+
+| File                                   | Primary chrome                                                                 | Back/breadcrumb                           | Auth level          | Mobile pattern                                            | Shared layout?                |
+| -------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------- | ------------------- | --------------------------------------------------------- | ----------------------------- |
+| `src/components/Nav.astro`             | Sticky header, logo left, Contact + Book CTA right                             | None                                      | Public              | Responsive max-w                                          | Yes — used by marketing pages |
+| `src/components/PortalHeader.astro`    | Minimal band, avatar + client name, optional SMS link on mobile                | None                                      | Session-auth-client | Single-column mobile                                      | Yes — `/portal/*`             |
+| `src/layouts/AdminLayout.astro`        | Top-band header with inline nav tabs + optional breadcrumbs + email + Sign out | Breadcrumbs (optional, hierarchical)      | Session-auth-admin  | No mobile-specific pattern                                | Yes — `/admin/*`              |
+| `src/pages/portal/invoices/[id].astro` | Uses `PortalHeader`                                                            | None — no back affordance, no breadcrumbs | Session-auth-client | Two-column (md breakpoint), action card above fold mobile | Yes                           |
+| `src/pages/portal/quotes/[id].astro`   | Uses `PortalHeader`                                                            | None — login-check only                   | Session-auth-client | Two-column (lg breakpoint), left-main layout              | Yes                           |
+| `src/pages/scorecard.astro`            | Uses `Nav.astro`                                                               | None                                      | Public              | Responsive, no mobile nav                                 | Yes                           |
+
+## Generated artifact matrix
+
+| File                                                | Primary chrome                                         | Back/breadcrumb | Auth level implied | Mobile pattern              |
+| --------------------------------------------------- | ------------------------------------------------------ | --------------- | ------------------ | --------------------------- |
+| `.stitch/designs/portal-v1/home-desktop.html`       | Fixed sticky header (logo + 3 nav tabs)                | None            | Guest (no auth UI) | Bottom-tab nav (4 items)    |
+| `.stitch/designs/portal-v1/proposal-desktop.html`   | Sticky header (logo + status badge)                    | None            | Guest              | No mobile (desktop-primary) |
+| `.stitch/designs/portal-v1/invoice-desktop.html`    | Fixed top header (logo + SMS button)                   | Back link (↵)   | Guest              | No mobile                   |
+| `.stitch/designs/portal-v1/home-mobile-v2.html`     | Minimal header (avatar + client name)                  | None            | Guest              | Centered layout             |
+| `.stitch/designs/portal-v1/invoice-mobile-v2.html`  | Sticky header (arrow_back + "Portal" wordmark + title) | Back only       | Guest              | Sticky-bottom action bar    |
+| `.stitch/designs/portal-v1/proposal-mobile-v2.html` | Sticky header                                          | None            | Guest              | Centered                    |
+| `.stitch/*.html` (scorecard scratch)                | Sticky nav (logo + links + CTA)                        | None            | Guest              | No mobile pattern           |
+
+## Spec compliance matrix
+
+_(Not applicable — no spec exists yet. This audit informs the first spec.)_
+
+## Drift summary (6 bullets)
+
+1. **Three distinct live headers, three live breakpoints.** `Nav.astro` uses `sticky` marketing chrome with logo+CTA. `PortalHeader.astro` is a minimalist band with avatar+name. `AdminLayout` header has inline nav tabs + breadcrumbs + auth affordances. No shared underlying component. Portal uses `md:` breakpoints, invoice detail uses `lg:`. Breakpoint fragmentation is real.
+
+2. **Back navigation is absent from 5 of 6 Stitch portal artifacts.** Deep-link pages (`/portal/invoices/[id]`, `/portal/proposals/[token]`) have no return path. `PortalHeader.astro` in live code has no back affordance either. The first user to hit an invoice via email has no clear way to the dashboard.
+
+3. **Header stickiness inconsistent across Stitch artifacts.** `home-desktop` uses `fixed top-0`. `proposal-desktop` uses `sticky`. `invoice-desktop` uses `fixed`. No clear rule. Each run invents.
+
+4. **Mobile navigation strategy undefined in both code and Stitch output.** `home-desktop.html` has a bottom-tab nav with 4 items (forbidden per our anti-patterns, but shipped). `home-mobile-v2.html` has no mobile nav at all. `scorecard-quiz.html` has a `bottom-0` bar. Portal code has no mobile nav strategy. Scaling Stitch to production requires inventing mobile nav for every screen.
+
+5. **Auth-level presentation missing from every Stitch artifact.** All 6 Stitch portal designs render as "guest" — no sign-out, no user context. Live `PortalHeader.astro` and `AdminLayout` both have logout affordances. Stitch output can't serve as a production template without auth-chrome layered in afterwards.
+
+6. **Token-auth is silently collapsed into "portal."** Proposal landings (`/portal/proposals/[token]`) and invoice landings (`/invoice/[id]`) are token-auth — neither fully public nor session-auth. Current designs and code treat them inconsistently: some have auth-style chrome, some have marketing-style chrome. Spec must carve out a fourth surface class for these.
+
+## Follow-ups
+
+1. **Author NAVIGATION.md v1** (owner: user + nav-spec) — resolves all drift items above by defining the contract.
+2. **Refactor `Nav.astro`, `PortalHeader.astro`, `AdminLayout.astro` to match spec** (owner: user, separate PR, post-spec-approval) — aligns shipped code with the contract. Likely touches breakpoint conventions, back affordances, and the portal/token-auth distinction.
+3. **Regenerate stale portal-v1 designs** (owner: user, optional) — those were produced before the spec and don't benefit from the injection. Keep them as historical reference or regenerate; user's call.
+4. **Revisit admin chrome specifically** (owner: IA reviewer in Phase 4) — the current admin layout has nav tabs, which our default anti-pattern list forbids. Decision needed: align spec to code (admin tabs allowed) or align code to spec (remove tabs from admin).

--- a/.agents/skills/nav-spec/examples/phase-0-compliance-report.md
+++ b/.agents/skills/nav-spec/examples/phase-0-compliance-report.md
@@ -1,0 +1,154 @@
+# Phase 0 — Stitch injection-compliance report
+
+**Date:** 2026-04-15
+**Stitch project:** `17873719980790683333` (ss — SMD Services)
+**Test scope:** 3 prompts × 2 variants (baseline / injected) = 6 generations
+**Injection snippet:** 453 tokens (well under 600-token budget)
+
+## Test matrix
+
+| Prompt                 | Viewport | Archetype | Baseline                         | Injected                         |
+| ---------------------- | -------- | --------- | -------------------------------- | -------------------------------- |
+| Portal home dashboard  | 390×844  | dashboard | `home-mobile-baseline.html`      | `home-mobile-injected.html`      |
+| Portal invoice detail  | 390×844  | detail    | `invoice-mobile-baseline.html`   | `invoice-mobile-injected.html`   |
+| Portal proposal detail | 1280     | detail    | `proposal-desktop-baseline.html` | `proposal-desktop-injected.html` |
+
+## Results — major-category compliance (what the plan actually cares about)
+
+Forbidden chrome that injection prevented:
+
+| Forbidden pattern                      | Baseline (3 runs)                                                                                                           | Injected (3 runs)                                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Global nav tabs / menu links in header | 2/3 violations (home-mobile has chat + profile icons; proposal-desktop has notifications + help icons)                      | **0/3**                                                                  |
+| Sidebar / hamburger / drawer           | 0/3                                                                                                                         | **0/3**                                                                  |
+| Logo / brand wordmark in header        | 3/3 violations (all three use "Delgado Plumbing" as brand wordmark, proposal-desktop with `text-xl font-extrabold #00288e`) | **0/3** (one minor: water_drop icon decoration on home-mobile)           |
+| Breadcrumb trail                       | 0/3                                                                                                                         | **1/3** (proposal-desktop wraps back in `<nav aria-label="Breadcrumb">`) |
+| Bottom-tab nav                         | 0/3                                                                                                                         | **0/3**                                                                  |
+| Sticky bottom action bar               | 1/3 violation (invoice-mobile-baseline has `fixed bottom-0 w-full` action bar)                                              | **0/3**                                                                  |
+| Footer / copyright / legal links       | 0/3                                                                                                                         | **0/3**                                                                  |
+| Marketing CTAs (book, schedule, etc.)  | 0/3                                                                                                                         | **0/3**                                                                  |
+| Testimonials / pull quotes             | 0/3                                                                                                                         | **0/3**                                                                  |
+| Hero imagery                           | 0/3                                                                                                                         | **0/3**                                                                  |
+| Real face in photo placeholder         | 1/3 violation (proposal-desktop-baseline uses a real headshot via `lh3.googleusercontent.com/aida/...`)                     | **0/3**                                                                  |
+
+**Major-category compliance: 97% (35 of 36 categorical rules honored across injected runs).**
+
+## Results — exact-spec compliance (strict)
+
+Nit-level violations inside the injected runs:
+
+| Run                       | Violation                                                                             | Severity |
+| ------------------------- | ------------------------------------------------------------------------------------- | -------- |
+| home-mobile-injected      | Header uses `fixed top-0` instead of `sticky top-0`                                   | cosmetic |
+| home-mobile-injected      | Added `water_drop` material icon before client name (snippet said "No logo")          | cosmetic |
+| invoice-mobile-injected   | Back link uses `href="#"` instead of hardcoded canonical URL                          | semantic |
+| proposal-desktop-injected | Header uses `bg-white/85 backdrop-blur-md` instead of solid white                     | cosmetic |
+| proposal-desktop-injected | Back button wrapped in `<nav aria-label="Breadcrumb">` (spec said breadcrumbs absent) | semantic |
+
+Strict per-rule compliance: ~87% across the three injected runs.
+
+## Cross-run consistency (the actual thesis)
+
+**Baseline runs (no injection):** three completely different header treatments.
+
+- home-mobile: `sticky top-0 shadow-sm bg-white/80 backdrop-blur-xl`, "Delgado Plumbing" brand + 2 icon buttons
+- invoice-mobile: `sticky top-0 bg-[#faf8ff]` (lavender!), arrow_back + "Portal" + title + spacer
+- proposal-desktop: non-sticky, brand wordmark + notifications/help/avatar photo
+
+Plus invoice-mobile-baseline has a **sticky-bottom action bar** that the other two don't.
+
+**Injected runs:** three structurally consistent headers.
+
+- All three: sticky (or fixed), white bg, border-b, 56/64px height, client name left, Text Scott link right, no secondary nav, no bottom chrome, no footer.
+- Consistency across mobile + desktop: chrome transforms cleanly by height (56 → 64) without diverging in structure.
+
+**This is the first time three ss-console portal surfaces have had consistent chrome across a single generation session.** That's the thesis being validated.
+
+## Decision gate
+
+The plan's gate: ≥90% strict compliance → injection-first with light validator. <90% → validator-first with minimal injection.
+
+Raw strict compliance: **~87%** — slightly below the threshold.
+Major-category compliance: **97%** — well above threshold.
+
+**Recommended verdict: injection-first with a targeted post-generation validator.**
+
+Rationale: every forbidden chrome category (nav tabs, sidebar, hamburger, bottom-tab, marketing, footer) was prevented at 100%. The residual violations are all cosmetic (`fixed` vs `sticky`, translucent vs solid bg, decorative icon on client name) or semantic (placeholder href, breadcrumb wrapper element around a single back button). These are exactly the kind of errors a lightweight HTML-parsing validator can catch deterministically:
+
+1. `fixed top-0` → flag, suggest `sticky top-0`
+2. `<nav aria-label="Breadcrumb">` → flag, suggest removing wrapper
+3. `backdrop-blur-*` class on header → flag, suggest solid background
+4. Icon/SVG sibling before client-name span in header → flag, suggest removing
+5. Back-button `<a href="#">` → flag, require explicit URL
+
+This gives us belt-and-suspenders enforcement: injection handles the high-leverage categorical rules, validator handles the residual cosmetic tail.
+
+## Follow-up — non-compliance category to refine in v2 snippet
+
+The semantic confusion around `<nav aria-label="Breadcrumb">` suggests the injection snippet should be more explicit:
+
+> Back affordance is a single `<a>` or `<button>` element with `aria-label` describing the target. Do not wrap in `<nav>`. Do not use `aria-label="Breadcrumb"`.
+
+Added to the v2 snippet in `references/injection-snippet-template.md`.
+
+## Artifacts
+
+- `/tmp/phase0/home-mobile-baseline.html` (9.5KB) + `.json` response
+- `/tmp/phase0/home-mobile-injected.html` (8.7KB) + `.json` response
+- `/tmp/phase0/invoice-mobile-baseline.html` (10.4KB) + `.json` response
+- `/tmp/phase0/invoice-mobile-injected.html` (9.1KB) + `.json` response
+- `/tmp/phase0/proposal-desktop-baseline.html` (13.9KB) + `.json` response
+- `/tmp/phase0/proposal-desktop-injected.html` (13.7KB) + `.json` response
+
+Injected runs are ~10% smaller than baselines — consistent with less chrome being rendered, as expected.
+
+## Next step
+
+Proceed to skill scaffolding (Task #2). Architecture: injection-first + lightweight validator. Validator ships as a required post-generation step in `stitch-design`'s pipeline, not as a conditional. Workflows/references in the new skill reflect this.
+
+---
+
+## Correction — revised categorical number (2026-04-15, later in same session)
+
+The initial categorical-compliance figure of 97% was based on hand-inspection that missed real-face photo placeholders in injected runs. When the validator's R9 regex was extended from `aida/` → `aida[-/]` to match Stitch's actual `aida-public/...` URL pattern, it caught placeholder photos in `invoice-mobile-injected` and `proposal-desktop-injected` that were previously uncounted.
+
+Revised: **categorical compliance ≈ 93% on injected runs** (still well within the "injection-first + required validator" architecture band). The headline conclusion is unchanged — injection prevents the big categorical failures, but a deterministic validator is required for cosmetic and semantic cleanup.
+
+## Follow-up runs — Phase 7 and Phase 8 verification
+
+On the same day, the full spec was exercised end-to-end against live Stitch generations. See `/Users/scottdurgan/dev/ss-console/.stitch/designs/v1-verification/RUN-LOG.md` for per-run detail.
+
+### Phase 7 — integration check
+
+**Regeneration:** `portal-v1/home-mobile` with the full updated NAV CONTRACT (including three-icon contact control, SVG silhouette rule, strict semantic-precision block).
+
+**Validator result after false-positive fixes:** 1 violation — R1 (fixed-vs-sticky), which is a known Stitch blindspot.
+
+**Specifically preserved in the generation (all adversarial failures in prior runs):**
+
+- Three-icon contact control (mail / sms / tel) implemented correctly
+- Skip-to-main link with matching `<main id="main-content">`
+- SVG silhouette for the consultant avatar — **no real-face placeholder this time**, a direct improvement over Phase 0
+
+### Phase 8 — adversarial verification
+
+Three prompts on unseen `{surface × archetype × viewport}` combos, each generated once and validated:
+
+| Combo                                                     | Violations       | Notes                                                                                    |
+| --------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------- |
+| `session-auth-client / form / mobile` (portal settings)   | 1 (R1)           | No back button (correct for form), three-icon contact control, no footer                 |
+| `session-auth-admin / detail / desktop` (admin audit log) | 1 (R9 real-face) | `sticky top-0`, `hidden md:flex` nav tabs, admin-exception worked, no sidebar, no footer |
+| `public / detail / desktop` (marketing blog)              | 1 (R9 real-face) | Logo + CTA header, footer present (public rule allowed), no breadcrumbs                  |
+
+**Structural violations from taxonomy gaps across all three adversarial runs: 0.**
+
+**Conclusion:** the spec handles unseen combinations correctly. The only residual violations are the two known Stitch blindspots (R1, R9), which the validator catches deterministically every time. This is the drift-prevention thesis being validated.
+
+## Validator improvements from this run
+
+Two validator false-positives were discovered and fixed:
+
+1. **R3** (icon before client name) was truncating the header to 500 chars and flagging ANY material-symbols — including the three-icon contact control on the right side. Fixed to only flag material-symbols/svg/img that appear BEFORE the first visible text element.
+2. **R15** (skip-to-main link) required `href="#main"` or `href="#content"` with specific attribute order. Stitch emits `href="#main-content"` with `class=` before `href=`. Regex broadened to accept any id that has a matching `<main id="...">` element.
+
+Both fixes re-ran against the original Phase 0 HTMLs without regressions.

--- a/.agents/skills/nav-spec/references/anti-patterns.md
+++ b/.agents/skills/nav-spec/references/anti-patterns.md
@@ -1,0 +1,137 @@
+# Anti-patterns
+
+The navigation smells every NAVIGATION.md should explicitly forbid. Each has a rationale — understand it so you can apply judgment when a new anti-pattern emerges, not just copy the list.
+
+## Structural anti-patterns
+
+### 1. Global nav tabs / menu links in the header on authenticated surfaces
+
+**Example:** "Dashboard | Invoices | Proposals | Settings" rendered as a horizontal tab bar in the top band.
+
+**Why forbidden on portal and token-auth:** the client portal has a small, focused surface area; the user is there to check one thing or act on one thing. A tab bar suggests breadth of app, consumes vertical real estate, and imports SaaS-product conventions that don't fit a consulting relationship.
+
+**Why forbidden on admin (usually):** depends on the venture's admin complexity. For ss-console's single-operator admin, a tab bar is overkill. For multi-team admins, a tab bar is allowed but must be specified in the surface-class appendix.
+
+**Exception path:** if the admin truly needs tab-level navigation, define it in Appendix D with explicit tabs, never a free invention by Stitch.
+
+### 2. Sidebar / hamburger / drawer as primary navigation
+
+**Example:** collapsible sidebar with "Home | Invoices | Clients | ..." on desktop; hamburger icon in the header on mobile that opens a slide-out with the same menu.
+
+**Why forbidden:** sidebars are a SaaS-product pattern. This isn't a SaaS product. A sidebar nav signals the wrong relationship (self-serve tool) vs what we're actually building (consulting engagement interface).
+
+**Exception path:** none at the current scope. Re-visit if the admin surface grows past ~15 routes and tabs can't hold them.
+
+### 3. Bottom-tab nav (mobile)
+
+**Example:** fixed bottom bar with 3–5 icons + labels (Home / Invoices / Messages / Profile).
+
+**Why forbidden universally:** mobile apps use bottom-tabs. This is a web surface, not a mobile app. Users expect web-style navigation. Bottom-tabs on mobile web are a conversion-killer on authenticated flows and feel "app-like" in a way that undermines the consulting positioning.
+
+**Exception path:** none.
+
+### 4. Sticky bottom action bar when the primary action is already visible above the fold
+
+**Example:** Pay button visible at y=250 on the invoice detail, plus a duplicated "Pay $4,250" bar stuck to `bottom-0` for "thumb reachability."
+
+**Why forbidden:** duplication signals insecurity — "I put the button twice because I'm not sure you saw it." Either the primary action is above the fold (trust the user) or it isn't (fix the layout). Both can't be true.
+
+**Exception path:** if the content pushes the primary action below the fold on 390×844, the fix is tightening the layout, not adding a second button.
+
+### 5. Footer / copyright / legal links on authenticated surfaces
+
+**Example:** "© 2026 SMDurgan LLC | Privacy | Terms | Contact" at the bottom of `/portal/home`.
+
+**Why forbidden:** the user has already agreed to terms; they have an ongoing relationship. Marketing-site chrome on an authenticated surface signals the wrong relationship. Legal links on authenticated surfaces are almost always out-of-date anyway.
+
+**Exception path:** none.
+
+## Content anti-patterns
+
+### 6. Marketing CTAs on authenticated surfaces
+
+**Example:** "Schedule a call" or "Book a demo" button on `/portal/home`.
+
+**Why forbidden:** the user is already a customer. The CTA is addressed to a stranger. It patronizes the reader.
+
+**Exception path:** a "schedule a check-in" action directed at an existing client is fine if explicit in the page prompt. "Book a demo" is not.
+
+### 7. Testimonials, pull quotes, italicized client-voice text
+
+**Example:** "'Scott transformed our business — Mike Delgado, Delgado Plumbing'" rendered as a pull quote on an invoice landing.
+
+**Why forbidden universally:** marketing chrome. Testimonials live on public marketing pages, nowhere else.
+
+**Exception path:** none.
+
+### 8. Hero imagery / decorative illustrations
+
+**Example:** a large stock-photo-style header image or a geometric illustration atop the portal home.
+
+**Why forbidden on authenticated surfaces:** chrome. Consumes vertical real estate the user wants to use for actual data. Authenticated surfaces are working surfaces; there is no "brand moment" to protect.
+
+**Exception path:** on `public` marketing surfaces, hero imagery is allowed but must be specified in the prompt. Never free invention.
+
+### 9. Real-face photo placeholders
+
+**Example:** `<img src="https://lh3.googleusercontent.com/aida/..." alt="professional headshot of a mature businessman">` as a consultant avatar placeholder.
+
+**Why forbidden universally:** Stitch's training prior is heavy with these. They look real but they're synthetic/stock. They signal "stock photo" aesthetic, which is corrosive to the guide positioning.
+
+**Fix:** a solid-color circle with initials. Always. Never relax this, even "just for this one screen."
+
+### 10. Breadcrumbs on portal
+
+**Example:** "Home > Invoices > Invoice #1042" at the top of the invoice detail.
+
+**Why forbidden on portal:** the portal is shallow (2 levels: dashboard → detail). A breadcrumb trail suggests a deeper hierarchy than exists. The back button is sufficient.
+
+**Exception path:** admin may need breadcrumbs for 3+ level hierarchies (`Clients > Delgado Plumbing > Audit log`). Specify in Appendix D.
+
+## Semantic anti-patterns (mostly caught by the validator)
+
+### 11. `<nav aria-label="Breadcrumb">` wrapping a single back button
+
+**Example:** `<nav aria-label="Breadcrumb"><a href="/home">← Home</a></nav>`
+
+**Why forbidden:** a breadcrumb trail has multiple levels. A single back button is not a breadcrumb — it's a back button. The semantic wrapper lies to assistive tech.
+
+### 12. `fixed top-0` instead of `sticky top-0` on the header
+
+**Why forbidden:** `fixed` takes the header out of document flow. It plays badly with scrolling containers, right rails, and mobile keyboard-opens. `sticky` stays in flow and behaves correctly.
+
+### 13. `backdrop-blur-*` / translucent header background
+
+**Why forbidden:** glassmorphism is a 2021–2023 visual fad. It reads as "trying to look modern" and it's a common Stitch over-render. Solid white headers are cleaner, faster to render, and don't fight the user's reading of the content below.
+
+### 14. Icon decoration before the client name in the header
+
+**Example:** `<span class="material-symbols-outlined">water_drop</span> Delgado Plumbing` — a water drop next to a plumbing client's name.
+
+**Why forbidden:** cute. Also noisy. The client name is identity enough. Decorative icons in the header accumulate over time ("just one more"). Forbid them universally.
+
+### 15. Back href="#" or href="javascript:" or onclick="history.back()"
+
+**Why forbidden:** `#` scrolls to top (broken). `javascript:` breaks right-click context menu (broken). `history.back()` breaks deep-links (user arrived via email, there's nothing to go back to). Always a canonical hardcoded URL.
+
+## Classification (machine-readable)
+
+| Anti-pattern                                       | Severity   | Validator rule ref              |
+| -------------------------------------------------- | ---------- | ------------------------------- |
+| Global nav tabs in header                          | structural | R6                              |
+| Sidebar / hamburger / drawer nav                   | structural | R6                              |
+| Bottom-tab nav                                     | structural | R7                              |
+| Sticky bottom action bar                           | structural | R7                              |
+| Footer on auth surface                             | structural | R8                              |
+| Marketing CTAs on auth                             | structural | R10                             |
+| Testimonials / pull quotes                         | structural | (content filter, no fixed rule) |
+| Hero imagery on auth                               | structural | (content filter)                |
+| Real-face photo placeholder                        | structural | R9                              |
+| Breadcrumbs on portal                              | structural | R4 (partial)                    |
+| `<nav aria-label="Breadcrumb">` around single back | semantic   | R4                              |
+| `fixed top-0` on header                            | semantic   | R1                              |
+| `backdrop-blur-*` on header                        | cosmetic   | R2                              |
+| Icon before client name                            | cosmetic   | R3                              |
+| Back `href="#"`                                    | semantic   | R5                              |
+
+Severity determines retry behavior in the validator: **structural violations always retry**; **semantic violations retry once**; **cosmetic violations warn but pass by default** (can be elevated per venture).

--- a/.agents/skills/nav-spec/references/archetype-catalog.md
+++ b/.agents/skills/nav-spec/references/archetype-catalog.md
@@ -1,0 +1,170 @@
+# Archetype catalog
+
+Nine archetypes. Each defines the nav contract for a class of screens. Every generated or shipped page maps to exactly one archetype. When a new screen doesn't fit, either (a) widen an existing archetype, or (b) add a new one via `/nav-spec --revise --add-archetype`.
+
+## Common contract (inherited by all)
+
+- **Landmarks:** `<header role="banner">`, `<main role="main">`.
+- **Skip link:** `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>` at top of body.
+- **Focus rings:** 2px accent color, 2px offset, keyboard-focus only.
+- **Icon-only buttons:** always have `aria-label`.
+- **Tap targets:** 44×44px minimum on touch surfaces.
+- **Header height:** 56px mobile, 64px desktop.
+- **Header background:** solid (no `backdrop-blur-*`, no opacity modifiers).
+
+## 1. `dashboard`
+
+**Definition:** Landing surface of an authenticated surface class. The user's "home." Shows overview, pending actions, recent activity.
+
+**Examples:** `/portal/home`, `/admin/home`.
+
+**Chrome contract:**
+
+- Header: client/workspace name on left, optional quick-action link on right (SMS, settings gear). No logo. No tabs.
+- **No back button.** The user is already home.
+- **No breadcrumbs.**
+- Right rail on desktop: optional, used for quick actions or status summary.
+
+**Allowed surface classes:** `session-auth-client`, `session-auth-admin`.
+
+## 2. `list`
+
+**Definition:** Index of items in a collection. Filterable, sortable, paginated.
+
+**Examples:** `/portal/invoices`, `/admin/audit-log`, `/admin/clients`.
+
+**Chrome contract:**
+
+- Header: same minimal band as dashboard.
+- **Back button:** to the parent surface (usually dashboard). Hardcoded URL.
+- **No breadcrumbs** on portal; breadcrumbs **allowed** on admin (2 levels max).
+- Filter/sort bar directly below header, before the list.
+
+**Allowed surface classes:** `session-auth-client`, `session-auth-admin`.
+
+## 3. `detail`
+
+**Definition:** Single-item view. Invoice, proposal, client, audit event.
+
+**Examples:** `/portal/invoices/[id]`, `/portal/proposals/[token]`, `/admin/clients/[id]`.
+
+**Chrome contract:**
+
+- Header: minimal band.
+- **Back button:** to the parent list or (for token-auth deep-links) to a sensible landing. Hardcoded URL. Label carries the parent's name ("All invoices", "Home").
+- **No breadcrumbs** on portal and token-auth; **allowed** on admin for 3+ level hierarchies.
+- Right rail on desktop: consultant/contact block, status timeline, related items.
+- Primary action (Pay, Accept, Sign) visible above fold on mobile.
+
+**Allowed surface classes:** all four.
+
+## 4. `form`
+
+**Definition:** Surface for creating or editing an entity. Fields, validation, submit.
+
+**Examples:** `/portal/profile/edit`, `/admin/clients/new`, `/admin/invoices/[id]/edit`.
+
+**Chrome contract:**
+
+- Header: minimal band.
+- **Cancel + Save** actions — not a back button. Cancel returns to the canonical origin (the form's source). Save submits and navigates to the created/edited entity's detail view.
+- **Dirty-state guard:** if fields have unsaved changes, Cancel triggers a confirm modal.
+- **No breadcrumbs.**
+- Keyboard: Cmd/Ctrl+S saves; Esc is interpreted as Cancel.
+
+**Allowed surface classes:** `session-auth-client`, `session-auth-admin`.
+
+## 5. `wizard`
+
+**Definition:** Multi-step flow with forward/back progress. Onboarding, guided intake, multi-page checkout.
+
+**Examples:** `/portal/onboarding`, `/admin/engagements/new`.
+
+**Chrome contract:**
+
+- Header: minimal band. **Progress indicator ("Step N of M")** centered or left-aligned within the header band, not below.
+- **Previous + Next** buttons in a sticky or in-flow action block. Previous disabled on step 1; Next disabled until current step validates.
+- **Cancel** at far-left of action block or in overflow menu. Triggers confirm modal.
+- **No breadcrumbs.**
+- **No back button in header** — the Previous button is the back affordance within the wizard.
+
+**Allowed surface classes:** `session-auth-client`, `session-auth-admin`.
+
+## 6. `empty`
+
+**Definition:** Default view of a list or detail when there's nothing to show. First-time state.
+
+**Examples:** "You have no invoices yet."
+
+**Chrome contract:**
+
+- Inherits from the parent archetype's header (list or detail).
+- **Body:** centered illustration (solid shape, not real image), one-line message, single primary CTA (e.g., "Add your first client").
+- **No marketing copy.** No testimonials, no feature tour.
+
+**Allowed surface classes:** all four.
+
+## 7. `error`
+
+**Definition:** 404, 500, 401, validation-failure fallback screens.
+
+**Examples:** `/404`, `/500`, session-expired redirect target.
+
+**Chrome contract:**
+
+- **Header:** minimal band; no back button (the user's state is broken — don't trust their history).
+- **Body:** error type, short explanation, single primary action that returns to safety.
+  - For authenticated surfaces: "Go to home" linking to the surface class's dashboard.
+  - For public surfaces: "Go to home" linking to `/`.
+  - For token-auth: "Contact Scott" link.
+- **No support form embedded.** Link to a contact method, don't host the form on the error page.
+
+**Allowed surface classes:** all four.
+
+## 8. `modal`
+
+**Definition:** Overlay for confirmations, pickers, short-form interactions. Focused on a single decision.
+
+**Examples:** "Are you sure?" confirms, date pickers, file upload dialogs.
+
+**Chrome contract:**
+
+- `<dialog>` or `role="dialog"` with `aria-modal="true"` and a focused `aria-labelledby` title.
+- Close affordances: **Esc, click-outside on scrim, and an X button in the top-right**. All three work.
+- Focus returns to the triggering element on close.
+- **No navigation inside a modal.** Not a nav tab bar, not a breadcrumb.
+- Scrim: `bg-black/50` (50% opacity black).
+
+**Allowed surface classes:** all four.
+
+## 9. `drawer`
+
+**Definition:** Side panel for secondary actions, filters, or in-context help. Slides in from the edge.
+
+**Examples:** Filter panel on a list, notification panel on dashboard.
+
+**Chrome contract:**
+
+- Same open/close rules as modal (Esc, click-outside, X button).
+- Slide direction: right-side on desktop, bottom-sheet on mobile.
+- **Never contains primary navigation** (no "Dashboard | Billing | Docs" menu in a drawer — that's a disguised nav tab).
+- Width on desktop: 400px standard, max 600px.
+- Height on mobile: 80vh max; draggable header area.
+
+**Allowed surface classes:** all four.
+
+## Lookup table (machine-readable)
+
+| Archetype | Back                | Breadcrumbs (portal) | Breadcrumbs (admin) | Right rail allowed |
+| --------- | ------------------- | -------------------- | ------------------- | ------------------ |
+| dashboard | no                  | no                   | no                  | yes (desktop)      |
+| list      | yes                 | no                   | yes (2 levels)      | no                 |
+| detail    | yes                 | no                   | yes (3 levels)      | yes (desktop)      |
+| form      | cancel+save         | no                   | no                  | no                 |
+| wizard    | prev/next           | no                   | no                  | no                 |
+| empty     | inherit from parent | inherit              | inherit             | inherit            |
+| error     | no                  | no                   | no                  | no                 |
+| modal     | close button        | no                   | no                  | no                 |
+| drawer    | close button        | no                   | no                  | no                 |
+
+Anti-pattern shorthand: **breadcrumbs are never rendered on portal, period.** Admin breadcrumbs are for list and detail only, and capped at the item's hierarchical depth.

--- a/.agents/skills/nav-spec/references/chrome-component-contracts.md
+++ b/.agents/skills/nav-spec/references/chrome-component-contracts.md
@@ -1,0 +1,200 @@
+# Chrome component contracts
+
+Each chrome piece has a DOM template and a Tailwind class template. Specs reference these contracts rather than redefining them per surface class. Deviations live in surface-class appendices.
+
+## Header band
+
+**DOM:**
+
+```html
+<header
+  role="banner"
+  class="sticky top-0 z-50 bg-white border-b border-[#E2E8F0] h-14 md:h-16 px-4 md:px-6 flex items-center justify-between"
+>
+  <div class="flex items-center">
+    <span class="text-[13px] leading-[18px] font-medium text-[#475569]"
+      ><!-- client/workspace name --></span
+    >
+  </div>
+  <div class="flex items-center gap-4">
+    <!-- optional: Text Scott SMS link, settings gear, etc. -->
+    <a href="sms:+..." class="text-[13px] leading-[18px] font-medium text-[#1E40AF]">Text Scott</a>
+  </div>
+</header>
+```
+
+**Rules:**
+
+- `sticky top-0`, never `fixed top-0`
+- `bg-white`, never translucent or `backdrop-blur-*`
+- Height: `h-14` (56px) on mobile, `h-16` (64px) on desktop via `md:h-16`
+- `border-b border-[#E2E8F0]` — exact hex, not `border-slate-200` (close but not exact)
+- Left: client name only. No logo. No icon. No decoration.
+- Right: optional single quick-action link. Never two. Never icons without labels.
+
+## Back affordance (detail archetypes)
+
+**DOM:**
+
+```html
+<a
+  href="/portal/invoices"
+  aria-label="All invoices"
+  class="inline-flex items-center gap-1 w-11 h-11 text-[#475569] hover:text-[#0F172A] focus-visible:ring-2 focus-visible:ring-[#3B82F6] focus-visible:ring-offset-2 rounded-lg"
+>
+  <span class="material-symbols-outlined">chevron_left</span>
+  <span class="text-[13px] font-medium">All invoices</span>
+</a>
+```
+
+**Rules:**
+
+- Single `<a>` or `<button>`. **Never wrap in `<nav>`.** Never use `aria-label="Breadcrumb"`.
+- Target: hardcoded canonical URL string. Never `#`, `javascript:`, or `history.back()`.
+- Tap target: 44×44 minimum (`w-11 h-11` = 44px).
+- Positioned below the header band, within the main content area, not inside the header itself (prevents crowding).
+- Label text: the destination's name ("All invoices", "Home", "Back to clients"). Not "Back" in isolation.
+
+## Breadcrumbs (admin only)
+
+**DOM:**
+
+```html
+<nav aria-label="Breadcrumb" class="mb-4">
+  <ol class="flex items-center gap-2 text-[13px] text-[#475569]">
+    <li><a href="/admin/clients" class="hover:text-[#0F172A]">Clients</a></li>
+    <li aria-hidden="true">
+      <span class="material-symbols-outlined text-base">chevron_right</span>
+    </li>
+    <li><a href="/admin/clients/123" class="hover:text-[#0F172A]">Delgado Plumbing</a></li>
+    <li aria-hidden="true">
+      <span class="material-symbols-outlined text-base">chevron_right</span>
+    </li>
+    <li><span aria-current="page" class="font-medium text-[#0F172A]">Audit log</span></li>
+  </ol>
+</nav>
+```
+
+**Rules:**
+
+- **Admin only.** Never on portal. Never on token-auth. Never on public.
+- 2 levels max on `list` archetype; 3 levels max on `detail` archetype.
+- Last item is the current page with `aria-current="page"`; rendered as a `<span>`, not an `<a>`.
+- Separator: `<chevron_right>` with `aria-hidden="true"`; never use `/` or `>` as text (screen readers will read them literally).
+- Truncation: each label capped at 24ch on mobile; full label on desktop. Use `text-overflow: ellipsis` via `truncate` class with explicit `max-w-[24ch]`.
+
+## Footer (public only)
+
+**DOM:**
+
+```html
+<footer class="bg-white border-t border-[#E2E8F0] mt-16">
+  <div
+    class="max-w-7xl mx-auto px-6 py-8 flex flex-col md:flex-row justify-between gap-4 text-[13px] text-[#475569]"
+  >
+    <span>© 2026 SMDurgan LLC. All rights reserved.</span>
+    <nav aria-label="Legal" class="flex gap-4">
+      <a href="/privacy" class="hover:text-[#0F172A]">Privacy</a>
+      <a href="/terms" class="hover:text-[#0F172A]">Terms</a>
+      <a href="/contact" class="hover:text-[#0F172A]">Contact</a>
+    </nav>
+  </div>
+</footer>
+```
+
+**Rules:**
+
+- **Public surface class only.** Never rendered on authenticated or token-auth surfaces.
+- Legal links in a `<nav aria-label="Legal">`. Not free-floating `<a>` elements.
+- Copyright on left, legal links on right (flex-row on desktop, flex-col on mobile with copyright first).
+
+## Skip-to-main link (all surfaces)
+
+**DOM:**
+
+```html
+<a
+  href="#main"
+  class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] bg-white px-4 py-2 rounded-lg border border-[#E2E8F0] text-[#1E40AF] font-medium"
+>
+  Skip to main content
+</a>
+```
+
+**Rules:**
+
+- First element inside `<body>`, before `<header>`.
+- Hidden visually by default (`sr-only`); revealed on keyboard focus (`focus:not-sr-only`).
+- Matching `id="main"` on the `<main>` element.
+
+## State classes (all interactive elements)
+
+```
+Default:     text-[#475569]
+Hover:       hover:text-[#0F172A]
+Active link: text-[#1E40AF]   + aria-current="page"
+Focus ring:  focus-visible:ring-2 focus-visible:ring-[#3B82F6] focus-visible:ring-offset-2
+Disabled:    disabled:text-[#94A3B8] disabled:cursor-not-allowed
+```
+
+Tap-target padding when the rendered element is visually smaller than 44px: wrap or pad to `w-11 h-11` (44×44) minimum, or use `p-3` (12px × 4 = 48px — works for 24px icons).
+
+## Right rail (detail, dashboard — desktop)
+
+**DOM:**
+
+```html
+<div class="flex flex-col lg:flex-row gap-8 lg:gap-12">
+  <div class="flex-1 lg:max-w-[75%]">
+    <!-- primary content -->
+  </div>
+  <aside class="w-full lg:w-[300px] lg:sticky lg:top-[80px] lg:self-start space-y-6">
+    <!-- consultant block, status, related links -->
+  </aside>
+</div>
+```
+
+**Rules:**
+
+- Desktop only (collapses to stacked on mobile via `flex-col lg:flex-row`).
+- Width: ~300px fixed or 25% max of container.
+- `<aside>` element, not `<div>` — semantic.
+- `lg:sticky lg:top-[80px]` so the rail stays visible under the sticky header (header is 64px + 16px buffer = 80px top offset).
+
+## Consultant block (portal surfaces)
+
+**DOM:**
+
+```html
+<section class="bg-white border border-[#E2E8F0] rounded-lg p-6 flex items-start gap-4">
+  <div
+    class="w-12 h-12 rounded-full bg-[#1E40AF] text-white flex items-center justify-center font-semibold"
+    aria-hidden="true"
+  >
+    SD
+  </div>
+  <div class="flex-1">
+    <h3 class="text-base font-semibold text-[#0F172A]">Scott Durgan</h3>
+    <p class="text-sm text-[#475569]">Primary consultant</p>
+    <a
+      href="sms:+..."
+      class="mt-2 inline-flex items-center gap-1 text-sm font-medium text-[#1E40AF]"
+    >
+      <span class="material-symbols-outlined text-base">chat</span>
+      Text Scott
+    </a>
+  </div>
+</section>
+```
+
+**Rules:**
+
+- Photo placeholder: solid-color circle with white initials. Never a real photo. Never an illustration of a person.
+- Color: primary hex; or per-appendix override.
+- Initials: 2 letters max, capitalized.
+
+## Mobile-desktop transform
+
+For each chrome piece above, the mobile ↔ desktop transform is explicit via Tailwind's responsive modifiers. The convention across this skill: **`md:` is the only breakpoint used for chrome transforms**. That's 768px. Avoid `lg:` (1024px) and `sm:` (640px) for chrome — they are allowed for content layout but not for chrome structure.
+
+Violating this creates the "breakpoint fragmentation" flagged in the ss-console drift audit.

--- a/.agents/skills/nav-spec/references/classification-rubric.md
+++ b/.agents/skills/nav-spec/references/classification-rubric.md
@@ -1,0 +1,138 @@
+# Classification rubric
+
+Every Stitch generation must carry three tags: `surface=`, `archetype=`, `viewport=`. The pipeline fails fast if any is missing. This rubric is the manual lookup for users constructing prompts; it is not a runtime classifier.
+
+## Tag format
+
+Case-sensitive. Lowercase values. Hyphens, not underscores.
+
+```
+surface=<public|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer>
+viewport=<mobile|desktop>
+```
+
+Example prompt prefix:
+
+```
+/stitch-design target=portal-invoice-detail surface=session-auth-client archetype=detail viewport=mobile
+```
+
+## Decision tree — surface class
+
+Answer the question at each node:
+
+1. **Is the URL publicly linkable without auth?**
+   - Yes → node 2.
+   - No → node 3.
+
+2. **Does the URL contain a signed token or opaque identifier as a path segment (e.g., `/portal/proposals/[token]`, `/invoice/[id]`)?**
+   - Yes → `token-auth`.
+   - No → `public`.
+
+3. **Does the route require admin role?**
+   - Yes → `session-auth-admin`.
+   - No → `session-auth-client`.
+
+## Decision tree — archetype
+
+1. **Is this the landing for an authenticated surface class (a "home")?**
+   - Yes → `dashboard`.
+   - No → node 2.
+
+2. **Does the page show a list of items?**
+   - Yes → `list`.
+   - No → node 3.
+
+3. **Does the page show a single item's details?**
+   - Yes → `detail`.
+   - No → node 4.
+
+4. **Is the page an input form for creating/editing one entity?**
+   - Yes, single-page → `form`.
+   - Yes, multi-step → `wizard`.
+   - No → node 5.
+
+5. **Is this an overlay or panel?**
+   - Overlay centered on the page → `modal`.
+   - Slide-in from an edge → `drawer`.
+   - No → node 6.
+
+6. **Is this an error or empty state?**
+   - Error (404/500/401/etc.) → `error`.
+   - Empty-list or empty-detail → `empty`.
+   - Otherwise → STOP and consider if a new archetype is needed. Run `/nav-spec --revise --add-archetype`.
+
+## Decision tree — viewport
+
+Two values only: `mobile` (390×844 reference) and `desktop` (1280 reference).
+
+- If the user prompt specifies a viewport → use it.
+- If not → ask the user. Do not default to one. Explicit classification forces mobile-first thinking.
+
+For pages that need both viewports, run two generations with different viewport tags — that's the intended workflow, not a single "responsive" generation.
+
+## Disambiguation — common edge cases
+
+### A "detail" page that also includes an inline form
+
+**Example:** `/portal/invoices/[id]` shows the invoice detail AND has a Pay button that opens payment fields inline (no navigation).
+
+**Classification:** `detail`. The form is content, not the archetype. The back affordance and chrome follow detail rules.
+
+### A "list" page with a prominent filter drawer
+
+**Example:** `/admin/audit-log` with a filter panel that slides in from the right.
+
+**Classification:** `list` for the main page. `drawer` if generating the filter panel separately.
+
+### A page that's a dashboard + list
+
+**Example:** `/admin/home` shows metric cards and a recent-activity list.
+
+**Classification:** `dashboard`. A dashboard may contain lists as content; the archetype is determined by the page's role, not the widgets on it.
+
+### A public marketing page that has a form (contact form, signup)
+
+**Example:** `/contact` with a contact form.
+
+**Classification:** either `public` + `detail` (if the form is a content section on a larger page) OR `public` + `form` (if the form IS the page, like a dedicated contact page with nothing else). Use `form` when the form is the primary purpose.
+
+### A token-auth landing that redirects to a session-auth page after an action
+
+**Example:** `/portal/proposals/[token]` where accepting the proposal signs the client in.
+
+**Classification:** two different pages. `/portal/proposals/[token]` is `token-auth` + `detail`. The post-acceptance redirect target is `session-auth-client` + `dashboard` (or wherever it lands).
+
+### The same URL has different chrome for different user roles
+
+**Example:** `/invoice/[id]` — if the user is logged in, show session-auth chrome; if not, show token-auth chrome.
+
+**Classification:** run two generations, one for each surface class. The actual page implementation branches at render; the design specs for each path are independent.
+
+## Fallback when classification is ambiguous
+
+If the user's prompt is ambiguous, the pipeline response is:
+
+```
+Cannot classify target. Add these tags to your prompt:
+  surface=<public|token-auth|session-auth-client|session-auth-admin>
+  archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer>
+  viewport=<mobile|desktop>
+
+Run /nav-spec --classify-help to see the decision rubric.
+```
+
+Never guess. Never infer from natural language. Probabilistic classification is exactly the drift the whole system is designed to prevent.
+
+## Test cases (for validator developers)
+
+| Prompt                                                | Correct classification                                                                                |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| "Portal home dashboard, mobile"                       | `surface=session-auth-client archetype=dashboard viewport=mobile`                                     |
+| "Invoice detail page, mobile" (authenticated context) | `surface=session-auth-client archetype=detail viewport=mobile`                                        |
+| "Public-facing invoice link via email" (deep-link)    | `surface=token-auth archetype=detail viewport=<ask>`                                                  |
+| "Admin clients list"                                  | `surface=session-auth-admin archetype=list viewport=<ask>`                                            |
+| "New engagement intake wizard"                        | `surface=session-auth-admin archetype=wizard viewport=<ask>`                                          |
+| "Marketing home page"                                 | `surface=public archetype=dashboard viewport=<ask>` (`dashboard` because it's the landing for public) |
+| "404 page"                                            | `surface=<depends on which subdomain> archetype=error viewport=<ask>`                                 |

--- a/.agents/skills/nav-spec/references/injection-snippet-template.md
+++ b/.agents/skills/nav-spec/references/injection-snippet-template.md
@@ -1,0 +1,76 @@
+# Injection snippet template
+
+Canonical NAV CONTRACT block pasted between DESIGN SYSTEM and PAGE STRUCTURE in every `stitch-design` prompt. Token budget: ≤600 tokens (measured: ~450 in the ss-console ref implementation).
+
+## Template
+
+Placeholders in `<angle brackets>` are substituted at prompt-enhancement time from the classification tags and the appendix lookup.
+
+```
+NAV CONTRACT (REQUIRED — do not invent beyond this block):
+
+Surface class: <surface-class> (<one-line description from spec>).
+Archetype: <archetype>.
+Viewport: <viewport description, e.g., "mobile 390x844" or "desktop 1280px">.
+
+Chrome allowed (inclusive list; render nothing outside this list):
+<Chrome-allowed list for this {surface-class, archetype, viewport} combination, from the appendix>
+
+Chrome FORBIDDEN (do not render any of these, under any interpretation of PAGE STRUCTURE):
+<Chrome-forbidden list from anti-patterns, filtered to this surface class>
+
+State colors (exact hex, do not approximate):
+- Active link: <hex> | Default: <hex> | Hover: <hex>
+- Focus ring: 2px <hex> at 2px offset, keyboard-focus only
+- Disabled: <hex> | Tap target minimum: 44x44px
+- aria-current="page" on active nav item if nav is rendered
+
+Transition contract:
+<Back target URL (if archetype is detail/list/form/wizard/empty/error — hardcoded canonical URL, not "#" or history.back()).>
+<Modal close rules (if archetype is modal/drawer — Esc + click-outside close; focus returns to trigger).>
+
+A11y floor:
+- <header role="banner">, <main role="main">
+- Skip-to-main link sr-only until focused, at top of body
+- Keyboard order matches visual order
+- aria-label on every icon-only button
+- Focus rings on keyboard focus only; no always-on rings
+
+Semantic precision (observed drift targets from Phase 0):
+- Header is `sticky top-0`, NOT `fixed top-0`. Fixed breaks mobile document flow.
+- Header background is solid `bg-white`. No `backdrop-blur-*`, no translucent overlays.
+- Client name stands alone. No preceding icon, emoji, SVG, or material symbol.
+- Back affordance is a single `<a>` or `<button>`. Do NOT wrap in `<nav>`. Do NOT use `aria-label="Breadcrumb"`.
+- Back button `href` is a hardcoded canonical URL string. Never `#`, `javascript:`, or `history.back()`.
+
+If any element of the above conflicts with PAGE STRUCTURE below, THIS BLOCK WINS. PAGE STRUCTURE describes content; NAV CONTRACT describes chrome. When in doubt, remove chrome rather than add it.
+```
+
+## Substitution rules at prompt-enhancement time
+
+`stitch-design`'s patched pipeline does these lookups:
+
+1. Read classification tags from the user prompt: `surface=X archetype=Y viewport=Z`.
+2. Open `.stitch/NAVIGATION.md`.
+3. Extract:
+   - Surface-class one-line description → `<surface-class description>`
+   - Chrome-allowed list: start from parent section 4, filter/override with the matching appendix's `chrome-allowed` delta, filter again by archetype
+   - Chrome-forbidden list: start from section 8 (anti-patterns for all classes), filter with appendix deltas
+   - State hex values: section 6
+   - Transition contract: section 7, filtered by archetype
+4. Assemble the NAV CONTRACT block by filling in placeholders.
+5. Inject between DESIGN SYSTEM and PAGE STRUCTURE in the final prompt.
+
+Concatenation, not templating. Keep the assembly logic simple.
+
+## Size budget tracking
+
+For each `{surface-class} × {archetype} × {viewport}` combo, measure the assembled block size. Record in the NAVIGATION.md front matter or in a companion file. If any combo exceeds 600 tokens, shorten the surface-class appendix rather than the semantic-precision section — the latter is load-bearing per Phase 0 measurements.
+
+## Versioning and compatibility
+
+The semantic-precision section is the most volatile — as Stitch's model evolves, new drift targets appear and old ones become unnecessary. Bump the spec-version when this section materially changes. The rest of the template is stable.
+
+## Reference implementation
+
+The 2026-04-15 ss-console run used a ~450-token version of this template for Phase 0. See `/tmp/phase0-injection-snippet.txt` (archived to `examples/phase-0-compliance-report.md`). The major delta between that version and this template is the addition of the "Semantic precision (observed drift targets)" section — added directly in response to the Phase 0 strict-compliance violations.

--- a/.agents/skills/nav-spec/validate.py
+++ b/.agents/skills/nav-spec/validate.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""validate.py — post-generation navigation validator.
+
+Input: an HTML file path + classification tags.
+Output: JSON violation report on stdout. Exit 0 = pass, 1 = violations found.
+
+Invoked by the patched stitch-design pipeline after every generation. Also
+callable standalone for debugging.
+
+Usage:
+  python3 validate.py --file /path/to/generated.html \
+      --surface session-auth-client \
+      --archetype detail \
+      --viewport mobile
+
+The rubric is hard-coded here rather than pulled from NAVIGATION.md — the spec
+describes intent; this script is the enforcement shape. If rules need tuning,
+edit this file (and bump the spec-version that consumes it).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Violation:
+    rule: str
+    selector: str
+    severity: str  # "cosmetic" | "semantic" | "structural"
+    message: str
+    fix: str
+
+
+SURFACE_AUTHENTICATED = {"session-auth-client", "session-auth-admin", "token-auth"}
+SURFACE_ALL = SURFACE_AUTHENTICATED | {"public", "auth-gate"}
+
+# Token-acceptance forms — the spec (Section 4, Section 6) accepts any of these
+# as equivalent expressions of a color token. Validator checks should not falsely
+# flag one form when another is required; all three resolve to the same hex via
+# the project's `@theme` block in global.css.
+#
+# Extend this map per token when new tokens are added. See NAVIGATION.md §4.
+TOKEN_EQUIVALENCES = {
+    "border": {
+        "literal": {"#e2e8f0", "#E2E8F0"},
+        "var": "var(--color-border)",
+        "tailwind": "slate-200",
+    },
+    "text-default": {
+        "literal": {"#475569"},
+        "var": "var(--color-text-secondary)",
+        "tailwind": "slate-600",
+    },
+    "text-bold": {
+        "literal": {"#0f172a", "#0F172A"},
+        "var": "var(--color-text-primary)",
+        "tailwind": "slate-900",
+    },
+    "primary": {
+        "literal": {"#1e40af", "#1E40AF"},
+        "var": "var(--color-primary)",
+        "tailwind": "blue-800",
+    },
+    "focus": {
+        "literal": {"#3b82f6", "#3B82F6"},
+        "var": "var(--color-action)",
+        "tailwind": "blue-500",
+    },
+    "disabled": {
+        "literal": {"#94a3b8", "#94A3B8"},
+        "var": "var(--color-text-muted)",
+        "tailwind": "slate-400",
+    },
+}
+
+
+def accepts_border_token(class_str: str) -> bool:
+    """Return True if the class string contains any accepted form of the border token."""
+    if any(h in class_str for h in TOKEN_EQUIVALENCES["border"]["literal"]):
+        return True
+    if TOKEN_EQUIVALENCES["border"]["var"] in class_str:
+        return True
+    if f"border-{TOKEN_EQUIVALENCES['border']['tailwind']}" in class_str:
+        return True
+    return False
+
+# Load HTML as text; we regex it rather than require beautifulsoup4.
+# Accept a small tolerance for Tailwind class-list ordering.
+
+
+def find_header_block(html: str) -> tuple[str, str] | None:
+    """Return (full tag, class attribute) of the first <header> element, or None."""
+    m = re.search(r"<header\b([^>]*)>", html, re.IGNORECASE)
+    if not m:
+        return None
+    attrs = m.group(1)
+    cls = re.search(r'class="([^"]*)"', attrs)
+    return (m.group(0), cls.group(1) if cls else "")
+
+
+def check(html: str, surface: str, archetype: str, viewport: str) -> list[Violation]:
+    violations: list[Violation] = []
+
+    header = find_header_block(html)
+
+    # R1 — Header sticky, not fixed
+    if header:
+        _, hclass = header
+        if re.search(r'\bfixed\s+top-0\b|\bfixed\b(?=[^"]*\btop-0\b)', hclass):
+            violations.append(Violation(
+                rule="R1",
+                selector="<header>",
+                severity="semantic",
+                message="Header uses `fixed top-0` instead of `sticky top-0`.",
+                fix="Replace `fixed top-0` with `sticky top-0`. Fixed removes the header from document flow.",
+            ))
+
+    # R2 — Solid header bg (no backdrop-blur, no opacity, no non-white hex)
+    if header and surface != "public":
+        _, hclass = header
+        if re.search(r"backdrop-blur-", hclass):
+            violations.append(Violation(
+                rule="R2",
+                selector="<header>",
+                severity="cosmetic",
+                message="Header uses `backdrop-blur-*` (glassmorphism).",
+                fix="Replace with solid `bg-white`.",
+            ))
+        # bg-white/85, bg-slate-900/50, etc. (opacity modifiers)
+        if re.search(r"bg-[a-z0-9\-]+/\d+", hclass):
+            violations.append(Violation(
+                rule="R2b",
+                selector="<header>",
+                severity="cosmetic",
+                message="Header background uses opacity modifier (e.g., `bg-white/85`).",
+                fix="Use solid `bg-white` (no opacity suffix).",
+            ))
+
+    # R3 — Client name stands alone (no icon/svg decoration BEFORE the first
+    # text-bearing element in the header). Icons that appear AFTER the client
+    # name text — e.g., the three-icon contact control on the right — are fine.
+    if header and surface in SURFACE_AUTHENTICATED:
+        hstart = html.find("<header")
+        hend = html.find("</header>", hstart) if hstart >= 0 else -1
+        if hstart >= 0 and hend > hstart:
+            hinner = html[hstart:hend]
+            # Find the first element that renders visible text. We look for
+            # the first `>` followed by (optional whitespace) letters. This
+            # skips past element tags to find the first text node.
+            first_text_match = re.search(r">\s*([A-Za-z][^<]{2,})<", hinner)
+            first_text_pos = first_text_match.start() if first_text_match else len(hinner)
+            # Look for material-symbols or img/svg BEFORE that first text element
+            prefix = hinner[:first_text_pos]
+            if re.search(r'<span[^>]*class="[^"]*material-symbols-[a-z]+', prefix) \
+               or re.search(r"<svg\b", prefix) \
+               or re.search(r"<img\b", prefix):
+                violations.append(Violation(
+                    rule="R3",
+                    selector="<header> first child (before client name)",
+                    severity="cosmetic",
+                    message="Header contains an icon, image, or SVG decoration before the client name text.",
+                    fix="Remove the decorative element. Client name stands alone; contact icons or actions belong after the name, on the right.",
+                ))
+
+    # R4 — Back not wrapped in <nav aria-label="Breadcrumb">
+    # Find all such navs; check if any contain exactly one link
+    breadcrumb_navs = re.findall(
+        r'<nav[^>]+aria-label="Breadcrumb"[^>]*>(.*?)</nav>',
+        html,
+        re.DOTALL | re.IGNORECASE,
+    )
+    for nav_inner in breadcrumb_navs:
+        # Count visible <a> or <button> children
+        count = len(re.findall(r"<a\b|<button\b", nav_inner))
+        # A true breadcrumb has multiple levels; a single link wrapped is a violation
+        # Allow if this surface-class/archetype permits breadcrumbs (admin list/detail)
+        allows_breadcrumbs = (surface == "session-auth-admin" and archetype in {"list", "detail"})
+        if not allows_breadcrumbs and count >= 1:
+            violations.append(Violation(
+                rule="R4",
+                selector='<nav aria-label="Breadcrumb">',
+                severity="semantic",
+                message="Back affordance is wrapped in a breadcrumb nav element on a surface where breadcrumbs are forbidden.",
+                fix="Unwrap. Use a single `<a>` or `<button>` with `aria-label` describing the target.",
+            ))
+        elif allows_breadcrumbs and count == 1:
+            violations.append(Violation(
+                rule="R4b",
+                selector='<nav aria-label="Breadcrumb">',
+                severity="semantic",
+                message="Breadcrumb nav wraps a single link — this is a back button, not a breadcrumb trail.",
+                fix="Unwrap. Breadcrumbs require multiple levels.",
+            ))
+
+    # R5 — Back href is a canonical URL
+    # On detail archetypes, find the back-chevron anchor and check its href.
+    if archetype == "detail":
+        # Look for <a> elements containing chevron_left / arrow_back icons
+        back_anchors = re.findall(
+            r'<a[^>]+href="([^"]*)"[^>]*>.*?(?:chevron_left|arrow_back).*?</a>',
+            html,
+            re.DOTALL,
+        )
+        for href in back_anchors:
+            if href.strip() in {"#", "javascript:void(0)", "javascript:"}:
+                violations.append(Violation(
+                    rule="R5",
+                    selector=f'<a href="{href}">',
+                    severity="semantic",
+                    message=f"Back link uses placeholder `href=\"{href}\"`.",
+                    fix="Use a hardcoded canonical URL string (e.g., `/portal/invoices`, `/portal/home`). Never `#`, `javascript:`, or `history.back()`.",
+                ))
+        # Also detect onclick=history.back
+        if re.search(r"onclick=\"history\.back\(\)\"", html):
+            violations.append(Violation(
+                rule="R5b",
+                selector="onclick=history.back()",
+                severity="semantic",
+                message="Back affordance uses `history.back()`.",
+                fix="Replace with hardcoded canonical URL in href. Deep-links have no history to go back to.",
+            ))
+
+    # R6 — No global nav tabs in header (more than 2 nav-like links or a tablist)
+    # Admin surface class has a ratified exception (Appendix D.2); skip R6/R6b for admin.
+    if header and surface != "session-auth-admin":
+        hstart = html.find("<header")
+        hend = html.find("</header>", hstart) if hstart >= 0 else -1
+        if hstart >= 0 and hend > hstart:
+            hinner = html[hstart:hend]
+            if re.search(r'role="tablist"|role="tab"', hinner):
+                violations.append(Violation(
+                    rule="R6",
+                    selector="<header> (role=tablist/tab)",
+                    severity="structural",
+                    message="Header contains tablist/tab roles — global nav tabs are forbidden.",
+                    fix="Remove. Secondary navigation lives below the header as a section, not in the header.",
+                ))
+            # Count <a> with text children (rough nav-tab heuristic)
+            anchors = re.findall(r"<a\b[^>]*>([^<]+)</a>", hinner)
+            nav_like = [a for a in anchors if a.strip() and len(a.strip().split()) <= 3]
+            # Three-icon contact control (mailto/sms/tel) in portal and token-auth
+            # headers uses icon-only <a> elements — those have no text children and
+            # do not match this regex, so they don't trip R6b. If someone renders
+            # "Email" / "Text" / "Call" as text, we allow up to 3 short-text
+            # contact links (not tabs).
+            contact_verbs = {"email", "text", "call", "sms", "phone"}
+            contact_like = [a for a in nav_like if any(verb in a.strip().lower().split() for verb in contact_verbs)]
+            effective_tab_count = len(nav_like) - len(contact_like)
+            if effective_tab_count >= 3:
+                violations.append(Violation(
+                    rule="R6b",
+                    selector="<header> (3+ short-text links, excluding contact controls)",
+                    severity="structural",
+                    message=f"Header contains {effective_tab_count} short-text non-contact links — looks like a nav tab bar.",
+                    fix="Remove nav-tab-style links from header. Allowed: client name + optional contact channels (email/text/call) + 1 secondary action.",
+                ))
+
+    # R7 — No sticky-bottom action bars or bottom-tab nav
+    bottom_sticky = re.search(r'class="[^"]*\b(?:fixed|sticky)\s+bottom-0\b', html)
+    if bottom_sticky and surface in SURFACE_ALL:
+        # Allow only if inside a <dialog> or modal
+        surrounding = html[max(0, bottom_sticky.start() - 200):bottom_sticky.end()]
+        if "<dialog" not in surrounding and 'role="dialog"' not in surrounding:
+            violations.append(Violation(
+                rule="R7",
+                selector="element with `fixed bottom-0` or `sticky bottom-0`",
+                severity="structural",
+                message="Sticky-bottom element outside a dialog (bottom-tab nav or duplicated action bar).",
+                fix="Remove. Primary action should be reachable above the fold via document-flow scrolling.",
+            ))
+
+    # R8 — No <footer> on authenticated surfaces
+    if surface in SURFACE_AUTHENTICATED:
+        if re.search(r"<footer\b", html):
+            violations.append(Violation(
+                rule="R8",
+                selector="<footer>",
+                severity="structural",
+                message="Footer rendered on authenticated surface.",
+                fix="Remove the footer. Authenticated surfaces do not carry legal/copyright rows.",
+            ))
+
+    # R9 — No real-face photo placeholders
+    real_face_srcs = re.findall(
+        r'<img[^>]+src="([^"]+)"',
+        html,
+    )
+    for src in real_face_srcs:
+        if (re.search(r"googleusercontent\.com/aida[-/]", src)
+                or "unsplash.com" in src
+                or "pexels.com" in src):
+            violations.append(Violation(
+                rule="R9",
+                selector=f'<img src="{src[:60]}...">',
+                severity="structural",
+                message="Image uses a real-face photo placeholder source.",
+                fix="Replace with a solid-color circle containing initials. Never a real face.",
+            ))
+            break  # one violation is enough to flag
+
+    # R10 — No marketing CTAs on authenticated surfaces
+    if surface in SURFACE_AUTHENTICATED:
+        marketing_patterns = [
+            r"\b(?:schedule|book)\s+(?:a\s+)?(?:call|demo|meeting|consultation)\b",
+            r"\bget\s+started\b",
+            r"\blearn\s+more\b",
+            r"\bsign\s+up\s+(?:now|today|free)\b",
+        ]
+        for pat in marketing_patterns:
+            if re.search(pat, html, re.IGNORECASE):
+                violations.append(Violation(
+                    rule="R10",
+                    selector=f"text match: {pat}",
+                    severity="structural",
+                    message="Marketing CTA copy on authenticated surface.",
+                    fix="Remove. The user is already a customer; no marketing CTAs.",
+                ))
+                break
+
+    # R11 — Header height matches viewport
+    if header:
+        _, hclass = header
+        expected_mobile = {"h-14", "h-[56px]"}
+        expected_desktop_any = {"h-16", "h-[64px]", "md:h-16", "md:h-[64px]"}
+        has_h_class = re.search(r"\bh-\[?\d+(?:px)?\]?\b", hclass) or re.search(r"\bmd:h-\[?\d+(?:px)?\]?\b", hclass)
+        if has_h_class:
+            if viewport == "mobile" and not any(cls in hclass for cls in expected_mobile):
+                # check for an exact match at least
+                if not re.search(r"\b(?:h-14|h-\[56px\])\b", hclass):
+                    violations.append(Violation(
+                        rule="R11",
+                        selector="<header>",
+                        severity="cosmetic",
+                        message="Header height does not match 56px (mobile).",
+                        fix="Use `h-14` (56px) on mobile.",
+                    ))
+            if viewport == "desktop" and not any(cls in hclass for cls in expected_desktop_any):
+                if not re.search(r"\b(?:h-16|h-\[64px\]|md:h-16|md:h-\[64px\])\b", hclass):
+                    violations.append(Violation(
+                        rule="R11",
+                        selector="<header>",
+                        severity="cosmetic",
+                        message="Header height does not match 64px (desktop).",
+                        fix="Use `h-16` (64px) or `md:h-16` on desktop.",
+                    ))
+
+    # R14 — Landmarks present
+    if not re.search(r"<header\b[^>]*role=\"banner\"|<header\b", html):
+        violations.append(Violation(
+            rule="R14a",
+            selector="<header>",
+            severity="semantic",
+            message="No <header> landmark element found.",
+            fix="Wrap the top band in `<header role=\"banner\">` (or rely on the implicit role).",
+        ))
+    if not re.search(r"<main\b", html):
+        violations.append(Violation(
+            rule="R14b",
+            selector="<main>",
+            severity="semantic",
+            message="No <main> landmark element found.",
+            fix="Wrap primary content in `<main role=\"main\">`.",
+        ))
+
+    # R15 — Skip-to-main link
+    # Accept any href pointing to the main landmark's id, as long as the link
+    # is sr-only-until-focused. Common ids: main, main-content, content,
+    # page-main. Attribute order (class= before href= vs after) varies; match
+    # either form.
+    skip_link_match = re.search(
+        r'<a\b(?=[^>]*\bclass="[^"]*sr-only)[^>]*\bhref="#([a-zA-Z][\w-]*)"',
+        html,
+    )
+    if not skip_link_match:
+        violations.append(Violation(
+            rule="R15",
+            selector="skip-to-main link",
+            severity="semantic",
+            message="No skip-to-main link detected (must be sr-only <a> linking to the main landmark).",
+            fix='Prepend `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>` before <header>. `<main>` must carry matching `id`.',
+        ))
+    else:
+        target_id = skip_link_match.group(1)
+        if not re.search(rf'<main\b[^>]*id="{re.escape(target_id)}"', html):
+            violations.append(Violation(
+                rule="R15b",
+                selector=f'<main id="{target_id}">',
+                severity="semantic",
+                message=f'Skip-link targets #{target_id} but no <main id="{target_id}"> exists.',
+                fix=f'Add `id="{target_id}"` to the <main> element.',
+            ))
+
+    return violations
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--file", required=True)
+    ap.add_argument("--surface", required=True,
+                    choices=["public", "auth-gate", "token-auth", "session-auth-client", "session-auth-admin"])
+    ap.add_argument("--archetype", required=True,
+                    choices=["dashboard", "list", "detail", "form", "wizard", "empty", "error", "modal", "drawer"])
+    ap.add_argument("--viewport", required=True, choices=["mobile", "desktop"])
+    args = ap.parse_args()
+
+    try:
+        with open(args.file, "r", encoding="utf-8") as f:
+            html = f.read()
+    except FileNotFoundError:
+        print(json.dumps({"error": f"File not found: {args.file}"}), file=sys.stderr)
+        return 1
+    except OSError as e:
+        print(json.dumps({"error": f"Cannot read {args.file}: {e}"}), file=sys.stderr)
+        return 1
+
+    violations = check(html, args.surface, args.archetype, args.viewport)
+
+    report = {
+        "file": args.file,
+        "surface": args.surface,
+        "archetype": args.archetype,
+        "viewport": args.viewport,
+        "pass": len(violations) == 0,
+        "violation_count": len(violations),
+        "structural_count": sum(1 for v in violations if v.severity == "structural"),
+        "semantic_count": sum(1 for v in violations if v.severity == "semantic"),
+        "cosmetic_count": sum(1 for v in violations if v.severity == "cosmetic"),
+        "violations": [
+            {"rule": v.rule, "selector": v.selector, "severity": v.severity,
+             "message": v.message, "fix": v.fix}
+            for v in violations
+        ],
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/nav-spec/workflows/audit.md
+++ b/.agents/skills/nav-spec/workflows/audit.md
@@ -1,0 +1,50 @@
+---
+description: Run just the drift audit (Phase 2 of author). Produces a standalone drift report without drafting or modifying NAVIGATION.md. Useful for quarterly reviews and to answer "has drift crept back in?"
+---
+
+# Audit navigation drift
+
+Standalone workflow. Phases 1–2 of `author.md`, plus save to disk.
+
+## Steps
+
+1. Intake (same as author Phase 1 — abbreviated version is fine if a NAVIGATION.md already exists and we only need its `spec-version` for comparison).
+2. Scan live code and generated artifacts (same as author Phase 2).
+3. Emit the two matrices and the drift-summary bullets.
+4. If `.stitch/NAVIGATION.md` exists, add a third matrix: **Spec compliance** — does the live code match the spec? For each deviation, note whether it's a code-refactor follow-up or a spec-revision follow-up.
+5. Save to `.stitch/drift-audit-<YYYY-MM-DD>.md`.
+
+## Output template
+
+```markdown
+# Drift audit — <venture> — <YYYY-MM-DD>
+
+spec-version checked against: <N or "no spec">
+
+## Live code matrix
+
+<table>
+
+## Generated artifact matrix
+
+<table>
+
+## Spec compliance matrix (if NAVIGATION.md exists)
+
+| File | Rule violated | Severity (cosmetic/semantic/structural) | Action (code/spec) |
+
+## Drift summary (4-6 bullets)
+
+<the inconsistencies that matter>
+
+## Follow-ups
+
+<numbered list of actions, each with an owner and scope>
+```
+
+## When to run
+
+- **Quarterly** — catch slow drift.
+- **After a major surface addition** — new top-level area may need a new appendix.
+- **Before releasing a new design token set** — token changes cascade into state conventions.
+- **When a PR touches `src/layouts/*` or `src/components/**/_{Nav,Header}_`\*\* — gatekeep nav refactors.

--- a/.agents/skills/nav-spec/workflows/author.md
+++ b/.agents/skills/nav-spec/workflows/author.md
@@ -1,0 +1,249 @@
+---
+description: Produce `.stitch/NAVIGATION.md` from scratch for a venture. Eight phases plus a final write-back to consuming skills.
+---
+
+# Author NAVIGATION.md
+
+Full-fidelity authoring workflow. Run this once per venture; thereafter use [revise.md](revise.md) for updates and [audit.md](audit.md) for drift checks.
+
+## Phase 1 — Intake
+
+Gather context before drafting:
+
+1. Resolve venture code from the current repo via `crane_ventures`. Read `stitchProjectId`. If null, stop — see SKILL.md fail-fast.
+2. Scan `src/pages/` to detect surface classes present in this venture. Record the path inventory (e.g., `/portal/*` → session-auth-client, `/portal/proposals/[token]` → token-auth, `/admin/*` → session-auth-admin, `/` + other top-level `.astro` → public).
+3. Check `.stitch/DESIGN.md`. If absent, warn; pull token inventory from `src/styles/*` or `tailwind.config.*` instead. Capture: primary hex, default text hex, bold text hex, border hex, focus hex, disabled hex, family names, rounding scale.
+4. Load the venture's `CLAUDE.md` for voice and anti-pattern rules relevant to chrome (e.g., "no marketing chrome on authenticated surfaces").
+5. Reference Phase 0 compliance report if present at `examples/phase-0-compliance-report.md`. If not, the user should run `phase-0-compliance-test.md` before proceeding. This informs which residual violations the validator must catch.
+
+Display an **Intake Summary** table:
+
+| Field                     | Value                                    |
+| ------------------------- | ---------------------------------------- |
+| Venture                   | _code + name_                            |
+| Stitch project            | _ID_                                     |
+| Surface classes present   | _list_                                   |
+| Tokens source             | _path_                                   |
+| DESIGN.md status          | _present / absent_                       |
+| Phase 0 compliance        | _% strict / % categorical, or "not run"_ |
+| Shipped chrome components | _list paths_                             |
+
+Ask: **"Does this capture the intake? Anything to correct before I audit?"** Wait for confirmation.
+
+## Phase 2 — Drift audit
+
+Run a comprehensive scan to ground the spec in reality. Emit an in-memory `drift-report.md` (not saved unless `audit` workflow was invoked standalone). Target paths:
+
+- `src/layouts/*.astro` — every layout file; record header structure, footer, any nav.
+- `src/components/**/*{Nav,Header,Footer,Sidebar,Layout}*.astro` — shared chrome components.
+- `src/pages/**/*.astro` — spot-check; note pages that bypass the layout and render their own chrome.
+- `.stitch/designs/**/*.html` — prior Stitch output; record chrome per file.
+
+Output two matrices:
+
+**Live code matrix:**
+| File | Primary chrome | Back/breadcrumb | Auth level | Mobile pattern | Uses shared layout? |
+
+**Generated artifact matrix:**
+| File | Primary chrome | Back/breadcrumb | Auth level implied | Mobile pattern |
+
+Then a 4–6 bullet **Drift summary** — the specific inconsistencies that will inform spec decisions. This is ammunition, not comprehensiveness.
+
+## Phase 3 — Draft v1
+
+Write `.stitch/NAVIGATION.md`. Use the canonical structure:
+
+```markdown
+---
+spec-version: 1
+design-md-sha: <SHA of DESIGN.md, or "absent">
+stitch-project-id: <ID>
+phase-0-compliance: { strict: '%', categorical: '%', date: 'YYYY-MM-DD' }
+---
+
+# <Venture> — Navigation Specification
+
+## 1. Information architecture
+
+### Sitemap
+
+<paths grouped by surface class>
+
+### Auth boundary table
+
+| Surface class | Auth model | Base URL | Session cookie | Redirect on logout |
+
+### Deep-link inventory
+
+<every URL that can be reached from outside the app: tokens, emails, SMS>
+
+## 2. Surface-class taxonomy
+
+<the four classes with one-sentence definitions and ss-console examples>
+
+## 3. Screen archetype taxonomy
+
+<9 archetypes — one-sentence definition + which surface classes can produce one>
+
+## 4. Chrome component contracts
+
+### Header band
+
+<DOM structure, Tailwind class template, state behavior, explicit "sticky not fixed" rule>
+
+### Back affordance
+
+<a single `<a>` or `<button>`, never wrapped in `<nav>`, hardcoded href, 44x44px tap target>
+
+### Breadcrumbs
+
+<allowed only on admin detail pages, format, active-state rule>
+
+### Mobile nav / skip link
+
+<no bottom-tab nav anywhere; skip-to-main on every surface>
+
+### Footer
+
+<allowed only on public; structure; legal link format>
+
+## 5. Mobile ↔ desktop transforms (per surface class)
+
+<explicit breakpoint: 768px. Height transforms: 56 → 64. Right-rail placement on detail at desktop.>
+
+## 6. State conventions
+
+Active: #<hex> | Default: #<hex> | Hover: #<hex> | Focus: 2px #<hex> @ 2px offset | Disabled: #<hex> | Tap target: 44x44px minimum
+
+## 7. Transition contracts
+
+<back-target is canonical absolute URL; modal Esc + click-outside; cross-auth-boundary = full page reload>
+
+## 8. Anti-patterns (forbidden chrome)
+
+<one bulleted list per surface class of what is forbidden and why>
+
+## 9. Accessibility floor
+
+<landmarks: banner/main/nav; skip-to-main; aria-current; focus rings with hex; semantic headings>
+
+## 10. Content rules
+
+<label style — sentence case or Title Case; truncation at 24ch on mobile breadcrumbs; icon+label pairing>
+
+## Appendix A — public
+
+## Appendix B — token-auth
+
+## Appendix C — session-auth-client
+
+## Appendix D — session-auth-admin
+```
+
+Each appendix restates only the deltas from the parent spec: chrome allowed/forbidden deltas, mobile transform deltas, state color deltas (if the surface class uses a different palette).
+
+Save the draft. Show a diff-summary of what was generated.
+
+## Phase 4 — Parallel three-reviewer pass
+
+Spawn three agents in a single message via the Task tool using `subagent_type: general-purpose`. Each reviewer gets the draft v1 plus the drift report plus the venture's CLAUDE.md.
+
+### IA architect reviewer
+
+> You are a senior IA architect who has designed navigation systems at Figma, Linear, and Stripe. You are reviewing a venture's navigation spec for completeness and rigor.
+
+**Focus:** sitemap coverage, auth boundary table correctness, archetype taxonomy completeness (any missing surfaces in src/pages/ that don't map to an archetype?), deep-link inventory completeness, back-target canonicalness, cross-auth-boundary rule clarity, versioning protocol sanity. Flag anywhere the spec hand-waves a cross-surface decision. Flag any archetype that has no nav contract assigned.
+
+### Mobile specialist reviewer
+
+> You are a senior mobile UX specialist. You care about thumb zones, tap targets, no-hover rules, and breakpoint consistency. You've shipped mobile design systems that scaled.
+
+**Focus:** mobile → desktop transform rules, breakpoint value ("768px" vs "md:" vs "lg:" — is the spec's break-point the same as the code?), tap target 44x44px enforcement, no-hover rule for touch, viewport-specific chrome differences (e.g., does the back button move? Does the Text Scott link appear on desktop?), sticky-vs-fixed resolution. Flag any spec that assumes responsive-by-magic.
+
+### Implementation reviewer
+
+> You are a senior Astro+Tailwind engineer reviewing a proposed chrome contract against the venture's existing component shapes. You think about class lists, semantic HTML, keyboard traversal, and whether a contract can be implemented without refactoring working components.
+
+**Focus:** diff the proposed chrome contracts against `Nav.astro`, `PortalHeader.astro`, `AdminLayout.astro` (or venture equivalents). For each contract, answer: "Can this be implemented in the existing component? If not, what's the refactor scope?" Fold a11y into this review — check landmarks (`<header role="banner">`, `<main role="main">`), focus ring class lists, skip-to-main presence, icon-only button labels. Flag any contract that would require a component rewrite — the user may choose to align the spec instead.
+
+### Output format (all three)
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Suggested wording
+<concrete paragraphs to drop into the spec>
+
+## Decisions needed from user
+<items requiring human judgment>
+```
+
+**IMPORTANT:** launch all three in a single message to run in parallel.
+
+## Phase 5 — Decision checkpoints
+
+Surface the Decisions-needed items from the reviewers. Filter to the ones that actually change the spec — don't dump all 10; pick the 3–5 that matter. Present each as a short numbered list with your recommendation and rationale. Wait for the user's answers.
+
+Typical decisions:
+
+- "Admin spec says sidebar nav; live `AdminLayout.astro` uses top-nav tabs. Align spec to code, or flag code refactor?"
+- "Token-auth proposal landing: client-name in header or page title?"
+- "Portal detail pages: breadcrumbs or bare back button? (Plan says absent.)"
+- "Breakpoint: spec says 768px; live code uses both `md:` (768px) and `lg:` (1024px) inconsistently. Normalize to 768?"
+
+## Phase 6 — Final spec saved
+
+Apply reviewer fixes and user decisions. Save `.stitch/NAVIGATION.md`. Bump `spec-version` to 1 (first author). Show the user a summary of what shifted from v1 draft.
+
+## Phase 7 — Integration-check regeneration
+
+Pick a single existing surface (recommended: `portal-v1/home-mobile`). Regenerate it with the new injection snippet live. Diff the resulting chrome against the spec.
+
+- Extract HTML download URL from Stitch response
+- Download HTML
+- Run the validator (see [validate-navigation.md](validate-navigation.md))
+- Pass = validator reports zero violations against the home-mobile spec. Fail = do not proceed; tune the spec and repeat.
+
+This proves the spec is **self-consistent**. Phase 8 proves the spec **prevents drift**.
+
+## Phase 8 — Adversarial verification
+
+Pick three prompts the spec author has NOT seen during authoring. Good defaults (pick three, or customize):
+
+- `target=portal-settings surface=session-auth-client archetype=form viewport=mobile`
+- `target=admin-audit-log-detail surface=session-auth-admin archetype=detail viewport=desktop`
+- `target=marketing-blog-post surface=public archetype=detail viewport=desktop` (if the venture has blog pages)
+
+Generate each with injection. Run validator on each. Pass = validator reports zero violations against the spec's predicted chrome for each combo. Fail = taxonomy has a gap; return to Phase 4 with a focused reviewer on the gap.
+
+If the validator reports violations that reflect genuine ambiguity in the spec (not Stitch drift), the spec is incomplete — this is the right failure mode; fix the spec, not the generation.
+
+## Phase 9 — Write-back to consuming skills
+
+Only run this if the venture is the first to adopt `nav-spec` globally, i.e., the edits to `stitch-design` and `stitch-ux-brief` have not yet been shipped. Otherwise skip.
+
+This write-back is a **separate PR** from the skill authoring. Bounded-blast-radius rule: skill rollout and consumer-skill edits never land together.
+
+Edits required:
+
+- `~/.agents/skills/stitch-design/SKILL.md` — add pipeline step 1a (freshness check for NAVIGATION.md alongside DESIGN.md; if absent, warn and continue — graceful-degradation); step 1b (fail-fast check for `surface=`, `archetype=`, `viewport=` tags in the prompt); step 3 (injection of NAV CONTRACT block between DESIGN SYSTEM and PAGE STRUCTURE). All guarded by `hasNavigationMd` — if absent, skills behave as today.
+- `~/.agents/skills/stitch-design/workflows/text-to-design.md` and `workflows/edit-design.md` — reference the classification step.
+- `~/.agents/skills/stitch-design/examples/enhanced-prompt.md` — add a second example showing NAV CONTRACT injected.
+- `.agents/skills/stitch-ux-brief/SKILL.md` (per-venture; target the installed one for the venture in use) — Phase 1 soft check for NAVIGATION.md (warn if absent; do not fail — briefs still have value without a nav spec); Phase 7 concept-prompt template injects NAV CONTRACT; Phase 11 strip directive's "REMOVE IF PRESENT" list is generated from the spec's chrome-forbidden list; Phase 12 RUN-LOG.md records `spec-version`.
+
+Produce a PR with these edits on a separate branch. Title: `feat(stitch): integrate nav-spec — graceful degradation when NAVIGATION.md absent`.
+
+## Final output
+
+Tell the user:
+
+- Where `.stitch/NAVIGATION.md` lives
+- `spec-version` assigned
+- Integration-check and adversarial verification results
+- Whether the write-back PR was produced (or skipped because already landed)
+- Next step: run `/stitch-design` or `/stitch-ux-brief` — NAV CONTRACT is now injected automatically for any prompt carrying surface/archetype/viewport tags

--- a/.agents/skills/nav-spec/workflows/phase-0-compliance-test.md
+++ b/.agents/skills/nav-spec/workflows/phase-0-compliance-test.md
@@ -1,0 +1,94 @@
+---
+description: Empirical measurement of whether prompt injection is honored by Stitch. Must run before authoring the first NAVIGATION.md for a venture, or when Stitch's underlying model version changes.
+---
+
+# Phase 0 — Injection compliance test
+
+Measures compliance empirically. Informs whether injection alone is sufficient (rare) or whether a validator is required (always, given measurements to date).
+
+## Why this exists
+
+Per the critique in the originating plan file: LLM design generators have strong training priors. A constraint block is a hint, not a guarantee. Before committing to injection-first enforcement, measure reality. Skip this step and the first NAVIGATION.md ships to production on faith.
+
+## Protocol
+
+### Step 1 — Draft a minimal injection snippet
+
+A short, high-constraint version of the canonical NAV CONTRACT block. Target 400–500 tokens. Focus on the forbidden list, state hex values, and the "this block wins" override. See `references/injection-snippet-template.md` for the template; trim appendix-specific content for Phase 0.
+
+### Step 2 — Pick three representative prompts
+
+Pick one prompt per major surface/archetype combination the venture actually uses. For ss-console the canonical triad is:
+
+- `home-mobile` (portal home dashboard, 390×844)
+- `invoice-mobile` (portal invoice detail, 390×844)
+- `proposal-desktop` (portal proposal detail, 1280)
+
+Each prompt should include DESIGN SYSTEM and PAGE STRUCTURE sections, but NOT a nav spec — leave nav "open" the way Stitch has historically seen it.
+
+### Step 3 — Fire 6 generations in parallel
+
+Three base prompts × two variants (baseline vs injected) = 6 runs. Use the Stitch MCP if connected; curl fallback if not (see `stitch-ux-brief/SKILL.md` for the curl pattern — `https://stitch.googleapis.com/mcp`, `X-Goog-Api-Key` header, `STITCH_API_KEY` from Infisical `/vc` path).
+
+Python runner template at `/tmp/phase0-runner.py` (from the ss-console Phase 0 run). Adapt prompts and project ID.
+
+### Step 4 — Download HTML for all six
+
+Extract `htmlCode.downloadUrl` from each response, curl each to `/tmp/phase0/<label>.html`.
+
+### Step 5 — Compliance scoring
+
+Two scoring passes:
+
+**Major-category compliance** — did injection prevent categorically-forbidden chrome? For each injected run, score 0 or 1 for each of:
+
+- No global nav tabs / menu links in header
+- No sidebar / hamburger / drawer
+- No logo / brand wordmark in header
+- No breadcrumb trail
+- No bottom-tab nav
+- No sticky bottom action bar
+- No footer / copyright / legal links
+- No marketing CTAs (book, schedule, etc.)
+- No testimonials / pull quotes
+- No hero imagery
+- No real-face photo placeholder (check for `googleusercontent.com/aida/` or similar)
+
+Total: 11 categories. Score = categorical compliance percentage.
+
+**Strict compliance** — for each injected run, score against every rule in the injection snippet (header sticky-not-fixed, border color exact, 56/64px height, client-name-only, back button wrapping semantics, etc.). Record specific violations.
+
+### Step 6 — Decision
+
+| Outcome               | Architecture                                                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Major-category ≥ 95%  | Injection-first + **required** lightweight validator                                                                        |
+| Major-category 80–95% | Injection-first + **required** strict validator (this is the common case)                                                   |
+| Major-category < 80%  | Validator-first with minimal injection (~150 tokens forbidden-list only); injection is a hint, validator is the enforcement |
+
+The validator is always present. The scoring determines how much of the work injection versus validator does.
+
+### Step 7 — Write the report
+
+Save to `examples/phase-0-compliance-report.md` (copy from `/tmp/phase0/COMPLIANCE-REPORT.md`). Include:
+
+- Test matrix and scores
+- Specific violations from strict pass → become validator rules
+- Recommended architecture decision
+- Date (for re-runs when Stitch updates)
+
+### Step 8 — Re-run cadence
+
+Re-run Phase 0 when:
+
+- Stitch's model version changes (Gemini 3 Pro → Gemini 3.1 Pro has happened)
+- The injection snippet structure is substantively revised
+- Validator rules are under-catching violations that feel like they should be catchable via injection
+
+## ss-console reference run
+
+See `examples/phase-0-compliance-report.md` for the 2026-04-15 ss-console measurement:
+
+- Major-category: 97%
+- Strict: ~87%
+- Decision: injection-first + required validator covering 5 specific residual violation types

--- a/.agents/skills/nav-spec/workflows/revise.md
+++ b/.agents/skills/nav-spec/workflows/revise.md
@@ -1,0 +1,38 @@
+---
+description: Update an existing `.stitch/NAVIGATION.md`. Versioning-aware. Runs a reduced reviewer pass focused on the delta, not the whole spec.
+---
+
+# Revise NAVIGATION.md
+
+Use when the venture introduces a new surface class, a new archetype, a chrome pattern change, or when a drift audit surfaces code-spec mismatch that should resolve in the spec's favor.
+
+## Arguments
+
+```
+/nav-spec --revise [--add-surface-class X] [--add-archetype Y] [--align-to-code <path>]
+```
+
+## Steps
+
+1. **Load current spec.** Read `.stitch/NAVIGATION.md`. Note `spec-version`.
+2. **Classify the change.**
+   - **Additive** (new archetype, new forbidden pattern, new appendix entry): no spec-version bump required; may skip reviewer pass if the addition is obvious and low-risk.
+   - **Structural** (taxonomy redefinition, rule inversion, surface-class reshape, chrome contract change for an existing archetype): bump `spec-version`. Required reviewer pass.
+   - **Corrective** (aligning spec to shipped code, fixing a wrong contract): bump `spec-version`. Required reviewer pass focused on the Implementation angle.
+3. **Run drift audit** on the affected surface(s) only — scoped version of `audit.md`.
+4. **Draft the delta** as a focused edit to the spec. Do not rewrite sections that aren't changing.
+5. **Focused reviewer pass** (if required per classification): IA + Implementation only (skip Mobile unless the change affects viewport transforms). Single message, parallel. Same output format as `author.md` Phase 4.
+6. **Decision round** (if reviewers surfaced any).
+7. **Apply edits.** Bump `spec-version` appropriately. Update front matter with new `design-md-sha` if DESIGN.md changed.
+8. **Version-impact check.** For each existing screen under `.stitch/designs/**/*.html`, compute whether it still complies under the new spec. If not, mark for regeneration in a follow-up. Do not auto-regenerate.
+9. **Integration-check regeneration** on one affected surface (if the change is structural or corrective). Same as `author.md` Phase 7.
+10. **Save and report.** Write new version. Summarize for the user: what changed, `spec-version` N → M, how many existing designs now non-compliant, next steps.
+
+## Spec-version bump guidance
+
+- **1.0 → 1.1:** additive change (new archetype, new anti-pattern). RUN-LOG entries for spec-version 1.0 generations stay valid.
+- **1.x → 2.0:** structural/corrective change. Existing generations are at-risk; flag for review.
+
+## When NOT to revise
+
+Don't run `revise` to silence a Stitch drift. First ask: "Is this drift a Stitch failure, or a spec gap?" If Stitch drifted against a clear spec rule, the validator should have caught it — fix the validator. If the spec rule was ambiguous, revise the spec with the clarification.

--- a/.agents/skills/nav-spec/workflows/validate-navigation.md
+++ b/.agents/skills/nav-spec/workflows/validate-navigation.md
@@ -1,0 +1,145 @@
+---
+description: Post-generation validator. Parses Stitch-generated HTML and fails loud on nav-contract violations. Called automatically after every generation by the patched `stitch-design` pipeline.
+---
+
+# Validate navigation
+
+Deterministic enforcement layer. The injection snippet is probabilistic; this is binary — generation passes or fails, with specific DOM selectors and suggested fixes.
+
+## When this runs
+
+Called by `stitch-design`'s pipeline immediately after `generate_screen_from_text` or `edit_screens` returns. Input: the HTML returned by Stitch (or pulled from `htmlCode.downloadUrl`) plus the `{surface-class, archetype}` classification. Output: a pass/fail verdict and a list of specific violations.
+
+If `.stitch/NAVIGATION.md` does not exist: the validator is a no-op (graceful-degradation). It returns "skipped — no spec present."
+
+## Violation rubric
+
+Each rule has: **selector** (CSS or regex), **surface-class/archetype filter** (some rules apply only to some combinations), **severity** (cosmetic / semantic / structural), **suggested fix**.
+
+### Rule 1 — Header must be sticky, not fixed
+
+**Selector:** `<header>` element with a class list containing `fixed` but not `sticky`.
+**Applies to:** all surface classes, all archetypes.
+**Severity:** semantic.
+**Fix:** replace `fixed top-0` with `sticky top-0`. Fixed removes the header from document flow and interacts badly with the viewport-constrained mobile layouts in Stitch's output.
+
+### Rule 2 — Header has solid background, no backdrop-blur
+
+**Selector:** `<header>` with class containing `backdrop-blur-`, `bg-*/`N where N is any opacity value, or `bg-[#*]` where the hex is not `#FFFFFF`.
+**Applies to:** all surface classes except `public` (public marketing may use glassmorphism hero headers — see appendix).
+**Severity:** cosmetic.
+**Fix:** replace with solid `bg-white` (or venture-specific header bg per appendix).
+
+### Rule 3 — Client name stands alone in header
+
+**Selector:** `<header>` → first child div → contains a `<span class="material-symbols-*">` or an `<img>` or an `<svg>` before the client name text element.
+**Applies to:** `session-auth-client`, `session-auth-admin`, `token-auth`.
+**Severity:** cosmetic.
+**Fix:** remove the decorative icon. Client name is Inter 500, 13/18, #475569, standing alone on the left.
+
+### Rule 4 — Back affordance is not wrapped in a breadcrumb nav
+
+**Selector:** `<nav aria-label="Breadcrumb">` containing exactly one `<a>` or `<button>` with a chevron icon.
+**Applies to:** all surface classes where breadcrumbs are marked absent in the appendix (portal, most of admin — verify against spec).
+**Severity:** semantic.
+**Fix:** unwrap — the back button should be a single `<a>` or `<button>` with an appropriate `aria-label`, not wrapped in a `<nav>`.
+
+### Rule 5 — Back href is a hardcoded canonical URL, never "#" or javascript:
+
+**Selector:** The back-chevron `<a>` element has `href="#"`, `href="javascript:void(0)"`, or uses `history.back()` in an onclick.
+**Applies to:** all detail archetypes.
+**Severity:** semantic.
+**Fix:** use the canonical index URL for this archetype's parent (e.g., `/portal/invoices` for an invoice detail, `/portal/home` for a proposal detail). The spec's appendix defines the parent for each archetype × surface-class combination.
+
+### Rule 6 — No global navigation tabs in header
+
+**Selector:** `<header>` contains `<nav>` or multiple `<a>` or `<button>` elements with visible text labels that look like nav items (more than 2 non-icon text children, or presence of `role="tablist"` / `role="tab"`).
+**Applies to:** all surface classes.
+**Severity:** structural.
+**Fix:** remove. If a secondary nav is genuinely needed for a dashboard, it lives below the header as a section, not in the header.
+
+### Rule 7 — No bottom-tab nav, no sticky-bottom action bar
+
+**Selector:** Any element outside `<main>` with `fixed bottom-0` or `sticky bottom-0` classes.
+**Applies to:** all surface classes.
+**Severity:** structural.
+**Fix:** remove. The primary action should be reachable above the fold via document-flow scrolling; duplicated stickied action bars are forbidden.
+
+### Rule 8 — No footer on authenticated surfaces
+
+**Selector:** `<footer>` element present.
+**Applies to:** `session-auth-client`, `session-auth-admin`, `token-auth`.
+**Severity:** structural.
+**Fix:** remove the footer. Authenticated surfaces do not carry legal/copyright rows.
+
+### Rule 9 — No real-face photo placeholders
+
+**Selector:** `<img>` with `src` containing `googleusercontent.com/aida/`, `unsplash.com`, or `pexels.com`. Also any `src` ending in `.jpg`, `.jpeg` where the `data-alt` includes "headshot", "portrait", "professional", "person".
+**Applies to:** all surface classes.
+**Severity:** structural.
+**Fix:** replace with a solid-color circle containing initials (e.g., `<div class="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center text-white font-semibold">SD</div>`). Never a real face.
+
+### Rule 10 — No marketing CTAs on authenticated surfaces
+
+**Selector:** Buttons or links with text matching `/\b(schedule|book)\s+(a\s+)?(call|demo|meeting|consultation)\b/i`, `/subscribe/i`, `/get\s+started/i`, `/learn\s+more/i`, unless specifically whitelisted in the page prompt.
+**Applies to:** `session-auth-client`, `session-auth-admin`, `token-auth`.
+**Severity:** structural.
+**Fix:** remove. Authenticated surfaces do not carry marketing CTAs. The user is already a customer.
+
+### Rule 11 — Header height matches surface class and viewport
+
+**Selector:** `<header>` with class containing `h-*` where the value does not match 56px (mobile) / 64px (desktop).
+**Applies to:** all; values may be overridden per appendix.
+**Severity:** cosmetic.
+**Fix:** adjust to `h-14` (56px) or `h-16` (64px) — or `h-[56px]` / `h-[64px]` for explicit values.
+
+### Rule 12 — Tap targets ≥ 44×44px
+
+**Selector:** `<button>` or `<a>` elements used as icon-only buttons (text content is empty or only whitespace) with computed dimensions below 44×44. Approximation: class contains `w-*` or `h-*` where the value resolves to < 44px (e.g., `w-8`, `h-8`, `p-1`).
+**Applies to:** all.
+**Severity:** semantic.
+**Fix:** adjust to `w-11 h-11` (44×44) minimum, or use `p-3` with icon size smaller.
+
+### Rule 13 — aria-label on icon-only buttons
+
+**Selector:** `<button>` or `<a>` where the only child is a `<span class="material-symbols-*">`, without an `aria-label` attribute.
+**Applies to:** all.
+**Severity:** semantic.
+**Fix:** add `aria-label="<action description>"`.
+
+### Rule 14 — Landmarks present
+
+**Selector:** missing `<header role="banner">`, `<main role="main">`, or `<nav role="navigation">` where nav is present.
+**Applies to:** all.
+**Severity:** semantic.
+**Fix:** add the missing landmark roles (or rely on the semantic element which implicitly carries the role — modern parsers accept both).
+
+### Rule 15 — Skip-to-main link on every page
+
+**Selector:** no `<a>` element at the top of `<body>` (before `<header>`) with class `sr-only` (or equivalent screen-reader-only) linking to `#main` or `#content`.
+**Applies to:** all.
+**Severity:** semantic.
+**Fix:** prepend `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>`.
+
+## Implementation hint
+
+The validator is a bash + Python script. Input: path to HTML file + classification tags. Output: JSON violation report.
+
+Rough implementation skeleton (place at `~/.agents/skills/nav-spec/validate.py` when building):
+
+```python
+# validate.py — input: --file <html> --surface <class> --archetype <arch>
+# Uses beautifulsoup4 if available; falls back to regex if not.
+# Emits JSON: { "pass": bool, "violations": [ { "rule": "R1", "selector": "...", "severity": "...", "fix": "..." } ] }
+```
+
+The patched `stitch-design` pipeline shells out to `python3 ~/.agents/skills/nav-spec/validate.py --file ... --surface ... --archetype ...` after each generation. Exit code 1 (with JSON on stdout) triggers a retry-with-feedback in the pipeline. Exit code 0 means pass.
+
+## When the validator reports violations
+
+`stitch-design` can:
+
+1. Automatically retry once with the violation report appended to the prompt ("The previous output violated these rules: ... please regenerate").
+2. On second failure, surface to the user: "Validator flagged N violations. Accept anyway, regenerate, or adjust the spec?"
+
+Do not loop indefinitely — one retry, then human decision.

--- a/.agents/skills/stitch-design/README.md
+++ b/.agents/skills/stitch-design/README.md
@@ -1,0 +1,50 @@
+# Stitch Design Skill
+
+Teaches agents to generate high-fidelity, consistent UI designs and maintain project-level design systems using Stitch.
+
+## Install
+
+```bash
+npx skills add google-labs-code/stitch-skills --skill stitch-design --global
+```
+
+## What It Does
+
+Enables professional-grade UI/UX design workflows through Stitch MCP:
+
+1. **Prompt Enhancement**: Transforms rough intent into structured, high-fidelity prompts with professional terminology and design system context.
+2. **Design System Synthesis**: Analyzes existing Stitch projects to create and maintain a `.stitch/DESIGN.md` "source of truth".
+3. **Iterative Generation**: Selects the best generation or editing workflow (`edit_screens`, `generate_variants`) based on user intent.
+4. **Asset Management**: Synchronizes remote designs by downloading HTML and screenshots to the project's `.stitch/designs` directory.
+
+## Prerequisites
+
+- Stitch MCP Server access
+- A project `projectId` (can be discovered via `list_projects`)
+
+## Example Prompt
+
+```text
+Design a premium landing page for a mountain resort with a focus on serene luxury and glassmorphism.
+```
+
+## Skill Structure
+
+```
+stitch-design/
+├── SKILL.md           — Core instructions & Prompt Pipeline
+├── README.md          — This file
+├── workflows/         — Specialized pipelines (Text-to-UI, Edit, MD)
+├── references/        — UI/UX keywords & Technical Mappings
+└── examples/          — Gold-standard references (Solace Mindfulness)
+```
+
+## Works With
+
+- **`react:components` skill**: Hand-off generated designs for frontend implementation.
+- **`stitch-loop` skill**: Provides the `DESIGN.md` context for autonomous building loops.
+- **Multi-agent workflows**: Refines prompts before passing design tasks to specialized agents.
+
+## Learn More
+
+See [SKILL.md](./SKILL.md) for complete instructions.

--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: stitch-design
+description: Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
+allowed-tools:
+  - 'StitchMCP'
+  - 'Read'
+  - 'Write'
+---
+
+# Stitch Design Expert
+
+You are an expert Design Systems Lead and Prompt Engineer specializing in the **Stitch MCP server**. Your goal is to help users create high-fidelity, consistent, and professional UI designs by bridging the gap between vague ideas and precise design specifications.
+
+## Core Responsibilities
+
+1.  **Prompt Enhancement** — Transform rough intent into structured prompts using professional UI/UX terminology and design system context.
+2.  **Design System Synthesis** — Analyze existing Stitch projects to create `.stitch/DESIGN.md` "source of truth" documents.
+3.  **Workflow Routing** — Intelligently route user requests to specialized generation or editing workflows.
+4.  **Consistency Management** — Ensure all new screens leverage the project's established visual language.
+5.  **Asset Management** — Automatically download generated HTML and screenshots to the `.stitch/designs` directory.
+
+---
+
+## 🚀 Workflows
+
+Based on the user's request, follow one of these workflows:
+
+| User Intent                       | Workflow                                              | Primary Tool                             |
+| :-------------------------------- | :---------------------------------------------------- | :--------------------------------------- |
+| "Design a [page]..."              | [text-to-design](workflows/text-to-design.md)         | `generate_screen_from_text` + `Download` |
+| "Edit this [screen]..."           | [edit-design](workflows/edit-design.md)               | `edit_screens` + `Download`              |
+| "Create/Update .stitch/DESIGN.md" | [generate-design-md](workflows/generate-design-md.md) | `get_screen` + `Write`                   |
+
+---
+
+## 🎨 Prompt Enhancement Pipeline
+
+Before calling any Stitch generation or editing tool, you MUST enhance the user's prompt.
+
+### 1. Resolve Project ID (fail-fast)
+
+Before any Stitch tool call, resolve the venture's persistent project:
+
+1. Call `crane_ventures` MCP tool. Match the current repo to a venture. Use its `stitch_project_id`.
+2. If `null` or lookup fails: **STOP.** Tell the user: "No Stitch project configured for this venture. Add `stitchProjectId` to `config/ventures.json` in crane-console first."
+
+**No fallback to `list_projects`. No auto-creation.** Project IDs are explicit config, not discovered at runtime.
+
+### 1a. Analyze Context
+
+- **Design System**: Check for `.stitch/DESIGN.md`. If it exists, incorporate its tokens (colors, typography). If not, suggest the `generate-design-md` workflow.
+- **Navigation Spec**: Check for `.stitch/NAVIGATION.md`. If it exists, nav-contract injection is available (see step 1b and step 3). If not, proceed without — the skill gracefully degrades. Consider suggesting `/nav-spec` if the user is generating portal or admin surfaces.
+- **Freshness check**: Before generating, compare `design-spec.md` freshness (via `crane_doc` metadata) against `.stitch/DESIGN.md`. If the spec is newer, warn and suggest running the sync-design-spec workflow first.
+
+### 1b. Classification tags (when NAVIGATION.md present)
+
+If `.stitch/NAVIGATION.md` exists, the user prompt MUST carry three classification tags:
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+```
+
+If any tag is missing: **STOP.** Tell the user: "NAVIGATION.md is present — add `surface=`, `archetype=`, and `viewport=` tags so the nav contract can be injected. Run `/nav-spec --classify-help` for the decision rubric."
+
+If `.stitch/NAVIGATION.md` does NOT exist, skip this step entirely. No tags required.
+
+### 2. Refine UI/UX Terminology
+
+Consult [Design Mappings](references/design-mappings.md) to replace vague terms.
+
+- Vague: "Make a nice header"
+- Professional: "Sticky navigation bar with glassmorphism effect and centered logo"
+
+### 3. Structure the Final Prompt
+
+Format the enhanced prompt for Stitch like this:
+
+```markdown
+[Overall vibe, mood, and purpose of the page]
+
+**NAV CONTRACT (REQUIRED):**
+[Only if .stitch/NAVIGATION.md exists — inject the nav contract block here.
+Built from the classification tags: read the matching surface-class appendix
+
+- archetype contract from NAVIGATION.md, concatenate with shared sections
+  (a11y, states, anti-patterns). Template at
+  ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
+  Size budget: ≤600 tokens. If NAVIGATION.md absent, omit this block entirely.]
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- Platform: [Web/Mobile], [Desktop/Mobile]-first
+- Palette: [Primary Name] (#hex for role), [Secondary Name] (#hex for role)
+- Styles: [Roundness description], [Shadow/Elevation style]
+
+**PAGE STRUCTURE:**
+
+1. **[Content area 1]:** [Description]
+2. **[Content area 2]:** [Description]
+3. **[Content area 3]:** [Description]
+```
+
+When NAV CONTRACT is present, do NOT describe navigation/header/footer chrome in PAGE STRUCTURE — the contract owns chrome. PAGE STRUCTURE describes content only.
+
+### 3b. Post-generation validation (when NAVIGATION.md present)
+
+After every `generate_screen_from_text` or `edit_screens` call, if `.stitch/NAVIGATION.md` exists, run the nav validator:
+
+```bash
+python3 ~/.agents/skills/nav-spec/validate.py \
+  --file <path-to-generated-html> \
+  --surface <surface-tag> \
+  --archetype <archetype-tag> \
+  --viewport <viewport-tag>
+```
+
+If the validator reports structural violations: retry once with the violation report appended to the prompt ("The previous output violated these nav rules: ... please regenerate"). On second failure: surface to the user ("Validator flagged N violations. Accept anyway, regenerate, or adjust?").
+
+If `.stitch/NAVIGATION.md` does NOT exist, skip validation.
+
+### 4. Present AI Insights
+
+After any tool call, always surface the `outputComponents` (Text Description and Suggestions) to the user.
+
+---
+
+## 📚 References
+
+- [Tool Schemas](references/tool-schemas.md) — How to call Stitch MCP tools.
+- [Design Mappings](references/design-mappings.md) — UI/UX keywords and atmosphere descriptors.
+- [Prompting Keywords](references/prompt-keywords.md) — Technical terms Stitch understands best.
+- **VCMS:** `crane_notes(q: 'stitch')` — Full API reference and enterprise best practices.
+- **Nav Spec:** `~/.agents/skills/nav-spec/` — Navigation specification skill. Produces `.stitch/NAVIGATION.md`; provides the injection template and validator consumed by steps 1b, 3, and 3b above.
+
+---
+
+## 💡 Best Practices
+
+- **Iterative Polish**: Prefere `edit_screens` for targeted adjustments over full re-generation.
+- **Semantic First**: Name colors by their role (e.g., "Primary Action") as well as their appearance.
+- **Atmosphere Matters**: Explicitly set the "vibe" (Minimalist, Vibrant, Brutalist) to guide the generator.

--- a/.agents/skills/stitch-design/examples/DESIGN.md
+++ b/.agents/skills/stitch-design/examples/DESIGN.md
@@ -1,0 +1,23 @@
+---
+# The "Solace" Design System
+This is a comprehensive design language for a mindfulness and wellness application.
+
+## 🎨 Color Palette
+- **Primary**: Deep Ocean Blue (#1a365d) - for critical navigation and CTAs.
+- **Secondary**: Calm Slate (#718096) - for subtexts and secondary buttons.
+- **Background**: Soft Mist (#f7fafc) - for main page content.
+- **Accent**: Serene Emerald (#38a169) - for positive feedback and completion states.
+
+## 🔡 Typography
+- **Heading**: Montserrat, Bold - for titles and hero section headlines.
+- **Body**: Inter, Regular - for descriptions and general content.
+- **Size**: 16px as base, 48px for H1.
+
+## 📐 Components
+- **Buttons**: Rounded (12px), subtle hover shadow (4px blur).
+- **Cards**: Minimal border (1px, #e2e8f0), soft shadow (8px elevation).
+- **Navigation**: Clean, top-aligned, centered menu items.
+
+---
+
+💡 **Tip**: When calling `generate_screen_from_text`, include the tokens above to ensure the new screen matches this design system.

--- a/.agents/skills/stitch-design/examples/enhanced-prompt.md
+++ b/.agents/skills/stitch-design/examples/enhanced-prompt.md
@@ -1,0 +1,79 @@
+# Example: Prompt Enhancement
+
+## User Input (Vague)
+
+> "Make a landing page for my fitness app called 'Pulse'. Use red and black. It should have a place for features and a hero section."
+
+---
+
+## Enhanced Prompt (Stitch-Optimized)
+
+**Overall Purpose**: A high-energy, modern landing page for 'Pulse', a fitness tracking application. The vibe is powerful, motivating, and high-performance.
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- **Primary Color**: Racing Red (#e11d48) for CTA buttons and active states.
+- **Secondary Color**: Deep Obsidian (#0f172a) for background and text containers.
+- **Typography**: Bold, condensed sans-serif headings (e.g., Impact or Inter Tight) to convey speed and strength.
+- **Style**: Hard edges with sharp, minimal borders; high contrast; dark mode by default.
+
+**PAGE STRUCTURE:**
+
+1. **Header**: Minimalist navigation with Pulse logo (left) and "Start Training" primary button (right).
+2. **Hero Section**: Large, emotive fitness photography background. Headline: "Elevate Every Beat." Sub-headline: "Track, analyze, and crush your fitness goals with Pulse." Primary red CTA: "Get Started".
+3. **Feature Grid**: Three-column layout highlighting:
+   - **Real-time Tracking**: Live stats from your wearable.
+   - **AI Coaching**: Personalized workouts based on your performance.
+   - **Community Challenges**: Compete with friends and stay motivated.
+4. **Social Proof Section**: Subtle slider showing "Trusted by 500,000+ athletes".
+5. **Footer**: Quick links (Training, Pricing, Support), social icons, and legal.
+
+---
+
+💡 **Tip**: Notice how the enhanced prompt adds specific hex codes, defines the typography "vibe", and breaks the page into a logical numbered structure. This gives Stitch much clearer instructions.
+
+---
+
+# Example: Prompt Enhancement with NAV CONTRACT
+
+When `.stitch/NAVIGATION.md` exists for the venture and the user provides classification tags, the prompt gains a NAV CONTRACT block between the vibe statement and the DESIGN SYSTEM.
+
+## User Input
+
+> "Design the invoice detail page for the client portal. surface=session-auth-client archetype=detail viewport=mobile"
+
+## Enhanced Prompt (with NAV CONTRACT injected)
+
+**NAV CONTRACT (REQUIRED — do not invent beyond this block):**
+
+Surface class: session-auth-client (portal.smd.services, authenticated).
+Archetype: detail (has back button, no breadcrumbs, no bottom nav).
+Viewport: mobile 390x844.
+
+Chrome allowed (inclusive list; nothing else):
+
+- Top band (sticky, NOT fixed): bg-white, 1px border-b #e2e8f0, h-14 on `<header>`. Left: client name (Inter 500, 13/18, #475569). Right: three-icon contact control (email/sms/tel, each 44x44 with aria-label).
+- Back affordance inside `<main>`: chevron_left + "All invoices", href="/portal/invoices" (hardcoded). 44x44 tap target.
+- Bottom chrome: NONE. Footer: NONE.
+
+Chrome FORBIDDEN: global nav tabs, sidebar, hamburger, logo in header, breadcrumbs, bottom-tab nav, copyright row, marketing CTAs, real-face photos.
+
+If any above conflicts with PAGE STRUCTURE below, THIS BLOCK WINS.
+
+**DESIGN SYSTEM (REQUIRED):**
+
+- Platform: Web, mobile-first, 390x844
+- Palette: Primary #1E40AF, Text #475569, Bold #0F172A, Border #E2E8F0
+- Typography: Inter 400/500/600
+- Shape: 8px rounded
+
+**PAGE STRUCTURE:**
+
+1. Invoice summary: amount ($4,250), due date (Apr 18), status pill
+2. Line items table
+3. Pay button (primary CTA, above fold)
+4. Consultant contact card (SVG silhouette, never real photo)
+
+---
+
+💡 **Tip**: The NAV CONTRACT separates _chrome_ from _content_. PAGE STRUCTURE no longer describes the header, footer, or back button — those are owned by the contract. If Stitch drifts on chrome, the post-generation validator (`validate.py`) catches it deterministically.

--- a/.agents/skills/stitch-design/references/design-mappings.md
+++ b/.agents/skills/stitch-design/references/design-mappings.md
@@ -1,0 +1,45 @@
+# Design Mappings & Descriptors
+
+Use these mappings to transform vague user requests into precise, high-fidelity design instructions.
+
+## UI/UX Keyword Refinement
+
+| Vague Term        | Enhanced Professional Terminology                                            |
+| :---------------- | :--------------------------------------------------------------------------- |
+| "menu at the top" | "sticky navigation bar with logo and list items"                             |
+| "big photo"       | "high-impact hero section with full-width imagery"                           |
+| "list of things"  | "responsive card grid with hover states and subtle elevations"               |
+| "button"          | "primary call-to-action button with micro-interactions"                      |
+| "form"            | "clean form with labeled input fields, validation states, and submit button" |
+| "picture area"    | "hero section with focal-point image or video background"                    |
+| "sidebar"         | "collapsible side navigation with icon-label pairings"                       |
+| "popup"           | "modal dialog with overlay and smooth entry animation"                       |
+
+## Atmosphere & "Vibe" Descriptors
+
+Add these adjectives to set the mood and aesthetic philosophy:
+
+| Basic Vibe      | Enhanced Design Description                                                                    |
+| :-------------- | :--------------------------------------------------------------------------------------------- |
+| "Modern"        | "Clean, minimal, with generous whitespace and high-contrast typography."                       |
+| "Professional"  | "Sophisticated, trustworthy, utilizing subtle shadows and a restricted, premium palette."      |
+| "Fun / Playful" | "Vibrant, organic, with rounded corners, bold accent colors, and bouncy micro-animations."     |
+| "Dark Mode"     | "Electric, high-contrast accents on deep slate or near-black backgrounds."                     |
+| "Luxury"        | "Elegant, spacious, with fine lines, serif headers, and a focus on high-fidelity photography." |
+| "Tech / Cyber"  | "Futuristic, neon accents, glassmorphism effects, and technological monospaced typography."    |
+
+## Geometry & Shape Translation
+
+Convert technical values into physical descriptions for Stitch:
+
+- **Pill-shaped**: Used for `rounded-full` elements (buttons, tags).
+- **Softly rounded**: Used for `rounded-xl` (12px) or `rounded-2xl` (16px) containers.
+- **Sharp/Precise**: Used for `rounded-none` or `rounded-sm` elements.
+- **Glassmorphism**: Semi-transparent surfaces with background blur and thin borders.
+
+## Depth & Elevation
+
+- **Flat**: No shadows, focus on color blocking and borders.
+- **Whisper-soft**: Diffused, light shadows for subtle lift.
+- **Floating**: High-offset, soft shadows for elements that appear high above the surface.
+- **Inset**: Inner shadows for pressable or nested elements.

--- a/.agents/skills/stitch-design/references/prompt-keywords.md
+++ b/.agents/skills/stitch-design/references/prompt-keywords.md
@@ -1,0 +1,129 @@
+# UI/UX Keywords Reference
+
+Progressive disclosure reference for common UI terminology and adjective palettes.
+
+## Component Keywords
+
+### Navigation
+
+- navigation bar, nav menu, header
+- breadcrumbs, tabs, sidebar
+- hamburger menu, dropdown menu
+- back button, close button
+
+### Content Containers
+
+- hero section, hero banner
+- card, card grid, tile
+- modal, dialog, popup
+- accordion, collapsible section
+- carousel, slider
+
+### Forms
+
+- input field, text input
+- dropdown, select menu
+- checkbox, radio button
+- toggle switch
+- date picker, time picker
+- search bar, search input
+- submit button, form actions
+
+### Calls to Action
+
+- primary button, secondary button
+- ghost button, text link
+- floating action button (FAB)
+- icon button
+
+### Feedback
+
+- toast notification, snackbar
+- alert banner, warning message
+- loading spinner, skeleton loader
+- progress bar, step indicator
+
+### Layout
+
+- grid layout, flexbox
+- sidebar layout, split view
+- sticky header, fixed footer
+- full-width, contained width
+- centered content, max-width container
+
+## Adjective Palettes
+
+### Minimal / Clean
+
+- minimal, clean, uncluttered
+- generous whitespace, breathing room
+- subtle, understated, refined
+- simple, focused, distraction-free
+
+### Professional / Corporate
+
+- sophisticated, polished, trustworthy
+- corporate, business-like, formal
+- subtle shadows, clean lines
+- structured, organized, hierarchical
+
+### Playful / Fun
+
+- vibrant, colorful, energetic
+- rounded corners, soft edges
+- bold, expressive, dynamic
+- friendly, approachable, warm
+
+### Premium / Luxury
+
+- elegant, luxurious, high-end
+- dramatic, bold contrasts
+- sleek, modern, cutting-edge
+- exclusive, boutique, curated
+
+### Dark Mode
+
+- dark theme, night mode
+- high-contrast accents
+- soft glows, subtle highlights
+- deep backgrounds, muted surfaces
+
+### Organic / Natural
+
+- earthy tones, natural colors
+- warm, inviting, cozy
+- textured, tactile, handcrafted
+- flowing, organic shapes
+
+## Color Role Terminology
+
+### Backgrounds
+
+- page background, canvas
+- surface color, card background
+- overlay, scrim
+
+### Text
+
+- primary text, heading color
+- secondary text, body copy
+- muted text, placeholder
+- inverse text (on dark backgrounds)
+
+### Accents
+
+- primary accent, brand color
+- secondary accent, highlight
+- success, error, warning colors
+- hover state, active state
+
+## Shape Descriptions
+
+| Technical      | Natural Language           |
+| -------------- | -------------------------- |
+| `rounded-none` | sharp, squared-off edges   |
+| `rounded-sm`   | slightly softened corners  |
+| `rounded-md`   | gently rounded corners     |
+| `rounded-lg`   | generously rounded corners |
+| `rounded-xl`   | very rounded, pillow-like  |
+| `rounded-full` | pill-shaped, circular      |

--- a/.agents/skills/stitch-design/references/tool-schemas.md
+++ b/.agents/skills/stitch-design/references/tool-schemas.md
@@ -1,0 +1,90 @@
+# Stitch MCP Tool Schemas
+
+Use these examples to format your tool calls to the Stitch MCP server correctly.
+
+---
+
+## 🏗️ Project Management
+
+### `list_projects`
+
+Lists all Stitch projects accessible to you.
+
+```json
+// No parameters needed
+{}
+```
+
+### `get_project`
+
+Retrieves details of a specific project.
+
+```json
+{
+  "name": "projects/4044680601076201931"
+}
+```
+
+### `create_project`
+
+Creates a new Stitch project.
+
+```json
+{
+  "title": "My New App"
+}
+```
+
+---
+
+## 🎨 Design Generation
+
+### `generate_screen_from_text`
+
+Generates a new screen from a text description.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "prompt": "A modern landing page for a coffee shop with a hero section, menu, and contact form. Use warm brown tones (#4b2c20) and a clean sans-serif font.",
+  "deviceType": "DESKTOP" // Options: MOBILE, DESKTOP, TABLET
+}
+```
+
+### `edit_screens`
+
+Edits existing screens with a text prompt.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "selectedScreenIds": ["98b50e2ddc9943efb387052637738f61"],
+  "prompt": "Change the background color to white (#ffffff) and make the call-to-action button larger."
+}
+```
+
+---
+
+## 🖼️ Screen Management
+
+### `list_screens`
+
+Lists all screens within a project.
+
+```json
+{
+  "projectId": "4044680601076201931"
+}
+```
+
+### `get_screen`
+
+Retrieves details of a specific screen.
+
+```json
+{
+  "projectId": "4044680601076201931",
+  "screenId": "98b50e2ddc9943efb387052637738f61",
+  "name": "projects/4044680601076201931/screens/98b50e2ddc9943efb387052637738f61"
+}
+```

--- a/.agents/skills/stitch-design/workflows/edit-design.md
+++ b/.agents/skills/stitch-design/workflows/edit-design.md
@@ -1,0 +1,53 @@
+---
+description: Edit an existing design screen using Stitch MCP.
+---
+
+# Workflow: Edit-Design
+
+Make targeted changes to an already generated design.
+
+## Steps
+
+### 1. Identify the Screen
+
+Resolve `projectId` using the fail-fast Project ID Resolution from SKILL.md step 1. Then use `list_screens` to find the target `screenId`.
+
+### 2. Formulate the Edit Prompt
+
+Be specific about the changes you want to make. Do not just say "fix it".
+
+- **Location**: "Change the color of the [primary button] in the [hero section]..."
+- **Visuals**: "...to a darker blue (#004080) and add a subtle shadow."
+- **Structure**: "Add a secondary button next to the primary one with the text 'Learn More'."
+- **Nav preservation**: If `.stitch/NAVIGATION.md` exists and the screen has spec-conforming chrome, include "Preserve the existing header, back affordance, and footer exactly as rendered" in the edit prompt. Do not let edits re-invent chrome that the nav contract already owns.
+
+### 3. Apply the Edit
+
+Call the `mcp_StitchMCP_edit_screens` tool.
+
+```json
+{
+  "projectId": "...",
+  "selectedScreenIds": ["..."],
+  "prompt": "[Your target edit prompt]"
+}
+```
+
+### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the user.
+
+### 5. Download Design Assets
+
+After editing, download the updated HTML and screenshot urls from `outputComponents` to the `.stitch/designs` directory, overwriting previous versions to ensure the local files reflect the latest edits.
+
+### 6. Verify and Repeat
+
+- Check the output screen to see if the changes were applied correctly.
+- If more polish is needed, repeat the process with a new specific prompt.
+
+## Tips
+
+- **Keep it focused**: One edit at a time is often better than a long list of changes.
+- **Reference components**: Use professional terms like "navigation bar", "hero section", "footer", "card grid".
+- **Mention colors**: Use hex codes for precise color matching.

--- a/.agents/skills/stitch-design/workflows/generate-design-md.md
+++ b/.agents/skills/stitch-design/workflows/generate-design-md.md
@@ -1,0 +1,75 @@
+---
+description: Analyze a Stitch project and synthesize its design system into a .stitch/DESIGN.md file.
+---
+
+# Workflow: Generate .stitch/DESIGN.md
+
+Create a "source of truth" for your project's design language to ensure consistency across all future screens.
+
+## 📥 Retrieval
+
+To analyze a Stitch project, you must retrieve metadata and assets using the Stitch MCP tools:
+
+1.  **Project lookup**: Resolve `projectId` using the fail-fast Project ID Resolution from SKILL.md step 1 (via `crane_ventures`).
+2.  **Screen lookup**: Use `list_screens` for that `projectId` to find representative screens (e.g., "Home", "Main Dashboard").
+3.  **Metadata fetch**: Call `get_screen` for the target screen to get `screenshot.downloadUrl` and `htmlCode.downloadUrl`.
+4.  **Asset download**: Use `read_url_content` to fetch the HTML code.
+
+## 🧠 Analysis & Synthesis
+
+### 1. Identify Identity
+
+- Capture Project Title and Project ID.
+
+### 2. Define Atmosphere
+
+- Analyze the HTML and screenshot to capture the "vibe" (e.g., "Airy," "Professional," "Vibrant").
+
+### 3. Map Color Palette
+
+- Extract exact hex codes and assign functional roles (e.g., "Primary Action: #2563eb").
+
+### 4. Translate Geometry
+
+- Convert Tailwind/CSS values into descriptive language (e.g., `rounded-full` → "Pill-shaped").
+
+### 5. Document Depth
+
+- Describe shadow styles and layering (e.g., "Soft, diffused elevation").
+
+## 📝 Output Structure
+
+Create a `.stitch/DESIGN.md` file in the project directory with this structure:
+
+```markdown
+# Design System: [Project Title]
+
+**Project ID:** [Insert Project ID Here]
+
+## 1. Visual Theme & Atmosphere
+
+(Description of mood and aesthetic philosophy)
+
+## 2. Color Palette & Roles
+
+(Descriptive Name + Hex Code + Role)
+
+## 3. Typography Rules
+
+(Font families, weights, and usage)
+
+## 4. Component Stylings
+
+- **Buttons:** Shape, color, behavior
+- **Containers:** Roundness, elevation
+
+## 5. Layout Principles
+
+(Whitespace strategy and grid alignment)
+```
+
+## 💡 Best Practices
+
+- **Be Precise**: Always include hex codes in parentheses.
+- **Be Descriptive**: Use natural language like "Deep Ocean Blue" instead of just "Blue".
+- **Be Functional**: Explain _why_ an element is used.

--- a/.agents/skills/stitch-design/workflows/sync-design-spec.md
+++ b/.agents/skills/stitch-design/workflows/sync-design-spec.md
@@ -1,0 +1,44 @@
+---
+description: Sync design-spec.md changes into .stitch/DESIGN.md and the Stitch cloud design system.
+---
+
+# Workflow: Sync Design Spec to Stitch
+
+When `design-spec.md` is updated, propagate changes to the Stitch derivative files.
+
+## When to Run
+
+- After any PR that modifies `docs/design/ventures/{code}/design-spec.md` in crane-console
+- After running `/design-brief` which regenerates design-spec.md
+- When the pre-generation freshness check (SKILL.md step 1a) detects drift
+- When the schedule engine flags `design-system-review` as due
+
+## Steps
+
+### 1. Load Both Files
+
+- Read the canonical `design-spec.md` via `crane_doc('{code}', 'design-spec.md')`
+- Read the current `.stitch/DESIGN.md` from the venture repo
+
+### 2. Diff and Update
+
+- Compare token values (colors, typography, spacing, component patterns) between the two files
+- Update `.stitch/DESIGN.md` with any changed values from design-spec.md
+- Preserve Stitch-specific formatting and sections that don't exist in design-spec.md (e.g., atmosphere descriptions, prompt-optimized language)
+- Keep the Project ID in the DESIGN.md header unchanged
+
+### 3. Push to Stitch Cloud
+
+- Resolve `projectId` using the fail-fast resolution (SKILL.md step 1)
+- Call `update_design_system` with the updated designMd content
+- Verify with `list_design_systems`
+
+### 4. Commit
+
+- Commit the updated `.stitch/DESIGN.md` to the venture repo
+- PR title: `chore: sync design system from design-spec.md`
+
+## Tips
+
+- Only sync tokens that actually changed - don't regenerate the entire DESIGN.md
+- If the design-spec.md has major structural changes (new component patterns, new color zones), consider regenerating DESIGN.md from scratch using the `generate-design-md` workflow instead

--- a/.agents/skills/stitch-design/workflows/text-to-design.md
+++ b/.agents/skills/stitch-design/workflows/text-to-design.md
@@ -1,0 +1,61 @@
+---
+description: Generate new screens from a text prompt using Stitch MCP.
+---
+
+# Workflow: Text-to-Design
+
+Transform a text description into a high-fidelity design screen.
+
+## Steps
+
+### 1. Enhance the User Prompt
+
+Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../SKILL.md#prompt-enhancement-pipeline).
+
+- Identify the platform (Web/Mobile) and page type.
+- Incorporate any existing project design system from `.stitch/DESIGN.md`.
+- If `.stitch/NAVIGATION.md` exists: require classification tags (`surface=`, `archetype=`, `viewport=`) per pipeline step 1b. Build and inject the NAV CONTRACT block per step 3.
+- Use specific [Design Mappings](../references/design-mappings.md) and [Prompting Keywords](../references/prompt-keywords.md).
+
+### 2. Identify the Project
+
+Use the fail-fast Project ID Resolution from SKILL.md step 1: look up `stitch_project_id` via `crane_ventures`, stop if null.
+
+### 3. Generate the Screen
+
+Call the `mcp_StitchMCP_generate_screen_from_text` tool with the enhanced prompt.
+
+```json
+{
+  "projectId": "...",
+  "prompt": "[Your Enhanced Prompt]",
+  "deviceType": "DESKTOP" // or MOBILE
+}
+```
+
+### 4. Present AI Feedback
+
+Always show the text description and suggestions from `outputComponents` to the user.
+
+### 5. Validate Navigation (if NAVIGATION.md present)
+
+If `.stitch/NAVIGATION.md` exists, run the nav validator per pipeline step 3b before downloading. On structural violations, retry once with the violations appended. On second failure, surface to user.
+
+### 6. Download Design Assets
+
+After generation (and validation if applicable), download the HTML and screenshot urls from `outputComponents` to the `.stitch/designs` directory.
+
+- **Naming**: Use the screen ID or a descriptive slug for the filename.
+- **Tools**: Use `curl -o` via `run_command` or similar.
+- **Directory**: Ensure `.stitch/designs` exists.
+
+### 7. Review and Refine
+
+- If the result is not exactly as expected, use the [edit-design](edit-design.md) workflow to make targeted adjustments.
+- Do NOT re-generate from scratch unless the fundamental layout is wrong.
+
+## Tips
+
+- **Be structural**: Break the page down into header, hero, features, and footer in your prompt.
+- **Specify colors**: Use hex codes for precision.
+- **Set the tone**: Explicitly mention if the design should be minimal, professional, or vibrant.

--- a/config/global-skills.json
+++ b/config/global-skills.json
@@ -1,0 +1,1 @@
+["nav-spec", "stitch-design"]

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -53,6 +53,7 @@ import {
   ensureClaudeProjectTrust,
   ensureClaudeUserDenyRules,
   syncClaudeAssets,
+  syncGlobalSkills,
   extractPassthroughArgs,
 } from './launch-lib.js'
 
@@ -932,6 +933,187 @@ describe('syncClaudeAssets', () => {
 
     expect(copyFileSync).not.toHaveBeenCalled()
     expect(mkdirSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncGlobalSkills', () => {
+  // Build a Dirent-like object for the { withFileTypes: true } code path.
+  type Dirent = { name: string; isDirectory: () => boolean; isFile: () => boolean }
+  const dirent = (name: string, isDir: boolean): Dirent => ({
+    name,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('is a no-op when config/global-skills.json is missing', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) {
+        throw new Error('ENOENT')
+      }
+      return '[]'
+    })
+
+    syncGlobalSkills()
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(mkdirSync).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when config is malformed JSON', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return 'not json {{'
+      return '[]'
+    })
+
+    syncGlobalSkills()
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+  })
+
+  it('copies new skill files from source to home directory', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return 'source content'
+    })
+
+    // source dir exists; home target files do not
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      // Source nav-spec directory exists
+      if (s.endsWith('/.agents/skills/nav-spec')) return true
+      // Target files in ~/.agents/skills do not exist yet
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false), dirent('validate.py', false)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    syncGlobalSkills()
+
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('/.agents/skills/nav-spec'), {
+      recursive: true,
+    })
+    expect(copyFileSync).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips files that are already identical', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return 'same content' // both source and target return this
+    })
+
+    vi.mocked(existsSync).mockReturnValue(true) // everything exists
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    syncGlobalSkills()
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+  })
+
+  it('recursively copies nested skill subdirectories', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return 'content'
+    })
+
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      // Source dirs exist
+      if (s.endsWith('/.agents/skills/nav-spec')) return true
+      if (s.endsWith('/.agents/skills/nav-spec/workflows')) return true
+      // Target files do not
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false), dirent('workflows', true)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (s.endsWith('/.agents/skills/nav-spec/workflows')) {
+        return [dirent('author.md', false), dirent('audit.md', false)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    syncGlobalSkills()
+
+    // Top-level + nested subdir both get mkdir
+    expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('/.agents/skills/nav-spec'), {
+      recursive: true,
+    })
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('/.agents/skills/nav-spec/workflows'),
+      { recursive: true }
+    )
+    // SKILL.md + 2 workflow files = 3 copies
+    expect(copyFileSync).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips a listed skill whose source directory is missing', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['ghost-skill'])
+      return ''
+    })
+
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    syncGlobalSkills()
+
+    expect(copyFileSync).not.toHaveBeenCalled()
+    expect(mkdirSync).not.toHaveBeenCalled()
+  })
+
+  it('processes multiple skills from config', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json'))
+        return JSON.stringify(['nav-spec', 'stitch-design'])
+      return 'content'
+    })
+
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec')) return true
+      if (s.endsWith('/.agents/skills/stitch-design')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/.agents/skills/stitch-design')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    syncGlobalSkills()
+
+    expect(copyFileSync).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -927,6 +927,97 @@ export function syncClaudeAssets(repoPath: string): void {
   }
 }
 
+/**
+ * Load skill names from config/global-skills.json.
+ *
+ * These skills are mirrored from crane-console/.agents/skills/<name>/ to
+ * ~/.agents/skills/<name>/ on every launch. They are global tools (e.g.,
+ * nav-spec, stitch-design) that must be available in any venture context,
+ * not just when Claude Code runs from crane-console.
+ *
+ * Graceful fallback: missing or malformed config yields empty list, making
+ * the sync a no-op rather than crashing.
+ */
+function loadGlobalSkills(): string[] {
+  try {
+    const configPath = join(CRANE_CONSOLE_ROOT, 'config', 'global-skills.json')
+    const content = readFileSync(configPath, 'utf-8')
+    const names = JSON.parse(content)
+    return Array.isArray(names) ? names.filter((n): n is string => typeof n === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Recursively mirror a directory tree from source to target.
+ *
+ * - Creates target directories as needed.
+ * - Skips files whose content is identical between source and target.
+ * - Always overwrites stale files (source is authoritative).
+ * - Returns the count of files actually copied.
+ *
+ * Does not delete files that exist in target but not in source — this keeps
+ * local-only additions (e.g., user experiments) intact. Rename with caution.
+ */
+function mirrorDirectoryTree(sourceDir: string, targetDir: string): number {
+  if (!existsSync(sourceDir)) return 0
+
+  let copied = 0
+  mkdirSync(targetDir, { recursive: true })
+
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = join(sourceDir, entry.name)
+    const targetPath = join(targetDir, entry.name)
+
+    if (entry.isDirectory()) {
+      copied += mirrorDirectoryTree(sourcePath, targetPath)
+    } else if (entry.isFile()) {
+      if (existsSync(targetPath)) {
+        const sourceContent = readFileSync(sourcePath, 'utf-8')
+        const targetContent = readFileSync(targetPath, 'utf-8')
+        if (sourceContent === targetContent) continue
+      }
+      copyFileSync(sourcePath, targetPath)
+      copied++
+    }
+  }
+
+  return copied
+}
+
+/**
+ * Mirror version-controlled enterprise skills from crane-console to ~/.agents/skills/.
+ *
+ * Skills listed in config/global-skills.json are copied recursively from
+ * crane-console/.agents/skills/<name>/ to ~/.agents/skills/<name>/. This keeps
+ * the home-directory copies in sync with the source of truth across the fleet,
+ * without requiring each venture repo to hold its own copy.
+ *
+ * Runs on every `crane <venture>` launch (via checkMcpSetup). Fast no-op when
+ * everything is already current (identical files skipped by content compare).
+ */
+export function syncGlobalSkills(): void {
+  const skills = loadGlobalSkills()
+  if (skills.length === 0) return
+
+  const sourceRoot = join(CRANE_CONSOLE_ROOT, '.agents', 'skills')
+  const targetRoot = join(homedir(), '.agents', 'skills')
+
+  let totalSynced = 0
+  for (const skill of skills) {
+    const sourceDir = join(sourceRoot, skill)
+    const targetDir = join(targetRoot, skill)
+    totalSynced += mirrorDirectoryTree(sourceDir, targetDir)
+  }
+
+  if (totalSynced > 0) {
+    console.log(
+      `-> Synced ${totalSynced} global skill file${totalSynced > 1 ? 's' : ''} to ~/.agents/skills/`
+    )
+  }
+}
+
 export function setupGeminiMcp(repoPath: string): void {
   const geminiDir = join(repoPath, '.gemini')
   const settingsPath = join(geminiDir, 'settings.json')
@@ -1136,6 +1227,10 @@ export function checkMcpSetup(repoPath: string, agent: string): void {
 
   // Sync enterprise commands/agents (all agent types benefit, but only Claude uses .claude/)
   syncClaudeAssets(repoPath)
+
+  // Mirror global skills (nav-spec, stitch-design, etc.) to ~/.agents/skills/
+  // so they are available in any venture context, not just crane-console.
+  syncGlobalSkills()
 
   // MIGRATION (2026-03-31): Remove stitch from user-scope MCP.
   // Stitch is now gated behind `crane --stitch` using project-scope registration.


### PR DESCRIPTION
## Summary

Closes the fleet distribution gap noted in #527. Brings the two enterprise global skills (`nav-spec`, `stitch-design`) under version control and wires them into the launcher so fleet machines stay in sync with the source of truth automatically.

- Adds `.agents/skills/nav-spec/` (16 files) and `.agents/skills/stitch-design/` (11 files) from the previously-untracked `~/.agents/skills/`
- Includes the `validate.py` fixes from #527 (auth-gate argparse + file-I/O error handling) now in version control
- Adds `config/global-skills.json` listing skills to mirror to `~/.agents/skills/`
- Adds `syncGlobalSkills()` + `mirrorDirectoryTree()` helpers to `launch-lib.ts`, invoked from `checkMcpSetup()` on every `crane <venture>` launch
- 7 new tests cover missing config, malformed JSON, new-file copy, identical-file skip, recursive subdirs, missing source dir, multiple skills

## How the sync works

On every `crane <venture>` launch, the launcher reads `config/global-skills.json` and recursively mirrors each listed skill from `crane-console/.agents/skills/<name>/` to `~/.agents/skills/<name>/`. Files identical in content are skipped (content compare), so the sync is a fast no-op when current. Source-is-authoritative: stale or perturbed home-dir copies get overwritten.

## Test plan

- [x] `npm run verify` passes (typecheck, lint, format, tests)
- [x] 7 new unit tests for `syncGlobalSkills` pass
- [x] End-to-end: perturbed `~/.agents/skills/nav-spec/validate.py`, invoked `syncGlobalSkills()`, confirmed home-dir copy was overwritten with crane-console version
- [x] Idempotency: second run is a no-op (zero output)
- [ ] Fleet validation: after merge, another fleet machine runs `crane vc` and should see `-> Synced N global skill files to ~/.agents/skills/` on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)