### PR TITLE
feat(skills): governance floor — schema, review, audit, deprecate, CI

### DIFF
--- a/.agents/skills/analytics/SKILL.md
+++ b/.agents/skills/analytics/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: analytics
 description: Site Traffic Report
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /analytics - Site Traffic Report

--- a/.agents/skills/build-log/SKILL.md
+++ b/.agents/skills/build-log/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: build-log
 description: Draft a Build Log Entry
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /build-log - Draft a Build Log Entry

--- a/.agents/skills/calendar-sync/SKILL.md
+++ b/.agents/skills/calendar-sync/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: calendar-sync
 description: Calendar Sync
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /calendar-sync - Calendar Sync

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: code-review
 description: Codebase Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /code-review - Codebase Review

--- a/.agents/skills/content-scan/SKILL.md
+++ b/.agents/skills/content-scan/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: content-scan
 description: Content Candidate Triage
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /content-scan - Content Candidate Triage

--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: context-refresh
 description: Enterprise Context Refresh
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /context-refresh - Enterprise Context Refresh

--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: critique
 description: Plan Critique & Auto-Revision
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /critique - Plan Critique & Auto-Revision

--- a/.agents/skills/design-brief/SKILL.md
+++ b/.agents/skills/design-brief/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: design-brief
 description: Multi-Agent Design Brief Generator
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /design-brief - Multi-Agent Design Brief Generator

--- a/.agents/skills/docs-refresh/SKILL.md
+++ b/.agents/skills/docs-refresh/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: docs-refresh
 description: Enterprise Docs Refresh
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /docs-refresh - Enterprise Docs Refresh

--- a/.agents/skills/edit-article/SKILL.md
+++ b/.agents/skills/edit-article/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: edit-article
 description: Editorial Review Agent
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /edit-article - Editorial Review Agent

--- a/.agents/skills/edit-log/SKILL.md
+++ b/.agents/skills/edit-log/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: edit-log
 description: Build Log Editorial Review
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /edit-log - Build Log Editorial Review

--- a/.agents/skills/enterprise-review/SKILL.md
+++ b/.agents/skills/enterprise-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: enterprise-review
 description: Cross-Venture Codebase Audit
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /enterprise-review - Cross-Venture Codebase Audit

--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: eos
 description: End of Session Handoff
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /eos - End of Session Handoff

--- a/.agents/skills/go-live/SKILL.md
+++ b/.agents/skills/go-live/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: go-live
 description: Venture Go-Live Process
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /go-live - Venture Go-Live Process

--- a/.agents/skills/heartbeat/SKILL.md
+++ b/.agents/skills/heartbeat/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: heartbeat
 description: Keep Session Alive
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /heartbeat - Keep Session Alive

--- a/.agents/skills/new-venture/SKILL.md
+++ b/.agents/skills/new-venture/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: new-venture
 description: Set Up a New Venture
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /new-venture - Set Up a New Venture

--- a/.agents/skills/platform-audit/SKILL.md
+++ b/.agents/skills/platform-audit/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: platform-audit
 description: Platform Audit
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /platform-audit - Platform Audit

--- a/.agents/skills/portfolio-review/SKILL.md
+++ b/.agents/skills/portfolio-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: portfolio-review
 description: Portfolio Status Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /portfolio-review - Portfolio Status Review

--- a/.agents/skills/prd-review/SKILL.md
+++ b/.agents/skills/prd-review/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: prd-review
 description: Multi-Agent PRD Review
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /prd-review - Multi-Agent PRD Review

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: ship
 description: Ship to Production
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /ship - Ship to Production

--- a/.agents/skills/skill-audit/SKILL.md
+++ b/.agents/skills/skill-audit/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: skill-audit
+description: Monthly skill health report. Walks every SKILL.md, parses frontmatter, computes staleness via git log, detects schema gaps, and surfaces the deprecation queue. Run this once a month to keep the skill library healthy.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_skill_audit
+    - crane_schedule
+---
+
+# /skill-audit - Monthly Skill Health Report
+
+Run a repo-wide audit of every SKILL.md in the enterprise and global skill libraries. The report surfaces schema gaps, stale skills, and skills that have passed their sunset date.
+
+## Usage
+
+```
+/skill-audit
+```
+
+No arguments required. The audit runs across all scopes by default.
+
+## What it checks
+
+| Section               | What it surfaces                                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Inventory**         | Total skill count, broken down by scope, status, and owner                                                            |
+| **Schema gaps**       | Skills missing one or more required frontmatter fields (`name`, `description`, `version`, `scope`, `owner`, `status`) |
+| **Staleness**         | Skills whose `SKILL.md` has not been touched in git for more than 180 days                                            |
+| **Deprecation queue** | Skills with `status: deprecated` that have a `sunset_date` set - sorted soonest-first                                 |
+
+Reference drift (broken `depends_on.mcp_tools`, `depends_on.files`, `depends_on.commands`) is NOT included in this tool - it requires invoking the `skill-review` CLI which cross-checks against live manifests. Run `/skill-review --all` for reference-drift details.
+
+## Workflow
+
+### Step 1: Run the audit
+
+Call the MCP tool:
+
+```
+crane_skill_audit()
+```
+
+Default parameters:
+
+- `scope`: `all` (enterprise + global)
+- `stale_threshold_days`: 180
+- `include_deprecated`: true
+
+You can narrow the scope:
+
+```
+crane_skill_audit(scope: "enterprise", stale_threshold_days: 90)
+```
+
+### Step 2: Interpret the report
+
+**Inventory** - Review the totals. A healthy library has no skills in `unknown` status. Skills in `draft` for more than 30 days should be reviewed.
+
+**Schema gaps** - Each entry names the skill and the missing fields. Schema gaps should be fixed before the skill is marked `stable`. Open a PR to fill them.
+
+**Staleness** - Skills not touched in 180+ days may be outdated. Review each:
+
+- If the skill is still accurate: touch the file (whitespace-only commit) to reset the clock.
+- If the skill is obsolete: run `/skill-deprecate <name>` to begin the retirement process.
+
+**Deprecation queue** - Skills sorted by days until sunset. Skills with `days_until_sunset <= 0` are past their sunset date. Bring these to the Captain for a removal directive. Removal is always a separate PR.
+
+### Step 3: Record completion
+
+After reviewing the report and taking any required actions, record the audit as complete:
+
+```
+crane_schedule(
+  action: "complete",
+  name: "skill-audit",
+  result: "success",
+  summary: "<one-line summary, e.g. '18 skills audited, 2 stale flagged, 0 schema gaps'>"
+)
+```
+
+## Cadence
+
+This skill is on a monthly cadence (`schedule_items` name: `skill-audit`). It surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- Staleness is derived from `git log -1 --format=%cI -- <path>`. Files never committed show as `last_touched: unknown` and are treated as maximally stale.
+- Skills with `backend_only: true` still appear in the audit - they just have no dispatcher parity requirement.
+- This tool does not modify any SKILL.md. It is read-only.

--- a/.agents/skills/skill-deprecate/SKILL.md
+++ b/.agents/skills/skill-deprecate/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+> ⚠️ **Captain-gated.** This skill requires explicit Captain confirmation before any changes are made.
+
+# /skill-deprecate - Captain-Gated Skill Sunset
+
+Formal deprecation flow for enterprise skills. Marks a skill for retirement with a 90-day grace period. The skill remains invocable throughout the grace period - this is NOT deletion.
+
+## When to Use
+
+Invoke `/skill-deprecate` when ALL of the following are true:
+
+- A skill has had zero invocations for 90+ days AND has been identified by `/skill-audit` as a deprecation candidate
+- Functionality has been fully merged into another skill, making the original redundant
+- A dependency (MCP tool, external service, file) the skill requires has been removed
+- An explicit Captain directive names the skill for sunset
+
+Do NOT invoke based on a single low-usage period or minor staleness. The audit surfaces candidates; the Captain decides.
+
+## Arguments
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+| Argument       | Required | Description                                        |
+| -------------- | -------- | -------------------------------------------------- |
+| `<skill-name>` | Yes      | Matches the directory name under `.agents/skills/` |
+| `--reason`     | No       | If omitted, agent will ask interactively           |
+| `--migration`  | No       | If omitted, agent will ask interactively           |
+
+## Preconditions (Fail-Fast)
+
+Run all checks before any changes. Stop and report if any fail.
+
+1. **Captain confirmation** - Ask in chat: "This will deprecate `<name>`. Confirm you're the Captain authorizing this deprecation? (yes/no)". Do not proceed until the Captain replies "yes" in the chat interface.
+
+2. **Skill exists** - Verify `.agents/skills/<name>/SKILL.md` is present. If missing, stop: "No skill found at `.agents/skills/<name>/SKILL.md`."
+
+3. **Not already deprecated** - Read current frontmatter. If `status` is already `deprecated`, stop: "`<name>` is already deprecated (since `<deprecation_date>`). Nothing to do."
+
+4. **Scope reminder** - Before proceeding, state to the Captain: "Per `guardrails.md`, deprecation is NOT removal. The skill remains invocable during the 90-day grace period. Removal requires a separate Captain directive after the sunset date."
+
+## Phases
+
+### Phase 1 - Gather Context
+
+Read the target SKILL.md. Extract current frontmatter (`version`, `status`, `description`).
+
+If `--reason` was not provided, ask:
+
+> "What's the deprecation reason? (1-2 sentences)"
+
+If `--migration` was not provided, ask:
+
+> "What should callers use instead? (migration path, or 'no direct replacement')"
+
+Once both are collected, echo everything back for confirmation:
+
+```
+About to deprecate: <name>
+Reason:    <reason>
+Migration: <migration>
+Sunset:    <today + 90 days>
+
+Proceed? (yes/no)
+```
+
+Do not advance to Phase 2 until the Captain confirms.
+
+### Phase 2 - Update Frontmatter
+
+Get today's date:
+
+```bash
+date +%Y-%m-%d
+```
+
+Get the sunset date (90 days out):
+
+```bash
+date -v+90d +%Y-%m-%d   # macOS
+# or: date -d '+90 days' +%Y-%m-%d   # Linux
+```
+
+Bump these fields in the target SKILL.md frontmatter:
+
+```yaml
+status: deprecated
+deprecation_date: YYYY-MM-DD # today
+sunset_date: YYYY-MM-DD # today + 90 days
+deprecation_notice: '<reason>. Migration: <migration>'
+```
+
+Bump `version` MINOR (e.g., `1.0.0` → `1.1.0`, `2.3.1` → `2.4.0`). This is a status change, not a breaking change.
+
+### Phase 3 - Inject Sunset Banner
+
+Insert the following block immediately after the closing `---` of the frontmatter and before the `# /<name>` heading in the target SKILL.md body:
+
+```markdown
+> ⚠️ **DEPRECATED** — Sunset: YYYY-MM-DD (90 days from deprecation).
+> Reason: <reason>
+> Migration: <migration>
+> Invocations during the grace period still work. Removal requires a separate Captain directive after the sunset date.
+```
+
+If a banner already exists at that position (e.g., a prior warning blockquote), replace it rather than prepending a second one.
+
+### Phase 4 - Log the Deprecation
+
+Append to `docs/skills/deprecated.md` (append-only - never edit existing entries):
+
+```markdown
+## <skill-name> (deprecated YYYY-MM-DD)
+
+- **Reason**: <reason>
+- **Migration**: <migration>
+- **Sunset date**: YYYY-MM-DD
+- **Deprecated by**: Captain (<session_id from crane_sos if available, otherwise omit>)
+```
+
+### Phase 5 - Branch, Commit, PR
+
+```bash
+# Create branch
+git checkout -b deprecate/<skill-name>-YYYY-MM-DD
+
+# Stage only the two modified files
+git add .agents/skills/<skill-name>/SKILL.md
+git add docs/skills/deprecated.md
+
+# Commit
+git commit -m "chore(skills): deprecate <skill-name> with 90-day sunset"
+
+# Push and open PR
+gh pr create \
+  --title "chore(skills): deprecate <skill-name>" \
+  --body "$(cat <<'EOF'
+## Skill Deprecation: <skill-name>
+
+**Reason:** <reason>
+
+**Migration:** <migration>
+
+**Sunset date:** YYYY-MM-DD
+
+The skill remains invocable during the 90-day grace period. This PR does NOT delete any files. Removal is a separate Captain-authorized PR after the sunset date.
+
+Changes:
+- `.agents/skills/<skill-name>/SKILL.md` — status, deprecation fields, sunset banner
+- `docs/skills/deprecated.md` — deprecation log entry
+EOF
+)"
+```
+
+Do NOT merge automatically. The PR goes through normal review.
+
+## What This Skill Does NOT Do
+
+- Delete any files
+- Remove the skill from `config/skill-owners.json` (owner stays until removal)
+- Skip or delegate the Captain confirmation
+- Bypass CI or merge the PR automatically
+- Affect invocability during the grace period
+
+## After Sunset
+
+Once `sunset_date` has passed, `/skill-audit` will flag the skill in the "Deprecation queue" section. The Captain then decides in a separate session:
+
+- **Delete** - new PR to remove the skill directory, dispatcher, and `skill-owners.json` entry
+- **Extend** - run `/skill-deprecate` again with a new sunset date (or edit manually)
+- **Reverse** - flip `status` back to `stable`, remove the banner and deprecation fields
+
+Removal is always a separate Captain-authorized PR. `guardrails.md` forbids removing features without a directive.
+
+## Cross-References
+
+- `docs/skills/governance.md` - lifecycle model (draft → stable → deprecated → removed)
+- `docs/skills/deprecated.md` - append-only deprecation log
+- `crane_doc('global', 'guardrails.md')` - feature-removal rules that govern this flow

