### PR TITLE
fix(crane-mcp): self-heal crane_handoff when in-memory session is null

### DIFF
--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -9,6 +9,7 @@ import { mockRepoInfo } from '../__fixtures__/repo-fixtures.js'
 vi.mock('../lib/repo-scanner.js')
 vi.mock('../lib/session-state.js')
 vi.mock('../lib/session-log.js')
+vi.mock('./sos.js')
 
 const getModule = async () => {
   vi.resetModules()
@@ -171,11 +172,12 @@ describe('handoff tool', () => {
     expect(body.last_activity_at).toBeUndefined()
   })
 
-  it('returns error when no session active', async () => {
+  it('returns [client] error when session null and CRANE_VENTURE_CODE missing', async () => {
     const { executeHandoff } = await getModule()
     const { getSessionContext } = await import('../lib/session-state.js')
 
     vi.mocked(getSessionContext).mockReturnValue(null)
+    delete process.env.CRANE_VENTURE_CODE
 
     const result = await executeHandoff({
       summary: 'Test summary',
@@ -183,8 +185,102 @@ describe('handoff tool', () => {
     })
 
     expect(result.success).toBe(false)
-    expect(result.message).toContain('No active session')
+    // Client-side failure must be unambiguously labeled.
+    expect(result.message).toMatch(/^\[client\]/)
+    expect(result.message).toContain('CRANE_VENTURE_CODE')
+    // Misattribution guard: no future edit may describe a client-side
+    // short-circuit using D1 / server / database. The SS agent's four-
+    // session narrative ("D1 save blocked by server-side bug") was
+    // exactly this kind of misattribution; these assertions prevent
+    // its re-emergence under different wording.
+    expect(result.message).not.toMatch(/\bD1\b/i)
+    expect(result.message).not.toMatch(/\bserver\b/i)
+    expect(result.message).not.toMatch(/\bdatabase\b/i)
+  })
+
+  it('self-heals when session null: calls crane_sos then handoff writes', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+    const { executeSos } = await import('./sos.js')
+
+    // Session is null on first read (triggers self-heal), populated on
+    // subsequent reads (executeSos would have called setSession).
+    vi.mocked(getSessionContext).mockReturnValueOnce(null).mockReturnValue({
+      sessionId: 'sess_recovered',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+    process.env.CRANE_VENTURE_CODE = 'vc'
+
+    vi.mocked(executeSos).mockResolvedValue({
+      status: 'valid',
+      current_dir: '/tmp',
+      message: 'ok',
+      p0_issues: [],
+      weekly_plan: { status: 'valid' },
+      active_sessions: [],
+      context: {
+        venture: 'vc',
+        venture_name: 'Venture Crane',
+        repo: 'venturecrane/crane-console',
+        branch: 'main',
+        session_id: 'sess_recovered',
+      },
+    })
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ventures: mockVentures }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      })
+
+    const result = await executeHandoff({
+      summary: 'recovered work',
+      status: 'done',
+    })
+
+    expect(vi.mocked(executeSos)).toHaveBeenCalledOnce()
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('sess_recovered')
+  })
+
+  it('returns [client] error when self-heal fails; forbidden substrings absent', async () => {
+    const { executeHandoff } = await getModule()
+    const { getSessionContext } = await import('../lib/session-state.js')
+    const { executeSos } = await import('./sos.js')
+
+    vi.mocked(getSessionContext).mockReturnValue(null)
+    process.env.CRANE_VENTURE_CODE = 'vc'
+
+    vi.mocked(executeSos).mockResolvedValue({
+      status: 'error',
+      current_dir: '/tmp',
+      message: 'Simulated recovery error for test',
+      p0_issues: [],
+      weekly_plan: { status: 'valid' },
+      active_sessions: [],
+    })
+
+    const result = await executeHandoff({
+      summary: 'Test summary',
+      status: 'done',
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toMatch(/^\[client\]/)
     expect(result.message).toContain('crane_sos')
+    expect(result.message).toContain('Simulated recovery error for test')
+    // Misattribution guard (see note in first null-session test).
+    expect(result.message).not.toMatch(/\bD1\b/i)
+    expect(result.message).not.toMatch(/\bserver\b/i)
+    expect(result.message).not.toMatch(/\bdatabase\b/i)
   })
 
   it('returns error when API key missing', async () => {

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -10,6 +10,27 @@ import { getSessionContext } from '../lib/session-state.js'
 import { getLastActivityTimestamp } from '../lib/session-log.js'
 import { getAgentId } from '../lib/agent-identity.js'
 import { ApiError } from '../lib/api-error.js'
+import { executeSos } from './sos.js'
+import type { SosResult } from './sos.js'
+
+/**
+ * Max time to wait on a self-heal `executeSos` call before giving up and
+ * returning a `[client]` failure. Prevents a slow/unreachable crane-context
+ * API from hanging `/eos` indefinitely across the fleet.
+ */
+const SELF_HEAL_TIMEOUT_MS = 5000
+
+async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  try {
+    return await Promise.race([p, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
 
 export const handoffInputSchema = z.object({
   summary: z.string().describe('Summary of work completed and any in-progress items'),
@@ -45,12 +66,60 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
     }
   }
 
-  // Require active session from SOD
-  const session = getSessionContext()
+  // Resolve active session. If the in-memory cache is null (common when
+  // the MCP subprocess restarts between /sos and /eos), self-heal by
+  // calling executeSos — which resumes or creates via the server's
+  // (agent, venture, repo, track) tuple. `setSession` is called inside
+  // executeSos on success, so sessionContext becomes populated.
+  //
+  // Failure messages on this path MUST start with [client] and avoid the
+  // words D1 / server / database so agents and operators can't misattribute
+  // a client-side short-circuit to a server or data-layer fault. Tests
+  // enforce both the positive tag and the forbidden substrings.
+  let session = getSessionContext()
   if (!session) {
-    return {
-      success: false,
-      message: 'No active session. Run crane_sos first to start a session.',
+    if (!process.env.CRANE_VENTURE_CODE) {
+      return {
+        success: false,
+        message:
+          '[client] crane launcher env not detected (CRANE_VENTURE_CODE missing). ' +
+          'Run inside the `crane <venture>` wrapper, not bare `claude`. Handoff not persisted.',
+      }
+    }
+
+    let sosResult: SosResult
+    try {
+      sosResult = await withTimeout(
+        executeSos({ venture: input.venture, mode: 'fleet' }),
+        SELF_HEAL_TIMEOUT_MS,
+        'crane_sos recovery'
+      )
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      return {
+        success: false,
+        message: `[client] Session recovery failed: ${reason}. Handoff not persisted. This is a client-side failure.`,
+      }
+    }
+
+    if (sosResult.status !== 'valid') {
+      const reason = sosResult.message.split('\n')[0] || sosResult.status
+      return {
+        success: false,
+        message:
+          `[client] Session recovery via crane_sos returned status="${sosResult.status}". ` +
+          `Reason: ${reason}. Handoff not persisted. This is a client-side failure.`,
+      }
+    }
+
+    session = getSessionContext()
+    if (!session) {
+      return {
+        success: false,
+        message:
+          '[client] crane_sos reported success but session state is still null. ' +
+          'Internal inconsistency; handoff not persisted.',
+      }
     }
   }
 


### PR DESCRIPTION
Closes #545. Related: #550 (structural follow-up).

## Summary

- `crane_handoff` was short-circuiting with "No active session" when the MCP subprocess restarted between `/sos` and `/eos` — a client-side short-circuit that agents across four SS sessions have been paraphrasing as "D1 save blocked by server-side bug."
- Self-heal: when `getSessionContext()` is null, call `executeSos()` to resume or create via the server's existing (agent, venture, repo, track) tuple, then continue.
- Four guardrails from the /critique pass: env precheck, 5s timeout, repo-mismatch check after healing (reuses existing path), `[client]`-tagged errors with forbidden-substring test assertions.

## Evidence this is the right cause

- Prod D1 shows 3 successful SS handoffs in the preceding 28 hours, including with dotted-agent names. Server path is fine.
- Active SS session `sess_01KPEYRXD6MTH6PR4K8EYEJAZH` (created 2026-04-18 00:10 UTC, heartbeat 02:18 UTC) sits in D1 with no handoff row — consistent with null-session short-circuit.
- `packages/crane-mcp/src/lib/session-state.ts:19` comment explicitly says "Persists for the lifetime of the MCP server process" — in-memory only.
- `.claude/commands/eos.md` calls `crane_handoff` directly without calling `/sos` first.

## Why this round is different from the last two

- Cause verified against D1 data, not speculated. Prior rounds (#486, #539) claimed "every macOS /sos failed since 4-09" which D1 data contradicts.
- Fix uses only existing helpers (`executeSos`, `getCurrentRepoInfo`, `findVentureByRepo`). No new abstractions.
- Test coverage includes forbidden-substring assertions (`D1`, `server`, `database` must not appear in client-side failure messages) so future edits mechanically cannot re-introduce the misattribution narrative.
- Fix is client-only; npm-link means `main` = live on every fleet machine after `git pull`, no deploy-matrix dependency.

## Tests

- 3 new unit tests in `handoff.test.ts`:
  - Null session + missing `CRANE_VENTURE_CODE` → `[client]` error
  - Null session + successful self-heal → handoff writes
  - Null session + failed self-heal → `[client]` error, forbidden substrings absent
- 528/528 tests pass.
- `npm run verify` clean.

## Out of scope — filed #550

Disk persistence of sessionContext. Self-heal is tactical (re-/sos via network); disk-persist is structural (survives subprocess restart without a round-trip). Filed in parallel to prevent drift.

## Post-merge verification

1. SS agent on m16 pulls `main`, runs `/sos` in `~/dev/ss-console`. Resumes `sess_01KPEYRXD6MTH6PR4K8EYEJAZH`.
2. SS agent runs `/eos`, passing the summary text from `~/dev/ss-console/.claude/handoff.md`.
3. Verify: `SELECT * FROM handoffs WHERE session_id='sess_01KPEYRXD6MTH6PR4K8EYEJAZH'` returns one row.
4. Confirm on mac23 or another fleet machine by closing/reopening Claude Code and running `/eos` without re-running `/sos` — self-heal should fire and write cleanly.

If any of those steps fails, `git revert <sha>` and push. npm-link propagates the revert on next `git pull`.

## Test plan

- [ ] Post-merge: SS agent recovery procedure (steps 1-3 above)
- [ ] Post-merge: cross-machine validation on a second fleet machine (subprocess-restart repro)
- [ ] Confirm `[client]` error path on an intentionally broken env (unset `CRANE_VENTURE_CODE`) on at least one machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)