### PR TITLE
feat(design-pipeline): revise-aware --set, extract-identity workflow, pipeline.md template

### DIFF
--- a/.agents/skills/design-brief/SKILL.md
+++ b/.agents/skills/design-brief/SKILL.md
@@ -21,7 +21,10 @@ Works in any venture console that has `docs/pm/prd.md`.
 
 ```
 /design-brief [rounds]
+/design-brief --extract-identity <path-to-frontend-design-output>
 ```
+
+**Default mode (with optional `rounds` argument):**
 
 - `rounds` - number of design rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
   - **1 round**: Independent analysis + synthesis. Fast. Good for greenfield projects or early design exploration.
@@ -31,6 +34,12 @@ Works in any venture console that has `docs/pm/prd.md`.
 Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
 
 Store as `TOTAL_ROUNDS`.
+
+**Identity-extraction mode (`--extract-identity`):**
+
+Ingests output from Anthropic's `frontend-design` plugin (HTML/CSS/component code produced by an identity exploration run) and extracts concrete tokens into the venture's `.design/DESIGN.md`. See [workflows/extract-identity.md](workflows/extract-identity.md).
+
+This mode skips the 4-agent brief process entirely. It parses visual output → token spec → file. Use when you've just run `/frontend-design` and need to codify the chosen aesthetic direction before running `/nav-spec`, `/ux-brief`, and `/product-design` downstream.
 
 ## Execution
 