--- a/.agents/skills/skill-review/SKILL.md
+++ b/.agents/skills/skill-review/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: skill-review
+description: Lint a skill or all skills in the repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  files:
+    - crane-console:config/skill-owners.json
+    - crane-console:config/mcp-tool-manifest.json
+    - crane-console:docs/skills/governance.md
+---
+
+# /skill-review
+
+Lint a skill directory (or all skills) against the governance schema defined in `docs/skills/governance.md`. Surfaces violations as structured output and exits non-zero in strict mode if any errors are found.
+
+## Behavior
+
+The skill delegates to the CLI at `packages/crane-mcp/src/cli/skill-review.ts`. It is the creation/change gate — run it before flipping `status: stable` and opening a PR. CI runs it in advisory mode on every PR that touches `.agents/skills/**`.
+
+### Invocation
+
+```bash
+# Review a single skill
+npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
+
+# Review all skills (advisory — exits 0 regardless of findings)
+npm run skill-review -w @venturecrane/crane-mcp -- --all
+
+# Review all skills, block on errors (CI strict mode)
+npm run skill-review -w @venturecrane/crane-mcp -- --all --strict
+
+# Machine-readable JSON output
+npm run skill-review -w @venturecrane/crane-mcp -- --all --json
+
+# Custom MCP tool manifest path
+npm run skill-review -w @venturecrane/crane-mcp -- --all --manifest config/mcp-tool-manifest.json
+```
+
+### Flags
+
+| Flag                | Default                         | Description                                                                |
+| ------------------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `--path <dir>`      | -                               | Review a single skill directory. Mutually exclusive with `--all`.          |
+| `--all`             | -                               | Review every skill in `.agents/skills/`. Mutually exclusive with `--path`. |
+| `--strict`          | advisory (exit 0)               | Exit 1 if any `error` violations are found.                                |
+| `--json`            | human-readable                  | Emit machine-readable JSON report.                                         |
+| `--manifest <path>` | `config/mcp-tool-manifest.json` | Path to MCP tool manifest used for `mcp_tools` validation.                 |
+
+## Rule Categories
+
+Five rule categories are checked. Each violation has a `severity` of `error`, `warning`, or `info`.
+
+### 1. Frontmatter Conformance (`frontmatter.*`)
+
+Validates the YAML frontmatter block at the top of each `SKILL.md`.
+
+Required fields: `name`, `description`, `version`, `scope`, `owner`, `status`.
+
+Violation examples:
+
+```
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+
+ERROR [frontmatter.name-mismatch] .agents/skills/foo/SKILL.md: name "bar" does not match directory name "foo"
+  Fix: Set `name: foo` in frontmatter to match the skill directory.
+
+ERROR [frontmatter.invalid-semver] .agents/skills/foo/SKILL.md: version "1.0" is not valid semver (expected MAJOR.MINOR.PATCH)
+  Fix: Set version to a semver string, e.g. `version: 1.0.0`.
+
+ERROR [frontmatter.invalid-scope] .agents/skills/foo/SKILL.md: scope "vc" is invalid. Must be enterprise, global, or venture:<code>
+  Fix: Set scope to one of: `enterprise`, `global`, or `venture:<lowercase-code>` (e.g. `venture:ss`).
+
+ERROR [frontmatter.invalid-status] .agents/skills/foo/SKILL.md: status "beta" is invalid. Must be one of: draft, stable, deprecated
+  Fix: Set status to `draft`, `stable`, or `deprecated`.
+
+ERROR [frontmatter.unknown-owner] .agents/skills/foo/SKILL.md: owner "unknown-team" is not a known key in config/skill-owners.json
+  Fix: Add the skill under an existing owner key (captain, agent-team) in config/skill-owners.json, or add a new owner key.
+```
+
+### 2. Dispatcher Parity (`dispatcher.*`)
+
+Unless `backend_only: true` is set, every skill must have a matching `.claude/commands/<name>.md` command dispatcher.
+
+Violation example:
+
+```
+ERROR [dispatcher.missing-command-file] .agents/skills/foo/SKILL.md: No dispatcher found at .claude/commands/foo.md
+  Fix: Create .claude/commands/foo.md, or set `backend_only: true` in frontmatter if this skill has no slash command.
+```
+
+### 3. Reference Validity (`references.*`)
+
+Validates entries in `depends_on.mcp_tools`, `depends_on.files`, and `depends_on.commands`.
+
+- `mcp_tools`: each name must appear in `config/mcp-tool-manifest.json` (errors if manifest exists).
+- `files`: each entry must be scope-prefixed (`crane-console:`, `venture:`, or `global:`). Unprefixed paths are an error. `crane-console:` paths are resolved from repo root. `venture:` paths require `CRANE_VENTURE_SAMPLE_REPO` env var (warning if unset). `global:` paths expand `~/` and check local filesystem; in CI (`CI=true`) they emit a warning instead of an error.
+- `commands`: checked via `which <cmd>`. Missing commands are warnings, not errors.
+
+Violation examples:
+
+```
+ERROR [references.unknown-mcp-tool] .agents/skills/foo/SKILL.md: MCP tool "crane_missing" not found in config/mcp-tool-manifest.json
+  Fix: Remove the tool reference, add it to the manifest, or check for a typo in the tool name.
+
+ERROR [references.file-missing-scope-prefix] .agents/skills/foo/SKILL.md: File path missing scope prefix (expected `crane-console:`, `venture:`, or `global:`): "docs/foo.md"
+  Fix: Prefix the file path with `crane-console:`, `venture:`, or `global:` to indicate where the file lives.
+
+ERROR [references.broken-crane-console-file] .agents/skills/foo/SKILL.md: crane-console file not found: "docs/missing.md"
+  Fix: Create the file at docs/missing.md relative to the repo root, or remove the reference.
+
+WARNING [references.venture-file-unverified] .agents/skills/foo/SKILL.md: venture file reference ".stitch/DESIGN.md" not verified — CRANE_VENTURE_SAMPLE_REPO is not set
+  Fix: Set CRANE_VENTURE_SAMPLE_REPO to a local venture repo path to enable validation, or verify the path manually.
+
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "missing-cli" not found on PATH
+  Fix: Install "missing-cli" or remove it from depends_on.commands if it is optional.
+```
+
+### 4. Structural Lint (`structure.*`)
+
+The SKILL.md body (text after the closing `---`) must:
+
+1. Have a top-level `#` heading that starts with `/<name>` (e.g. `# /skill-review` or `# /skill-review - Title`).
+2. Contain at least one second-level section named `## Phases`, `## Workflow`, or `## Behavior`.
+
+Violation examples:
+
+```
+ERROR [structure.missing-h1-heading] .agents/skills/foo/SKILL.md: Body has no top-level # heading
+  Fix: Add a `# /foo` heading as the first heading in the SKILL.md body.
+
+ERROR [structure.heading-mismatch] .agents/skills/foo/SKILL.md: First # heading "Foo" does not start with "/foo"
+  Fix: Change the first heading to `# /foo` or `# /foo - Description`.
+
+ERROR [structure.missing-workflow-section] .agents/skills/foo/SKILL.md: Body is missing a workflow section (## Phases, ## Workflow, or ## Behavior)
+  Fix: Add a `## Phases`, `## Workflow`, or `## Behavior` section describing how the skill executes.
+```
+
+### 5. Deprecation Sanity (`deprecation.*`)
+
+If `status: deprecated`, both `deprecation_date` and `sunset_date` must be present, parseable as ISO dates, and `sunset_date` must be strictly after `deprecation_date`.
+
+Violation examples:
+
+```
+ERROR [deprecation.missing-deprecation-date] .agents/skills/foo/SKILL.md: status is deprecated but deprecation_date is missing
+  Fix: Add `deprecation_date: YYYY-MM-DD` to frontmatter.
+
+ERROR [deprecation.missing-sunset-date] .agents/skills/foo/SKILL.md: status is deprecated but sunset_date is missing
+  Fix: Add `sunset_date: YYYY-MM-DD` to frontmatter (typically deprecation_date + 90 days).
+
+ERROR [deprecation.sunset-before-deprecation] .agents/skills/foo/SKILL.md: sunset_date "2025-01-01" must be after deprecation_date "2025-03-01"
+  Fix: Set sunset_date to a date strictly after deprecation_date.
+```
+
+## Output Formats
+
+### Human-readable (default)
+
+```
+Reviewed 3 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" not found on PATH
+  Fix: Install "jq" or remove it from depends_on.commands if it is optional.
+```
+
+### JSON (`--json`)
+
+```json
+{
+  "skills_reviewed": 3,
+  "total_violations": 2,
+  "by_severity": { "error": 1, "warning": 1, "info": 0 },
+  "violations": [
+    {
+      "rule": "frontmatter.missing-field",
+      "severity": "error",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Missing required field: owner",
+      "fix": "Add `owner: <team>` to frontmatter. See docs/skills/governance.md."
+    },
+    {
+      "rule": "references.missing-command",
+      "severity": "warning",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Command \"jq\" not found on PATH",
+      "fix": "Install \"jq\" or remove it from depends_on.commands if it is optional."
+    }
+  ]
+}
+```
+
+## Adding a New Skill
+
+Follow the workflow in `docs/skills/governance.md`:
+
+1. Scaffold the skill directory at `.agents/skills/<name>/SKILL.md`.
+2. Fill in all required frontmatter fields (start with `status: draft`).
+3. Ensure `config/skill-owners.json` has the owning key.
+4. Create `.claude/commands/<name>.md` unless `backend_only: true`.
+5. Run `/skill-review --path .agents/skills/<name>` until zero errors.
+6. Flip to `status: stable` and open a PR.
+
+## Reference
+
+Full governance spec: `docs/skills/governance.md`
+
+CLI source: `packages/crane-mcp/src/cli/skill-review.ts`

--- a/.agents/skills/sos/SKILL.md
+++ b/.agents/skills/sos/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: sos
 description: Start of Session
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /sos - Start of Session

--- a/.agents/skills/sprint/SKILL.md
+++ b/.agents/skills/sprint/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: sprint
 description: Sequential sprint execution of GitHub issues on separate branches
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
-# Sprint
+# /sprint - Sequential sprint execution
 
 Takes a set of pre-selected GitHub issue numbers, builds an optimal wave-based execution plan, and implements them sequentially on separate branches. The prior step (human or planning agent) selects which issues go into the sprint. This skill handles execution.
 

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: status
 description: Show Session Status
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /status - Show Session Status

--- a/.agents/skills/stitch-ux-brief/SKILL.md
+++ b/.agents/skills/stitch-ux-brief/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: stitch-ux-brief
 description: Stitch UX Brief & Generation
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
 ---
 
 # /stitch-ux-brief - Stitch UX Brief & Generation

--- a/.agents/skills/update/SKILL.md
+++ b/.agents/skills/update/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: update
 description: Update Session Context
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+backend_only: true
 ---
 
 # /update - Update Session Context

--- a/.agents/skills/work-plan/SKILL.md
+++ b/.agents/skills/work-plan/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: work-plan
 description: Work Planning
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
 ---
 
 # /work-plan - Work Planning

--- a/.claude/commands/skill-audit.md
+++ b/.claude/commands/skill-audit.md
@@ -1,0 +1,50 @@
+---
+name: skill-audit
+description: Monthly skill health report. Audits all SKILL.md files for schema gaps, staleness, and deprecation queue status.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-audit - Monthly Skill Health Report
+
+Invoke the `crane_skill_audit` MCP tool and walk through the report.
+
+## How to run
+
+```
+/skill-audit
+```
+
+This command:
+
+1. Calls `crane_skill_audit()` with default parameters (`scope: all`, `stale_threshold_days: 180`, `include_deprecated: true`).
+2. Displays the structured report with sections for inventory, schema gaps, staleness, and the deprecation queue.
+3. Prompts you to review any flagged items.
+4. Records completion via `crane_schedule(action: "complete", name: "skill-audit", ...)`.
+
+## What to expect
+
+The report contains four sections:
+
+- **Inventory** - Total skills by scope, status, and owner.
+- **Schema gaps** - Skills missing required frontmatter fields. Each entry shows which fields are missing.
+- **Staleness** - Skills not touched in git for more than 180 days, sorted worst-first.
+- **Deprecation queue** - Skills with `status: deprecated`, sorted by days until sunset.
+
+Reference drift checking (broken MCP tool / file / command references) is not included here. Run `/skill-review --all` separately for that.
+
+## Options
+
+You can customize the audit:
+
+```
+crane_skill_audit(scope: "enterprise")          # enterprise skills only
+crane_skill_audit(stale_threshold_days: 90)     # tighter staleness window
+crane_skill_audit(include_deprecated: false)    # exclude deprecated from counts
+```
+
+## Full workflow
+
+See `.agents/skills/skill-audit/SKILL.md` for the complete step-by-step workflow including how to act on each report section and record completion.

--- a/.claude/commands/skill-deprecate.md
+++ b/.claude/commands/skill-deprecate.md
@@ -1,0 +1,29 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically

--- a/.claude/commands/skill-review.md
+++ b/.claude/commands/skill-review.md
@@ -1,0 +1,72 @@
+---
+name: skill-review
+description: Lint a skill or the entire repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-review
+
+Lint a skill directory or all skills against the schema in `docs/skills/governance.md`.
+
+## Usage
+
+```
+/skill-review [skill-name] [--strict]
+```
+
+- `/skill-review` - review all skills in advisory mode (always exits 0)
+- `/skill-review sos` - review the `sos` skill only
+- `/skill-review --strict` - review all skills, exit 1 on errors
+- `/skill-review sos --strict` - review `sos`, exit 1 on errors
+
+## What the Agent Does
+
+When you invoke `/skill-review`, the agent runs:
+
+```bash
+# Single skill
+npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
+
+# All skills
+npm run skill-review -w @venturecrane/crane-mcp -- --all [--strict] [--json]
+```
+
+The CLI builds from TypeScript, runs all five checks against each `SKILL.md`, then prints a human-readable report (or JSON with `--json`).
+
+## Output
+
+Human-readable (default):
+
+```
+Reviewed 12 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" not found on PATH
+  Fix: Install "jq" or remove it from depends_on.commands if it is optional.
+```
+
+JSON (with `--json`):
+
+```json
+{
+  "skills_reviewed": 12,
+  "total_violations": 2,
+  "by_severity": { "error": 1, "warning": 1, "info": 0 },
+  "violations": [...]
+}
+```
+
+## Exit Codes
+
+- Default (advisory): always exits 0
+- `--strict`: exits 1 if any `error`-severity violations are found
+
+## Reference
+
+Full governance spec and rule definitions: `docs/skills/governance.md`
+
+CLI source: `packages/crane-mcp/src/cli/skill-review.ts`

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,99 @@
+name: skill-review (advisory)
+
+# Lints every skill on PRs that touch skill/command files.
+# Currently ADVISORY — findings post as a PR comment but never block merge.
+# Flip to blocking after 30 days of observation by removing `|| true` below.
+# See docs/skills/governance.md and the `skill-review-flip-to-blocking`
+# schedule_items cadence entry seeded in migration 0033.
+
+on:
+  pull_request:
+    paths:
+      - '.agents/skills/**'
+      - '.claude/commands/**'
+      - 'config/skill-owners.json'
+      - 'config/global-skills.json'
+      - 'config/skill-exclusions.json'
+      - 'docs/skills/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build crane-mcp
+        run: npm run build -w @venturecrane/crane-mcp
+
+      - name: Snapshot MCP tool manifest
+        run: npm run skill-review:snapshot
+
+      - name: Run skill-review (advisory — never blocks)
+        id: review
+        run: |
+          mkdir -p /tmp/skill-review
+          npm run skill-review -- --all --json > /tmp/skill-review/report.json || true
+          cat /tmp/skill-review/report.json
+
+      - name: Post findings as PR comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync('/tmp/skill-review/report.json', 'utf-8'));
+            } catch (e) {
+              console.log('No report available, skipping comment');
+              return;
+            }
+
+            const total = report.total_violations ?? 0;
+            const bySev = report.by_severity ?? { error: 0, warning: 0, info: 0 };
+
+            let body = `### 🧪 Skill review (advisory)\n\n`;
+            body += `**Skills reviewed:** ${report.skills_reviewed ?? 0}  \n`;
+            body += `**Violations:** ${total} (errors: ${bySev.error}, warnings: ${bySev.warning}, info: ${bySev.info})\n\n`;
+
+            if (total === 0) {
+              body += `✅ All skills pass governance checks.\n`;
+            } else {
+              body += `<details><summary>Violations</summary>\n\n`;
+              for (const v of (report.violations ?? []).slice(0, 50)) {
+                body += `- \`${v.severity}\` **${v.rule}** — \`${v.path}\`: ${v.message}\n`;
+                if (v.fix) body += `  - Fix: ${v.fix}\n`;
+              }
+              if ((report.violations ?? []).length > 50) {
+                body += `\n... and ${report.violations.length - 50} more\n`;
+              }
+              body += `\n</details>\n\n`;
+              body += `ℹ️ Advisory mode — this check does not block merge. See \`docs/skills/governance.md\`.\n`;
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            // Update existing bot comment if present, else create a new one
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) =>
+              c.user?.type === 'Bot' && c.body?.startsWith('### 🧪 Skill review')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ workers/crane-context/manual-test-log.md
 
 # Vercel CLI per-developer link state (vercel link writes here)
 .vercel/
+
+# Generated MCP tool manifest (see scripts/snapshot-mcp-tools.ts)
+config/mcp-tool-manifest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,19 +54,20 @@ Injected by `crane` launcher: `CRANE_ENV`, `CRANE_VENTURE_CODE`, `CRANE_VENTURE_
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module                    | Key Rule (always applies)                                                          | Fetch for details                                        |
-| ------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `secrets.md`              | Verify secret VALUES, not just key existence                                       | Infisical, vault, API keys, GitHub App                   |
-| `content-policy.md`       | Never auto-save to VCMS; agents ARE the voice                                      | VCMS tags, storage rules, editorial, style               |
-| `team-workflow.md`        | All changes through PRs; never push to main                                        | Full workflow, QA grades, escalation triggers            |
-| `fleet-ops.md`            | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh       | SSH, machines, Tailscale, macOS                          |
-| `creating-issues.md`      | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                      | Templates, labels, target repos                          |
-| `pr-workflow.md`          | Push branch, `gh pr create`, assign QA grade - never skip the PR                   | Branch naming, commit format, PR template, post-merge QA |
-| `guardrails.md`           | Never deprecate features, drop schema, or change auth without Captain directive    | Protected actions, escalation format, feature manifests  |
-| `wireframe-guidelines.md` | Wireframe committed and linked before status:ready (UI stories)                    | Wireframe generation, file conventions, quality bar      |
-| `design-system.md`        | Load design spec before wireframe/UI work: `crane_doc('{code}', 'design-spec.md')` | Design tokens, component patterns, venture specs         |
+| Module                    | Key Rule (always applies)                                                                                                       | Fetch for details                                          |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `secrets.md`              | Verify secret VALUES, not just key existence                                                                                    | Infisical, vault, API keys, GitHub App                     |
+| `content-policy.md`       | Never auto-save to VCMS; agents ARE the voice                                                                                   | VCMS tags, storage rules, editorial, style                 |
+| `team-workflow.md`        | All changes through PRs; never push to main                                                                                     | Full workflow, QA grades, escalation triggers              |
+| `fleet-ops.md`            | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh                                                    | SSH, machines, Tailscale, macOS                            |
+| `creating-issues.md`      | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                                                                   | Templates, labels, target repos                            |
+| `pr-workflow.md`          | Push branch, `gh pr create`, assign QA grade - never skip the PR                                                                | Branch naming, commit format, PR template, post-merge QA   |
+| `guardrails.md`           | Never deprecate features, drop schema, or change auth without Captain directive                                                 | Protected actions, escalation format, feature manifests    |
+| `wireframe-guidelines.md` | Wireframe committed and linked before status:ready (UI stories)                                                                 | Wireframe generation, file conventions, quality bar        |
+| `design-system.md`        | Load design spec before wireframe/UI work: `crane_doc('{code}', 'design-spec.md')`                                              | Design tokens, component patterns, venture specs           |
+| `skills/governance.md`    | Every SKILL.md has full frontmatter (name, description, version, scope, owner, status); new/changed skills pass `/skill-review` | Schema, scopes, lifecycle, review gate, audit, deprecation |
 
-Fetch with: `crane_doc('global', '<module>')`
+Fetch with: `crane_doc('global', '<module>')` (or read local `docs/skills/governance.md` directly for the skill governance module)
 
 ## Architecture Reference
 

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "Skill ownership catalog. Source of truth for the 'owner' frontmatter field on every SKILL.md. Skills are grouped by owning team. See docs/skills/governance.md.",
+  "captain": [
+    "sos",
+    "eos",
+    "status",
+    "heartbeat",
+    "update",
+    "ship",
+    "work-plan",
+    "portfolio-review",
+    "platform-audit",
+    "enterprise-review",
+    "context-refresh",
+    "go-live",
+    "sprint",
+    "code-review",
+    "prd-review",
+    "critique",
+    "skill-review",
+    "skill-audit",
+    "skill-deprecate",
+    "skill-creator"
+  ],
+  "agent-team": [
+    "build-log",
+    "edit-article",
+    "edit-log",
+    "docs-refresh",
+    "new-venture",
+    "content-scan",
+    "analytics",
+    "calendar-sync",
+    "stitch-design",
+    "nav-spec",
+    "design-brief",
+    "stitch-ux-brief",
+    "react-components",
+    "enhance-prompt",
+    "agent-browser"
+  ]
+}

--- a/docs/skills/deprecated.md
+++ b/docs/skills/deprecated.md
@@ -1,0 +1,9 @@
+# Deprecated Skills
+
+Append-only log of skills that have been marked for sunset via `/skill-deprecate`. Each entry records the skill name, deprecation date, sunset date, reason, and migration path.
+
+See `docs/skills/governance.md` for the lifecycle model.
+
+---
+
+<!-- New entries appended below by /skill-deprecate -->

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -1,0 +1,153 @@
+# Skill Governance
+
+This document defines how skills are created, reviewed, audited, and retired in the Venture Crane enterprise.
+
+A **skill** is a structured prompt file at `.agents/skills/<name>/SKILL.md` that an agent invokes via a slash command (`/<name>`). Skills may bundle supporting files (workflows, references, examples, scripts) in sibling directories. Skills are this enterprise's operating system — every agent workflow (`/sos`, `/work-plan`, `/stitch-ux-brief`) is a skill.
+
+## Frontmatter schema
+
+Every `SKILL.md` MUST have YAML frontmatter at the top of the file:
+
+```yaml
+---
+name: skill-name
+description: One-line purpose statement (1-2 sentences).
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_sos
+    - crane_schedule
+  files:
+    - crane-console:docs/planning/WEEKLY_PLAN.md
+    - venture:.stitch/NAVIGATION.md
+    - global:~/.agents/skills/nav-spec/validate.py
+  commands:
+    - gh
+    - npm
+---
+```
+
+### Required fields
+
+| Field         | Type          | Description                                                                                                                                 |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | string        | kebab-case, MUST match the parent directory name and the `# /<name>` heading in the body                                                    |
+| `description` | string        | 1-2 sentence purpose statement, used by the Claude Code harness to decide when to trigger the skill                                         |
+| `version`     | semver string | `MAJOR.MINOR.PATCH`. Bump MINOR on additive changes, MAJOR on breaking restructures, PATCH on fixes                                         |
+| `scope`       | enum          | `enterprise` (crane-console workflow), `global` (usable in any venture context), or `venture:<code>` (venture-specific, e.g., `venture:ss`) |
+| `owner`       | string        | MUST be a key from `config/skill-owners.json`. Currently: `captain` or `agent-team`                                                         |
+| `status`      | enum          | `draft` (in-progress, not yet stable), `stable` (production), `deprecated` (being retired)                                                  |
+
+### Optional fields
+
+| Field                  | Type     | Description                                                                                                                                                                         |
+| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `depends_on.mcp_tools` | string[] | MCP tool names this skill calls. Validated against `config/mcp-tool-manifest.json` (CI-generated)                                                                                   |
+| `depends_on.files`     | string[] | File references, **scope-prefixed**: `crane-console:<path>`, `venture:<path>`, or `global:<path>`. The `/skill-review` validator enforces the correct scope when checking existence |
+| `depends_on.commands`  | string[] | External shell commands the skill invokes. Checked as PATH warnings only                                                                                                            |
+| `backend_only`         | boolean  | If `true`, the skill has no matching `.claude/commands/<name>.md` dispatcher. Default `false`                                                                                       |
+| `deprecation_date`     | ISO date | Set by `/skill-deprecate` when status flips to `deprecated`                                                                                                                         |
+| `sunset_date`          | ISO date | Set by `/skill-deprecate`. Skill is a candidate for removal after this date                                                                                                         |
+| `deprecation_notice`   | string   | Human-readable reason + migration path, shown in the SKILL.md banner                                                                                                                |
+
+### Deliberately not in the schema
+
+- **`last_reviewed`** — staleness is derived from `git log -1 --format=%cI -- <path>`, which gives truthful data for free. Stored dates drift into lies.
+- **`allowed_tools`** — some legacy skills have this field; leave it in place during backfill but don't elevate it to governance. The Claude Code harness enforces tool access separately via `settings.json`.
+
+## Scopes — where do skills live?
+
+| Scope            | On-disk location                        | Distribution mechanism                                                                                                                     |
+| ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enterprise`     | `crane-console/.agents/skills/<name>/`  | Primary — loaded directly when Claude Code runs in crane-console. Follow-up work will mirror to venture repos                              |
+| `global`         | `~/.agents/skills/<name>/`              | Mirrored from `crane-console/.agents/skills/<name>/` to home via `config/global-skills.json` + launcher `syncGlobalSkills()` (see PR #528) |
+| `venture:<code>` | `<venture-repo>/.agents/skills/<name>/` | Venture-specific. Not synced from crane-console. Example: a skill only useful in ss-console                                                |
+
+## Lifecycle: draft → stable → deprecated → sunset
+
+```
+  draft ────── /skill-review passes ────▶ stable
+    ▲                                        │
+    │                                        │ /skill-deprecate
+    │                                        ▼
+    └────── reverted / reopened ────── deprecated
+                                             │
+                                             │ Captain directive after sunset_date
+                                             ▼
+                                          removed (separate PR)
+```
+
+- **draft** — in progress. `/skill-review` surfaces issues but the skill isn't advertised.
+- **stable** — production. The default status after a passing review.
+- **deprecated** — `/skill-deprecate` has set `deprecation_date` and `sunset_date`. Warning banner injected into the SKILL.md body. Invocations still work during the grace period.
+- **removed** — after `sunset_date`, Captain can delete the skill in a separate PR. `guardrails.md` forbids removing features without Captain directive, so this is always manual.
+
+## Review gate
+
+`/skill-review` lints a single skill or the whole repo:
+
+```bash
+npm run skill-review -- --path .agents/skills/<name>
+npm run skill-review -- --all --strict
+```
+
+Checks:
+
+1. **Frontmatter conformance** — required fields present, enums valid, semver parseable.
+2. **Dispatcher parity** — matching `.claude/commands/<name>.md` exists (unless `backend_only: true`).
+3. **Reference validity**:
+   - `depends_on.mcp_tools` — every name exists in `config/mcp-tool-manifest.json` (CI-generated).
+   - `depends_on.files` — scope-prefixed; validator checks the correct location per scope.
+   - `depends_on.commands` — checked on PATH as warnings only.
+4. **Structural lint** — `# /<name>` heading matches frontmatter, `## Phases` or `## Workflow` section present.
+5. **Deprecation sanity** — `status: deprecated` requires `deprecation_date` and `sunset_date`, and `sunset_date > deprecation_date`.
+
+CI runs `skill-review` on every PR that touches `.agents/skills/**`. **Currently in advisory mode** (findings posted as PR comment, never blocks merge). A cadence item 30 days out reminds the Captain to flip to blocking.
+
+## Audit
+
+`/skill-audit` runs a repo-wide health check. Monthly cadence, driven by `schedule_items` in crane-context D1. Surfaces in `/sos` briefing when due.
+
+Report sections:
+
+1. **Inventory** — totals by scope, status, owner.
+2. **Schema gaps** — skills missing required frontmatter.
+3. **Reference drift** — broken MCP tools / files / commands.
+4. **Staleness** — skills whose SKILL.md hasn't been touched in git for > 180 days.
+5. **Deprecation queue** — skills past `sunset_date`, flagged for Captain review.
+
+No usage signal yet — invocation telemetry is a follow-up (see below). Staleness is git-touched-date for now, not "never invoked."
+
+## Deprecation
+
+`/skill-deprecate <name>` is Captain-gated. It:
+
+1. Prompts for confirmation (cross-references `guardrails.md`).
+2. Bumps frontmatter: `status: deprecated`, `deprecation_date: today`, `sunset_date: today + 90d`, `deprecation_notice: "<reason>"`.
+3. Injects a warning banner at the top of the SKILL.md body.
+4. Appends an entry to `docs/skills/deprecated.md`.
+5. Creates a branch + PR for review.
+
+The skill is NOT deleted. Removal is always a separate PR after `sunset_date`.
+
+## Adding a new skill
+
+1. Use `/skill-creator` to scaffold (or copy an existing skill's structure).
+2. Fill out the frontmatter using the schema above. Default `status: draft` until ready.
+3. Add the skill name to `config/skill-owners.json` under the owning team.
+4. Write `.claude/commands/<name>.md` (unless `backend_only: true`).
+5. Run `npm run skill-review -- --path .agents/skills/<name>` until it passes.
+6. Flip `status: stable` and open a PR. CI will re-run `/skill-review`.
+
+## Deferred (not yet implemented)
+
+The following governance features are planned but not in this session's landing:
+
+- **Invocation telemetry** — a harness-level hook will record each skill invocation to D1. The audit will gain a "usage signal" section (skills with zero invocations in 90 days → deprecation candidate). Prose-level "call this tool first" conventions are deliberately avoided because LLM compliance produces unreliable signal.
+- **Venture-repo skill sync** — the launcher currently syncs `.claude/commands/` (via `syncClaudeAssets`) and global skills to `~/.agents/skills/` (via `syncGlobalSkills`). Extending this to mirror `.agents/skills/` to venture repos requires a reconcile pass for ss-console's 16 hand-ported skills; that work is tracked separately.
+- **Blocking CI gate** — `/skill-review` CI is advisory for 30 days, then flips to blocking via a one-line PR. A cadence reminder is seeded.
+
+See `docs/skills/deprecated.md` for the deprecation log.

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,14 +82,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@cfworker/json-schema": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
-      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@cloudflare/workers-types": {
       "version": "4.20260405.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
@@ -850,18 +842,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2123,18 +2103,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -2414,6 +2382,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -2600,6 +2581,18 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2846,6 +2839,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2882,6 +2888,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/has-flag": {
@@ -3055,6 +3098,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -3232,6 +3284,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3244,280 +3305,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -4272,6 +4059,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -4378,6 +4175,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -4596,6 +4406,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4661,6 +4477,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -4779,6 +4604,26 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {
@@ -5166,6 +5011,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "gray-matter": "^4.0.3",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -5176,6 +5022,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.0.18",
+        "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.18"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test:canary": "npm run --prefix workers/crane-context test:canary",
     "verify": "npm run typecheck && npm run format:check && npm run lint && npm run test && npm run test:canary && npm run build -w @venturecrane/crane-mcp && npm run build -w @venturecrane/crane-test-harness",
     "postinstall": "npm run build -w @venturecrane/crane-test-harness && npm install --prefix workers/crane-context && npm install --prefix workers/crane-watch && npm install --prefix workers/crane-mcp-remote",
-    "prepare": "node -e \"if(process.env.CI)process.exit(0)\" && husky"
+    "prepare": "node -e \"if(process.env.CI)process.exit(0)\" && husky",
+    "skill-review": "npm run skill-review -w @venturecrane/crane-mcp --",
+    "skill-review:snapshot": "npm run skill-review:snapshot -w @venturecrane/crane-mcp"
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",

--- a/packages/crane-mcp/package.json
+++ b/packages/crane-mcp/package.json
@@ -11,20 +11,25 @@
   },
   "scripts": {
     "build": "tsc",
+    "postbuild": "npx tsx ../../scripts/snapshot-mcp-tools.ts",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "skill-review": "npm run build && node dist/cli/skill-review.js",
+    "skill-review:snapshot": "npx tsx ../../scripts/snapshot-mcp-tools.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "gray-matter": "^4.0.3",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.0.18",
+    "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },

--- a/packages/crane-mcp/src/cli/skill-review.test.ts
+++ b/packages/crane-mcp/src/cli/skill-review.test.ts
@@ -1,0 +1,625 @@
+/**
+ * Tests for skill-review CLI logic.
+ *
+ * All filesystem access is mocked via vi.mock('fs') so these tests run in
+ * isolation without requiring the actual skill tree or config files.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+
+// ---------------------------------------------------------------------------
+// Mock child_process (for `which` checks in checkReferenceValidity)
+// ---------------------------------------------------------------------------
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}))
+
+// ---------------------------------------------------------------------------
+// Mock fs — must be set up before the module under test is imported
+// ---------------------------------------------------------------------------
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(() => ''),
+  readdirSync: vi.fn(() => []),
+  statSync: vi.fn(() => ({ isDirectory: () => true })),
+}))
+
+import { spawnSync } from 'child_process'
+
+import {
+  parseFrontmatter,
+  checkFrontmatterConformance,
+  checkDispatcherParity,
+  checkReferenceValidity,
+  checkStructuralLint,
+  checkDeprecationSanity,
+  loadSkillOwners,
+  loadMcpToolManifest,
+  aggregateResults,
+  formatHuman,
+  formatJson,
+  parseArgs,
+} from './skill-review.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SKILL_PATH = '.agents/skills/foo/SKILL.md'
+const REPO_ROOT = '/repo'
+const KNOWN_OWNERS = ['captain', 'agent-team']
+
+function goodFrontmatter() {
+  return {
+    name: 'foo',
+    description: 'Does something useful.',
+    version: '1.0.0',
+    scope: 'enterprise',
+    owner: 'captain',
+    status: 'stable',
+  }
+}
+
+function makeSkillMd(fm: Record<string, unknown>, body: string): string {
+  const fmLines = Object.entries(fm)
+    .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+    .join('\n')
+  return `---\n${fmLines}\n---\n${body}`
+}
+
+// ---------------------------------------------------------------------------
+// parseFrontmatter
+// ---------------------------------------------------------------------------
+
+describe('parseFrontmatter', () => {
+  it('returns empty data when no frontmatter delimiter', () => {
+    const { data, content } = parseFrontmatter('# No frontmatter here')
+    expect(data).toEqual({})
+    expect(content).toContain('# No frontmatter')
+  })
+
+  it('parses basic scalar fields', () => {
+    const raw = `---\nname: my-skill\nversion: 1.2.3\nstatus: stable\n---\n# body`
+    const { data } = parseFrontmatter(raw)
+    expect(data.name).toBe('my-skill')
+    expect(data.version).toBe('1.2.3')
+    expect(data.status).toBe('stable')
+  })
+
+  it('parses boolean backend_only', () => {
+    const raw = `---\nname: x\nbackend_only: true\n---\n`
+    const { data } = parseFrontmatter(raw)
+    expect(data.backend_only).toBe(true)
+  })
+
+  it('separates content from frontmatter', () => {
+    const raw = `---\nname: x\n---\n# /x\n\n## Behavior\nDoes stuff.`
+    const { content } = parseFrontmatter(raw)
+    expect(content).toContain('# /x')
+    expect(content).toContain('## Behavior')
+  })
+
+  it('parses nested depends_on with list items', () => {
+    const raw = `---\nname: x\ndepends_on:\n  mcp_tools:\n    - crane_sos\n    - crane_schedule\n---\n`
+    const { data } = parseFrontmatter(raw)
+    const dep = data.depends_on as Record<string, unknown>
+    expect(dep).toBeDefined()
+    expect(dep.mcp_tools).toContain('crane_sos')
+    expect(dep.mcp_tools).toContain('crane_schedule')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkFrontmatterConformance
+// ---------------------------------------------------------------------------
+
+describe('checkFrontmatterConformance', () => {
+  it('returns no violations for a well-formed skill', () => {
+    const violations = checkFrontmatterConformance(
+      SKILL_PATH,
+      SKILL_PATH,
+      goodFrontmatter(),
+      'foo',
+      KNOWN_OWNERS
+    )
+    expect(violations).toHaveLength(0)
+  })
+
+  it('errors on missing required field', () => {
+    const fm = { ...goodFrontmatter(), owner: undefined }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.missing-field')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+    expect(v!.message).toContain('owner')
+  })
+
+  it('errors on bad semver', () => {
+    const fm = { ...goodFrontmatter(), version: '1.0' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.invalid-semver')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors on invalid scope enum', () => {
+    const fm = { ...goodFrontmatter(), scope: 'vc' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.invalid-scope')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('accepts valid venture scope', () => {
+    const fm = { ...goodFrontmatter(), scope: 'venture:ss' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    expect(violations.filter((v) => v.rule === 'frontmatter.invalid-scope')).toHaveLength(0)
+  })
+
+  it('errors on invalid status enum', () => {
+    const fm = { ...goodFrontmatter(), status: 'beta' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.invalid-status')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors on unknown owner', () => {
+    const fm = { ...goodFrontmatter(), owner: 'unknown-team' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.unknown-owner')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors on name-directory mismatch', () => {
+    const fm = { ...goodFrontmatter(), name: 'bar' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    const v = violations.find((x) => x.rule === 'frontmatter.name-mismatch')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('skips owner check when knownOwners is empty (manifest missing)', () => {
+    const fm = { ...goodFrontmatter(), owner: 'anything' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', [])
+    expect(violations.filter((v) => v.rule === 'frontmatter.unknown-owner')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkDispatcherParity
+// ---------------------------------------------------------------------------
+
+describe('checkDispatcherParity', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset()
+  })
+
+  it('passes when command file exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('errors when command file is missing', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT)
+    const v = violations.find((x) => x.rule === 'dispatcher.missing-command-file')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+    expect(v!.message).toContain('.claude/commands/foo.md')
+  })
+
+  it('skips check when backend_only is true', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const fm = { ...goodFrontmatter(), backend_only: true }
+    const violations = checkDispatcherParity(SKILL_PATH, fm, REPO_ROOT)
+    expect(violations).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkReferenceValidity
+// ---------------------------------------------------------------------------
+
+describe('checkReferenceValidity', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReset()
+    vi.mocked(spawnSync).mockReset()
+    process.env = { ...OLD_ENV }
+    delete process.env.CI
+    delete process.env.CRANE_VENTURE_SAMPLE_REPO
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  it('returns no violations when no depends_on', () => {
+    const violations = checkReferenceValidity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, [])
+    expect(violations).toHaveLength(0)
+  })
+
+  it('errors when mcp_tool not in manifest', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { mcp_tools: ['crane_missing'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, ['crane_sos'])
+    const v = violations.find((x) => x.rule === 'references.unknown-mcp-tool')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+    expect(v!.message).toContain('crane_missing')
+  })
+
+  it('skips mcp_tools check when manifest is empty (file missing)', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { mcp_tools: ['crane_missing'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    expect(violations.filter((v) => v.rule === 'references.unknown-mcp-tool')).toHaveLength(0)
+  })
+
+  it('passes when mcp_tool is in manifest', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { mcp_tools: ['crane_sos'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, ['crane_sos'])
+    expect(violations.filter((v) => v.rule === 'references.unknown-mcp-tool')).toHaveLength(0)
+  })
+
+  it('errors on file path without scope prefix', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { files: ['docs/some-doc.md'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    const v = violations.find((x) => x.rule === 'references.file-missing-scope-prefix')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+    expect(v!.message).toContain('docs/some-doc.md')
+  })
+
+  it('errors when crane-console file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { files: ['crane-console:docs/missing.md'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    const v = violations.find((x) => x.rule === 'references.broken-crane-console-file')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('passes when crane-console file exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { files: ['crane-console:docs/existing.md'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    expect(
+      violations.filter((v) => v.rule === 'references.broken-crane-console-file')
+    ).toHaveLength(0)
+  })
+
+  it('warns (not errors) for venture file when CRANE_VENTURE_SAMPLE_REPO is not set', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { files: ['venture:.stitch/DESIGN.md'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    const v = violations.find((x) => x.rule === 'references.venture-file-unverified')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('warning')
+  })
+
+  it('warns (not errors) for missing commands', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1 } as ReturnType<typeof spawnSync>)
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { commands: ['missing-cli'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    const v = violations.find((x) => x.rule === 'references.missing-command')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('warning')
+  })
+
+  it('skips global file check in CI', () => {
+    process.env.CI = 'true'
+    const fm = {
+      ...goodFrontmatter(),
+      depends_on: { files: ['global:~/.agents/skills/x/validate.py'] },
+    }
+    const violations = checkReferenceValidity(SKILL_PATH, fm, REPO_ROOT, [])
+    const v = violations.find((x) => x.rule === 'references.global-file-unverified')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('warning')
+    // Must NOT also produce a broken-global-file error
+    expect(violations.filter((x) => x.rule === 'references.broken-global-file')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkStructuralLint
+// ---------------------------------------------------------------------------
+
+describe('checkStructuralLint', () => {
+  it('passes for well-formed body', () => {
+    const content = '# /foo - Does something\n\n## Behavior\nDoes stuff.\n'
+    const violations = checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('passes when heading is exactly # /name', () => {
+    const content = '# /foo\n\n## Workflow\nDoes stuff.\n'
+    const violations = checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)
+    expect(violations).toHaveLength(0)
+  })
+
+  it('errors when no # heading exists', () => {
+    const content = 'Some prose without a heading.\n\n## Behavior\nDoes stuff.\n'
+    const violations = checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)
+    const v = violations.find((x) => x.rule === 'structure.missing-h1-heading')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when # heading does not start with skill name', () => {
+    const content = '# Foo Tool\n\n## Phases\nDoes stuff.\n'
+    const violations = checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)
+    const v = violations.find((x) => x.rule === 'structure.heading-mismatch')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+    expect(v!.message).toContain('/foo')
+  })
+
+  it('flags missing workflow section as info (advisory)', () => {
+    // Use a section heading that is NOT in the accepted list so the check fires
+    const content = '# /foo\n\n## Notes\nDoes stuff.\n'
+    const violations = checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)
+    const v = violations.find((x) => x.rule === 'structure.missing-workflow-section')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('info')
+  })
+
+  it('accepts ## Phases as workflow section', () => {
+    const content = '# /foo\n\n## Phases\nDoes stuff.\n'
+    expect(checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)).toHaveLength(0)
+  })
+
+  it('accepts ## Workflow as workflow section', () => {
+    const content = '# /foo\n\n## Workflow\nDoes stuff.\n'
+    expect(checkStructuralLint(SKILL_PATH, goodFrontmatter(), content)).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkDeprecationSanity
+// ---------------------------------------------------------------------------
+
+describe('checkDeprecationSanity', () => {
+  it('returns no violations for non-deprecated skills', () => {
+    expect(checkDeprecationSanity(SKILL_PATH, goodFrontmatter())).toHaveLength(0)
+  })
+
+  it('errors when deprecated but sunset_date is missing', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2025-01-01',
+    }
+    const violations = checkDeprecationSanity(SKILL_PATH, fm)
+    const v = violations.find((x) => x.rule === 'deprecation.missing-sunset-date')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when deprecated but deprecation_date is missing', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      sunset_date: '2025-04-01',
+    }
+    const violations = checkDeprecationSanity(SKILL_PATH, fm)
+    const v = violations.find((x) => x.rule === 'deprecation.missing-deprecation-date')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when sunset_date is not after deprecation_date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2025-04-01',
+      sunset_date: '2025-01-01',
+    }
+    const violations = checkDeprecationSanity(SKILL_PATH, fm)
+    const v = violations.find((x) => x.rule === 'deprecation.sunset-before-deprecation')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('passes when both dates are valid and sunset is after deprecation', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2025-01-01',
+      sunset_date: '2025-04-01',
+    }
+    expect(checkDeprecationSanity(SKILL_PATH, fm)).toHaveLength(0)
+  })
+
+  it('errors when deprecation_date is not a valid ISO date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: 'not-a-date',
+      sunset_date: '2025-04-01',
+    }
+    const violations = checkDeprecationSanity(SKILL_PATH, fm)
+    const v = violations.find((x) => x.rule === 'deprecation.invalid-deprecation-date')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Config loaders
+// ---------------------------------------------------------------------------
+
+describe('loadSkillOwners', () => {
+  beforeEach(() => vi.mocked(existsSync).mockReset())
+
+  it('returns keys from skill-owners.json', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ captain: ['sos'], 'agent-team': ['build-log'] })
+    )
+    const owners = loadSkillOwners(REPO_ROOT)
+    expect(owners).toContain('captain')
+    expect(owners).toContain('agent-team')
+  })
+
+  it('returns empty array when file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    expect(loadSkillOwners(REPO_ROOT)).toEqual([])
+  })
+})
+
+describe('loadMcpToolManifest', () => {
+  beforeEach(() => vi.mocked(existsSync).mockReset())
+
+  it('returns array of tool names', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify(['crane_sos', 'crane_schedule']))
+    const tools = loadMcpToolManifest('/repo/config/mcp-tool-manifest.json')
+    expect(tools).toContain('crane_sos')
+    expect(tools).toContain('crane_schedule')
+  })
+
+  it('returns empty array when file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    expect(loadMcpToolManifest('/repo/config/mcp-tool-manifest.json')).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Aggregation and formatting
+// ---------------------------------------------------------------------------
+
+describe('aggregateResults', () => {
+  it('counts violations correctly', () => {
+    const violations = [
+      {
+        rule: 'r1',
+        severity: 'error' as const,
+        path: 'p',
+        message: 'm',
+        fix: 'f',
+      },
+      {
+        rule: 'r2',
+        severity: 'warning' as const,
+        path: 'p',
+        message: 'm',
+        fix: 'f',
+      },
+    ]
+    const result = aggregateResults(violations, 5)
+    expect(result.skills_reviewed).toBe(5)
+    expect(result.total_violations).toBe(2)
+    expect(result.by_severity.error).toBe(1)
+    expect(result.by_severity.warning).toBe(1)
+    expect(result.by_severity.info).toBe(0)
+  })
+
+  it('handles zero violations', () => {
+    const result = aggregateResults([], 3)
+    expect(result.total_violations).toBe(0)
+    expect(result.by_severity.error).toBe(0)
+  })
+})
+
+describe('formatHuman', () => {
+  it('shows "All skills pass." when no violations', () => {
+    const result = aggregateResults([], 2)
+    expect(formatHuman(result)).toContain('All skills pass.')
+  })
+
+  it('formats each violation with severity and fix', () => {
+    const violations = [
+      {
+        rule: 'frontmatter.missing-field',
+        severity: 'error' as const,
+        path: '.agents/skills/foo/SKILL.md',
+        message: 'Missing required field: owner',
+        fix: 'Add owner field.',
+      },
+    ]
+    const output = formatHuman(aggregateResults(violations, 1))
+    expect(output).toContain('ERROR')
+    expect(output).toContain('[frontmatter.missing-field]')
+    expect(output).toContain('Missing required field: owner')
+    expect(output).toContain('Fix: Add owner field.')
+  })
+})
+
+describe('formatJson', () => {
+  it('produces valid JSON with expected shape', () => {
+    const result = aggregateResults([], 1)
+    const json = JSON.parse(formatJson(result)) as typeof result
+    expect(json).toHaveProperty('skills_reviewed', 1)
+    expect(json).toHaveProperty('total_violations', 0)
+    expect(json).toHaveProperty('by_severity')
+    expect(json).toHaveProperty('violations')
+    expect(Array.isArray(json.violations)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('parses --path', () => {
+    const args = parseArgs(['--path', '.agents/skills/foo'])
+    expect(args.path).toBe('.agents/skills/foo')
+    expect(args.all).toBe(false)
+  })
+
+  it('parses --all', () => {
+    const args = parseArgs(['--all'])
+    expect(args.all).toBe(true)
+    expect(args.path).toBeUndefined()
+  })
+
+  it('parses --strict', () => {
+    expect(parseArgs(['--strict']).strict).toBe(true)
+  })
+
+  it('parses --json', () => {
+    expect(parseArgs(['--json']).json).toBe(true)
+  })
+
+  it('parses --manifest', () => {
+    const args = parseArgs(['--manifest', '/custom/path.json'])
+    expect(args.manifest).toBe('/custom/path.json')
+  })
+
+  it('defaults to advisory (strict=false)', () => {
+    expect(parseArgs(['--all']).strict).toBe(false)
+  })
+
+  it('defaults json to false', () => {
+    expect(parseArgs(['--all']).json).toBe(false)
+  })
+})

--- a/packages/crane-mcp/src/cli/skill-review.ts
+++ b/packages/crane-mcp/src/cli/skill-review.ts
@@ -1,0 +1,851 @@
+/**
+ * skill-review - lint SKILL.md files against the governance schema
+ *
+ * Usage:
+ *   npm run skill-review -- --path .agents/skills/sos
+ *   npm run skill-review -- --all --strict
+ *   npm run skill-review -- --all --json
+ *
+ * All logic is in the exported functions so the test suite can import
+ * and exercise them without touching the filesystem.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { join, dirname } from 'path'
+import { homedir } from 'os'
+import { spawnSync } from 'child_process'
+import { fileURLToPath } from 'url'
+
+// ---------------------------------------------------------------------------
+// Repo root resolution (same pattern as launch-lib.ts)
+// Compiled path: packages/crane-mcp/dist/cli/skill-review.js -> 4 levels up
+// ---------------------------------------------------------------------------
+const __filename = fileURLToPath(import.meta.url)
+export const CRANE_CONSOLE_ROOT = join(dirname(__filename), '..', '..', '..', '..')
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Severity = 'error' | 'warning' | 'info'
+
+export interface Violation {
+  rule: string
+  severity: Severity
+  path: string
+  line?: number
+  message: string
+  fix: string
+}
+
+export interface ReviewResult {
+  skills_reviewed: number
+  total_violations: number
+  by_severity: Record<Severity, number>
+  violations: Violation[]
+}
+
+interface Frontmatter {
+  name?: unknown
+  description?: unknown
+  version?: unknown
+  scope?: unknown
+  owner?: unknown
+  status?: unknown
+  backend_only?: unknown
+  deprecation_date?: unknown
+  sunset_date?: unknown
+  deprecation_notice?: unknown
+  depends_on?: {
+    mcp_tools?: unknown
+    files?: unknown
+    commands?: unknown
+  }
+  [key: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter parser (hand-rolled to avoid gray-matter until npm install)
+// Actually: we're adding gray-matter to package.json. But the typecheck step
+// runs before npm install in the task instructions, so we implement a minimal
+// YAML frontmatter parser here to keep things self-contained and avoid the
+// import-before-install problem at typecheck time.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse YAML frontmatter from a markdown string.
+ * Returns { data, content } where data is the parsed frontmatter object and
+ * content is the body after the closing `---`.
+ *
+ * Supports: strings, booleans, null, simple lists (- item), and nested maps
+ * (key:\n  subkey: val). This is sufficient for the SKILL.md schema.
+ */
+export function parseFrontmatter(raw: string): { data: Frontmatter; content: string } {
+  const lines = raw.split('\n')
+
+  // Must start with ---
+  if (lines[0]?.trim() !== '---') {
+    return { data: {}, content: raw }
+  }
+
+  // Find closing ---
+  let closeIdx = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]?.trim() === '---') {
+      closeIdx = i
+      break
+    }
+  }
+
+  if (closeIdx === -1) {
+    return { data: {}, content: raw }
+  }
+
+  const yamlLines = lines.slice(1, closeIdx)
+  const content = lines.slice(closeIdx + 1).join('\n')
+  const data = parseYamlBlock(yamlLines)
+  return { data, content }
+}
+
+function parseYamlBlock(lines: string[]): Frontmatter {
+  const result: Frontmatter = {}
+  if (lines.length === 0) return result
+
+  // Detect the indent depth of the first non-blank, non-comment line. All
+  // siblings at this block share this depth. Child lines have strictly greater
+  // indent and are collected, then recursed with their common indent stripped.
+  let baseIndent = -1
+  for (const line of lines) {
+    if (!line || line.trim() === '' || line.trim().startsWith('#')) continue
+    baseIndent = line.length - line.trimStart().length
+    break
+  }
+  if (baseIndent === -1) return result
+
+  const siblingRe = /^([a-zA-Z_][a-zA-Z0-9_-]*):\s*(.*)$/
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+    if (!line || line.trim() === '' || line.trim().startsWith('#')) {
+      i++
+      continue
+    }
+
+    const indent = line.length - line.trimStart().length
+    if (indent < baseIndent) break // dedent — done with this block
+    if (indent > baseIndent) {
+      // stray child line without a parent sibling; skip
+      i++
+      continue
+    }
+
+    const trimmed = line.trimStart()
+    const keyMatch = siblingRe.exec(trimmed)
+    if (!keyMatch) {
+      i++
+      continue
+    }
+
+    const key = keyMatch[1]
+    const rest = keyMatch[2].trim()
+
+    if (rest === '' || rest === null) {
+      // Collect children — lines with strictly greater indent than our siblings
+      const children: string[] = []
+      let j = i + 1
+      while (j < lines.length) {
+        const childLine = lines[j]
+        if (!childLine) {
+          children.push(childLine)
+          j++
+          continue
+        }
+        if (childLine.trim() === '') {
+          children.push(childLine)
+          j++
+          continue
+        }
+        const childIndent = childLine.length - childLine.trimStart().length
+        if (childIndent <= baseIndent) break
+        children.push(childLine)
+        j++
+      }
+
+      // Trim trailing blanks in children
+      while (
+        children.length > 0 &&
+        (!children[children.length - 1] || children[children.length - 1].trim() === '')
+      ) {
+        children.pop()
+      }
+
+      const firstNonBlank = children.find((c) => c && c.trim() !== '')
+      if (firstNonBlank && firstNonBlank.trimStart().startsWith('- ')) {
+        // Simple string list
+        result[key] = children
+          .filter((c) => c && c.trim().startsWith('-'))
+          .map((c) => c.replace(/^\s*-\s*/, '').trim())
+          .filter((c) => c.length > 0)
+        i = j
+      } else if (children.length > 0) {
+        // Nested map (e.g. depends_on)
+        const nested = parseYamlBlock(children)
+        result[key] = nested
+        i = j
+      } else {
+        result[key] = null
+        i++
+      }
+    } else {
+      result[key] = coerceScalar(rest)
+      i++
+    }
+  }
+
+  return result
+}
+
+function coerceScalar(val: string): unknown {
+  if (val === 'true') return true
+  if (val === 'false') return false
+  if (val === 'null' || val === '~') return null
+  // Strip surrounding quotes
+  if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+    return val.slice(1, -1)
+  }
+  return val
+}
+
+// ---------------------------------------------------------------------------
+// Config loaders
+// ---------------------------------------------------------------------------
+
+export function loadSkillOwners(repoRoot: string): string[] {
+  const p = join(repoRoot, 'config', 'skill-owners.json')
+  if (!existsSync(p)) return []
+  try {
+    const raw = readFileSync(p, 'utf-8')
+    const obj = JSON.parse(raw) as Record<string, string[]>
+    return Object.keys(obj)
+  } catch {
+    return []
+  }
+}
+
+export function loadMcpToolManifest(manifestPath: string): string[] {
+  if (!existsSync(manifestPath)) return []
+  try {
+    const raw = readFileSync(manifestPath, 'utf-8')
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed)) return parsed as string[]
+    return []
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+const REQUIRED_FIELDS = ['name', 'description', 'version', 'scope', 'owner', 'status'] as const
+const VALID_STATUSES = ['draft', 'stable', 'deprecated'] as const
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+const SCOPE_RE = /^(enterprise|global|venture:[a-z]+)$/
+const FILE_SCOPE_PREFIXES = ['crane-console:', 'venture:', 'global:']
+
+export function checkFrontmatterConformance(
+  skillPath: string,
+  relPath: string,
+  fm: Frontmatter,
+  dirName: string,
+  knownOwners: string[]
+): Violation[] {
+  const violations: Violation[] = []
+
+  // Required fields present
+  for (const field of REQUIRED_FIELDS) {
+    if (fm[field] === undefined || fm[field] === null || fm[field] === '') {
+      violations.push({
+        rule: 'frontmatter.missing-field',
+        severity: 'error',
+        path: skillPath,
+        message: `Missing required field: ${field}`,
+        fix: `Add \`${field}: <value>\` to frontmatter. See docs/skills/governance.md.`,
+      })
+    }
+  }
+
+  // name matches directory name
+  if (fm.name && fm.name !== dirName) {
+    violations.push({
+      rule: 'frontmatter.name-mismatch',
+      severity: 'error',
+      path: skillPath,
+      message: `name "${String(fm.name)}" does not match directory name "${dirName}"`,
+      fix: `Set \`name: ${dirName}\` in frontmatter to match the skill directory.`,
+    })
+  }
+
+  // version is semver
+  if (fm.version !== undefined && fm.version !== null) {
+    if (!SEMVER_RE.test(String(fm.version))) {
+      violations.push({
+        rule: 'frontmatter.invalid-semver',
+        severity: 'error',
+        path: skillPath,
+        message: `version "${String(fm.version)}" is not valid semver (expected MAJOR.MINOR.PATCH)`,
+        fix: 'Set version to a semver string, e.g. `version: 1.0.0`.',
+      })
+    }
+  }
+
+  // scope enum
+  if (fm.scope !== undefined && fm.scope !== null) {
+    if (!SCOPE_RE.test(String(fm.scope))) {
+      violations.push({
+        rule: 'frontmatter.invalid-scope',
+        severity: 'error',
+        path: skillPath,
+        message: `scope "${String(fm.scope)}" is invalid. Must be enterprise, global, or venture:<code>`,
+        fix: 'Set scope to one of: `enterprise`, `global`, or `venture:<lowercase-code>` (e.g. `venture:ss`).',
+      })
+    }
+  }
+
+  // status enum
+  if (fm.status !== undefined && fm.status !== null) {
+    if (!(VALID_STATUSES as readonly unknown[]).includes(fm.status)) {
+      violations.push({
+        rule: 'frontmatter.invalid-status',
+        severity: 'error',
+        path: skillPath,
+        message: `status "${String(fm.status)}" is invalid. Must be one of: draft, stable, deprecated`,
+        fix: 'Set status to `draft`, `stable`, or `deprecated`.',
+      })
+    }
+  }
+
+  // owner is a known key
+  if (fm.owner !== undefined && fm.owner !== null && fm.owner !== '') {
+    if (knownOwners.length > 0 && !knownOwners.includes(String(fm.owner))) {
+      violations.push({
+        rule: 'frontmatter.unknown-owner',
+        severity: 'error',
+        path: skillPath,
+        message: `owner "${String(fm.owner)}" is not a known key in config/skill-owners.json`,
+        fix: `Add the skill under an existing owner key (${knownOwners.join(', ')}) in config/skill-owners.json, or add a new owner key.`,
+      })
+    }
+  }
+
+  return violations
+}
+
+export function checkDispatcherParity(
+  skillPath: string,
+  fm: Frontmatter,
+  repoRoot: string
+): Violation[] {
+  if (fm.backend_only === true) return []
+
+  const name = String(fm.name ?? '')
+  if (!name) return []
+
+  const commandFile = join(repoRoot, '.claude', 'commands', `${name}.md`)
+  if (!existsSync(commandFile)) {
+    return [
+      {
+        rule: 'dispatcher.missing-command-file',
+        severity: 'error',
+        path: skillPath,
+        message: `No dispatcher found at .claude/commands/${name}.md`,
+        fix: `Create .claude/commands/${name}.md, or set \`backend_only: true\` in frontmatter if this skill has no slash command.`,
+      },
+    ]
+  }
+  return []
+}
+
+export function checkReferenceValidity(
+  skillPath: string,
+  fm: Frontmatter,
+  repoRoot: string,
+  manifestTools: string[]
+): Violation[] {
+  const violations: Violation[] = []
+  const dependsOn = fm.depends_on
+
+  if (!dependsOn || typeof dependsOn !== 'object') return []
+
+  // mcp_tools
+  const mcpTools = (dependsOn as Frontmatter).mcp_tools
+  if (Array.isArray(mcpTools) && manifestTools.length > 0) {
+    for (const tool of mcpTools as string[]) {
+      if (!manifestTools.includes(tool)) {
+        violations.push({
+          rule: 'references.unknown-mcp-tool',
+          severity: 'error',
+          path: skillPath,
+          message: `MCP tool "${tool}" not found in config/mcp-tool-manifest.json`,
+          fix: `Remove the tool reference, add it to the manifest, or check for a typo in the tool name.`,
+        })
+      }
+    }
+  }
+
+  // files
+  const files = (dependsOn as Frontmatter).files
+  if (Array.isArray(files)) {
+    for (const fileRef of files as string[]) {
+      if (!FILE_SCOPE_PREFIXES.some((prefix) => fileRef.startsWith(prefix))) {
+        violations.push({
+          rule: 'references.file-missing-scope-prefix',
+          severity: 'error',
+          path: skillPath,
+          message: `File path missing scope prefix (expected \`crane-console:\`, \`venture:\`, or \`global:\`): "${fileRef}"`,
+          fix: 'Prefix the file path with `crane-console:`, `venture:`, or `global:` to indicate where the file lives.',
+        })
+        continue
+      }
+
+      if (fileRef.startsWith('crane-console:')) {
+        const relFile = fileRef.slice('crane-console:'.length)
+        const absFile = join(repoRoot, relFile)
+        if (!existsSync(absFile)) {
+          violations.push({
+            rule: 'references.broken-crane-console-file',
+            severity: 'error',
+            path: skillPath,
+            message: `crane-console file not found: "${relFile}"`,
+            fix: `Create the file at ${relFile} relative to the repo root, or remove the reference.`,
+          })
+        }
+      } else if (fileRef.startsWith('venture:')) {
+        const relFile = fileRef.slice('venture:'.length)
+        const sampleRepo = process.env.CRANE_VENTURE_SAMPLE_REPO
+        if (sampleRepo) {
+          const absFile = join(sampleRepo, relFile)
+          if (!existsSync(absFile)) {
+            violations.push({
+              rule: 'references.broken-venture-file',
+              severity: 'warning',
+              path: skillPath,
+              message: `venture file not found in CRANE_VENTURE_SAMPLE_REPO: "${relFile}"`,
+              fix: `Create the file at ${relFile} inside the venture repo, or remove the reference.`,
+            })
+          }
+        } else {
+          violations.push({
+            rule: 'references.venture-file-unverified',
+            severity: 'warning',
+            path: skillPath,
+            message: `venture file reference "${relFile}" not verified — CRANE_VENTURE_SAMPLE_REPO is not set`,
+            fix: 'Set CRANE_VENTURE_SAMPLE_REPO to a local venture repo path to enable validation, or verify the path manually.',
+          })
+        }
+      } else if (fileRef.startsWith('global:')) {
+        const relFile = fileRef.slice('global:'.length)
+        const expandedPath = relFile.startsWith('~/')
+          ? join(homedir(), relFile.slice(2))
+          : join(homedir(), relFile)
+
+        if (process.env.CI) {
+          violations.push({
+            rule: 'references.global-file-unverified',
+            severity: 'warning',
+            path: skillPath,
+            message: `global file reference "${relFile}" not verified in CI environment`,
+            fix: 'Verify the file exists locally at the expanded path. CI skips global file checks.',
+          })
+        } else if (!existsSync(expandedPath)) {
+          violations.push({
+            rule: 'references.broken-global-file',
+            severity: 'error',
+            path: skillPath,
+            message: `global file not found at: "${expandedPath}"`,
+            fix: `Create the file at the expanded path, or remove the reference from depends_on.files.`,
+          })
+        }
+      }
+    }
+  }
+
+  // commands
+  const commands = (dependsOn as Frontmatter).commands
+  if (Array.isArray(commands)) {
+    for (const cmd of commands as string[]) {
+      const result = spawnSync('which', [cmd], { encoding: 'utf-8' })
+      if (result.status !== 0) {
+        violations.push({
+          rule: 'references.missing-command',
+          severity: 'warning',
+          path: skillPath,
+          message: `Command "${cmd}" not found on PATH`,
+          fix: `Install "${cmd}" or remove it from depends_on.commands if it is optional.`,
+        })
+      }
+    }
+  }
+
+  return violations
+}
+
+export function checkStructuralLint(
+  skillPath: string,
+  fm: Frontmatter,
+  content: string
+): Violation[] {
+  const violations: Violation[] = []
+  const name = String(fm.name ?? '')
+
+  if (!name) return violations
+
+  const lines = content.split('\n')
+
+  // Find first top-level # heading
+  const firstH1Idx = lines.findIndex((l) => /^#\s/.test(l))
+  if (firstH1Idx === -1) {
+    violations.push({
+      rule: 'structure.missing-h1-heading',
+      severity: 'error',
+      path: skillPath,
+      message: `Body has no top-level # heading`,
+      fix: `Add a \`# /${name}\` heading as the first heading in the SKILL.md body.`,
+    })
+  } else {
+    const h1 = lines[firstH1Idx].replace(/^#\s+/, '').trim()
+    // Accept "/<name>" anywhere at the start of the heading or "/<name> - ..."
+    if (!h1.startsWith(`/${name}`)) {
+      violations.push({
+        rule: 'structure.heading-mismatch',
+        severity: 'error',
+        path: skillPath,
+        message: `First # heading "${h1}" does not start with "/${name}"`,
+        fix: `Change the first heading to \`# /${name}\` or \`# /${name} - Description\`.`,
+      })
+    }
+  }
+
+  // Soft convention: skills benefit from a clearly-named workflow section.
+  // Accept the common variants seen across the repo; surface as INFO rather
+  // than ERROR because many legitimate skills use numbered steps directly
+  // under the heading without a separate section header.
+  const hasWorkflowSection = lines.some((l) =>
+    /^##\s+(Phases|Workflow|Behavior|Steps|Process|Execution|Arguments|Rules)/.test(l)
+  )
+  if (!hasWorkflowSection) {
+    violations.push({
+      rule: 'structure.missing-workflow-section',
+      severity: 'info',
+      path: skillPath,
+      message: 'Body has no named workflow section',
+      fix: 'Consider adding a `## Phases`, `## Workflow`, `## Behavior`, or `## Steps` section to make the execution shape easier to scan.',
+    })
+  }
+
+  return violations
+}
+
+export function checkDeprecationSanity(skillPath: string, fm: Frontmatter): Violation[] {
+  if (fm.status !== 'deprecated') return []
+
+  const violations: Violation[] = []
+
+  const depDate = fm.deprecation_date
+  const sunDate = fm.sunset_date
+
+  if (!depDate) {
+    violations.push({
+      rule: 'deprecation.missing-deprecation-date',
+      severity: 'error',
+      path: skillPath,
+      message: 'status is deprecated but deprecation_date is missing',
+      fix: 'Add `deprecation_date: YYYY-MM-DD` to frontmatter.',
+    })
+  }
+
+  if (!sunDate) {
+    violations.push({
+      rule: 'deprecation.missing-sunset-date',
+      severity: 'error',
+      path: skillPath,
+      message: 'status is deprecated but sunset_date is missing',
+      fix: 'Add `sunset_date: YYYY-MM-DD` to frontmatter (typically deprecation_date + 90 days).',
+    })
+  }
+
+  if (depDate && sunDate) {
+    const dep = new Date(String(depDate))
+    const sun = new Date(String(sunDate))
+
+    if (isNaN(dep.getTime())) {
+      violations.push({
+        rule: 'deprecation.invalid-deprecation-date',
+        severity: 'error',
+        path: skillPath,
+        message: `deprecation_date "${String(depDate)}" is not a valid ISO date`,
+        fix: 'Set deprecation_date to a valid ISO date, e.g. `2025-01-15`.',
+      })
+    }
+
+    if (isNaN(sun.getTime())) {
+      violations.push({
+        rule: 'deprecation.invalid-sunset-date',
+        severity: 'error',
+        path: skillPath,
+        message: `sunset_date "${String(sunDate)}" is not a valid ISO date`,
+        fix: 'Set sunset_date to a valid ISO date, e.g. `2025-04-15`.',
+      })
+    }
+
+    if (!isNaN(dep.getTime()) && !isNaN(sun.getTime()) && sun <= dep) {
+      violations.push({
+        rule: 'deprecation.sunset-before-deprecation',
+        severity: 'error',
+        path: skillPath,
+        message: `sunset_date "${String(sunDate)}" must be after deprecation_date "${String(depDate)}"`,
+        fix: 'Set sunset_date to a date strictly after deprecation_date.',
+      })
+    }
+  }
+
+  return violations
+}
+
+// ---------------------------------------------------------------------------
+// Review a single skill directory
+// ---------------------------------------------------------------------------
+
+export function reviewSkill(
+  skillDir: string,
+  repoRoot: string,
+  manifestTools: string[],
+  knownOwners: string[]
+): Violation[] {
+  const skillMdPath = join(skillDir, 'SKILL.md')
+  const dirName = skillDir.split('/').filter(Boolean).pop() ?? ''
+
+  // Relative path for display
+  const relPath = skillMdPath.startsWith(repoRoot)
+    ? skillMdPath.slice(repoRoot.length).replace(/^\//, '')
+    : skillMdPath
+
+  if (!existsSync(skillMdPath)) {
+    return [
+      {
+        rule: 'frontmatter.missing-skill-md',
+        severity: 'error',
+        path: relPath,
+        message: `SKILL.md not found in ${skillDir}`,
+        fix: 'Create a SKILL.md file with required frontmatter. See docs/skills/governance.md.',
+      },
+    ]
+  }
+
+  const raw = readFileSync(skillMdPath, 'utf-8')
+  const { data: fm, content } = parseFrontmatter(raw)
+
+  const violations: Violation[] = [
+    ...checkFrontmatterConformance(relPath, relPath, fm, dirName, knownOwners),
+    ...checkDispatcherParity(relPath, fm, repoRoot),
+    ...checkReferenceValidity(relPath, fm, repoRoot, manifestTools),
+    ...checkStructuralLint(relPath, fm, content),
+    ...checkDeprecationSanity(relPath, fm),
+  ]
+
+  return violations
+}
+
+// ---------------------------------------------------------------------------
+// Discover all skill directories
+// ---------------------------------------------------------------------------
+
+export function discoverSkillDirs(repoRoot: string): string[] {
+  const skillsBase = join(repoRoot, '.agents', 'skills')
+  if (!existsSync(skillsBase)) return []
+
+  return readdirSync(skillsBase)
+    .filter((entry) => {
+      try {
+        return statSync(join(skillsBase, entry)).isDirectory()
+      } catch {
+        return false
+      }
+    })
+    .map((entry) => join(skillsBase, entry))
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate results
+// ---------------------------------------------------------------------------
+
+export function aggregateResults(allViolations: Violation[], skillCount: number): ReviewResult {
+  const by_severity: Record<Severity, number> = { error: 0, warning: 0, info: 0 }
+  for (const v of allViolations) {
+    by_severity[v.severity]++
+  }
+  return {
+    skills_reviewed: skillCount,
+    total_violations: allViolations.length,
+    by_severity,
+    violations: allViolations,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+export function formatHuman(result: ReviewResult): string {
+  const lines: string[] = []
+
+  lines.push(
+    `Reviewed ${result.skills_reviewed} skill(s) — ` +
+      `${result.total_violations} violation(s) ` +
+      `(${result.by_severity.error} error, ${result.by_severity.warning} warning, ${result.by_severity.info} info)`
+  )
+
+  if (result.violations.length === 0) {
+    lines.push('All skills pass.')
+    return lines.join('\n')
+  }
+
+  lines.push('')
+  for (const v of result.violations) {
+    lines.push(`${v.severity.toUpperCase()} [${v.rule}] ${v.path}: ${v.message}`)
+    lines.push(`  Fix: ${v.fix}`)
+  }
+
+  return lines.join('\n')
+}
+
+export function formatJson(result: ReviewResult): string {
+  return JSON.stringify(result, null, 2)
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  path?: string
+  all: boolean
+  strict: boolean
+  json: boolean
+  manifest: string
+  help: boolean
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    all: false,
+    strict: false,
+    json: false,
+    manifest: join(CRANE_CONSOLE_ROOT, 'config', 'mcp-tool-manifest.json'),
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--path':
+        args.path = argv[++i]
+        break
+      case '--all':
+        args.all = true
+        break
+      case '--strict':
+        args.strict = true
+        break
+      case '--json':
+        args.json = true
+        break
+      case '--manifest':
+        args.manifest = argv[++i]
+        break
+      case '--help':
+      case '-h':
+        args.help = true
+        break
+    }
+  }
+
+  return args
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
+  const args = parseArgs(argv)
+
+  if (args.help) {
+    console.log(`skill-review — lint SKILL.md files against the governance schema
+
+Usage:
+  npm run skill-review -- --path .agents/skills/<name>
+  npm run skill-review -- --all [--strict] [--json] [--manifest <path>]
+
+Options:
+  --path <dir>       Review a single skill directory
+  --all              Review every skill in .agents/skills/
+  --strict           Exit 1 if any error violations found (default: advisory, exit 0)
+  --json             Emit machine-readable JSON instead of human-readable report
+  --manifest <path>  Path to MCP tool manifest (default: config/mcp-tool-manifest.json)
+
+See docs/skills/governance.md for the full schema reference.`)
+    return
+  }
+
+  if (!args.path && !args.all) {
+    console.error('Error: specify --path <dir> or --all')
+    process.exit(1)
+  }
+
+  if (args.path && args.all) {
+    console.error('Error: --path and --all are mutually exclusive')
+    process.exit(1)
+  }
+
+  const repoRoot = CRANE_CONSOLE_ROOT
+  const manifestTools = loadMcpToolManifest(args.manifest)
+  const knownOwners = loadSkillOwners(repoRoot)
+
+  let skillDirs: string[]
+  if (args.all) {
+    skillDirs = discoverSkillDirs(repoRoot)
+  } else {
+    // Resolve --path relative to cwd if not absolute
+    const rawPath = args.path!
+    skillDirs = [rawPath.startsWith('/') ? rawPath : join(process.cwd(), rawPath)]
+  }
+
+  const allViolations: Violation[] = []
+  for (const dir of skillDirs) {
+    const violations = reviewSkill(dir, repoRoot, manifestTools, knownOwners)
+    allViolations.push(...violations)
+  }
+
+  const result = aggregateResults(allViolations, skillDirs.length)
+
+  if (args.json) {
+    console.log(formatJson(result))
+  } else {
+    console.log(formatHuman(result))
+  }
+
+  if (args.strict && result.by_severity.error > 0) {
+    process.exit(1)
+  }
+}
+
+// Run when executed directly (not when imported by tests)
+const isDirectInvocation = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (isDirectInvocation) {
+  main().catch((err: Error) => {
+    console.error('Error:', err.message)
+    process.exit(1)
+  })
+}

--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -28,6 +28,7 @@ import {
   executeNotificationUpdate,
 } from './tools/notifications.js'
 import { deployHeartbeatInputSchema, executeDeployHeartbeat } from './tools/deploy-heartbeat.js'
+import { skillAuditInputSchema, executeSkillAudit } from './tools/skill-audit.js'
 import { logTokenUsage } from './lib/token-tracker.js'
 import { refreshSessionHeartbeatIfNeeded, startHeartbeatTimer } from './lib/heartbeat-refresh.js'
 
@@ -500,6 +501,31 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['venture'],
         },
       },
+      {
+        name: 'crane_skill_audit',
+        description:
+          'Monthly skill staleness report. Walks every SKILL.md, parses frontmatter, computes staleness via git log, detects schema gaps, and emits a structured report.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            scope: {
+              type: 'string',
+              enum: ['enterprise', 'global', 'all'],
+              description: 'Which skills to audit. Default: all.',
+            },
+            stale_threshold_days: {
+              type: 'number',
+              description:
+                'Days without a git touch before a skill is considered stale. Default: 180.',
+            },
+            include_deprecated: {
+              type: 'boolean',
+              description:
+                'Include deprecated skills in staleness and inventory counts. Default: true.',
+            },
+          },
+        },
+      },
     ],
   }
 })
