### PR TITLE
fix(deploy): build crane-contracts before npm-ci crane-context

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: workers/${{ matrix.worker }}/package-lock.json
 
+      # crane-context imports @venturecrane/crane-contracts via a `file:`
+      # dependency. When npm installs the file dep it respects the package's
+      # `"files": ["dist"]` allow-list, so `dist/` must exist on disk before
+      # the worker install — otherwise wrangler's esbuild pass fails to
+      # resolve the package. Only crane-context depends on contracts today.
+      - name: Build @venturecrane/crane-contracts
+        if: steps.changes.outputs.skip != 'true' && matrix.worker == 'crane-context'
+        run: |
+          npm ci --prefix packages/crane-contracts
+          npm run build --prefix packages/crane-contracts
+
       - name: Install dependencies
         if: steps.changes.outputs.skip != 'true'
         run: npm ci --prefix workers/${{ matrix.worker }}
@@ -149,6 +160,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: workers/${{ matrix.worker }}/package-lock.json
+
+      # See staging job for why crane-context needs contracts built first.
+      - name: Build @venturecrane/crane-contracts
+        if: matrix.worker == 'crane-context'
+        run: |
+          npm ci --prefix packages/crane-contracts
+          npm run build --prefix packages/crane-contracts
 
       - name: Install dependencies
         run: npm ci --prefix workers/${{ matrix.worker }}


### PR DESCRIPTION
## Summary

Unbreak the `Deploy Workers` workflow on main. `crane-context` depends on `@venturecrane/crane-contracts` via `file:../../packages/crane-contracts`, and npm respects the contracts package's `"files": ["dist"]` allow-list when copying the file-dep — so `dist/` must exist on disk before the worker install, otherwise wrangler's esbuild bundling fails to resolve the import.

Latent bug; surfaced because the deploy job's path-filter only runs `crane-context` when `workers/crane-context/**` changes, and #560 (rename) was the first post-PR #539 merge to touch that subtree.

## The fix

Dedicated `Build @venturecrane/crane-contracts` step before `Install dependencies`, gated on `matrix.worker == 'crane-context'` so it's a no-op for crane-watch / crane-mcp-remote. Mirrored in both staging and production deploy jobs.

## Test plan

- [ ] This PR's Verify + Deploy Workers runs green (deploy.yml is in the path-filter so all three worker deploys will re-run).
- [ ] `Deploy crane-context to staging` job passes — previously it failed with `Could not resolve "@venturecrane/crane-contracts"`.
- [ ] Fleet smoke-test-e2e continues passing downstream of the deploy.

## Notes

Semgrep flagged the pre-existing `workflow_run` + `checkout head_sha` pattern on line 33. Not in this PR's diff; defensible today because `branches: [main]` limits the trigger to main-branch workflow runs (gated by branch protection + the `* @SMDurgan` CODEOWNERS rule). Worth opening a separate issue if we want to tighten further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)