### PR TITLE
fix(crane-context): deterministic isSessionStale boundary test

### DIFF
--- a/workers/crane-context/test/sessions.test.ts
+++ b/workers/crane-context/test/sessions.test.ts
@@ -4,7 +4,7 @@
  * Tests session lifecycle, staleness detection, heartbeat jitter, and state transitions
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { isSessionStale, getStaleThreshold, calculateNextHeartbeat } from '../src/sessions'
 import type { SessionRecord } from '../src/types'
 import {
@@ -72,15 +72,24 @@ describe('Staleness Detection', () => {
     })
 
     it('returns false for session exactly at threshold', () => {
-      // Use fixed threshold to avoid timing issues
-      const staleThreshold = subtractMinutes(45)
-      const session = createMockSession({
-        last_heartbeat_at: staleThreshold, // Exactly at threshold
-      })
+      // Freeze Date.now() so both subtractMinutes(45) calls — the one below
+      // and the one inside isSessionStale — return identical timestamps.
+      // Without fake timers, CI-level jitter between the two calls flipped
+      // the `<` comparison and made this test flaky (see git blame).
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-04-20T12:00:00.000Z'))
+      try {
+        const staleThreshold = subtractMinutes(45)
+        const session = createMockSession({
+          last_heartbeat_at: staleThreshold, // Exactly at threshold
+        })
 
-      // Session at exactly 45 minutes is NOT stale (< not <=)
-      // When last_heartbeat_at === staleThreshold, the < comparison is false
-      expect(isSessionStale(session)).toBe(false)
+        // Session at exactly 45 minutes is NOT stale (< not <=)
+        // When last_heartbeat_at === staleThreshold, the < comparison is false
+        expect(isSessionStale(session)).toBe(false)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('returns true for session beyond threshold', () => {


### PR DESCRIPTION
## Summary

Fixes a real timing race in the \"returns false for session exactly at threshold\" test in \`workers/crane-context/test/sessions.test.ts\`. The test computed \`subtractMinutes(45)\` in test code, then \`isSessionStale\` computed \`subtractMinutes(45)\` again — any wall-clock drift between the two \`Date.now()\` calls flipped the \`<\` comparison.

## Why now

PR #575 CI caught this; main has been green because the race has been landing favorably. The test has been flaky since it was written — this is a genuine test bug, not a production issue.

## Change

\`vi.useFakeTimers()\` + \`vi.setSystemTime\` around the assertion so both \`subtractMinutes(45)\` calls produce identical timestamps. Production code path unchanged.

## Test plan

- [x] \`cd workers/crane-context && npm test -- --run test/sessions.test.ts\` — 40/40 pass
- [x] Runs the test boundary case 10x locally to confirm no residual flakiness (no time-dependent paths remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)