### PR TITLE
fix(sos): make CI/CD alerts section fleet-wide (closes #564)

### DIFF
--- a/packages/crane-mcp/src/lib/health-checks.ts
+++ b/packages/crane-mcp/src/lib/health-checks.ts
@@ -113,9 +113,12 @@ export const notificationsTruthWindowCheck: HealthCheck = {
       }
     }
 
+    // Fleet-wide count, matching the SOS-side query (see #564). The check
+    // is comparing the TRUE fleet count to the displayed value — passing
+    // venture here would make the check always false-fail for sessions
+    // where other ventures have open notifications.
     const counts = await ctx.api.getNotificationCounts({
       status: 'new',
-      venture: ctx.venture,
     })
 
     if (counts.total !== ctx.ciCountsTotal) {
@@ -159,9 +162,9 @@ export const notificationRetentionWindowCheck: HealthCheck = {
     // the request directly via the api's underlying fetch infra.
     // For v1 we just call /notifications/counts and look at the
     // window.retention_days field, then issue a sentinel comparison.
+    // Fleet-wide to match the SOS alerts section (see #564).
     const counts = await ctx.api.getNotificationCounts({
       status: 'new',
-      venture: ctx.venture,
     })
 
     const retentionDays = counts.window.retention_days

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -312,6 +312,11 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
         // The counts call is what fixes the "10 unresolved" lie: it returns
         // the true 270 (or whatever the DB actually contains), and the
         // display renders it via formatTruthfulCount.
+        //
+        // Scope: fleet-wide. The notifications inbox is inherently cross-
+        // venture — a red deploy on ke-console is a captain concern whether
+        // the session is vc or ke. The table shows repo per row so operators
+        // can still see which venture each alert belongs to. See #564.
         const CI_DISPLAY_LIMIT = 10
         let ciAlertsTruncated: Truncated<Notification> = exact<Notification>([])
         let ciCounts: NotificationCountsResponse | null = null
@@ -319,11 +324,9 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
           const [countsResult, listResult] = await Promise.all([
             api.getNotificationCounts({
               status: 'new',
-              venture: venture.code,
             }),
             api.listNotifications({
               status: 'new',
-              venture: venture.code,
               limit: CI_DISPLAY_LIMIT,
             }),
           ])
@@ -590,8 +593,8 @@ interface BuildSosMessageParams {
    */
   ciAlerts?: Truncated<Notification>
   /**
-   * Full notification counts for the venture (Plan §B.3). Used for the
-   * header line "270 total (12 critical, 45 warning, 213 info)".
+   * Fleet-wide notification counts (Plan §B.3, fleet-scoped per #564).
+   * Used for the header line "270 total (12 critical, 45 warning, 213 info)".
    */
   ciCounts?: NotificationCountsResponse | null
   /**
@@ -824,7 +827,7 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
         // Fallback path if the counts endpoint failed: render via the
         // truthful-display helper using whatever total we have. The helper
         // will produce "(showing X, +N more)" when truncated.
-        message += `**${formatTruthfulCount(ciAlertsTruncated, 'CI/CD Alerts unresolved', { hint: `run \`crane_notifications(venture: "${venture.code}")\`` })}**\n`
+        message += `**${formatTruthfulCount(ciAlertsTruncated, 'CI/CD Alerts unresolved', { hint: `run \`crane_notifications()\`` })}**\n`
       }
 
       for (const n of critical) {
@@ -840,10 +843,10 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
       const trueCritWarn = ciAlertsTruncated.total
       const shownCount = critical.length + warnings.length
       if (trueCritWarn > shownCount) {
-        message += `- _+${trueCritWarn - shownCount} more critical/warning — run \`crane_notifications(venture: "${venture.code}")\`_\n`
+        message += `- _+${trueCritWarn - shownCount} more critical/warning — run \`crane_notifications()\`_\n`
       }
 
-      message += `\nDetails: \`crane_notifications(venture: "${venture.code}")\`\n\n`
+      message += `\nDetails: \`crane_notifications()\`\n\n`
     }
 
     if (activeSessions.length > 0) {
@@ -1158,7 +1161,7 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
   if (droppedSections.length > 0) {
     const banner =
       `> **SOS BUDGET WARNING:** ${droppedSections.join('; ')}.\n` +
-      `> Run \`crane_status\`, \`crane_notifications(venture: "${venture.code}")\`, ` +
+      `> Run \`crane_status\`, \`crane_notifications()\`, ` +
       `or \`crane_schedule(action: 'list')\` for full details.\n\n`
     message = banner + message
   }


### PR DESCRIPTION
## Summary

Closes #564. The /sos alerts header was scoped to the current venture, so a vc session reporting "6 unresolved total" was hiding 557 open notifications on sibling ventures. The inbox is inherently cross-venture — the list rows already carry `repo`, so no information is lost by aggregating.

## Changes

- `packages/crane-mcp/src/tools/sos.ts`
  - Drop `venture: venture.code` from the two notification calls (counts + list).
  - Update hint strings from `crane_notifications(venture: "<code>")` to `crane_notifications()`.
  - Doc line updated to note fleet scope.
- `packages/crane-mcp/src/lib/health-checks.ts`
  - `notifications-truth-window` and `notification-retention-window` also drop the venture filter. Both compare against the fleet-wide displayed count; keeping venture here would false-fail every session where sibling ventures have open notifications.

## Test plan

- [x] `npm test -w @venturecrane/crane-mcp` — 526 tests pass locally.
- [x] `npm run verify` equivalents pass via pre-push hook.
- [ ] Post-merge: open a fresh /sos in any venture, confirm the CI/CD Alerts section reports the same count as `crane_notifications()`.

## Out of scope

- The user-facing `crane_notifications` tool still honors the `venture:` parameter — that's an explicit query operator.
- The `notifications-backfill` script is untouched — different concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)