### PR TITLE
chore(scripts): whitelist operating-ethos.md in upload script

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -54,6 +54,7 @@ GLOBAL_DOCS=(
   "content-policy.md"
   "fleet-ops.md"
   "guardrails.md"
+  "operating-ethos.md"
   "creating-issues.md"
   "pr-workflow.md"
   "wireframe-guidelines.md"


### PR DESCRIPTION
## Summary
- Adds `operating-ethos.md` to the `GLOBAL_DOCS` whitelist in `scripts/upload-doc-to-context-worker.sh`.
- The ethos doc landed as a global doc in #549 and is referenced from `sos.ts` directives and `CLAUDE.md` Instruction Modules. Without this whitelist entry, future uploads of the doc require passing `global` as an explicit second arg.
- Doc is already uploaded to the context worker (v3) and resolves via `crane_doc('global', 'operating-ethos.md')`.

## Test plan
- [x] Ran `./scripts/upload-doc-to-context-worker.sh docs/instructions/operating-ethos.md` without scope arg — script correctly detects whitelisted doc and uploads to `global/`.
- [x] Verified doc is live: `crane_doc('global', 'operating-ethos.md')` returns v3.
- [x] `npm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)