### PR TITLE
feat(foundation): wire NODE_AUTH_TOKEN for GitHub Packages auth

### DIFF
--- a/config/ventures.json
+++ b/config/ventures.json
@@ -13,7 +13,8 @@
       "CRANE_ADMIN_KEY",
       "GH_TOKEN",
       "VERCEL_TOKEN",
-      "CLOUDFLARE_API_TOKEN"
+      "CLOUDFLARE_API_TOKEN",
+      "NODE_AUTH_TOKEN"
     ]
   },
   "ventures": [

--- a/docs/infra/github-packages-auth.md
+++ b/docs/infra/github-packages-auth.md
@@ -1,0 +1,103 @@
+# GitHub Packages Auth
+
+How ventures authenticate to `npm.pkg.github.com` to install `@venturecrane/*` packages.
+
+## Why a registry (not tarball URLs)
+
+`@venturecrane/crane-test-harness` and any future shared `@venturecrane/*` packages are published to the GitHub Packages npm registry. Consumers install via semver (`"@venturecrane/crane-test-harness": "^0.1.0"`), not pinned release tarball URLs.
+
+This is the durable factory-scale shape:
+
+- **Dependabot** sees registry packages and proposes version bumps across the fleet.
+- **Semver + dist-tags** — `latest` for stable, `rc` for pre-release. One venture can opt in to `@rc` while others stay on `latest`.
+- **Lockfile integrity** — registry tarballs are immutable once published; re-uploading a release asset cannot silently break downstream lockfiles.
+- **`npm audit`** and `npm outdated` cover the supply chain.
+- **Abstraction** — registry changes (self-host, move to public npm) require one `.npmrc` edit per consumer, not `package.json` URL rewrites.
+
+The only cost is authentication, and every piece of auth infrastructure this pattern needs already exists in the fleet (Infisical, `crane` launcher env injection, Actions' `GITHUB_TOKEN`).
+
+## Auth model
+
+| Consumer              | Token source                      | How it arrives                                               |
+| --------------------- | --------------------------------- | ------------------------------------------------------------ |
+| Local dev (any agent) | Infisical `/vc` `NODE_AUTH_TOKEN` | Injected by `crane` launcher into agent shell env            |
+| GitHub Actions        | `${{ secrets.GITHUB_TOKEN }}`     | Provided by Actions; needs `packages: read` permission block |
+| Fleet machines        | Infisical `/vc` `NODE_AUTH_TOKEN` | Same as local dev via `crane` launcher + Machine Identity    |
+
+`NODE_AUTH_TOKEN` is listed in `config/ventures.json` `sharedSecrets.keys`, so `scripts/sync-shared-secrets.sh --fix` propagates the `/vc` value to every venture's Infisical path.
+
+## Token: classic PAT, `read:packages` only
+
+Fine-grained PATs have persistent compatibility gaps with `npm.pkg.github.com`. Classic PAT with the single `read:packages` scope is the battle-tested, correctly-documented path.
+
+**Settings:**
+
+- Name: `enterprise-packages-read-YYYY` (year of creation)
+- Expiration: 366 days (1 year maximum meaningful value)
+- Scopes: **only** `read:packages` — no `repo`, `workflow`, `user`, `read:org`, or anything else.
+- Owned by the SMDurgan account (sole venturecrane org owner).
+
+**Blast radius if leaked:** read access to `@venturecrane/*` packages. These are internal libs every venture already consumes. Not secrets, not credentials, not write access. Rotate annually anyway.
+
+## Consumer setup
+
+Every venture that installs `@venturecrane/*` packages needs an `.npmrc` at repo root:
+
+```
+@venturecrane:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+```
+
+`templates/venture/.npmrc` is this exact file. New ventures get it automatically.
+
+CI workflows (`verify.yml`, `deploy.yml`, `security.yml`) need `actions/setup-node` configured for the registry:
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version-file: '.nvmrc'
+    registry-url: 'https://npm.pkg.github.com'
+    scope: '@venturecrane'
+
+- run: npm ci
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+No secret management in CI — `GITHUB_TOKEN` is provided by Actions. The workflow just needs `packages: read` in the job `permissions:` block if the default is restrictive.
+
+## Rotation
+
+Annual. See `docs/infra/secrets-rotation-runbook.md` for the procedure.
+
+Short version: regenerate PAT on GitHub with the same settings, `infisical secrets set "NODE_AUTH_TOKEN=$(pbpaste | tr -d '[:space:]')" --path /vc --env prod >/dev/null 2>&1 && echo set`, then `bash scripts/sync-shared-secrets.sh --fix` to propagate. No code changes, no PR.
+
+## Troubleshooting
+
+**`401 Unauthorized` on `npm install`:**
+
+1. Verify token is present in agent env: `echo ${NODE_AUTH_TOKEN:+present}` (prints `present` or nothing; never prints value).
+2. Verify token length: `echo -n "$NODE_AUTH_TOKEN" | wc -c` — expect 40 for a classic PAT.
+3. Verify token works: `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $NODE_AUTH_TOKEN" https://npm.pkg.github.com/@venturecrane%2Fcrane-test-harness` — expect `200`.
+4. Token may be expired. Check github.com/settings/tokens; regenerate per rotation runbook.
+5. Token may be missing from Infisical. `infisical secrets get NODE_AUTH_TOKEN --path /vc --env prod --plain | wc -c` (length-only check). If missing, see rotation runbook for restoration.
+
+**Launcher not injecting `NODE_AUTH_TOKEN`:**
+
+The launcher (`packages/crane-mcp/src/cli/launch-lib.ts`) hardcodes env var allowlists for Gemini and Codex MCP servers. Claude Code inherits `process.env` directly. If a new agent is added, its allowlist must include `NODE_AUTH_TOKEN` — the hardcoded lists are slated for consolidation with `config/ventures.json` `sharedSecrets.keys` (see GitHub issue on crane-console).
+
+## Upgrade trigger
+
+Move from classic PAT to a GitHub App with a token broker when **any** of these is true:
+
+- A second operator joins the org (classic PAT remains tied to SMDurgan; rotation becomes a coordination problem).
+- Compliance requirement introduces audit/revocation trails this token cannot satisfy (SOC 2, etc.).
+- Fine-grained PAT support for `npm.pkg.github.com` stabilizes across both local and Actions and is documented as first-class.
+
+Until one of those is true, classic PAT with minimal scope is the right-sized choice.
+
+## History
+
+- 2026-04-07 — ss-console adopts `@venturecrane/crane-test-harness` via registry. First consumer.
+- 2026-04-08 — sc, dfg, ke, dc adopt via GitHub Releases tarball URL instead. Drift introduced.
+- 2026-04-20 — Token loss + enterprise audit. Registry pattern standardized. Classic PAT chosen; added to Infisical `/vc`; launcher allowlists extended; `.npmrc` template updated; this doc written. Per-venture migration PRs to follow.

--- a/docs/infra/secrets-management.md
+++ b/docs/infra/secrets-management.md
@@ -567,6 +567,8 @@ Different credential types behave differently when rotated. This affects go-live
 
 - `docs/infra/machine-inventory.md` - Machine setup status
 - `docs/process/new-venture-setup-checklist.md` - New venture setup (includes Infisical)
+- `docs/infra/github-packages-auth.md` - `@venturecrane/*` npm registry auth (NODE_AUTH_TOKEN)
+- `docs/infra/secrets-rotation-runbook.md` - Scheduled rotation procedures
 
 ## Last Updated
 

--- a/docs/infra/secrets-rotation-runbook.md
+++ b/docs/infra/secrets-rotation-runbook.md
@@ -1,0 +1,77 @@
+# Secrets Rotation Runbook
+
+Scheduled rotation procedures for shared secrets. Surfaced by `/sos` as a cadence item; review quarterly, execute per the intervals below.
+
+## Principles
+
+- **Rotate on schedule**, not on incident. Incident-driven rotation is too late.
+- **Never echo values into agent sessions.** See `docs/infra/secrets-management.md` — CLI transcripts persist and are sent to the API provider.
+- **Move secrets via `pbpaste` + output-suppressed pipe** into Infisical. Both halves: source (`pbpaste`) and sink (`>/dev/null 2>&1 && echo set`).
+- **Length-only verification.** After setting, check `infisical secrets get KEY --path … --plain | wc -c`; never inspect values directly.
+- **Propagate after setting.** `bash scripts/sync-shared-secrets.sh --fix` copies shared keys from `/vc` to every venture path.
+
+## Schedule
+
+| Secret            | Cadence | Last rotated | Next due   | Owner   | Runbook                             |
+| ----------------- | ------- | ------------ | ---------- | ------- | ----------------------------------- |
+| `NODE_AUTH_TOKEN` | 1 year  | 2026-04-20   | 2027-04-20 | Captain | [NODE_AUTH_TOKEN](#node_auth_token) |
+
+## NODE_AUTH_TOKEN
+
+Classic PAT on SMDurgan account, scope `read:packages` only, used by every venture's `npm install` to fetch `@venturecrane/*` packages from `npm.pkg.github.com`. See `docs/infra/github-packages-auth.md` for design context.
+
+**Rotation procedure:**
+
+1. Create the replacement before revoking the current — eliminates window of breakage.
+   - github.com/settings/tokens → **Generate new token (classic)**
+   - Name: `enterprise-packages-read-<year>` (reflect the new rotation year)
+   - Expiration: 366 days (Custom)
+   - Scopes: **only** `read:packages`
+   - Description: "Read-only access to @venturecrane/\* packages on npm.pkg.github.com. Stored in Infisical /vc as NODE_AUTH_TOKEN; injected into agent and fleet env by crane launcher. Rotation: see crane-console/docs/infra/secrets-rotation-runbook.md"
+   - **Generate token**, copy to clipboard.
+
+2. Push into Infisical with output suppression:
+
+   ```bash
+   infisical secrets set "NODE_AUTH_TOKEN=$(pbpaste | tr -d '[:space:]')" --path /vc --env prod >/dev/null 2>&1 && echo set
+   ```
+
+3. Verify length only:
+
+   ```bash
+   infisical secrets get NODE_AUTH_TOKEN --path /vc --env prod --plain | wc -c
+   ```
+
+   Expect `41` (40-char classic PAT + newline).
+
+4. Propagate to every venture's Infisical path:
+
+   ```bash
+   cd ~/dev/crane-console && bash scripts/sync-shared-secrets.sh --fix
+   ```
+
+5. Verify in a venture:
+
+   ```bash
+   cd ~/dev/ss-console && rm -rf node_modules && npm install
+   ```
+
+   `@venturecrane/crane-test-harness` should resolve without 401.
+
+6. Revoke the old token on github.com/settings/tokens → delete the previous year's token entry. **Do this last**; deleting before the new token propagates breaks every active session and CI run.
+
+7. Clear clipboard by copying harmless text.
+
+8. Update the **Last rotated** and **Next due** dates in the schedule table above.
+
+**If something goes wrong mid-rotation:**
+
+- Old token still valid until step 6. If new token fails verification at step 3 or 5, regenerate and repeat. The old token keeps production working during the retry window.
+- If a value was accidentally echoed into a transcript, treat the token as compromised and return to step 1 with a fresh PAT.
+
+## How to add a new entry
+
+1. Add a row to the schedule table above.
+2. Add a `## SECRET_NAME` section with the rotation procedure, following the structure of `NODE_AUTH_TOKEN`.
+3. Reference any relevant design doc in `docs/infra/`.
+4. Link from the relevant `docs/infra/*-auth.md` doc's "Rotation" section.

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -77,6 +77,7 @@ const EXPECTED_ENV_KEYS = [
   'GH_TOKEN',
   'VERCEL_TOKEN',
   'CLOUDFLARE_API_TOKEN',
+  'NODE_AUTH_TOKEN',
 ]
 
 function getWritten(): Record<string, unknown> {
@@ -201,6 +202,7 @@ describe('setupGeminiMcp', () => {
             GH_TOKEN: '$GH_TOKEN',
             VERCEL_TOKEN: '$VERCEL_TOKEN',
             CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+            NODE_AUTH_TOKEN: '$NODE_AUTH_TOKEN',
           },
         },
       },

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1219,6 +1219,7 @@ export function setupGeminiMcp(repoPath: string): void {
     GH_TOKEN: '$GH_TOKEN',
     VERCEL_TOKEN: '$VERCEL_TOKEN',
     CLOUDFLARE_API_TOKEN: '$CLOUDFLARE_API_TOKEN',
+    NODE_AUTH_TOKEN: '$NODE_AUTH_TOKEN',
   }
 
   // Gemini CLI sanitizes process.env before passing to MCP servers, stripping
@@ -1289,7 +1290,7 @@ export function setupCodexMcp(): void {
   //   2. shell_environment_policy - stops the default filter for shell
   //      commands so gh CLI etc. can access GH_TOKEN
   const envVars =
-    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN"]'
+    '["CRANE_CONTEXT_KEY", "CRANE_ENV", "CRANE_VENTURE_CODE", "CRANE_VENTURE_NAME", "CRANE_REPO", "GH_TOKEN", "VERCEL_TOKEN", "CLOUDFLARE_API_TOKEN", "NODE_AUTH_TOKEN"]'
 
   let updated = false
 

--- a/templates/venture/.npmrc
+++ b/templates/venture/.npmrc
@@ -1,0 +1,2 @@
+@venturecrane:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/templates/venture/package.json
+++ b/templates/venture/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",
     "@eslint/js": "^9.18.0",
-    "@venturecrane/crane-test-harness": "https://github.com/venturecrane/crane-console/releases/download/crane-test-harness-v0.1.0/venturecrane-crane-test-harness-0.1.0.tgz",
+    "@venturecrane/crane-test-harness": "^0.1.0",
     "eslint": "^9.18.0",
     "globals": "^15.0.0",
     "husky": "^9.1.0",


### PR DESCRIPTION
## Status: Draft — blocked on token provisioning

**Do not merge** until Captain provisions a classic PAT with `read:packages` scope in Infisical `/vc` as `NODE_AUTH_TOKEN`, then runs `scripts/sync-shared-secrets.sh --fix` to propagate to every venture path. Until then this foundation is inert — consumers still use tarball URLs and ss-console's `.npmrc`-referenced token stays 401.

## Summary

Foundation for consuming `@venturecrane/*` packages from the GitHub Packages npm registry (replacing pinned release-tarball URLs).

- Add `NODE_AUTH_TOKEN` to shared-secrets sync list in `config/ventures.json`.
- Wire `NODE_AUTH_TOKEN` into Gemini and Codex MCP env allowlists in `packages/crane-mcp/src/cli/launch-lib.ts`. Claude doesn't have an allowlist — `childEnv` already spreads `secrets`, so Claude sessions get it automatically once Infisical has the value.
- `templates/venture/package.json`: switch `crane-test-harness` from tarball URL to `^0.1.0` semver — the factory-scale shape that enables Dependabot, lockfile integrity, and registry abstraction.
- `templates/venture/.npmrc` (new): scope + token template.
- `docs/infra/github-packages-auth.md` (new): end-to-end auth model.
- `docs/infra/secrets-rotation-runbook.md` (new): scheduled rotation procedures.

## Why registry over tarball URLs

See `docs/infra/github-packages-auth.md` for the full rationale. Summary: Dependabot sees registry packages; semver + dist-tags enable `@rc` pre-releases; lockfile integrity (tarballs are immutable once published); `npm audit` + `npm outdated` cover the supply chain; abstraction (one `.npmrc` edit vs per-repo URL rewrites).

## What this does NOT do

- **Per-venture package.json migrations** — ss-console first (since it already has `.npmrc`), then the rest. Each in its own PR once the token is live.
- **Actions workflow updates** — the CI `npm ci` in each venture needs a `permissions: packages: read` block and `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`. Per-repo, post-token.
- **The `.npmrc` template alone does NOT unblock ss-console.** ss-console already has its own `.npmrc`; the blocker is the token.

## Test plan

- [x] `npm --workspace packages/crane-mcp test` — 535/535 pass
- [x] `npm run verify` — green
- [ ] Captain provisions `NODE_AUTH_TOKEN` in Infisical `/vc` with `read:packages` PAT
- [ ] `scripts/sync-shared-secrets.sh --fix` propagates to all venture paths
- [ ] ss-console session: `npm ci` succeeds against `npm.pkg.github.com` (smoke test the auth end-to-end)
- [ ] Un-draft and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)