### PR TITLE
feat(notifications): branch-deleted resolver + stale-branch TTL sweep (closes #563)

### DIFF
--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -244,6 +244,9 @@ export const NOTIFICATION_AUTO_RESOLVE_REASONS = [
   'in_table_backfill',
   'manual',
   'admin_resolve',
+  // Issue #563: branch-deleted webhook resolver + cron TTL backstop.
+  'branch_deleted',
+  'aged_out_non_main',
 ] as const
 export type NotificationAutoResolveReason = (typeof NOTIFICATION_AUTO_RESOLVE_REASONS)[number]
 

--- a/workers/crane-context/src/endpoints/notifications.ts
+++ b/workers/crane-context/src/endpoints/notifications.ts
@@ -18,6 +18,7 @@ import {
   processGreenEvent,
   countNotifications,
   getOldestNotification,
+  resolveNotificationsByBranch,
 } from '../notifications'
 import { normalizeGitHubEvent, computeGitHubDedupeHash } from '../notifications-github'
 import { normalizeVercelDeployment, computeVercelDedupeHash } from '../notifications-vercel'
@@ -430,6 +431,79 @@ export async function handleNotificationOldest(request: Request, env: Env): Prom
     )
   } catch (error) {
     console.error('GET /notifications/oldest error:', error)
+    return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
+  }
+}
+
+// ============================================================================
+// POST /notifications/branch-deleted  (Issue #563)
+// ============================================================================
+//
+// Called by crane-watch when GitHub emits a `delete` webhook with
+// ref_type=branch. Resolves every open notification whose (repo, branch)
+// matches the deleted branch. A deleted branch cannot produce a subsequent
+// green workflow_run, so those notifications would otherwise pile up
+// forever (see #563 motivation: 415 such rows were cleared by hand during
+// the 2026-04-20 triage).
+
+interface BranchDeletedBody {
+  repo: string
+  branch: string
+}
+
+export async function handleBranchDeleted(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  try {
+    const body = (await request.json()) as BranchDeletedBody
+
+    if (!body.repo || typeof body.repo !== 'string') {
+      return validationErrorResponse(
+        [{ field: 'repo', message: 'Required string field' }],
+        context.correlationId
+      )
+    }
+    if (!body.branch || typeof body.branch !== 'string') {
+      return validationErrorResponse(
+        [{ field: 'branch', message: 'Required string field' }],
+        context.correlationId
+      )
+    }
+
+    // Refuse to act on main/master. The caller should never send these
+    // (GitHub blocks deleting a default branch), but defense-in-depth: a
+    // misconfigured webhook must not silently clear real red signal.
+    if (body.branch === 'main' || body.branch === 'master') {
+      return jsonResponse(
+        {
+          ignored: true,
+          reason: 'default_branch_refused',
+          correlation_id: context.correlationId,
+        },
+        HTTP_STATUS.OK,
+        context.correlationId
+      )
+    }
+
+    const result = await resolveNotificationsByBranch(
+      env.DB,
+      body.repo,
+      body.branch,
+      'branch_deleted'
+    )
+
+    return jsonResponse(
+      {
+        resolved_count: result.resolved_count,
+        matched_ids: result.matched_ids,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /notifications/branch-deleted error:', error)
     return errorResponse('Internal server error', HTTP_STATUS.INTERNAL_ERROR, context.correlationId)
   }
 }

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -69,6 +69,7 @@ import {
   handleUpdateNotificationStatus,
   handleNotificationCounts,
   handleNotificationOldest,
+  handleBranchDeleted,
 } from './endpoints/notifications'
 import {
   handleListPendingMatches,
@@ -104,6 +105,7 @@ import {
   handleSmokeTestList,
 } from './endpoints/smoke-test'
 import { runReconciliation } from './deploy-heartbeats-reconcile'
+import { runStaleBranchSweep } from './notifications'
 import { verifyAdminKey } from './endpoints/admin-shared'
 import { handleMcpRequest } from './mcp'
 import { errorResponse } from './utils'
@@ -498,6 +500,10 @@ export default {
         return await handleNotificationOldest(request, env)
       }
 
+      if (pathname === '/notifications/branch-deleted' && method === 'POST') {
+        return await handleBranchDeleted(request, env)
+      }
+
       if (pathname === '/notifications' && method === 'GET') {
         return await handleListNotifications(request, env)
       }
@@ -647,5 +653,14 @@ export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
     console.log(`scheduled: ${event.cron} fired at ${new Date().toISOString()}`)
     ctx.waitUntil(runReconciliation(env))
+    // Issue #563: sweep stale non-main notifications older than 7 days. This
+    // is the cron backstop for the branch-deleted path — branches that were
+    // force-pushed, rebased away, or abandoned without an explicit `delete`
+    // webhook get aged out here.
+    ctx.waitUntil(
+      runStaleBranchSweep(env.DB).catch((err) => {
+        console.error('stale-branch sweep error:', err)
+      })
+    )
   },
 }

--- a/workers/crane-context/src/notifications-log.ts
+++ b/workers/crane-context/src/notifications-log.ts
@@ -31,6 +31,9 @@ export type NotificationLogEvent =
   | 'success_event_received_no_match'
   | 'green_event_idempotent_skip'
   | 'auto_resolve_failed'
+  // Issue #563: bulk-resolve paths.
+  | 'notifications_resolved_by_branch'
+  | 'notifications_stale_branch_sweep'
 
 /**
  * Emit a structured log line for a notification state transition.

--- a/workers/crane-context/src/notifications.ts
+++ b/workers/crane-context/src/notifications.ts
@@ -479,6 +479,112 @@ export async function updateNotificationStatus(
 }
 
 // ============================================================================
+// Auto-Resolve (branch-deleted and stale-branch TTL)
+// ============================================================================
+//
+// Two bulk-resolve paths that complement `processGreenEvent`:
+//
+// - `resolveNotificationsByBranch` fires on GitHub `delete` webhooks with
+//   ref_type=branch. A deleted branch cannot produce a subsequent green
+//   event, so any open notifications on it are permanently stuck. Issue #563.
+//
+// - `runStaleBranchSweep` is the cron backstop for branches abandoned
+//   without an explicit delete event (force-pushed refs, detached-HEAD
+//   experiments, dropped forks). Only touches non-default branches to keep
+//   main red-signal pristine.
+
+export interface ResolveByBranchResult {
+  resolved_count: number
+  matched_ids: string[]
+}
+
+/**
+ * Resolve every open notification on (repo, branch). Idempotent: running it
+ * twice resolves nothing the second time.
+ */
+export async function resolveNotificationsByBranch(
+  db: D1Database,
+  repo: string,
+  branch: string,
+  reason: NotificationAutoResolveReason
+): Promise<ResolveByBranchResult> {
+  const now = nowIso()
+
+  const openRows = await db
+    .prepare(
+      `SELECT id FROM notifications
+       WHERE status = 'new' AND repo = ? AND branch = ?`
+    )
+    .bind(repo, branch)
+    .all<{ id: string }>()
+
+  const matched_ids = (openRows.results || []).map((r) => r.id)
+  if (matched_ids.length === 0) {
+    return { resolved_count: 0, matched_ids: [] }
+  }
+
+  await db
+    .prepare(
+      `UPDATE notifications
+       SET status = 'resolved', updated_at = ?, resolved_at = ?, auto_resolve_reason = ?
+       WHERE status = 'new' AND repo = ? AND branch = ?`
+    )
+    .bind(now, now, reason, repo, branch)
+    .run()
+
+  logNotificationEvent('notifications_resolved_by_branch', {
+    repo,
+    branch,
+    reason,
+    count: matched_ids.length,
+  })
+
+  return { resolved_count: matched_ids.length, matched_ids }
+}
+
+export interface StaleBranchSweepResult {
+  resolved_count: number
+  cutoff_days: number
+}
+
+/**
+ * Resolve open notifications on non-default branches older than N days.
+ * Default 7 days. Never touches main/master — those represent real red
+ * signal that deserves a human decision.
+ */
+export async function runStaleBranchSweep(
+  db: D1Database,
+  cutoffDays = 7
+): Promise<StaleBranchSweepResult> {
+  const cutoffIso = new Date(Date.now() - cutoffDays * 24 * 60 * 60 * 1000).toISOString()
+  const now = nowIso()
+
+  const result = await db
+    .prepare(
+      `UPDATE notifications
+       SET status = 'resolved', updated_at = ?, resolved_at = ?,
+           auto_resolve_reason = 'aged_out_non_main'
+       WHERE status = 'new'
+         AND branch IS NOT NULL
+         AND branch NOT IN ('main', 'master')
+         AND created_at < ?`
+    )
+    .bind(now, now, cutoffIso)
+    .run()
+
+  const resolved_count = result.meta?.changes ?? 0
+
+  if (resolved_count > 0) {
+    logNotificationEvent('notifications_stale_branch_sweep', {
+      cutoff_days: cutoffDays,
+      count: resolved_count,
+    })
+  }
+
+  return { resolved_count, cutoff_days: cutoffDays }
+}
+
+// ============================================================================
 // Auto-Resolve (processGreenEvent)
 // ============================================================================
 

--- a/workers/crane-context/test/notifications-log.test.ts
+++ b/workers/crane-context/test/notifications-log.test.ts
@@ -36,6 +36,8 @@ import {
   processGreenEvent,
   computeDedupeHash,
   buildMatchKey,
+  resolveNotificationsByBranch,
+  runStaleBranchSweep,
 } from '../src/notifications'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -49,6 +51,8 @@ const VALID_EVENTS = [
   'success_event_received_no_match',
   'green_event_idempotent_skip',
   'auto_resolve_failed',
+  'notifications_resolved_by_branch',
+  'notifications_stale_branch_sweep',
 ] as const
 
 type LogCapture = Array<{ stream: 'log' | 'warn' | 'error'; line: string }>
@@ -448,5 +452,244 @@ describe('SQL invariant', () => {
     // include it, so we count occurrences.
     const matches = fnBody.match(/AND auto_resolved_by_id IS NULL/g) || []
     expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+// ============================================================================
+// Issue #563: branch-deleted + stale-branch TTL auto-resolvers
+// ============================================================================
+
+/**
+ * Create an open failure notification on a caller-specified branch with an
+ * optional backdated created_at. Used to set up scenarios for the two
+ * bulk-resolvers below.
+ */
+async function makeOpenFailureOn(
+  db: D1Database,
+  opts: {
+    repo: string
+    branch: string
+    workflowId: number
+    createdAt?: string // ISO; overrides the default NOW()
+  }
+): Promise<{ id: string }> {
+  const { match_key } = buildMatchKey({
+    source: 'github',
+    kind: 'workflow_run',
+    repo_full_name: opts.repo,
+    branch: opts.branch,
+    workflow_id: opts.workflowId,
+  })
+  const dedupe = await computeDedupeHash({
+    source: 'github',
+    event_type: 'workflow_run.failure',
+    repo: opts.repo,
+    branch: opts.branch,
+    content_key: `workflow_run:${opts.repo}:${opts.branch}:${opts.workflowId}`,
+  })
+  const cap = captureLogs()
+  let id: string
+  try {
+    const result = await createNotification(db, {
+      source: 'github',
+      event_type: 'workflow_run.failure',
+      severity: 'critical',
+      summary: 'CI failure',
+      details_json: '{}',
+      dedupe_hash: dedupe,
+      venture: 'vc',
+      repo: opts.repo,
+      branch: opts.branch,
+      environment: 'production',
+      actor_key_id: 'test',
+      workflow_id: opts.workflowId,
+      head_sha: 'sha',
+      match_key,
+      match_key_version: 'v2_id',
+      run_started_at: '2026-04-01T00:00:00Z',
+    })
+    id = result.notification!.id
+  } finally {
+    cap.restore()
+  }
+  if (opts.createdAt) {
+    await db
+      .prepare('UPDATE notifications SET created_at = ? WHERE id = ?')
+      .bind(opts.createdAt, id)
+      .run()
+  }
+  return { id }
+}
+
+async function statusOf(db: D1Database, id: string): Promise<string> {
+  const row = await db
+    .prepare('SELECT status FROM notifications WHERE id = ?')
+    .bind(id)
+    .first<{ status: string }>()
+  return row!.status
+}
+
+describe('resolveNotificationsByBranch', () => {
+  it('resolves every open row on (repo, branch) and leaves others alone', async () => {
+    const db = await setupDb()
+
+    const stale = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'feature/stitch-retirement',
+      workflowId: 1001,
+    })
+    const other = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'main',
+      workflowId: 1002,
+    })
+    const otherRepo = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/sc-console',
+      branch: 'feature/stitch-retirement', // same branch name, different repo
+      workflowId: 1003,
+    })
+
+    const cap = captureLogs()
+    const result = await resolveNotificationsByBranch(
+      db,
+      'venturecrane/ke-console',
+      'feature/stitch-retirement',
+      'branch_deleted'
+    )
+    cap.restore()
+
+    expect(result.resolved_count).toBe(1)
+    expect(result.matched_ids).toEqual([stale.id])
+    expect(await statusOf(db, stale.id)).toBe('resolved')
+    expect(await statusOf(db, other.id)).toBe('new')
+    expect(await statusOf(db, otherRepo.id)).toBe('new')
+
+    const row = await db
+      .prepare('SELECT auto_resolve_reason FROM notifications WHERE id = ?')
+      .bind(stale.id)
+      .first<{ auto_resolve_reason: string }>()
+    expect(row?.auto_resolve_reason).toBe('branch_deleted')
+
+    const events = findStructuredEvents(cap.capture).filter(
+      (e) => e.event === 'notifications_resolved_by_branch'
+    )
+    expect(events.length).toBe(1)
+    expect(events[0].parsed.count).toBe(1)
+    expect(events[0].parsed.branch).toBe('feature/stitch-retirement')
+  })
+
+  it('returns 0 and emits no log when no rows match', async () => {
+    const db = await setupDb()
+    await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'main',
+      workflowId: 2001,
+    })
+
+    const cap = captureLogs()
+    const result = await resolveNotificationsByBranch(
+      db,
+      'venturecrane/ke-console',
+      'feature/nothing-here',
+      'branch_deleted'
+    )
+    cap.restore()
+
+    expect(result.resolved_count).toBe(0)
+    expect(result.matched_ids).toEqual([])
+    const events = findStructuredEvents(cap.capture).filter(
+      (e) => e.event === 'notifications_resolved_by_branch'
+    )
+    expect(events.length).toBe(0)
+  })
+})
+
+describe('runStaleBranchSweep', () => {
+  it('resolves non-main rows older than cutoff, leaves main and fresh rows', async () => {
+    const db = await setupDb()
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 3600 * 1000).toISOString()
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 3600 * 1000).toISOString()
+
+    const staleFeature = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'feature/ancient',
+      workflowId: 3001,
+      createdAt: tenDaysAgo,
+    })
+    const staleMain = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'main',
+      workflowId: 3002,
+      createdAt: tenDaysAgo,
+    })
+    const freshFeature = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'feature/recent',
+      workflowId: 3003,
+      createdAt: twoDaysAgo,
+    })
+
+    const cap = captureLogs()
+    const result = await runStaleBranchSweep(db, 7)
+    cap.restore()
+
+    expect(result.resolved_count).toBe(1)
+    expect(result.cutoff_days).toBe(7)
+    expect(await statusOf(db, staleFeature.id)).toBe('resolved')
+    expect(await statusOf(db, staleMain.id)).toBe('new') // main is sacred
+    expect(await statusOf(db, freshFeature.id)).toBe('new') // too recent
+
+    const row = await db
+      .prepare('SELECT auto_resolve_reason FROM notifications WHERE id = ?')
+      .bind(staleFeature.id)
+      .first<{ auto_resolve_reason: string }>()
+    expect(row?.auto_resolve_reason).toBe('aged_out_non_main')
+
+    const events = findStructuredEvents(cap.capture).filter(
+      (e) => e.event === 'notifications_stale_branch_sweep'
+    )
+    expect(events.length).toBe(1)
+    expect(events[0].parsed.count).toBe(1)
+  })
+
+  it('is a no-op and emits no log when nothing qualifies', async () => {
+    const db = await setupDb()
+    await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'main',
+      workflowId: 4001,
+      createdAt: new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString(),
+    })
+
+    const cap = captureLogs()
+    const result = await runStaleBranchSweep(db, 7)
+    cap.restore()
+
+    expect(result.resolved_count).toBe(0)
+    const events = findStructuredEvents(cap.capture).filter(
+      (e) => e.event === 'notifications_stale_branch_sweep'
+    )
+    expect(events.length).toBe(0)
+  })
+
+  it('respects the cutoff_days parameter', async () => {
+    const db = await setupDb()
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 3600 * 1000).toISOString()
+    const fresh = await makeOpenFailureOn(db, {
+      repo: 'venturecrane/ke-console',
+      branch: 'feature/five-days',
+      workflowId: 5001,
+      createdAt: fiveDaysAgo,
+    })
+
+    // 7-day cutoff: 5-day-old row is still fresh → no-op
+    let result = await runStaleBranchSweep(db, 7)
+    expect(result.resolved_count).toBe(0)
+    expect(await statusOf(db, fresh.id)).toBe('new')
+
+    // 3-day cutoff: 5-day-old row is now stale → resolved
+    result = await runStaleBranchSweep(db, 3)
+    expect(result.resolved_count).toBe(1)
+    expect(await statusOf(db, fresh.id)).toBe('resolved')
   })
 })

