### PR TITLE
ci(dependabot): wire GitHub Packages registry auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+# Dependabot config for crane-console.
+#
+# The private @venturecrane/* scope lives on GitHub Packages
+# (npm.pkg.github.com). Dependabot needs read:packages auth to resolve
+# the workspace dependency graph; without it, security updates abort
+# with `security_update_not_possible` because Dependabot can't see the
+# private packages and fails the resolver.
+#
+# Auth is wired via the `github-packages` registry below, which reads
+# the `NODE_AUTH_TOKEN` Dependabot secret (Classic PAT, read:packages).
+# Secret is managed in Infisical at /vc and set via
+# `gh secret set NODE_AUTH_TOKEN --app dependabot`.
+
+version: 2
+
+registries:
+  github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.NODE_AUTH_TOKEN }}
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /packages/crane-mcp
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /workers/crane-context
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /workers/crane-mcp-remote
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /workers/crane-watch
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /site
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /templates/venture
+    registries:
+      - github-packages
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with a `github-packages` registry block authenticated by the `NODE_AUTH_TOKEN` Dependabot secret (Classic PAT, `read:packages`).
- Wires the registry into every npm update directory Dependabot currently scans (`/`, `/packages/crane-mcp`, `/workers/crane-context`, `/workers/crane-mcp-remote`, `/workers/crane-watch`, `/site`, `/templates/venture`).
- Adds a `github-actions` ecosystem for workflow-file bumps.
- Prerequisite secrets already set: `NODE_AUTH_TOKEN` seeded to both Dependabot and Actions scopes on this repo earlier this session.

## Why

Security-update runs have been failing for 4+ days with `security_update_not_possible` on `ajv` (stuck at 8.17.1 per advisory GHSA, needs 8.18.0) and `hono`. Root cause: the workspace imports `@venturecrane/crane-mcp` and `@venturecrane/crane-contracts` from GitHub Packages, but without registry auth, Dependabot's proxy returns `404` for those packages against public npm. The workspace resolver breaks, and the updater can't compute an upgrade path.

Latest failed run log: https://github.com/venturecrane/crane-console/actions/runs/24692727001 — the proxy fetches `registry.npmjs.org/@venturecrane%2Fcrane-mcp` → 404, then reports `latest-resolvable-version: 8.17.1`, `lowest-non-vulnerable-version: 8.18.0`, `conflicting-dependencies: []`.

## Test plan

- [x] `NODE_AUTH_TOKEN` Dependabot secret set on `venturecrane/crane-console`
- [x] `NODE_AUTH_TOKEN` Actions secret set on `venturecrane/crane-console`
- [ ] Merge this PR
- [ ] Trigger Dependabot re-run on `ajv` advisory via Security → Dependabot → "Check for updates"
- [ ] Confirm new run succeeds and produces a PR bumping ajv to 8.18.0 (or equivalent)
- [ ] Confirm `hono` advisory follow-up PRs also land

## Follow-ups

- The 12 stale CI/CD notifications on main (from runs #88–#93) will be resolved in VCMS once the next Dependabot run succeeds.

Refs: session `sess_01KPQ6J4KYYMRZA7BNBZM95NZX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)