--- a/.agents/skills/design-brief/workflows/extract-identity.md
+++ b/.agents/skills/design-brief/workflows/extract-identity.md
@@ -1,0 +1,187 @@
+# Extract identity — frontend-design output → `.design/DESIGN.md`
+
+Invoked via `/design-brief --extract-identity <path>`.
+
+Anthropic's `frontend-design` plugin generates distinctive UI for greenfield surfaces — typography, color, spacing, motion, component style. That output is pixels. To plug it into our harness (nav-spec → ux-brief → product-design), we need concrete tokens in `.design/DESIGN.md`.
+
+This workflow parses one or more frontend-design outputs and produces a token spec the downstream skills consume.
+
+## Input
+
+Either:
+
+- A single HTML file (`path/to/frontend-design-output.html`)
+- A directory of related outputs (`path/to/frontend-design-session/` containing multiple views)
+- Inline paste (if the user pastes CSS/HTML directly into the conversation)
+
+The workflow accepts all three. For a directory, process each file and synthesize common tokens across them.
+
+## Steps
+
+### 1. Parse the source
+
+Read every HTML/CSS file under the input path. Extract:
+
+- **Color values** — hex, rgb, oklch, hsl. Group by semantic role based on usage context (backgrounds, text, borders, primary actions, attention states, etc.). Frontend-design output often uses inline Tailwind arbitrary values (`bg-[#1a1a1a]`); resolve those.
+- **Typography** — `font-family` declarations, `font-weight` ranges, `font-size` + `line-height` pairs. Group by role (display headline, section heading, body, caption). Note if fonts are imported from a CDN (e.g., Google Fonts `<link>`).
+- **Spacing** — padding/margin values. Identify the rhythm (is it a 4px base? 8px? custom?). Record the discrete values in use; don't invent scales.
+- **Radius** — `border-radius` values. Usually 2-4 distinct values (sharp / small / medium / pill).
+- **Shadows / depth** — `box-shadow` strings if present. Note if the direction uses shadows at all (some aesthetic directions reject them).
+- **Motion / transitions** — `transition`, `animation`, `transform` declarations. Record duration + easing.
+
+If the output uses semantic CSS variables (`--color-primary`, etc.), prefer those over raw hex values — the aesthetic is already thinking in tokens.
+
+### 2. Name the identity
+
+Frontend-design picks a direction (brutalist, luxury, retro-futuristic, etc.). Read the first 20 lines of any source file to surface that language. Capture the direction as a one-line identity statement at the top of the extracted DESIGN.md:
+
+```markdown
+**Identity direction:** Brutalist — bold typography, sharp edges, high contrast, minimal motion.
+```
+
+This becomes the north star for the venture. Downstream skills cite it.
+
+### 3. Emit `.design/DESIGN.md`
+
+Write a structured token spec to `<venture>/.design/DESIGN.md`. Template:
+
+```markdown
+# {VENTURE_NAME} — Design Identity
+
+**Identity direction:** {one-line statement from step 2}
+
+**Source:** Extracted from `frontend-design` output on {DATE}. Regenerate when identity is revised.
+
+## Color
+
+Semantic roles and hex values (downstream consumers reference these by role, not hex):
+
+| Role           | Hex     | Usage                  |
+| -------------- | ------- | ---------------------- |
+| primary        | #XXXXXX | Links, primary actions |
+| primary-hover  | #XXXXXX |                        |
+| surface        | #XXXXXX | Card/panel backgrounds |
+| background     | #XXXXXX | Page background        |
+| border         | #XXXXXX | Dividers, card edges   |
+| text-primary   | #XXXXXX | Body copy              |
+| text-secondary | #XXXXXX | Captions, metadata     |
+| text-muted     | #XXXXXX | Placeholders, disabled |
+| action         | #XXXXXX | Focus rings            |
+| complete       | #XXXXXX | Success state          |
+| attention      | #XXXXXX | Warning state          |
+| error          | #XXXXXX | Error state            |
+| meta           | #XXXXXX | Eyebrow labels, accent |
+
+Add or omit rows per the identity's actual palette — don't invent roles the source didn't establish.
+
+## Typography
+
+| Role    | Family   | Weight   | Size / Line-height | Letter-spacing | Notes                  |
+| ------- | -------- | -------- | ------------------ | -------------- | ---------------------- |
+| display | {family} | {weight} | {px/lh}            | {tracking}     | hero/landing headlines |
+| title   | {family} | {weight} | {px/lh}            |                | section titles         |
+| heading | {family} | {weight} | {px/lh}            |                | subsection             |
+| body-lg | {family} | {weight} | {px/lh}            |                | prose, long-form       |
+| body    | {family} | {weight} | {px/lh}            |                | default body           |
+| caption | {family} | {weight} | {px/lh}            | {tracking}     | metadata, timestamps   |
+| label   | {family} | {weight} | {px/lh}            | {tracking}     | uppercase eyebrows     |
+| money   | {family} | {weight} | {px/lh}            | tabular-nums   | dollar figures         |
+
+**Font loading:** {list imports — Google Fonts `<link>`, @font-face, etc.}
+
+## Spacing
+
+Discrete values in the source, and the semantic naming we'll use:
+
+| Token   | Value | Usage                             |
+| ------- | ----- | --------------------------------- |
+| section | {Npx} | Gap between major page sections   |
+| card    | {Npx} | Card internal padding             |
+| stack   | {Npx} | Vertical stack of sibling content |
+| row     | {Npx} | Gap between list rows             |
+
+Add more rows if the identity uses more distinct values. If the identity is maximalist with 12 spacing values, record them all.
+
+## Shape
+
+| Token         | Value   | Usage              |
+| ------------- | ------- | ------------------ |
+| radius-card   | {Npx}   | Card/panel corners |
+| radius-button | {Npx}   | Button corners     |
+| radius-badge  | {value} | Pill shape         |
+
+If the identity rejects rounding entirely (brutalist), document that: `radius-card: 0 — sharp corners per identity direction`.
+
+## Motion
+
+- **Defaults:** `{duration} {easing}` for simple state transitions (hover, focus).
+- **Page transitions:** {describe if any}
+- **Scroll-triggered:** {describe if any — some identities use heavy scroll animations, some reject them}
+- **Rejection clause:** e.g., "No scroll-driven parallax; identity is print-inspired."
+
+## Shadows / depth
+
+Either: list the shadow tokens (`shadow-sm`, `shadow-md`, etc.) with their values.
+Or: document rejection if the identity is flat.
+
+## Anti-patterns (identity-level)
+
+List visual/structural things this identity explicitly rejects:
+
+- Generic SaaS purple gradients
+- System font fallbacks
+- {whatever the source output clearly avoided}
+
+## Voice notes
+
+If the frontend-design output included copy, note the tone register (terse / warm / formal / irreverent). This informs downstream ux-brief authoring.
+
+## Mapping to Tailwind v4 `@theme`
+
+The tokens above must land in the venture's `src/styles/global.css` `@theme` block (Tailwind v4) for Astro/Next.js consumers. Emit a second file: `.design/theme.css` containing the `@theme { ... }` block ready to paste or merge. Downstream product-design invocations consume these tokens via semantic class names (`bg-[color:var(--color-primary)]`, etc.).
+```
+
+### 4. Emit `.design/theme.css` (Tailwind v4 `@theme` block)
+
+A paste-ready `@theme` declaration derived from the DESIGN.md tokens. This is what the venture's `src/styles/global.css` needs to include for Tailwind to generate the utility classes the product-design skill will emit.
+
+Example:
+
+```css
+@theme {
+  --color-primary: #1e40af;
+  --color-primary-hover: #1e3a8a;
+  /* ... */
+
+  --text-display: 2rem;
+  --text-display--line-height: 2.5rem;
+  --text-display--font-weight: 700;
+  /* ... */
+
+  --spacing-section: 2rem;
+  --spacing-card: 1.5rem;
+  /* ... */
+
+  --radius-badge: 9999px;
+  --radius-card: 0.75rem;
+  --radius-button: 0.5rem;
+}
+```
+
+### 5. Report
+
+Tell the Captain:
+
+- Path to the new/updated `.design/DESIGN.md`
+- Path to `.design/theme.css`
+- Identity direction (one line)
+- Key tokens extracted (counts: N colors, N type roles, N spacing values)
+- Next step prompt: "Identity captured. Next: `/nav-spec` (if structural spec not yet authored) → `/ux-brief <surface-area>` → `/product-design --set <surface-area>`."
+
+Do NOT modify the venture's `global.css` automatically — that's a human/agent decision about when to cut over to the new identity. The captain or a follow-up agent merges `theme.css` into `global.css` when ready.
+
+## Failure modes
+
+- **Source is ambiguous or contradictory.** If the frontend-design output contains multiple inconsistent directions (e.g., brutalist heading + glassmorphism cards), surface the inconsistency rather than averaging it. Ask the Captain which direction wins.
+- **Source has no identifiable tokens.** Happens with hand-typed inline styles rather than systematic design. Extract what's there and flag the gaps.
+- **Fonts require licensing we can't resolve.** If frontend-design chose a commercial font (e.g., a licensed specimen from a type foundry), record the selection but flag that the license purchase is a Captain-gated external dependency.

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -44,7 +44,7 @@ For greenfield ventures with no pages yet, you may also produce a page wiring ex
 ```
 
 - `--surface <name>` — generate a single surface (e.g., `portal-quotes-detail`). Surface names must match the classification in the venture's NAVIGATION.md.
-- `--set <surface-set>` — generate a batch (e.g., `portal` generates every client-portal surface declared in NAVIGATION.md §1 task model).
+- `--set <surface-set>` — generate or revise a batch (e.g., `portal` covers every client-portal surface declared in NAVIGATION.md §1 task model). **Revise-aware:** for each surface, if a component file already exists at the target path, the skill loads it as prior-version context before generating (same as `--revise` for a single file). This makes `--set` the right tool for both greenfield batch generation AND identity-reset sweeps across shipped surfaces.
 - `--revise <path>` — revise an existing component file with a new request. Reads the existing file, treats it as prior context, generates a new version.
 - No args — ask the user which surface or set to generate; route accordingly.
 

--- a/.agents/skills/product-design/workflows/generate-surface-set.md
+++ b/.agents/skills/product-design/workflows/generate-surface-set.md
@@ -36,11 +36,16 @@ If the Captain confirms, proceed. If not, ask for a narrower set.
 
 **Serial, not parallel.** Max plan billing means everything runs in this session. Parallel spawning is Phase 2+ territory.
 
+**Revise-aware by default.** For each surface in the resolved set, check whether a component file already exists at the target path. If it does, load it as prior-version context (same behavior as `--revise <path>` for a single surface) before generating. This makes `--set` the right tool for both greenfield batch generation AND identity-reset sweeps across shipped surfaces. No separate `--revise-all` flag.
+
 For each surface in the resolved set:
 
-1. Run [generate-single-surface.md](generate-single-surface.md) for that surface
-2. Capture outcome: path, iterations used, violations caught, final status (pass / build-fail / validator-fail / refused)
-3. Move to the next surface — **do not stop the batch on a single failure.** Failures go into the summary; the Captain decides what to do after.
+1. Resolve the target component path via the adapter convention (e.g., `src/components/portal/QuoteDetail.astro`).
+2. **If the file exists:** read it, include it in the prompt as "Current version of the file — reproduce the rendering intent against the updated spec (DESIGN.md / NAVIGATION.md / ux-brief)." This is the revise path.
+3. **If the file does not exist:** proceed fresh, no prior-version block in the prompt.
+4. Run [generate-single-surface.md](generate-single-surface.md) for that surface with the prompt assembled per step 2 or 3.
+5. Capture outcome: path, iterations used, violations caught, final status (pass / build-fail / validator-fail / refused), and **whether it was a revise or a fresh generation** (affects summary display).
+6. Move to the next surface — **do not stop the batch on a single failure.** Failures go into the summary; the Captain decides what to do after.
 
 ## Exception: structural dependency order
 
@@ -55,15 +60,15 @@ After all surfaces complete, print a table:
 ```
 Batch complete. Summary:
 
