### PR TITLE
fix(skills): flip skill-review CI to blocking (closes #532)

### DIFF
--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools:
   - Agent
 ---
 
-# Nav Spec Authority
+# /nav-spec - Nav Spec Authority
 
 You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture, then enforce it across every subsequent Stitch generation. You have seen what happens when navigation is left "open" per surface: three portal pages, three different headers, no back affordance where it matters, a token-auth landing that looks like a marketing page. Your output is the thing that stops that.
 

--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools:
   - 'Write'
 ---
 
-# Stitch Design Expert
+# /stitch-design - Stitch Design Expert
 
 You are an expert Design Systems Lead and Prompt Engineer specializing in the **Stitch MCP server**. Your goal is to help users create high-fidelity, consistent, and professional UI designs by bridging the gap between vague ideas and precise design specifications.
 

--- a/.claude/commands/stitch-design.md
+++ b/.claude/commands/stitch-design.md
@@ -1,0 +1,22 @@
+---
+name: stitch-design
+description: Unified entry point for Stitch design work. Handles prompt enhancement, design system synthesis, and high-fidelity screen generation via Stitch MCP.
+version: 1.0.0
+scope: global
+owner: agent-team
+status: stable
+---
+
+# /stitch-design - Stitch Design Expert
+
+Thin dispatcher for the `stitch-design` skill. The full workflow lives at `~/.agents/skills/stitch-design/SKILL.md` (mirrored from `crane-console/.agents/skills/stitch-design/` via `syncGlobalSkills`).
+
+## Usage
+
+```
+/stitch-design [description of what you want to design]
+```
+
+When invoked, the skill guides you through: prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (`.stitch/DESIGN.md`), and high-fidelity screen generation or editing via Stitch MCP.
+
+See the full SKILL.md for workflow details, Stitch MCP fallback patterns, and the companion `/nav-spec` integration.

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,10 +1,8 @@
-name: skill-review (advisory)
+name: skill-review
 
 # Lints every skill on PRs that touch skill/command files.
-# Currently ADVISORY — findings post as a PR comment but never block merge.
-# Flip to blocking after 30 days of observation by removing `|| true` below.
-# See docs/skills/governance.md and the `skill-review-flip-to-blocking`
-# schedule_items cadence entry seeded in migration 0033.
+# BLOCKING — errors fail the job. Findings also post as a PR comment for
+# actionable visibility. See docs/skills/governance.md.
 
 on:
   pull_request:
@@ -40,12 +38,15 @@ jobs:
       - name: Snapshot MCP tool manifest
         run: npm run skill-review:snapshot
 
-      - name: Run skill-review (advisory — never blocks)
+      - name: Run skill-review
         id: review
         run: |
           mkdir -p /tmp/skill-review
+          # Emit JSON report for the PR comment step regardless of pass/fail.
+          # The second invocation with --strict fails the job on any error.
           npm run skill-review -- --all --json > /tmp/skill-review/report.json || true
           cat /tmp/skill-review/report.json
+          npm run skill-review -- --all --strict
 
       - name: Post findings as PR comment
         if: always()
@@ -80,7 +81,7 @@ jobs:
                 body += `\n... and ${report.violations.length - 50} more\n`;
               }
               body += `\n</details>\n\n`;
-              body += `ℹ️ Advisory mode — this check does not block merge. See \`docs/skills/governance.md\`.\n`;
+              body += `See \`docs/skills/governance.md\`. Any \`error\`-severity violation blocks merge.\n`;
             }
 
             const { owner, repo } = context.repo;

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -105,7 +105,7 @@ Checks:
 4. **Structural lint** — `# /<name>` heading matches frontmatter, `## Phases` or `## Workflow` section present.
 5. **Deprecation sanity** — `status: deprecated` requires `deprecation_date` and `sunset_date`, and `sunset_date > deprecation_date`.
 
-CI runs `skill-review` on every PR that touches `.agents/skills/**`. **Currently in advisory mode** (findings posted as PR comment, never blocks merge). A cadence item 30 days out reminds the Captain to flip to blocking.
+CI runs `skill-review` on every PR that touches `.agents/skills/**`. **Blocking mode** — any `error`-severity violation fails the check and blocks merge. Findings also post as a PR comment so fixes are actionable. Lower severities (`warning`, `info`) surface in the comment but don't block.
 
 ## Audit
 
@@ -148,6 +148,6 @@ The following governance features are planned but not in this session's landing:
 
 - **Invocation telemetry** — a harness-level hook will record each skill invocation to D1. The audit will gain a "usage signal" section (skills with zero invocations in 90 days → deprecation candidate). Prose-level "call this tool first" conventions are deliberately avoided because LLM compliance produces unreliable signal.
 - **Venture-repo skill sync** — the launcher currently syncs `.claude/commands/` (via `syncClaudeAssets`) and global skills to `~/.agents/skills/` (via `syncGlobalSkills`). Extending this to mirror `.agents/skills/` to venture repos requires a reconcile pass for ss-console's 16 hand-ported skills; that work is tracked separately.
-- **Blocking CI gate** — `/skill-review` CI is advisory for 30 days, then flips to blocking via a one-line PR. A cadence reminder is seeded.
+<!-- CI is already blocking; this item has shipped. Kept here as a historical note for future lifecycle entries. -->
 
 See `docs/skills/deprecated.md` for the deprecation log.


### PR DESCRIPTION
## Summary
- Remove `|| true` from skill-review.yml. Add a `--strict` run that fails the job on error violations.
- Fix 3 real errors found by strict mode: nav-spec + stitch-design heading mismatches, stitch-design missing command dispatcher.
- Update governance.md: blocking-mode language replaces advisory-mode.

## Test plan
- [x] `npm run skill-review -- --all --strict` exits 0 (0 errors, 4 info)
- [x] `npm run verify` passes
- [ ] This PR's own skill-review CI check passes (confirms blocking works without deadlock)

Closes #532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)