@@ -683,6 +709,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'crane_deploy_heartbeat': {
         const input = deployHeartbeatInputSchema.parse(args)
         const result = await executeDeployHeartbeat(input)
+        const response = { content: [{ type: 'text' as const, text: result.message }] }
+        logToolTokens(name, args, response, startMs)
+        return response
+      }
+
+      case 'crane_skill_audit': {
+        const input = skillAuditInputSchema.parse(args)
+        const result = await executeSkillAudit(input)
         const response = { content: [{ type: 'text' as const, text: result.message }] }
         logToolTokens(name, args, response, startMs)
         return response

--- a/packages/crane-mcp/src/tools/skill-audit.test.ts
+++ b/packages/crane-mcp/src/tools/skill-audit.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for skill-audit.ts tool
+ *
+ * Mocks fs (readdirSync, readFileSync, existsSync) and child_process (execSync)
+ * to exercise inventory, staleness, schema-gap, and deprecation-queue logic
+ * without touching disk or git.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before any dynamic import
+// ---------------------------------------------------------------------------
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    existsSync: vi.fn(),
+  }
+})
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal SKILL.md frontmatter block. */
+function skillMd(fm: Record<string, string>, extra = ''): string {
+  const lines = ['---']
+  for (const [k, v] of Object.entries(fm)) lines.push(`${k}: ${v}`)
+  lines.push('---', '', extra)
+  return lines.join('\n')
+}
+
+const FULL_FM = {
+  name: 'my-skill',
+  description: 'Does a thing.',
+  version: '1.0.0',
+  scope: 'enterprise',
+  owner: 'captain',
+  status: 'stable',
+}
+
+// A date 10 days ago and 200 days ago in ISO format
+function daysAgoISO(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('skill-audit tool', () => {
+  let fsMock: typeof import('fs')
+  let cpMock: typeof import('child_process')
+
+  beforeEach(async () => {
+    vi.resetModules()
+    fsMock = await import('fs')
+    cpMock = await import('child_process')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  // Helper: load module fresh after mocks are configured
+  const getModule = async () => {
+    vi.resetModules()
+    return import('./skill-audit.js')
+  }
+
+  // -------------------------------------------------------------------------
+  // Empty result when no skills match scope
+  // -------------------------------------------------------------------------
+
+  it('returns empty inventory when no skills exist', async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(false)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([])
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.inventory.total).toBe(0)
+    expect(result.schema_gaps).toHaveLength(0)
+    expect(result.staleness).toHaveLength(0)
+    expect(result.deprecation_queue).toHaveLength(0)
+    expect(result.summary).toContain('0 skill(s)')
+  })
+
+  // -------------------------------------------------------------------------
+  // Inventory counts by scope / status / owner
+  // -------------------------------------------------------------------------
+
+  it('counts skills by scope, status, and owner', async () => {
+    // Two enterprise skills: one stable/captain, one draft/agent-team
+    const stableSkillMd = skillMd({ ...FULL_FM, name: 'alpha', status: 'stable', owner: 'captain' })
+    const draftSkillMd = skillMd({
+      name: 'beta',
+      description: 'Beta.',
+      version: '0.1.0',
+      scope: 'enterprise',
+      owner: 'agent-team',
+      status: 'draft',
+    })
+
+    vi.mocked(fsMock.existsSync).mockImplementation((p) => {
+      const path = String(p)
+      // Base skills dirs exist
+      if (path.endsWith('/.agents/skills') || path.endsWith('/skills')) return true
+      // SKILL.md files exist for both skills
+      if (path.endsWith('/alpha/SKILL.md') || path.endsWith('/beta/SKILL.md')) return true
+      return false
+    })
+
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'alpha', isDirectory: () => true },
+      { name: 'beta', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+
+    vi.mocked(fsMock.readFileSync).mockImplementation((p) => {
+      if (String(p).endsWith('/alpha/SKILL.md')) return stableSkillMd
+      if (String(p).endsWith('/beta/SKILL.md')) return draftSkillMd
+      return ''
+    })
+
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.inventory.total).toBe(2)
+    expect(result.inventory.by_status['stable']).toBe(1)
+    expect(result.inventory.by_status['draft']).toBe(1)
+    expect(result.inventory.by_owner['captain']).toBe(1)
+    expect(result.inventory.by_owner['agent-team']).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // Staleness detection
+  // -------------------------------------------------------------------------
+
+  it('flags skills whose git-last-touched exceeds the threshold', async () => {
+    const freshSkill = skillMd({ ...FULL_FM, name: 'fresh' })
+    const staleSkill = skillMd({ ...FULL_FM, name: 'old-skill', owner: 'agent-team' })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'fresh', isDirectory: () => true },
+      { name: 'old-skill', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+
+    vi.mocked(fsMock.readFileSync).mockImplementation((p) => {
+      if (String(p).includes('/fresh/')) return freshSkill
+      if (String(p).includes('/old-skill/')) return staleSkill
+      return ''
+    })
+
+    // fresh = touched 10 days ago, old-skill = touched 200 days ago
+    vi.mocked(cpMock.execSync).mockImplementation((cmd) => {
+      if (String(cmd).includes('/fresh/')) return daysAgoISO(10) as unknown as Buffer
+      return daysAgoISO(200) as unknown as Buffer
+    })
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.staleness).toHaveLength(1)
+    expect(result.staleness[0].skill).toBe('old-skill')
+    expect(result.staleness[0].days_since).toBeGreaterThan(180)
+    expect(result.staleness[0].owner).toBe('agent-team')
+  })
+
+  it('marks skill as stale when git log returns empty (never committed)', async () => {
+    const skill = skillMd({ ...FULL_FM, name: 'uncommitted' })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'uncommitted', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(skill)
+    // git log returns empty string (not yet committed)
+    vi.mocked(cpMock.execSync).mockReturnValue('' as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.staleness).toHaveLength(1)
+    expect(result.staleness[0].last_touched).toBe('unknown')
+    expect(result.staleness[0].days_since).toBe(Infinity)
+  })
+
+  // -------------------------------------------------------------------------
+  // Schema gap detection
+  // -------------------------------------------------------------------------
+
+  it('reports missing required fields', async () => {
+    // Missing: version, scope, owner, status
+    const incomplete = skillMd({ name: 'partial', description: 'A partial skill.' })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'partial', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(incomplete)
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.schema_gaps).toHaveLength(1)
+    expect(result.schema_gaps[0].skill).toBe('partial')
+    expect(result.schema_gaps[0].missing_fields).toContain('version')
+    expect(result.schema_gaps[0].missing_fields).toContain('scope')
+    expect(result.schema_gaps[0].missing_fields).toContain('owner')
+    expect(result.schema_gaps[0].missing_fields).toContain('status')
+  })
+
+  it('reports no schema gaps for fully-specified skills', async () => {
+    const complete = skillMd({ ...FULL_FM })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'my-skill', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(complete)
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.schema_gaps).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // Deprecation queue
+  // -------------------------------------------------------------------------
+
+  it('populates deprecation_queue for deprecated skills with sunset_date in the past', async () => {
+    const pastSunset = new Date()
+    pastSunset.setDate(pastSunset.getDate() - 10)
+    const pastDeprecation = new Date()
+    pastDeprecation.setDate(pastDeprecation.getDate() - 100)
+
+    const deprecatedSkill = skillMd({
+      ...FULL_FM,
+      name: 'old-way',
+      status: 'deprecated',
+      deprecation_date: pastDeprecation.toISOString().slice(0, 10),
+      sunset_date: pastSunset.toISOString().slice(0, 10),
+    })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'old-way', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(deprecatedSkill)
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.deprecation_queue).toHaveLength(1)
+    expect(result.deprecation_queue[0].skill).toBe('old-way')
+    expect(result.deprecation_queue[0].days_until_sunset).toBeLessThanOrEqual(0)
+  })
+
+  it('populates deprecation_queue for deprecated skills with sunset_date in the future', async () => {
+    const futureSunset = new Date()
+    futureSunset.setDate(futureSunset.getDate() + 30)
+    const pastDeprecation = new Date()
+    pastDeprecation.setDate(pastDeprecation.getDate() - 5)
+
+    const deprecatedSkill = skillMd({
+      ...FULL_FM,
+      name: 'retiring-soon',
+      status: 'deprecated',
+      deprecation_date: pastDeprecation.toISOString().slice(0, 10),
+      sunset_date: futureSunset.toISOString().slice(0, 10),
+    })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'retiring-soon', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(deprecatedSkill)
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.deprecation_queue).toHaveLength(1)
+    expect(result.deprecation_queue[0].skill).toBe('retiring-soon')
+    expect(result.deprecation_queue[0].days_until_sunset).toBeGreaterThan(0)
+  })
+
+  it('does not populate deprecation_queue for stable skills', async () => {
+    const stable = skillMd({ ...FULL_FM })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'my-skill', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockReturnValue(stable)
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.deprecation_queue).toHaveLength(0)
+  })
+
+  // -------------------------------------------------------------------------
+  // include_deprecated = false
+  // -------------------------------------------------------------------------
+
+  it('excludes deprecated skills from inventory when include_deprecated is false', async () => {
+    const stable = skillMd({ ...FULL_FM, name: 'keep-me' })
+    const deprecated = skillMd({
+      ...FULL_FM,
+      name: 'drop-me',
+      status: 'deprecated',
+      deprecation_date: '2025-01-01',
+      sunset_date: '2025-04-01',
+    })
+
+    vi.mocked(fsMock.existsSync).mockReturnValue(true)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([
+      { name: 'keep-me', isDirectory: () => true },
+      { name: 'drop-me', isDirectory: () => true },
+    ] as ReturnType<typeof import('fs').readdirSync>)
+    vi.mocked(fsMock.readFileSync).mockImplementation((p) => {
+      if (String(p).includes('/keep-me/')) return stable
+      return deprecated
+    })
+    vi.mocked(cpMock.execSync).mockReturnValue(daysAgoISO(5) as unknown as Buffer)
+
+    const { runSkillAudit } = await getModule()
+    const result = runSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: false,
+    })
+
+    expect(result.inventory.total).toBe(1)
+    expect(result.inventory.by_status['deprecated']).toBeUndefined()
+    expect(result.inventory.by_status['stable']).toBe(1)
+  })
+
+  // -------------------------------------------------------------------------
+  // executeSkillAudit wrapper
+  // -------------------------------------------------------------------------
+
+  it('executeSkillAudit returns success with formatted message', async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(false)
+    vi.mocked(fsMock.readdirSync).mockReturnValue([])
+
+    const { executeSkillAudit } = await getModule()
+    const result = await executeSkillAudit({
+      scope: 'enterprise',
+      stale_threshold_days: 180,
+      include_deprecated: true,
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.message).toContain('Skill Audit Report')
+  })
+})

