### PR TITLE
fix(fleet): deploy-crane-mcp.sh runs npm install at workspace root (closes #580)

### DIFF
--- a/scripts/deploy-crane-mcp.sh
+++ b/scripts/deploy-crane-mcp.sh
@@ -11,7 +11,8 @@
 #   1. SSH to each machine
 #   2. Stash any local changes
 #   3. Pull latest from origin/main
-#   4. Run npm run build
+#   4. Run `npm install` at the workspace root (triggers postinstall builds)
+#   5. Rebuild and re-link crane-mcp
 #
 # Environment Variables:
 #   DRY_RUN=true     Preview actions without executing
@@ -93,7 +94,8 @@ for SSH_HOST in "${MACHINE_LIST[@]}"; do
     echo -e "    1. cd ~/dev/crane-console"
     echo -e "    2. git stash --include-untracked (if needed)"
     echo -e "    3. git pull origin main"
-    echo -e "    4. cd packages/crane-mcp && npm install && npm run build && npm link"
+    echo -e "    4. npm install (root — runs postinstall builds)"
+    echo -e "    5. cd packages/crane-mcp && npm run build && npm link"
     echo ""
     ((SUCCESS_COUNT++))
     continue
@@ -115,10 +117,21 @@ git fetch origin
 git checkout main 2>/dev/null || true
 git pull origin main
 
-# Build crane-mcp from monorepo
-echo "Installing dependencies..."
-cd packages/crane-mcp
+# Install at the workspace ROOT first. The root package.json has a
+# postinstall hook that builds @venturecrane/crane-contracts and
+# @venturecrane/crane-test-harness. Those builds need devDeps from their
+# respective packages (e.g., @cloudflare/workers-types for the harness).
+# A workspace-scoped install (`cd packages/crane-mcp && npm install`) only
+# installs that child's deps, so the postinstall hook fails on Linux
+# fleet machines that don't already have the other packages' deps cached.
+# Root install guarantees every workspace's deps are present before
+# postinstall runs. See venturecrane/crane-console issue #580.
+echo "Installing dependencies (root workspace install)..."
 npm install
+
+# Rebuild and re-link crane-mcp specifically; root postinstall does not
+# cover crane-mcp's own build step.
+cd packages/crane-mcp
 
 echo "Building crane-mcp..."
 npm run build


### PR DESCRIPTION
## Summary

- `scripts/deploy-crane-mcp.sh` now runs `npm install` at the workspace ROOT before cd'ing into `packages/crane-mcp` for the package-specific build + `npm link`.

## Root cause

The root `package.json` has a `postinstall` hook that builds `@venturecrane/crane-contracts` and `@venturecrane/crane-test-harness`. Those builds need devDeps from their respective packages — notably `@cloudflare/workers-types` for the harness.

The previous deploy flow (`cd packages/crane-mcp && npm install`) invoked that postinstall hook but only installed the crane-mcp workspace child's deps. Packages like `@cloudflare/workers-types` declared in crane-test-harness's devDeps were never installed. On fleet Linux machines without a prior root install, the postinstall build of crane-test-harness fails with:

```
error TS2688: Cannot find type definition file for '@cloudflare/workers-types'.
```

mac23 "worked" only because earlier local root installs had cached `node_modules/@cloudflare/workers-types` — the script was silently dependent on that state.

## Fix

Root install first → every workspace's deps are installed → postinstall builds succeed. Then cd into `packages/crane-mcp` for the build + link steps that target crane-mcp specifically. No behavior change on mac23 (already had the deps cached); resolves the failure on Linux fleet machines.

## Test plan

- [x] `DRY_RUN=true bash scripts/deploy-crane-mcp.sh` shows the updated order (root install, then cd + build + link).
- [ ] After merge: run `bash scripts/deploy-crane-mcp.sh` and verify all 3 fleet machines (mbp27, think, mini) report Success.

Closes #580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)