### PR TITLE
fix(launcher): --stitch as no-op pending product-design gate 0

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1549,40 +1549,18 @@ export function launchAgent(
     ENABLE_TOOL_SEARCH: 'false',
   }
 
-  // Inject Stitch MCP when --stitch is passed. We register the local proxy
-  // subprocess (Option 1 in Stitch's docs) because Claude Code ignores pre-shared
-  // headers on HTTP-transport MCP servers and attempts OAuth dynamic client
-  // registration, which Stitch doesn't support. See the comment on
-  // STITCH_MCP_PACKAGE for details.
+  // --stitch is a no-op pending the product-design skill gate 0 (see
+  // .claude/plans/cached-sparking-cook.md). The 0.5.3 proxy subprocess
+  // hard-requires STITCH_API_KEY, Google's backend now rejects API keys on the
+  // endpoints that do real work ("API keys are not supported by this API"),
+  // and HTTP transport trips claude-code#41664. There is no configuration of
+  // the current architecture that works today. We leave the flag parsing, the
+  // skill files, the STITCH_API_KEY secret, and the cleanup block below intact
+  // so the replacement is a one-line revert if gate 0 fails.
   if (enableStitch && agent === 'claude') {
-    const stitchApiKey = secrets.STITCH_API_KEY || process.env.STITCH_API_KEY
-    if (stitchApiKey) {
-      try {
-        spawnSync(
-          'claude',
-          [
-            'mcp',
-            'add',
-            'stitch',
-            '-e',
-            `STITCH_API_KEY=${stitchApiKey}`,
-            '-s',
-            'project',
-            '--',
-            'npx',
-            '-y',
-            STITCH_MCP_PACKAGE,
-            'proxy',
-          ],
-          { cwd: venture.localPath!, stdio: debug ? 'inherit' : 'pipe' }
-        )
-        console.log('-> Stitch MCP enabled for this session (proxy subprocess)')
-      } catch {
-        console.warn('-> Warning: failed to add Stitch MCP')
-      }
-    } else {
-      console.warn('-> Warning: --stitch passed but STITCH_API_KEY not found in secrets')
-    }
+    console.log('-> --stitch is temporarily disabled pending the product-design skill gate 0.')
+    console.log('   See: .claude/plans/cached-sparking-cook.md (Phase 0 → Phase 1 on ss-console).')
+    console.log('   No Stitch MCP will be registered for this session.')
   }
 
   // Auto-inject startup prompt for interactive sessions.


### PR DESCRIPTION
## Summary

- `--stitch` launcher flag becomes a no-op with a friendly message pointing to the product-design replacement plan
- No files removed, no secrets rotated, no skill deprecations — one-line revert if gate 0 fails
- Stops the bleeding: Stitch has burned 4 fix PRs (#362, #371, #395, #525) in 4 months and failed again today with a Google-side policy change no config-level fix can solve

## Why

Live-test findings on m16 today (2026-04-17):

1. `@_davideast/stitch-mcp@0.5.3` proxy hard-requires `STITCH_API_KEY` (verified by reading `dist/chunk-6wvst7z8.js`: `createProxy({ apiKey: process.env.STITCH_API_KEY })`)
2. Google rejects API keys on real endpoints: `"API keys are not supported by this API. Expected OAuth2 access token or other authentication credentials that assert a principal"` — this is a Google IAM endpoint-policy message, not a revoked-key message
3. `curl -X POST https://stitch.googleapis.com/mcp -H "Authorization: Bearer <ADC_token>"` returns HTTP 200 with valid OAuth, confirming backend works — just not with API keys
4. [claude-code#41664](https://github.com/anthropics/claude-code/issues/41664) (HTTP transport ignores headers) is still OPEN in v2.1.113

No configuration of 0.5.3 works from Claude Code today.

## What's preserved

- `--stitch` flag parsing stays in place
- `STITCH_API_KEY` stays in Infisical
- `stitch-design` / `stitch-ux-brief` skill files untouched
- Cleanup block at session exit (lines 1642-1650) still runs — defends against stale registrations
- `ventures.json` `stitchProjectId` entries untouched
- `.stitch/designs/` historical artifacts untouched (60+ baseline designs on ss-console remain available)

## What's next

Full replacement plan: `.claude/plans/cached-sparking-cook.md`

Phase 1: `product-design` skill + ss-console client portal gate 0 (next session).

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + 900+ tests)
- [x] All 66 `launch-lib.test.ts` tests pass including existing stitch-cleanup tests
- [ ] `crane ss --stitch` now prints the friendly message and continues without registering Stitch MCP (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)