### PR TITLE
fix(fleet): fail loudly when npm ci fails in fleet-exec

### DIFF
--- a/scripts/fleet-exec.sh
+++ b/scripts/fleet-exec.sh
@@ -97,9 +97,25 @@ EOF
   exit 1
 fi
 
-# Install dependencies if package.json exists
+# Install dependencies if package.json exists.
+#
+# Fail loudly on npm ci failure instead of letting a silent swallow mask
+# auth problems (e.g. the ss-console NODE_AUTH_TOKEN incident 2026-04-20
+# where `npm ci` was returning 401 against npm.pkg.github.com but the
+# `|| true` here hid it and the agent ran against an empty node_modules
+# until pre-push CI finally complained).
+#
+# Output is captured to $TASK_DIR/npm-ci.log so the failure reason is
+# preserved for whoever inspects the task, and status.json carries a
+# machine-readable error so the dispatcher can report it.
 if [ -f "$WORKTREE_PATH/package.json" ]; then
-  (cd "$WORKTREE_PATH" && npm ci --prefer-offline > /dev/null 2>&1) || true
+  if ! (cd "$WORKTREE_PATH" && npm ci --prefer-offline) > "$TASK_DIR/npm-ci.log" 2>&1; then
+    echo "Error: npm ci failed in $WORKTREE_PATH (see $TASK_DIR/npm-ci.log)" >&2
+    cat > "$TASK_DIR/status.json" <<EOF
+{"status":"failed","task_id":"$TASK_ID","issue":"$ISSUE_NUMBER","error":"npm ci failed","log":"$TASK_DIR/npm-ci.log","started_at":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
+EOF
+    exit 1
+  fi
 fi
 
 # Fetch issue body for prompt


### PR DESCRIPTION
## Summary

Removes the \`|| true\` swallow around \`npm ci\` in \`scripts/fleet-exec.sh\`. Output is now captured to \`\$TASK_DIR/npm-ci.log\` and failures produce a real status.json transition with exit 1.

## Why

Root-cause evidence from the ss-console incident 2026-04-20: node_modules was empty because fleet-exec's \`npm ci\` hit 401 against \`npm.pkg.github.com\` (\`NODE_AUTH_TOKEN\` not provisioned yet), but the \`|| true\` hid it completely — no log, no status transition. The agent was then handed a broken worktree and spent minutes on pre-push verify before anyone noticed.

This is the fleet-side equivalent of the verify-before-deploy rule: silent \`|| true\` is the anti-pattern that makes real failures indistinguishable from success.

## Change

Before:
\`\`\`sh
(cd \"\$WORKTREE_PATH\" && npm ci --prefer-offline > /dev/null 2>&1) || true
\`\`\`

After: output captured to task dir, failure writes status.json and exits 1.

## Test plan

- [x] \`bash -n scripts/fleet-exec.sh\` — passes shell syntax check
- [ ] Dispatch a fleet task against a repo with intentionally broken npm auth — expect status.json to show \`{\"status\":\"failed\",\"error\":\"npm ci failed\"}\` and the dispatcher to surface the failure (needs a live dispatch test post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)