### PR TITLE
chore(identity): rename GitHub username smdurgan-llc → SMDurgan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,11 @@
 # Per plan v3.1 §D.1 (supply-chain hardening for /version endpoint).
 # GitHub applies the LAST matching pattern to each file, so order matters.
 #
-# Default owner: the captain (smdurgan-llc). Anyone can open a PR, but
+# Default owner: the captain (SMDurgan). Anyone can open a PR, but
 # specific files below require explicit captain review on merge because
 # they are the source of truth for deployed-state invariants.
 
-* @smdurgan-llc
+* @SMDurgan
 
 # ---- Plan v3.1 §D.1 — build-info injection is the /version source of truth ----
 #
@@ -16,17 +16,17 @@
 # fake "we are up-to-date" claim, bypassing invariant I-1 forever. Any
 # change to the injector or the generated placeholder requires captain
 # review.
-/scripts/inject-version.mjs @smdurgan-llc
-/workers/crane-context/src/generated/build-info.ts @smdurgan-llc
-/workers/crane-watch/src/generated/build-info.ts @smdurgan-llc
-/workers/crane-mcp-remote/src/generated/build-info.ts @smdurgan-llc
+/scripts/inject-version.mjs @SMDurgan
+/workers/crane-context/src/generated/build-info.ts @SMDurgan
+/workers/crane-watch/src/generated/build-info.ts @SMDurgan
+/workers/crane-mcp-remote/src/generated/build-info.ts @SMDurgan
 
 # ---- Plan v3.1 §D.3 — migration tracking is a one-shot foot-gun ----
 #
 # 0027 + the compute-schema-hash.sh script + the check-d1-migrations.sh
 # pre-flight guard are the only things standing between the captain and
 # a corrupted production D1. Any change to them requires captain review.
-/workers/crane-context/migrations/0027_backfill_d1_migrations.sql @smdurgan-llc
-/workers/crane-context/migrations/schema.hash @smdurgan-llc
-/workers/crane-context/scripts/compute-schema-hash.sh @smdurgan-llc
-/workers/crane-context/scripts/check-d1-migrations.sh @smdurgan-llc
+/workers/crane-context/migrations/0027_backfill_d1_migrations.sql @SMDurgan
+/workers/crane-context/migrations/schema.hash @SMDurgan
+/workers/crane-context/scripts/compute-schema-hash.sh @SMDurgan
+/workers/crane-context/scripts/check-d1-migrations.sh @SMDurgan

--- a/workers/crane-context/test/harness/migrations.test.ts
+++ b/workers/crane-context/test/harness/migrations.test.ts
@@ -157,7 +157,7 @@ describe('crane-context migrations via harness', () => {
       branch: 'main',
       commit_sha: 'abc123def456',
       html_url: 'https://example.com',
-      actor: 'smdurgan-llc',
+      actor: 'SMDurgan',
       event: 'push',
     })
     await db

--- a/workers/crane-mcp-remote/wrangler.toml
+++ b/workers/crane-mcp-remote/wrangler.toml
@@ -27,7 +27,7 @@ id = "7ad676059255437aa54eb18e72fd3975"
 
 [vars]
 CRANE_CONTEXT_API_URL = "https://crane-context-staging.automation-ab6.workers.dev"
-ALLOWED_GITHUB_USERS = "smdurgan-llc"
+ALLOWED_GITHUB_USERS = "SMDurgan"
 ENVIRONMENT = "staging"
 
 # Secrets (set via: wrangler secret put <NAME>)
@@ -58,5 +58,5 @@ id = "4894c5edc332485ba155bda8ac72a342"
 
 [env.production.vars]
 CRANE_CONTEXT_API_URL = "https://crane-context.automation-ab6.workers.dev"
-ALLOWED_GITHUB_USERS = "smdurgan-llc"
+ALLOWED_GITHUB_USERS = "SMDurgan"
 ENVIRONMENT = "production"


### PR DESCRIPTION
## Summary

- Captain's GitHub username was renamed from `smdurgan-llc` to `SMDurgan`. This PR updates the three load-bearing / source-of-truth references so the new login is authoritative.
- `.github/CODEOWNERS` — `@smdurgan-llc` → `@SMDurgan` (8 lines).
- `workers/crane-mcp-remote/wrangler.toml` — `ALLOWED_GITHUB_USERS` (staging + production) → `"SMDurgan"`. **Requires redeploy** after merge so OAuth to the remote MCP server accepts the renamed captain.
- `workers/crane-context/test/harness/migrations.test.ts` — `actor` fixture in the legacy-shape notification backfill test.

## Blast-radius check

Grepped all 9 local repos; only crane-console touches the string. No repos owned directly by the user account (all work lives under org accounts: venturecrane, siliconcrane, durganfieldguide, etc.), so git remotes are unaffected.

## Test plan

- [x] `npm run verify` green locally (pre-push hook also re-ran it: typecheck + format + lint + 1,090 tests + canary + builds).
- [ ] After merge, redeploy `crane-mcp-remote` to staging and production so the new allowlist takes effect.
- [ ] Confirm OAuth to the remote MCP server still works under the renamed account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)