--- a/workers/crane-watch/src/index.ts
+++ b/workers/crane-watch/src/index.ts
@@ -169,6 +169,55 @@ async function forwardToNotifications(
 }
 
 // ============================================================================
+// BRANCH-DELETED FORWARDING (Issue #563)
+// ============================================================================
+//
+// GitHub emits `delete` events when a branch or tag is removed. For branches
+// this is the signal that any open notifications on that branch are
+// permanently stuck — a deleted branch can't produce a subsequent green
+// workflow_run to auto-resolve them. We forward to crane-context which
+// bulk-resolves matching (repo, branch) rows.
+
+async function forwardBranchDeleted(env: Env, repo: string, branch: string): Promise<void> {
+  const relayKey = env.CONTEXT_RELAY_KEY
+  if (!relayKey) {
+    console.error('CONTEXT_RELAY_KEY not configured, skipping branch-delete forwarding')
+    return
+  }
+
+  const fetcher = env.CRANE_CONTEXT || null
+  const contextUrl = env.CRANE_CONTEXT_URL
+  if (!fetcher && !contextUrl) {
+    console.error(
+      'Neither CRANE_CONTEXT service binding nor CRANE_CONTEXT_URL configured, skipping branch-delete forwarding'
+    )
+    return
+  }
+
+  try {
+    const requestInit: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Relay-Key': relayKey,
+      },
+      body: JSON.stringify({ repo, branch }),
+    }
+
+    const response = fetcher
+      ? await fetcher.fetch('https://crane-context/notifications/branch-deleted', requestInit)
+      : await fetch(`${contextUrl}/notifications/branch-deleted`, requestInit)
+
+    if (!response.ok) {
+      const text = await response.text()
+      console.error(`Branch-delete forwarding failed: ${response.status} ${text}`)
+    }
+  } catch (err) {
+    console.error('Branch-delete forwarding error:', err)
+  }
+}
+
+// ============================================================================
 // DEPLOY HEARTBEAT FORWARDING
 // ============================================================================
 //
