### PR TITLE
docs(guardrails): add Client-Facing Content Fabrication section (#377)

### DIFF
--- a/docs/instructions/guardrails.md
+++ b/docs/instructions/guardrails.md
@@ -7,6 +7,7 @@
 - Never remove, deprecate, or disable existing features without explicit Captain directive
 - Never drop database columns/tables or run destructive migrations without Captain directive
 - Never modify authentication flows or remove access controls without Captain directive
+- Never invent client-facing content — no fallback sentences, borrowed copy, or fabricated defaults (Pattern A / Pattern B below)
 - "Unused" is not sufficient justification - external consumers, bookmarks, and integrations may depend on it
 - Infrastructure changes that affect agent-facing tools must update the corresponding instruction modules in the same PR
 - When in doubt, STOP and escalate using the format below
@@ -47,6 +48,55 @@ Modifications to how users authenticate or what they can access:
 - Modifying OAuth flows, callback URLs, or token lifetimes
 - Changing which roles can access which endpoints
 
+### Client-Facing Content Fabrication
+
+Agents do not invent content that a client sees. This applies to any surface
+rendered to an end-customer of a venture: client portals, public marketing
+pages, proposal / invoice / SOW PDFs, email bodies sent to customers. Every
+timeline, schedule, deliverable, pricing term, consultant name, scope
+sentence, guarantee, or post-signing promise MUST come from data a human has
+authored for the specific engagement — a reviewed database column, CMS
+content, or a source file that Captain has explicitly reviewed. See the
+ss-console venture `CLAUDE.md` "No fabricated client-facing content" section
+for the pattern that triggered this rule (#377 incident, 2026-04-13).
+
+Two violation patterns are prohibited:
+
+- **Pattern A — committed template sentences that imply uncontracted
+  commitments.** Hardcoded sentences in source, even ones that interpolate
+  authored values, that promise specific business behavior (delivery cadence,
+  post-signing actions, SLA windows, brand identity, scope claims) the
+  engagement has not actually contracted. Example from the ss-console audit:
+  `'We'll reach out to schedule kickoff.'`. Example: `'Work begins within
+two weeks of signing.'`. The tell: every client sees the same sentence
+  regardless of what was sold.
+
+- **Pattern B — runtime fabrication from non-authoritative fields.** Values
+  rendered from sources never authored as client-facing content: placeholder
+  defaults, parsed or derived text, brief-borrowed copy, scope-summary
+  borrows. Example from the audit: a 3-week schedule constant
+  (`'We shadow and observe.'` / `'We redesign together.'` / `'Training and
+handoff.'`) rendered to every proposal regardless of the real engagement.
+  Example: `contactName: primaryContact?.name ?? 'Business Owner'` rendered
+  on a signed SOW.
+
+**If authored data is missing**, render nothing or an explicit "TBD" marker
+— never invent plausible content. See the ss-console empty-state pattern
+doc (`docs/style/empty-state-pattern.md`) for the sanctioned approach.
+
+**Exemption for signed contractual documents.** SOW PDFs, countersigned
+agreements, and invoices may contain authored standard-practice template
+language describing engagement mechanics (quote validity windows,
+termination notice, stabilization period existence) as long as no
+fixed duration is committed outside the per-engagement scope. Same
+principle as fixed-timeframe content rules in venture CLAUDE.md files.
+
+**Enforcement.** Each venture that renders client-facing content should
+ship a `forbidden-strings` regression test (see
+`ss-console/tests/forbidden-strings.test.ts`) that greps the shipped
+source for re-introductions of the specific Pattern A / Pattern B
+strings the audit surfaced.
+
 ---
 
 ## Concrete Heuristics
@@ -60,6 +110,8 @@ Bias toward false positives (stopping when unnecessary) over false negatives
 - **Dropping a database column marked "deprecated" in a comment** - STOP, comments are not Captain directives
 - **Removing a feature flag check because the flag is always true** - STOP, the flag may be used for rollback
 - **Consolidating two endpoints into one** - STOP, the old endpoint path is a public contract
+- **Adding a "sensible default" string to a client-facing template because the data source is missing** - STOP, this is Pattern B fabrication; render nothing or a "TBD" marker instead
+- **Hardcoding a post-signing commitment sentence ("we'll reach out...") in a client-visible file** - STOP, this is Pattern A fabrication; the sentence must be authored per-engagement or removed
 
 **Standing rule:** If you are deleting a route, page, component, API endpoint,
 or database table that currently exists in the production codebase, treat it as


### PR DESCRIPTION
## Summary

Closes the cross-repo AC from ss-console issue [#377](https://github.com/venturecrane/ss-console/issues/377) that required the global guardrails doc to name both Pattern A and Pattern B fabrication with examples drawn from the 2026-04-15 client-facing-content audit.

## Changes

- New **Client-Facing Content Fabrication** section under Protected Actions defining both patterns with canonical examples, the "render nothing or TBD" escape hatch, and the signed-contract exemption.
- Two new Concrete Heuristics entries: the "sensible default" case and the "hardcoded post-signing commitment" case.
- One line in the SOD summary so the rule surfaces in start-of-day briefings alongside other protected actions.
- Reference to ss-console's `forbidden-strings` regression test as the per-venture enforcement pattern.

## After merge

Upload to the context worker:

```bash
./scripts/upload-doc-to-context-worker.sh docs/instructions/guardrails.md
```

## Test plan

- [x] Markdown renders correctly
- [ ] After merge + upload: `crane_doc('global', 'guardrails.md')` returns v23 with the new section
- [ ] SOD briefing for any venture shows the new Pattern A/B line in the summary section

🤖 Generated with [Claude Code](https://claude.com/claude-code)