-| Surface                      | Status      | Iterations | Notes |
-|------------------------------|-------------|------------|-------|
-| portal-quotes-detail         | pass        | 1          | -     |
-| portal-invoices-detail       | pass        | 2          | build-fix: missing import |
-| portal-quotes-list           | validator-fail | 2       | R17 reachability violation — see report |
-| portal-invoices-list         | pass        | 1          | -     |
-| portal-documents             | pass        | 1          | -     |
-| portal-home                  | refused     | -          | brief does not cover dashboard surface |
-| portal-engagement            | pass        | 1          | -     |
+| Surface                      | Mode    | Status         | Iterations | Notes |
+|------------------------------|---------|----------------|------------|-------|
+| portal-quotes-detail         | revise  | pass           | 1          | -     |
+| portal-invoices-detail       | revise  | pass           | 2          | build-fix: missing import |
+| portal-quotes-list           | revise  | validator-fail | 2          | R17 reachability violation — see report |
+| portal-invoices-list         | fresh   | pass           | 1          | -     |
+| portal-documents             | fresh   | pass           | 1          | -     |
+| portal-home                  | revise  | refused        | -          | brief does not cover dashboard surface |
+| portal-engagement            | fresh   | pass           | 1          | -     |
 
 Preview routes live. Run the venture's dev command (`npm run dev` / `pnpm dev` / `yarn dev` — detected from lockfile) and navigate to:
   http://localhost:<port>/design-preview/portal-quotes-detail

