### PR TITLE
ci(npm): add repo-root .npmrc with @venturecrane scope mapping

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@venturecrane:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}


### PR DESCRIPTION
## Summary

Follow-up to #583. Adds `.npmrc` at repo root with the `@venturecrane` scope → `npm.pkg.github.com` mapping that Dependabot (and local/CI `npm install`) needs to resolve private workspace packages.

## Why

#583 added Dependabot registry auth for `npm.pkg.github.com`. The 8 Dependabot runs that auto-fired on merge confirmed the config: 7/8 succeeded. The only failure was `/packages/crane-mcp` — the only workspace that depends on `@venturecrane/crane-contracts` by semver (`^0.1.0`) rather than a `file:` path. Failure log ([run 24705563905](https://github.com/venturecrane/crane-console/actions/runs/24705563905)) shows npm hitting `registry.npmjs.org/@venturecrane/crane-mcp` → 404, never falling through to `npm.pkg.github.com`.

The Dependabot `registries:` block sets up auth; it does not install a scope mapping. The mapping has to live in a committed `.npmrc` that npm can find via its upward-lookup.

## What

- New `.npmrc` at repo root, identical to `templates/venture/.npmrc` (established as the fleet pattern in #579):

  ```
  @venturecrane:registry=https://npm.pkg.github.com
  //npm.pkg.github.com/:_authToken=\${NODE_AUTH_TOKEN}
  ```

- npm walks up from cwd, so every workspace Dependabot scans inherits this automatically — no per-workspace copies needed.

## Test plan

- [x] Secrets in place: `NODE_AUTH_TOKEN` set on both Dependabot and Actions scopes (done in session prior to #583)
- [ ] Merge this PR
- [ ] Trigger Dependabot check-for-updates on `/packages/crane-mcp` (or wait for the next weekly run); confirm the previously-failing run now succeeds
- [ ] Resolve the 12 stale CI/CD notifications carried over from pre-fix runs

## Refs

- Blocks: clearance of 12 stale Dependabot CI/CD notifications
- Continuation of: #579 (NODE_AUTH_TOKEN foundation), #583 (registry config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)