### PR TITLE
feat(sos): add Context7 directive to briefing

### DIFF
--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -737,6 +737,7 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
   message += `- Run \`npm run verify\` before pushing. Fix root causes, not symptoms.\n`
   message += `- Scope discipline: finish current task, file new issues for discovered work.\n`
   message += `- Never switch repos or ventures without explicit Captain approval. Announce all context switches.\n`
+  message += `- Before editing against any third-party API/SDK/CLI (GitHub, Vercel, Cloudflare, npm, etc.), consult Context7 (\`mcp__plugin_context7_context7__*\`) — training data is frozen; don't guess at vendor syntax. Full tooling catalog: \`crane_doc('global', 'tooling.md')\`.\n`
 
   // Inlined from guardrails.md SOD markers (avoids HTTP fetch per session)
   message += `- Never drop database columns/tables or run destructive migrations without Captain directive.\n`


### PR DESCRIPTION
## Summary

- Adds a single named-trigger directive to the `crane_sos` Directives block reminding agents to consult Context7 before editing against any third-party API/SDK/CLI (GitHub, Vercel, Cloudflare, npm, etc.)
- One edit reaches every venture's session start — no need to update 5+ venture `CLAUDE.md` module tables or per-project memory

## Why

Investigation this session surfaced that Context7 is installed at user scope and enabled for every venture, but agents across ventures continued to guess at vendor API syntax (fine-grained PAT scopes, `npm.pkg.github.com` auth semantics, etc.) — including a vc agent running in this very repo. The MCP server's auto-injected instruction and the `tooling.md` module pointer in `crane-console/CLAUDE.md` both exist, but neither was binding enough to change behavior.

The named-trigger format ("before editing against third-party X, do Y") is deliberately more specific than generic "use Context7" guidance. Vague guidance proved easy to skip; specific triggers bind the tool to a concrete situation.

## Test plan

- [x] `npm --workspace packages/crane-mcp test` — 535/535 pass
- [x] `npm run verify` — typecheck + lint + format + build all green
- [ ] After merge: `/ship` rebuilds crane-mcp and distributes to fleet (standard flow)
- [ ] Verify next `/sos` session in another venture (e.g. ke, ss) shows the new directive line

## Related

Separate PR on `feat/github-packages-auth-foundation` wires the `NODE_AUTH_TOKEN` plumbing for GitHub Packages auth (foundation only; blocked on Captain rotating/provisioning a classic PAT with `read:packages` scope in Infisical `/vc`).

## Follow-ups

- If this doesn't change behavior within ~1 week of sessions, escalate to a harder-edged mechanism (pre-edit hook or workflow gate) rather than adding more text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)