### PR TITLE
feat(publish): add GitHub Packages workflows for crane-contracts and crane-mcp

### DIFF
--- a/.github/workflows/publish-crane-contracts.yml
+++ b/.github/workflows/publish-crane-contracts.yml
@@ -1,0 +1,94 @@
+name: Publish crane-contracts
+
+# Publishes @venturecrane/crane-contracts to GitHub Packages on tag push.
+#
+# Tag conventions:
+#   crane-contracts-v0.1.0       → publishes 0.1.0 as 'latest'
+#   crane-contracts-v0.1.0-rc.1  → publishes 0.1.0-rc.1 with --tag rc
+#                                  (does NOT update the 'latest' tag)
+#
+# After publish, runs an `npm view` smoke check to confirm the registry
+# actually has the package. If the smoke check fails, the workflow fails so
+# downstream consumers (crane-mcp, fleet ventures) get a clear signal.
+
+on:
+  push:
+    tags:
+      - 'crane-contracts-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.0 or 0.1.0-rc.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build contracts package
+        run: npm run build -w @venturecrane/crane-contracts
+
+      - name: Determine npm dist-tag
+        id: tag
+        run: |
+          VERSION=$(node -p "require('./packages/crane-contracts/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Publishing version $VERSION with dist-tag $(grep dist_tag $GITHUB_OUTPUT)"
+
+      - name: Publish
+        working-directory: packages/crane-contracts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --tag ${{ steps.tag.outputs.dist_tag }}
+
+      - name: Post-publish smoke check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          for attempt in 1 2 3 4 5; do
+            echo "Attempt $attempt: npm view @venturecrane/crane-contracts@$VERSION"
+            if npm view "@venturecrane/crane-contracts@$VERSION" version 2>&1 | grep -q "$VERSION"; then
+              echo "Smoke check passed: $VERSION is on the registry."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Smoke check failed: @venturecrane/crane-contracts@$VERSION is not on the registry after 5 attempts."
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## crane-contracts publish"
+            echo ""
+            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
+            echo "- Dist-tag: \`${{ steps.tag.outputs.dist_tag }}\`"
+            echo "- Registry: https://github.com/venturecrane/crane-console/pkgs/npm/crane-contracts"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-crane-mcp.yml
+++ b/.github/workflows/publish-crane-mcp.yml
@@ -1,0 +1,100 @@
+name: Publish crane-mcp
+
+# Publishes @venturecrane/crane-mcp to GitHub Packages on tag push.
+#
+# Tag conventions:
+#   crane-mcp-v0.2.0       → publishes 0.2.0 as 'latest'
+#   crane-mcp-v0.2.0-rc.1  → publishes 0.2.0-rc.1 with --tag rc
+#                            (does NOT update the 'latest' tag)
+#
+# crane-mcp depends on @venturecrane/crane-contracts. The monorepo workspace
+# resolver satisfies that at build time from the local sibling package, so
+# `npm ci` works even if a published crane-contracts isn't yet live. The
+# published crane-mcp declares crane-contracts as a registry dep; consumers
+# installing crane-mcp from the registry will fetch crane-contracts from the
+# registry too, so crane-contracts must be published first.
+#
+# After publish, runs an `npm view` smoke check to confirm the registry has
+# the package.
+
+on:
+  push:
+    tags:
+      - 'crane-mcp-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.2.0 or 0.2.0-rc.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build crane-mcp package
+        run: npm run build -w @venturecrane/crane-mcp
+
+      - name: Determine npm dist-tag
+        id: tag
+        run: |
+          VERSION=$(node -p "require('./packages/crane-mcp/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Publishing version $VERSION with dist-tag $(grep dist_tag $GITHUB_OUTPUT)"
+
+      - name: Publish
+        working-directory: packages/crane-mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --tag ${{ steps.tag.outputs.dist_tag }}
+
+      - name: Post-publish smoke check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          for attempt in 1 2 3 4 5; do
+            echo "Attempt $attempt: npm view @venturecrane/crane-mcp@$VERSION"
+            if npm view "@venturecrane/crane-mcp@$VERSION" version 2>&1 | grep -q "$VERSION"; then
+              echo "Smoke check passed: $VERSION is on the registry."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Smoke check failed: @venturecrane/crane-mcp@$VERSION is not on the registry after 5 attempts."
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## crane-mcp publish"
+            echo ""
+            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
+            echo "- Dist-tag: \`${{ steps.tag.outputs.dist_tag }}\`"
+            echo "- Registry: https://github.com/venturecrane/crane-console/pkgs/npm/crane-mcp"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/crane-mcp/package.json
+++ b/packages/crane-mcp/package.json
@@ -47,5 +47,14 @@
     "venture-crane"
   ],
   "author": "Venture Crane",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/venturecrane/crane-console.git",
+    "directory": "packages/crane-mcp"
+  }
 }


### PR DESCRIPTION
## Summary

Completes the registry migration foundation laid in #579. Two tag-driven publish workflows, cloned from the working \`publish-test-harness.yml\` pattern, plus the missing \`publishConfig\`/\`repository\` fields on \`crane-mcp/package.json\`.

**Tag conventions** match the harness:

| Tag | Publishes | Dist-tag |
|-----|-----------|----------|
| \`crane-contracts-v0.1.0\` | \`@venturecrane/crane-contracts@0.1.0\` | \`latest\` |
| \`crane-contracts-v0.1.0-rc.1\` | \`@venturecrane/crane-contracts@0.1.0-rc.1\` | \`rc\` |
| \`crane-mcp-v0.2.0\` | \`@venturecrane/crane-mcp@0.2.0\` | \`latest\` |
| \`crane-mcp-v0.2.0-rc.1\` | \`@venturecrane/crane-mcp@0.2.0-rc.1\` | \`rc\` |

Workflows use \`GITHUB_TOKEN\` with \`packages: write\` permission — no separate PAT needed. Post-publish smoke check retries \`npm view\` up to 5 times to handle registry propagation lag.

## Why

Dependabot's \`/packages/crane-mcp\` runs have been failing because \`@venturecrane/crane-mcp\` references \`@venturecrane/crane-contracts\` as a registry semver dep (\`^0.1.0\`), but neither package was actually published to \`npm.pkg.github.com\`. Dependabot's workspace resolver hits the registry, gets 404, aborts with \`security_update_not_possible\`. The other 7 Dependabot directories already went green after #583 + #613; this is the last loose end.

## Publish order after merge

1. Push tag \`crane-contracts-v0.1.0\` → wait for workflow → registry smoke check
2. Push tag \`crane-mcp-v0.2.0\` → wait for workflow → registry smoke check

Order matters: \`crane-mcp\`'s published \`package.json\` declares \`crane-contracts\` as a registry dep, so consumers installing \`crane-mcp\` need \`crane-contracts\` on the registry first.

## Test plan

- [x] \`publishConfig\` + \`repository\` added to \`crane-mcp/package.json\` mirroring the harness/contracts pattern
- [x] Workflows mirror the proven \`publish-test-harness.yml\` reference
- [ ] PR merged
- [ ] \`crane-contracts-v0.1.0\` tagged, workflow green, \`npm view\` returns 0.1.0
- [ ] \`crane-mcp-v0.2.0\` tagged, workflow green, \`npm view\` returns 0.2.0
- [ ] Next Dependabot run on \`/packages/crane-mcp\` returns success

## Refs

- #579 (NODE_AUTH_TOKEN foundation)
- #583 (Dependabot registry auth)
- #613 (root \`.npmrc\` scope mapping)
- \`.github/workflows/publish-test-harness.yml\` (cloned pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)