--- a/packages/crane-mcp/src/tools/skill-audit.ts
+++ b/packages/crane-mcp/src/tools/skill-audit.ts
@@ -1,0 +1,451 @@
+/**
+ * crane_skill_audit tool - Monthly skill staleness and health report
+ *
+ * Walks SKILL.md files, parses frontmatter, computes staleness from git log,
+ * detects schema gaps, and builds a structured report. No D1, no HTTP.
+ */
+
+import { z } from 'zod'
+import { execSync } from 'child_process'
+import { readdirSync, readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// ---------------------------------------------------------------------------
+// Input schema
+// ---------------------------------------------------------------------------
+
+export const skillAuditInputSchema = z.object({
+  scope: z
+    .enum(['enterprise', 'global', 'all'])
+    .optional()
+    .default('all')
+    .describe('Which skills to audit. Default: all.'),
+  stale_threshold_days: z
+    .number()
+    .optional()
+    .default(180)
+    .describe('Days without a git touch before a skill is considered stale. Default: 180.'),
+  include_deprecated: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Include deprecated skills in staleness and inventory counts. Default: true.'),
+})
+
+export type SkillAuditInput = z.infer<typeof skillAuditInputSchema>
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+export interface SkillInventory {
+  total: number
+  by_scope: Record<string, number>
+  by_status: Record<string, number>
+  by_owner: Record<string, number>
+}
+
+export interface SchemaGap {
+  skill: string
+  path: string
+  missing_fields: string[]
+}
+
+export interface StalenessEntry {
+  skill: string
+  path: string
+  last_touched: string
+  days_since: number
+  owner: string
+}
+
+export interface DeprecationEntry {
+  skill: string
+  path: string
+  deprecation_date: string
+  sunset_date: string
+  days_until_sunset: number
+}
+
+export interface SkillAuditResult {
+  inventory: SkillInventory
+  schema_gaps: SchemaGap[]
+  staleness: StalenessEntry[]
+  deprecation_queue: DeprecationEntry[]
+  summary: string
+}
+
+export interface SkillAuditToolResult {
+  status: 'success' | 'error'
+  message: string
+}
+
+// ---------------------------------------------------------------------------
+// Required frontmatter fields (governance.md §Required fields)
+// ---------------------------------------------------------------------------
+
+const REQUIRED_FIELDS = ['name', 'description', 'version', 'scope', 'owner', 'status'] as const
+
+// ---------------------------------------------------------------------------
+// Frontmatter parsing (gray-matter-compatible manual parser as fallback)
+// ---------------------------------------------------------------------------
+
+interface Frontmatter {
+  name?: string
+  description?: string
+  version?: string
+  scope?: string
+  owner?: string
+  status?: string
+  deprecation_date?: string
+  sunset_date?: string
+  deprecation_notice?: string
+  backend_only?: boolean
+  [key: string]: unknown
+}
+
+function parseFrontmatter(content: string): Frontmatter {
+  // Try gray-matter first (may not be installed yet during dev)
+  try {
+    // Dynamic require to avoid hard dep at module load time
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const matter = require('gray-matter')
+    return matter(content).data as Frontmatter
+  } catch {
+    // Fallback: minimal YAML parser for simple key: value pairs
+    return parseSimpleFrontmatter(content)
+  }
+}
+
+function parseSimpleFrontmatter(content: string): Frontmatter {
+  const result: Frontmatter = {}
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match) return result
+
+  const yaml = match[1]
+  for (const line of yaml.split('\n')) {
+    const colonIdx = line.indexOf(':')
+    if (colonIdx === -1) continue
+    const key = line.slice(0, colonIdx).trim()
+    const rawVal = line.slice(colonIdx + 1).trim()
+    if (!key || rawVal === '') continue
+
+    // Handle booleans
+    if (rawVal === 'true') {
+      result[key] = true
+    } else if (rawVal === 'false') {
+      result[key] = false
+    } else {
+      // Strip optional surrounding quotes
+      result[key] = rawVal.replace(/^['"]|['"]$/g, '')
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+function gitLastTouched(filePath: string): string | null {
+  try {
+    const iso = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+    return iso || null
+  } catch {
+    return null
+  }
+}
+
+function daysSince(isoDate: string, now: Date = new Date()): number {
+  const then = new Date(isoDate)
+  return Math.floor((now.getTime() - then.getTime()) / 86_400_000)
+}
+
+function daysUntil(isoDate: string, now: Date = new Date()): number {
+  const then = new Date(isoDate)
+  return Math.floor((then.getTime() - now.getTime()) / 86_400_000)
+}
+
+// ---------------------------------------------------------------------------
+// Skill discovery
+// ---------------------------------------------------------------------------
+
+interface DiscoveredSkill {
+  name: string
+  skillPath: string // path to SKILL.md
+  resolvedScope: 'enterprise' | 'global'
+}
+
+function discoverSkills(
+  scope: 'enterprise' | 'global' | 'all',
+  consoleRoot: string
+): DiscoveredSkill[] {
+  const skills: DiscoveredSkill[] = []
+
+  const collect = (baseDir: string, resolvedScope: 'enterprise' | 'global') => {
+    if (!existsSync(baseDir)) return
+    let entries: string[]
+    try {
+      entries = readdirSync(baseDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      const skillPath = join(baseDir, entry, 'SKILL.md')
+      if (existsSync(skillPath)) {
+        skills.push({ name: entry, skillPath, resolvedScope })
+      }
+    }
+  }
+
+  if (scope === 'enterprise' || scope === 'all') {
+    collect(join(consoleRoot, '.agents', 'skills'), 'enterprise')
+  }
+  if (scope === 'global' || scope === 'all') {
+    collect(join(homedir(), '.agents', 'skills'), 'global')
+  }
+
+  return skills
+}
+
+// ---------------------------------------------------------------------------
+// Main executor
+// ---------------------------------------------------------------------------
+
+export async function executeSkillAudit(input: SkillAuditInput): Promise<SkillAuditToolResult> {
+  try {
+    const parsed = skillAuditInputSchema.parse(input)
+    const result = runSkillAudit(parsed)
+    return { status: 'success', message: formatReport(result) }
+  } catch (error) {
+    return {
+      status: 'error',
+      message: `Skill audit failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}
+
+export function runSkillAudit(input: SkillAuditInput): SkillAuditResult {
+  // Locate crane-console root: walk up from __dirname until we find CLAUDE.md
+  const consoleRoot = findConsoleRoot()
+  const now = new Date()
+
+  const discovered = discoverSkills(input.scope ?? 'all', consoleRoot)
+
+  const inventory: SkillInventory = {
+    total: 0,
+    by_scope: {},
+    by_status: {},
+    by_owner: {},
+  }
+  const schema_gaps: SchemaGap[] = []
+  const staleness: StalenessEntry[] = []
+  const deprecation_queue: DeprecationEntry[] = []
+
+  for (const skill of discovered) {
+    let content: string
+    try {
+      content = readFileSync(skill.skillPath, 'utf8')
+    } catch {
+      continue
+    }
+
+    const fm = parseFrontmatter(content)
+    const status = (fm.status as string | undefined) ?? 'unknown'
+
+    // Optionally skip deprecated skills in counts
+    if (!input.include_deprecated && status === 'deprecated') continue
+
+    // -----------------------------------------------------------------------
+    // Inventory
+    // -----------------------------------------------------------------------
+    inventory.total++
+
+    const scopeKey = (fm.scope as string | undefined) ?? skill.resolvedScope
+    inventory.by_scope[scopeKey] = (inventory.by_scope[scopeKey] ?? 0) + 1
+    inventory.by_status[status] = (inventory.by_status[status] ?? 0) + 1
+    const ownerKey = (fm.owner as string | undefined) ?? 'unknown'
+    inventory.by_owner[ownerKey] = (inventory.by_owner[ownerKey] ?? 0) + 1
+
+    // -----------------------------------------------------------------------
+    // Schema gaps
+    // -----------------------------------------------------------------------
+    const missingFields = REQUIRED_FIELDS.filter((f) => !fm[f])
+    if (missingFields.length > 0) {
+      schema_gaps.push({ skill: skill.name, path: skill.skillPath, missing_fields: missingFields })
+    }
+
+    // -----------------------------------------------------------------------
+    // Staleness
+    // -----------------------------------------------------------------------
+    const lastTouched = gitLastTouched(skill.skillPath)
+    if (lastTouched) {
+      const days = daysSince(lastTouched, now)
+      if (days > (input.stale_threshold_days ?? 180)) {
+        staleness.push({
+          skill: skill.name,
+          path: skill.skillPath,
+          last_touched: lastTouched,
+          days_since: days,
+          owner: ownerKey,
+        })
+      }
+    } else {
+      // Never committed or git unavailable — treat as infinitely stale
+      staleness.push({
+        skill: skill.name,
+        path: skill.skillPath,
+        last_touched: 'unknown',
+        days_since: Infinity,
+        owner: ownerKey,
+      })
+    }
+
+    // -----------------------------------------------------------------------
+    // Deprecation queue
+    // -----------------------------------------------------------------------
+    if (status === 'deprecated' && fm.deprecation_date && fm.sunset_date) {
+      const daysLeft = daysUntil(fm.sunset_date as string, now)
+      deprecation_queue.push({
+        skill: skill.name,
+        path: skill.skillPath,
+        deprecation_date: fm.deprecation_date as string,
+        sunset_date: fm.sunset_date as string,
+        days_until_sunset: daysLeft,
+      })
+    }
+  }
+
+  // Sort staleness worst-first
+  staleness.sort((a, b) => b.days_since - a.days_since)
+  // Sort deprecation queue soonest-first
+  deprecation_queue.sort((a, b) => a.days_until_sunset - b.days_until_sunset)
+
+  const summary = buildSummary(inventory, schema_gaps, staleness, deprecation_queue)
+
+  return { inventory, schema_gaps, staleness, deprecation_queue, summary }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findConsoleRoot(): string {
+  // Walk up from current file location until CLAUDE.md found
+  // Fallback: process.cwd()
+  const parts = new URL(import.meta.url).pathname.split('/')
+  for (let i = parts.length - 1; i > 0; i--) {
+    const candidate = parts.slice(0, i).join('/')
+    if (existsSync(join(candidate, 'CLAUDE.md'))) return candidate
+  }
+  return process.cwd()
+}
+
+function buildSummary(
+  inventory: SkillInventory,
+  gaps: SchemaGap[],
+  stale: StalenessEntry[],
+  queue: DeprecationEntry[]
+): string {
+  const parts: string[] = [
+    `${inventory.total} skill(s) audited across ${Object.keys(inventory.by_scope).length} scope(s).`,
+  ]
+  if (gaps.length > 0) parts.push(`${gaps.length} skill(s) have schema gaps.`)
+  if (stale.length > 0) parts.push(`${stale.length} skill(s) are stale.`)
+  if (queue.length > 0) {
+    const overdue = queue.filter((d) => d.days_until_sunset <= 0).length
+    if (overdue > 0) parts.push(`${overdue} skill(s) are past sunset date and ready for removal.`)
+    else parts.push(`${queue.length} skill(s) in deprecation queue.`)
+  }
+  if (gaps.length === 0 && stale.length === 0 && queue.length === 0) {
+    parts.push('All skills are healthy.')
+  } else {
+    parts.push(
+      'Run /skill-review --all for reference-drift details (MCP tool / file / command validity).'
+    )
+  }
+  return parts.join(' ')
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatReport(result: SkillAuditResult): string {
+  const lines: string[] = ['## Skill Audit Report', '']
+
+  // Inventory
+  lines.push('### Inventory')
+  lines.push(`Total: ${result.inventory.total}`)
+  lines.push('')
+  lines.push('**By scope:**')
+  for (const [k, v] of Object.entries(result.inventory.by_scope)) {
+    lines.push(`- ${k}: ${v}`)
+  }
+  lines.push('')
+  lines.push('**By status:**')
+  for (const [k, v] of Object.entries(result.inventory.by_status)) {
+    lines.push(`- ${k}: ${v}`)
+  }
+  lines.push('')
+  lines.push('**By owner:**')
+  for (const [k, v] of Object.entries(result.inventory.by_owner)) {
+    lines.push(`- ${k}: ${v}`)
+  }
+  lines.push('')
+
+  // Schema gaps
+  lines.push('### Schema Gaps')
+  if (result.schema_gaps.length === 0) {
+    lines.push('None.')
+  } else {
+    for (const gap of result.schema_gaps) {
+      lines.push(`- **${gap.skill}** — missing: ${gap.missing_fields.join(', ')}`)
+    }
+  }
+  lines.push('')
+
+  // Staleness
+  lines.push('### Staleness')
+  if (result.staleness.length === 0) {
+    lines.push('No stale skills.')
+  } else {
+    for (const s of result.staleness) {
+      const days = isFinite(s.days_since) ? `${s.days_since}d` : 'never committed'
+      lines.push(`- **${s.skill}** — ${days} since last touch (owner: ${s.owner})`)
+    }
+  }
+  lines.push('')
+
+  // Deprecation queue
+  lines.push('### Deprecation Queue')
+  if (result.deprecation_queue.length === 0) {
+    lines.push('No skills in deprecation queue.')
+  } else {
+    for (const d of result.deprecation_queue) {
+      const label = d.days_until_sunset <= 0 ? 'OVERDUE' : `${d.days_until_sunset}d remaining`
+      lines.push(
+        `- **${d.skill}** — sunset ${d.sunset_date} (${label}), deprecated ${d.deprecation_date}`
+      )
+    }
+  }
+  lines.push('')
+
+  // Reference drift note
+  lines.push(
+    '> Reference drift (broken MCP tools / file refs / commands): run `/skill-review --all` for details.'
+  )
+  lines.push('')
+
+  // Summary
+  lines.push('### Summary')
+  lines.push(result.summary)
+
+  return lines.join('\n')
+}

--- a/scripts/snapshot-mcp-tools.ts
+++ b/scripts/snapshot-mcp-tools.ts
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * snapshot-mcp-tools.ts
+ *
+ * Scans packages/crane-mcp/src/tools/*.ts (excluding *.test.ts) and extracts
+ * MCP tool names, writing the result to config/mcp-tool-manifest.json.
+ *
+ * Run via: npx tsx scripts/snapshot-mcp-tools.ts
+ *
+ * This file is intentionally dependency-free (pure Node builtins only).
+ * Do NOT import from crane-mcp package internals.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { join, dirname, basename } from 'path'
+import { fileURLToPath } from 'url'
+
+// ---------------------------------------------------------------------------
+// Repo root resolution (mirrors launch-lib.ts CRANE_CONSOLE_ROOT pattern)
+// When running as source via tsx: __filename = scripts/snapshot-mcp-tools.ts
+// ---------------------------------------------------------------------------
+const __filename = fileURLToPath(import.meta.url)
+const REPO_ROOT = join(dirname(__filename), '..')
+
+const TOOLS_DIR = join(REPO_ROOT, 'packages', 'crane-mcp', 'src', 'tools')
+const OUTPUT_PATH = join(REPO_ROOT, 'config', 'mcp-tool-manifest.json')
+const MCP_JSON_PATH = join(REPO_ROOT, '.mcp.json')
+
+// ---------------------------------------------------------------------------
+// Regex patterns for extracting crane_ tool names
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches crane_ tool names in JSDoc comment lines.
+ * Handles:
+ *   - Single tool:    " * crane_foo tool - description"
+ *   - Multiple tools: " * crane_foo / crane_bar tools"
+ *   - Inline refs:    " * crane_foo: ..."
+ */
+const CRANE_NAME_REGEX = /\bcrane_[a-z][a-z0-9_]*\b/g
+
+/**
+ * Extract tool names from the leading JSDoc block of a file.
+ * Only looks in the first JSDoc comment (/** ... * /) to avoid picking up
+ * tool names mentioned in implementation comments or string literals that
+ * are cross-references rather than definitions.
+ */
+function extractToolNames(filePath: string, content: string): string[] {
+  // Find the opening JSDoc block (must start at line 1 or 2)
+  const jsdocMatch = content.match(/^\/\*\*([\s\S]*?)\*\//m)
+  if (!jsdocMatch) {
+    return extractFromFallback(content)
+  }
+
+  const jsdocBody = jsdocMatch[1]
+
+  // Extract the first line(s) of the JSDoc that declare the tool name(s).
+  // The declaring lines are those that contain "tool" or "tools" after the
+  // crane_ name, signalling this is the tool declaration, not a reference.
+  const declaringLines: string[] = []
+  for (const line of jsdocBody.split('\n')) {
+    // A declaring line: contains crane_xxx and either "tool" keyword or " / " separator
+    if (/\bcrane_[a-z]/.test(line) && (/\btool\b/.test(line) || /\s\/\s/.test(line))) {
+      declaringLines.push(line)
+    }
+  }
+
+  if (declaringLines.length === 0) {
+    // Fall back: just grab all crane_ names from the entire JSDoc
+    return extractNamesFromText(jsdocBody, filePath)
+  }
+
+  const names = new Set<string>()
+  for (const line of declaringLines) {
+    const matches = line.match(CRANE_NAME_REGEX)
+    if (matches) {
+      for (const m of matches) {
+        names.add(m)
+      }
+    }
+  }
+
+  return [...names]
+}
+
+/**
+ * Fallback: grab any crane_ names from the whole file content.
+ * Used when JSDoc detection fails. Warns on stderr.
+ */
+function extractFromFallback(content: string): string[] {
+  return extractNamesFromText(content, '(unknown)')
+}
+
+function extractNamesFromText(text: string, _label: string): string[] {
+  const names = new Set<string>()
+  const matches = text.match(CRANE_NAME_REGEX)
+  if (matches) {
+    for (const m of matches) {
+      names.add(m)
+    }
+  }
+  return [...names]
+}
+
+// ---------------------------------------------------------------------------
+// External MCP servers from .mcp.json
+// ---------------------------------------------------------------------------
+function readExternalServers(): string[] {
+  if (!existsSync(MCP_JSON_PATH)) {
+    return []
+  }
+  try {
+    const raw = readFileSync(MCP_JSON_PATH, 'utf-8')
+    const config = JSON.parse(raw) as { mcpServers?: Record<string, unknown> }
+    const servers = Object.keys(config.mcpServers ?? {})
+    // Exclude the crane-mcp server itself (named "crane")
+    return servers.filter((s) => s !== 'crane')
+  } catch (err) {
+    process.stderr.write(`[snapshot] Warning: could not parse .mcp.json: ${err}\n`)
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+function main() {
+  if (!existsSync(TOOLS_DIR)) {
+    process.stderr.write(`[snapshot] Error: tools directory not found: ${TOOLS_DIR}\n`)
+    process.exit(1)
+  }
+
+  const entries = readdirSync(TOOLS_DIR).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'))
+
+  const allTools = new Set<string>()
+
+  for (const entry of entries) {
+    const filePath = join(TOOLS_DIR, entry)
+    let content: string
+    try {
+      content = readFileSync(filePath, 'utf-8')
+    } catch (err) {
+      process.stderr.write(`[snapshot] Warning: could not read ${entry}: ${err}\n`)
+      continue
+    }
+
+    const names = extractToolNames(filePath, content)
+
+    if (names.length === 0) {
+      process.stderr.write(`[snapshot] Warning: no crane_ tool name found in ${entry} — skipping\n`)
+      continue
+    }
+
+    for (const name of names) {
+      allTools.add(name)
+    }
+  }
+
+  const toolsSorted = [...allTools].sort()
+  const externalServers = readExternalServers()
+
+  const manifest = {
+    generated_at: new Date().toISOString(),
+    source: 'packages/crane-mcp/src/tools/',
+    tools: toolsSorted,
+    external_servers: externalServers,
+  }
+
+  // Ensure config/ directory exists
+  const configDir = dirname(OUTPUT_PATH)
+  if (!existsSync(configDir)) {
+    mkdirSync(configDir, { recursive: true })
+  }
+
+  writeFileSync(OUTPUT_PATH, JSON.stringify(manifest, null, 2) + '\n', 'utf-8')
+
+  process.stdout.write(
+    `[snapshot] Wrote ${toolsSorted.length} tool(s) to config/mcp-tool-manifest.json\n`
+  )
+  process.stdout.write(`[snapshot] Tools: ${toolsSorted.join(', ')}\n`)
+  if (externalServers.length > 0) {
+    process.stdout.write(`[snapshot] External servers: ${externalServers.join(', ')}\n`)
+  }
+}
+
+main()

--- a/workers/crane-context/migrations/0033_add_skill_audit_cadence.sql
+++ b/workers/crane-context/migrations/0033_add_skill_audit_cadence.sql
@@ -1,0 +1,57 @@
+-- Migration 0033: Seed skill governance cadence items
+--
+-- Adds two schedule_items that drive the skill governance lifecycle:
+--   1. skill-audit — monthly audit of all skills (schema gaps, reference drift, staleness)
+--   2. skill-review-flip-to-blocking — 30-day reminder to flip /skill-review CI from
+--      advisory to blocking after observation window (per governance rollout plan)
+--
+-- Both items are idempotent via INSERT OR REPLACE.
+-- See docs/skills/governance.md.
+
+-- Monthly skill audit — surfaces in /sos briefing when due (>=30 days since last_completed_at).
+-- Runs as a recurring item; Captain or agent completes via
+-- crane_schedule(action:'complete', name:'skill-audit', result:'success', summary:'...')
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_skill_audit',
+  'skill-audit',
+  'Skill Audit',
+  'Run /skill-audit to check frontmatter conformance, reference drift, and staleness across all skills. Report covers inventory, schema gaps, deprecation queue, and staleness (skills whose SKILL.md has not been touched in git for >180 days).',
+  30,
+  'global',
+  1,
+  NULL,
+  NULL,
+  NULL,
+  1,
+  datetime('now'),
+  datetime('now')
+);
+
+-- Follow-up reminder: flip /skill-review CI from advisory to blocking after 30 days
+-- of observation. Seeded as "just completed" so it first fires on day 30. Priority 1
+-- (HIGH) so it stands out in the /sos briefing when due.
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_skill_review_flip',
+  'skill-review-flip-to-blocking',
+  'Flip /skill-review CI to blocking',
+  'After 30 days of observing /skill-review in advisory mode, review findings and flip the CI check to blocking by removing `|| true` from .github/workflows/skill-review.yml. If findings indicate the check is still too noisy, defer and complete this cadence item with result:skipped and a summary explaining why.',
+  30,
+  'global',
+  1,
+  datetime('now'),
+  'captain',
+  'scheduled',
+  1,
+  datetime('now'),
+  datetime('now')
+);

--- a/workers/crane-mcp-remote/package-lock.json
+++ b/workers/crane-mcp-remote/package-lock.json
@@ -662,7 +662,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,7 +678,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,7 +694,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,7 +710,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,7 +726,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,7 +742,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,7 +758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,7 +774,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,7 +790,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -815,7 +806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -832,7 +822,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,7 +838,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -866,7 +854,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -883,7 +870,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -900,7 +886,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,7 +902,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -934,7 +918,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,7 +934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,7 +950,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -985,7 +966,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,7 +982,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1019,7 +998,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,7 +1014,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1053,7 +1030,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,7 +1046,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1087,7 +1062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2786,7 +2760,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3038,7 +3012,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3410,7 +3383,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3431,7 +3403,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3452,7 +3423,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3473,7 +3443,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3494,7 +3463,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3515,7 +3483,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3536,7 +3503,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3557,7 +3523,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3578,7 +3543,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3599,7 +3563,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3620,7 +3583,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Lands the skill governance system per the approved one-session plan (revised after `/critique`).

## What lands

| Piece | Where |
|---|---|
| **Schema + doc** | `docs/skills/governance.md`, `config/skill-owners.json` |
| **Frontmatter backfill** | 26 enterprise + 6 global SKILL.md files + 3 new governance skills |
| **`/skill-review`** | `packages/crane-mcp/src/cli/skill-review.ts` + `.agents/skills/skill-review/` |
| **`/skill-audit`** | `packages/crane-mcp/src/tools/skill-audit.ts` (MCP tool `crane_skill_audit`) + `.agents/skills/skill-audit/` |
| **`/skill-deprecate`** | `.agents/skills/skill-deprecate/` + `.claude/commands/skill-deprecate.md` + `docs/skills/deprecated.md` |
| **Cadence seed** | `workers/crane-context/migrations/0033_add_skill_audit_cadence.sql` |
| **CI (advisory)** | `.github/workflows/skill-review.yml` |
| **MCP tool manifest** | `scripts/snapshot-mcp-tools.ts` + `config/mcp-tool-manifest.json` (gitignored) |

## How it works

Every SKILL.md now has required frontmatter (`name`, `description`, `version`, `scope`, `owner`, `status`) plus optional `depends_on` (scope-prefixed paths). `/skill-review` lints a skill or the repo against 5 rule categories. `/skill-audit` walks all skills and emits a staleness/schema report. `/skill-deprecate` is a Captain-gated sunset flow.

CI runs on any PR touching skill/command files. **Advisory mode** — findings post as a PR comment but don't block merge. Cadence item `skill-review-flip-to-blocking` reminds the Captain at +30 days to flip.

Monthly `skill-audit` cadence item surfaces in `/sos` briefing when due.

## Deferred to follow-up sessions

1. Invocation telemetry — harness-level, not prose-level
2. Venture-repo `.agents/skills/` sync — needs reconcile pass for ss-console
3. Flip `/skill-review` CI to blocking — one-line PR, seeded as a cadence reminder

## Critic fixes (pre-approval)

- Migration 0031→0033 (0031/0032 taken)
- Telemetry deferred (prose convention = unreliable signal)
- Venture-repo sync deferred (silent clobber risk on ss-console)
- CI advisory mode (bootstrap deadlock solved)
- `last_reviewed` derived from git, not frontmatter
- Serial backfill, not parallel
- MCP manifest gitignored
- Path-scope prefixes on `depends_on.files`

## Test plan

- [x] `npm run verify` passes — 462/462 tests, typecheck + lint + format clean
- [x] `npm run skill-review -- --all` — 29 skills reviewed, 0 errors, 0 warnings, 3 info (advisory noise on three skills missing a named workflow section)
- [x] 56/56 unit tests for `skill-review.ts`
- [x] 11/11 unit tests for `skill-audit.ts`
- [x] `crane_skill_audit()` end-to-end — structured report with inventory, schema gaps, staleness, deprecation queue
- [ ] On merge: cadence migration 0033 deploys, `crane_schedule(action:'list')` surfaces `skill-audit` as untracked/HIGH
- [ ] On merge: first PR that edits `.agents/skills/**` triggers `skill-review.yml` and posts a PR comment (advisory, non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)