@@ -271,6 +320,21 @@ async function handleGitHubWebhook(
   if (eventType === 'push') {
     ctx.waitUntil(forwardToDeployHeartbeats(env, 'push', payload))
     return new Response('OK - push event forwarded', { status: 200 })
+  }
+
+  // Branch-delete events (Issue #563) clear open notifications on the
+  // deleted branch — no subsequent green can auto-resolve them. Tags are
+  // ignored because they don't have associated workflow notifications.
+  if (eventType === 'delete' && payload.ref_type === 'branch') {
+    const branch = typeof payload.ref === 'string' ? payload.ref : null
+    const repoObj = payload.repository as { full_name?: unknown } | undefined
+    const repo = typeof repoObj?.full_name === 'string' ? repoObj.full_name : null
+    if (repo && branch) {
+      ctx.waitUntil(forwardBranchDeleted(env, repo, branch))
+      return new Response('OK - branch-delete forwarded', { status: 200 })
+    }
+    console.error('delete event missing repo or branch fields')
+    return new Response('OK - delete event ignored (missing fields)', { status: 200 })
   }
 
   // All other events (including issues) are acknowledged but not processed.


### PR DESCRIPTION
## Summary

Closes #563. Two new auto-resolve paths that together close the stale-branch residue gap (415 open notifications on non-main branches were piled up on 2026-04-20 because a deleted/abandoned branch can't produce a subsequent green workflow_run).

### Branch-deleted resolver
- `crane-watch` forwards GitHub `delete` webhooks with `ref_type=branch` to the new `crane-context` endpoint `POST /notifications/branch-deleted`.
- `resolveNotificationsByBranch(db, repo, branch, 'branch_deleted')` bulk-resolves every open row on that `(repo, branch)`. Idempotent.
- Defense-in-depth: refuses to act when branch is `main`/`master` with `{ ignored, reason: 'default_branch_refused' }`. GitHub blocks default-branch deletion, but this guards against a misconfigured webhook or a replay.

### TTL sweep backstop
- `runStaleBranchSweep(db, cutoffDays=7)` resolves open notifications on non-default branches older than the cutoff, tagged `auto_resolve_reason='aged_out_non_main'`.
- Wired into crane-context's existing 6-hour scheduled trigger. Never touches main/master.
- Covers the gap where a branch is force-pushed away, rebased into oblivion, or otherwise abandoned without a `delete` webhook.

## Contract changes
- `NOTIFICATION_AUTO_RESOLVE_REASONS` adds `branch_deleted` + `aged_out_non_main`.
- `NotificationLogEvent` adds `notifications_resolved_by_branch` + `notifications_stale_branch_sweep`.

## Test plan
- [x] 5 new unit tests in `notifications-log.test.ts`: happy path, no-match no-op, other-branch isolation, main-sacred invariant, fresh-row skip, cutoff parameterization.
- [x] `npm run verify` green — 526 mcp + 371 crane-context + 36 harness + 8 crane-watch + 25 crane-mcp-remote tests pass.
- [ ] After deploy: verify next scheduled run (within 6h) logs a `notifications_stale_branch_sweep` line. Next PR or manual scan will validate the branch-deleted path once a PR branch gets deleted post-merge.

## Out of scope
- No endpoint HTTP test for `/notifications/branch-deleted` — logic is covered at the function layer; the HTTP wrapper is thin validation + dispatch.
- No direct unit test for crane-watch's new `delete` handler branch — forwarder mirrors the existing `forwardToNotifications` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)