### PR TITLE
feat(stitch): wire consumer skills to nav-spec v3 five-tag classification

### DIFF
--- a/.agents/skills/stitch-design/SKILL.md
+++ b/.agents/skills/stitch-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: stitch-design
 description: Unified entry point for Stitch design work. Handles prompt enhancement (UI/UX keywords, atmosphere), design system synthesis (.stitch/DESIGN.md), and high-fidelity screen generation/editing via Stitch MCP.
-version: 1.0.0
+version: 1.1.0
 scope: global
 owner: agent-team
 status: stable
@@ -60,15 +60,21 @@ Before any Stitch tool call, resolve the venture's persistent project:
 
 ### 1b. Classification tags (when NAVIGATION.md present)
 
-If `.stitch/NAVIGATION.md` exists, the user prompt MUST carry three classification tags:
+If `.stitch/NAVIGATION.md` exists, read its `spec-version` frontmatter to determine the required tag set:
+
+**spec-version >= 3** — the user prompt MUST carry **five** classification tags:
 
 ```
 surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
 archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
 viewport=<mobile|desktop>
+task=<short-name from venture's task model, NAVIGATION.md §1>
+pattern=<name from pattern-catalog.md, NAVIGATION.md §4>
 ```
 
-If any tag is missing: **STOP.** Tell the user: "NAVIGATION.md is present — add `surface=`, `archetype=`, and `viewport=` tags so the nav contract can be injected. Run `/nav-spec --classify-help` for the decision rubric."
+If any of the five tags is missing: **STOP.** Tell the user: "NAVIGATION.md v3+ is present — add `surface=`, `archetype=`, `viewport=`, `task=`, and `pattern=` tags so the nav contract can be injected. Run `/nav-spec --classify-help` for the decision rubric."
+
+**spec-version < 3 (legacy)** — the user prompt MUST carry **three** classification tags (`surface=`, `archetype=`, `viewport=`). The `task=` and `pattern=` tags do not apply to legacy specs.
 
 If `.stitch/NAVIGATION.md` does NOT exist, skip this step entirely. No tags required.
 
@@ -93,7 +99,10 @@ Built from the classification tags: read the matching surface-class appendix
 - archetype contract from NAVIGATION.md, concatenate with shared sections
   (a11y, states, anti-patterns). Template at
   ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
-  Size budget: ≤600 tokens. If NAVIGATION.md absent, omit this block entirely.]
+  When spec-version >= 3, populate Task and Pattern in the Classification
+  section from the venture's task model (§1) and pattern catalog (§4).
+  Size budget: ≤500 essential, ≤800 essential+extended combined.
+  If NAVIGATION.md absent, omit this block entirely.]
 
 **DESIGN SYSTEM (REQUIRED):**
 
@@ -119,8 +128,12 @@ python3 ~/.agents/skills/nav-spec/validate.py \
   --file <path-to-generated-html> \
   --surface <surface-tag> \
   --archetype <archetype-tag> \
-  --viewport <viewport-tag>
+  --viewport <viewport-tag> \
+  --task <task-tag> \
+  --pattern <pattern-tag>
 ```
+
+When spec-version < 3, omit `--task` and `--pattern` (the validator soft-skips R25/R26 when those inputs are missing).
 
 If the validator reports structural violations: retry once with the violation report appended to the prompt ("The previous output violated these nav rules: ... please regenerate"). On second failure: surface to the user ("Validator flagged N violations. Accept anyway, regenerate, or adjust?").
 

--- a/.agents/skills/stitch-design/examples/enhanced-prompt.md
+++ b/.agents/skills/stitch-design/examples/enhanced-prompt.md
@@ -40,7 +40,9 @@ When `.stitch/NAVIGATION.md` exists for the venture and the user provides classi
 
 ## User Input
 
-> "Design the invoice detail page for the client portal. surface=session-auth-client archetype=detail viewport=mobile"
+> "Design the invoice detail page for the client portal. surface=session-auth-client archetype=detail viewport=mobile task=pay-invoice pattern=nested-doll"
+
+(The `task=` and `pattern=` tags are required when NAVIGATION.md spec-version >= 3. For legacy specs, only surface/archetype/viewport are needed.)
 
 ## Enhanced Prompt (with NAV CONTRACT injected)
 

--- a/.agents/skills/stitch-design/workflows/text-to-design.md
+++ b/.agents/skills/stitch-design/workflows/text-to-design.md
@@ -14,7 +14,7 @@ Before calling the Stitch MCP tool, apply the [Prompt Enhancement Pipeline](../S
 
 - Identify the platform (Web/Mobile) and page type.
 - Incorporate any existing project design system from `.stitch/DESIGN.md`.
-- If `.stitch/NAVIGATION.md` exists: require classification tags (`surface=`, `archetype=`, `viewport=`) per pipeline step 1b. Build and inject the NAV CONTRACT block per step 3.
+- If `.stitch/NAVIGATION.md` exists: require classification tags per pipeline step 1b (3 tags for legacy specs, 5 tags including `task=` and `pattern=` for spec-version >= 3). Build and inject the NAV CONTRACT block per step 3.
 - Use specific [Design Mappings](../references/design-mappings.md) and [Prompting Keywords](../references/prompt-keywords.md).
 
 ### 2. Identify the Project

--- a/.agents/skills/stitch-ux-brief/SKILL.md
+++ b/.agents/skills/stitch-ux-brief/SKILL.md
@@ -66,7 +66,7 @@ Scan the repo for context:
 - `tailwind.config.*` for palette and type scale
 - Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
 - `.stitch/DESIGN.md` if present (established design system for the venture)
-- `.stitch/NAVIGATION.md` if present (navigation specification — governs chrome in concept prompts and strip passes). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value.
+- `.stitch/NAVIGATION.md` if present (navigation specification — governs chrome in concept prompts and strip passes). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value. When present and `spec-version >= 3`, each concept must include `task=` and `pattern=` tags per-screen (sourced from the spec's task model in §1 and pattern catalog in §4) in addition to the standard surface/archetype/viewport tags.
 
 Display an **Intake Summary** table:
 
@@ -391,7 +391,9 @@ NAV CONTRACT (REQUIRED):
  appendix + archetype contract from NAVIGATION.md. Concatenate shared
  sections (a11y, states, anti-patterns). Inject using the template at
  ~/.agents/skills/nav-spec/references/injection-snippet-template.md.
- Size budget: ≤600 tokens.
+ When spec-version >= 3, the Classification section must include Task
+ (from §1 task model) and Pattern (from §4 pattern catalog) for this
+ concept's primary screen. Size budget: ≤500 essential, ≤800 combined.
  If NAVIGATION.md absent: OMIT this entire block. Describe header/footer
  inline in PAGE STRUCTURE as before (legacy behavior).]
 


### PR DESCRIPTION
## Summary
- Updates stitch-design step 1b with version-aware tag requirements: 5 tags for nav-spec v3+ specs, 3 tags for legacy
- Adds --task and --pattern flags to post-generation validator invocation
- Updates stitch-ux-brief Phase 1 intake and Phase 7 concept template to populate Task/Pattern from nav-spec v3 task model and pattern catalog
- Bumps stitch-design version to 1.1.0

## Test plan
- [x] `npm run verify` passes
- [x] `npm run skill-review -- --path .agents/skills/stitch-design --strict` exits 0
- [x] `npm run skill-review -- --path .agents/skills/stitch-ux-brief --strict` exits 0
- [ ] CI skill-review.yml runs blocking and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)