--- a/.claude/commands/design-brief.md
+++ b/.claude/commands/design-brief.md
@@ -1,5 +1,7 @@
 # /design-brief - Multi-Agent Design Brief Generator
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 
 The design brief answers "how should this look and feel?" - downstream of the PRD ("what to build and why?"). It requires a PRD to exist before running.
@@ -10,7 +12,10 @@ Works in any venture console that has `docs/pm/prd.md`.
 
 ```
 /design-brief [rounds]
+/design-brief --extract-identity <path-to-frontend-design-output>
 ```
+
+**Default mode (with optional `rounds` argument):**
 
 - `rounds` - number of design rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
   - **1 round**: Independent analysis + synthesis. Fast. Good for greenfield projects or early design exploration.
@@ -20,6 +25,12 @@ Works in any venture console that has `docs/pm/prd.md`.
 Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
 
 Store as `TOTAL_ROUNDS`.
+
+**Identity-extraction mode (`--extract-identity`):**
+
+Ingests output from Anthropic's `frontend-design` plugin (HTML/CSS/component code produced by an identity exploration run) and extracts concrete tokens into the venture's `.design/DESIGN.md`. See [workflows/extract-identity.md](workflows/extract-identity.md).
+
+This mode skips the 4-agent brief process entirely. It parses visual output → token spec → file. Use when you've just run `/frontend-design` and need to codify the chosen aesthetic direction before running `/nav-spec`, `/ux-brief`, and `/product-design` downstream.
 
 ## Execution
 

