### PR TITLE
fix(skills): backfill governance frontmatter on nav-spec + stitch-design

### DIFF
--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: nav-spec
 description: Authors and enforces `.stitch/NAVIGATION.md` — the per-venture navigation specification that eliminates chrome drift across Stitch-generated screens and live code. Companion to `stitch-design` and `stitch-ux-brief`.
+version: 1.0.0
+scope: global
+owner: agent-team
+status: stable
 allowed-tools:
   - Read
   - Write

--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: stitch-design
 description: Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
+version: 1.0.0
+scope: global
+owner: agent-team
+status: stable
 allowed-tools:
   - 'StitchMCP'
   - 'Read'


### PR DESCRIPTION
## Summary
- The enterprise copies of nav-spec and stitch-design (landed in #528) predated the backfill worker that ran in #529
- `/skill-audit` flagged them as schema gaps on the first post-merge run
- This fixes them to match the home-dir copies (version 1.0.0, scope global, owner agent-team, status stable)

## Test plan
- [x] `npm run skill-review -- --all` exits clean (0 errors)
- [x] `crane_skill_audit()` shows 0 schema gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)