--- a/.claude/commands/product-design.md
+++ b/.claude/commands/product-design.md
@@ -21,7 +21,7 @@ For greenfield ventures with no pages yet, you may also produce a page wiring ex
 ```
 
 - `--surface <name>` — generate a single surface (e.g., `portal-quotes-detail`). Surface names must match the classification in the venture's NAVIGATION.md.
-- `--set <surface-set>` — generate a batch (e.g., `portal` generates every client-portal surface declared in NAVIGATION.md §1 task model).
+- `--set <surface-set>` — generate or revise a batch (e.g., `portal` covers every client-portal surface declared in NAVIGATION.md §1 task model). **Revise-aware:** for each surface, if a component file already exists at the target path, the skill loads it as prior-version context before generating (same as `--revise` for a single file). This makes `--set` the right tool for both greenfield batch generation AND identity-reset sweeps across shipped surfaces.
 - `--revise <path>` — revise an existing component file with a new request. Reads the existing file, treats it as prior context, generates a new version.
 - No args — ask the user which surface or set to generate; route accordingly.
 

--- a/templates/venture/.design/pipeline.md
+++ b/templates/venture/.design/pipeline.md
@@ -1,0 +1,80 @@
+# {VENTURE_NAME} — Design Pipeline State
+
+Tracks progress through the design skill stack for this venture. Agents update the checkboxes as they complete each step; humans use the table to know where to pick up.
+
+## Stack overview
+
+| Step | Skill                                     | Scope                                                          | Output                                               |
+| ---- | ----------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------- |
+| 1    | `/design-brief`                           | Product-level (PRD → charter)                                  | `docs/design/brief.md`, `docs/design/design-spec.md` |
+| 2    | `/frontend-design`                        | Identity exploration (Anthropic plugin)                        | Generated UI (pixels we extract tokens from)         |
+| 3    | `/design-brief --extract-identity <path>` | Tokens from step 2 → `.design/DESIGN.md` + `.design/theme.css` | Concrete token spec                                  |
+| 4    | `/nav-spec`                               | IA + patterns + chrome                                         | `.design/NAVIGATION.md` v3+                          |
+| 5    | `/ux-brief <area>`                        | Per-surface-area brief                                         | `.design/<area>-ux-brief.md`                         |
+| 6    | `/product-design --set <area>`            | Realization (revise-aware)                                     | Components in `src/components/<area>/`               |
+
+Steps 1–4 run once per product. Steps 5–6 run once per surface area (portal, admin, marketing, etc.).
+
+## Product-level
+
+- [ ] **Step 1 — `/design-brief`**
+      Output: `docs/design/brief.md`
+      Date: _(not started)_
+
+- [ ] **Step 2 — `/frontend-design`** (Anthropic plugin)
+      Identity direction chosen: _(not started)_
+      Date: _(not started)_
+
+- [ ] **Step 3 — `/design-brief --extract-identity <path>`**
+      Output: `.design/DESIGN.md` + `.design/theme.css`
+      Date: _(not started)_
+
+- [ ] **Step 4 — `/nav-spec`**
+      Output: `.design/NAVIGATION.md`
+      Version: _(not started)_
+      Date: _(not started)_
+
+## Per-surface-area
+
+### portal
+
+- [ ] **Step 5 — `/ux-brief portal`**
+      Output: `.design/portal-ux-brief.md`
+      Date: _(not started)_
+
+- [ ] **Step 6 — `/product-design --set portal`**
+      Components: `src/components/portal/`
+      Preview: `/design-preview/portal-*`
+      Date: _(not started)_
+
+### admin
+
+- [ ] **Step 5 — `/ux-brief admin`**
+      Output: `.design/admin-ux-brief.md`
+      Date: _(not started)_
+
+- [ ] **Step 6 — `/product-design --set admin`**
+      Components: `src/components/admin/`
+      Preview: `/design-preview/admin-*`
+      Date: _(not started)_
+
+### marketing
+
+- [ ] **Step 5 — `/ux-brief marketing`**
+      Output: `.design/marketing-ux-brief.md`
+      Date: _(not started)_
+
+- [ ] **Step 6 — `/product-design --set marketing`**
+      Components: `src/components/` (or venture-specific path)
+      Preview: `/design-preview/marketing-*`
+      Date: _(not started)_
+
+## Notes
+
+- **Identity reset on an existing venture:** restart from step 2 (`/frontend-design`), extract via step 3, then re-run step 6 (`/product-design --set <area>`) on each surface area. Step 6 is revise-aware — existing shipped components are loaded as prior-version context automatically.
+- **`ux-brief` updates:** if identity changes materially, step 5 per area needs a refresh (run `/ux-brief <area> --revise`) before step 6 reruns.
+- **`nav-spec` usually survives identity resets.** Structural rules (IA, patterns, chrome correctness) are orthogonal to aesthetic direction. Only revise step 4 if the new identity introduces new surface classes or pattern needs.
+
+## Rename or add surface areas
+
+Add more surface-area blocks as the product grows (e.g., `### onboarding`, `### settings`). Each block mirrors the portal/admin/marketing shape above.


### PR DESCRIPTION
Three streamline changes to the design skill stack, prepping for the SS identity reset.

## Changes

1. **`product-design --set` is revise-aware by default.** If a component file exists at the target path, load it as prior-version context before generating. If not, generate fresh. Same invocation handles greenfield AND identity-reset sweeps.
2. **`design-brief --extract-identity <path>`** — new workflow that ingests Anthropic frontend-design plugin output (HTML/CSS) and produces `.design/DESIGN.md` + `.design/theme.css` (Tailwind v4 `@theme` block) the downstream skills consume.
3. **`.design/pipeline.md` template** — state-tracker checklist of the 6-step pipeline (design-brief → frontend-design → extract-identity → nav-spec → ux-brief → product-design). Lives in the venture template; agents update checkboxes as steps complete.

Full stack now:

| # | Skill | Scope |
|---|---|---|
| 1 | `/design-brief` | Product-level (PRD → charter) |
| 2 | `/frontend-design` | Identity exploration (Anthropic plugin) |
| 3 | `/design-brief --extract-identity <path>` | Tokens → `.design/DESIGN.md` |
| 4 | `/nav-spec` | IA + patterns + chrome |
| 5 | `/ux-brief <area>` | Per-surface brief |
| 6 | `/product-design --set <area>` | Realization |

## Next

After this merges: apply to SS client portal as the first identity reset target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)