### PR TITLE
ci(dependabot): enable auto-merge for safe bumps; add grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@
 # the `NODE_AUTH_TOKEN` Dependabot secret (Classic PAT, read:packages).
 # Secret is managed in Infisical at /vc and set via
 # `gh secret set NODE_AUTH_TOKEN --app dependabot`.
+#
+# Grouping: each npm directory defines the same `groups` block to
+# collapse related bumps into one PR per ecosystem area. Verbose by
+# design — Dependabot's parser does not reliably honor YAML anchors,
+# so the block is spelled out per directory. Patch and dev-minor bumps
+# auto-merge via .github/workflows/dependabot-auto-merge.yml once CI
+# passes; majors and runtime minors still require review.
 
 version: 2
 
@@ -26,6 +33,35 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
+      ai-sdks:
+        patterns: ['@anthropic-ai/*', 'anthropic']
+        update-types: ['minor', 'patch']
+      astro:
+        patterns: ['astro', '@astrojs/*']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /packages/crane-mcp
@@ -33,6 +69,32 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
+      ai-sdks:
+        patterns: ['@anthropic-ai/*', 'anthropic']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /workers/crane-context
@@ -40,6 +102,29 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /workers/crane-mcp-remote
@@ -47,6 +132,29 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /workers/crane-watch
@@ -54,6 +162,29 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /site
@@ -61,6 +192,29 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      astro:
+        patterns: ['astro', '@astrojs/*']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: npm
     directory: /templates/venture
@@ -68,8 +222,36 @@ updates:
       - github-packages
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      toolchain:
+        patterns:
+          [
+            'typescript',
+            '@types/*',
+            'eslint*',
+            '@typescript-eslint/*',
+            'typescript-eslint',
+            'prettier',
+            'vitest',
+            '@vitest/*',
+            'lint-staged',
+            'husky',
+          ]
+        update-types: ['minor', 'patch']
+      build-tooling:
+        patterns: ['vite', 'vite-*', '@vitejs/*', 'esbuild', '@swc/*', 'rollup']
+        update-types: ['minor', 'patch']
+      cloudflare:
+        patterns: ['wrangler', '@cloudflare/*', 'miniflare']
+        update-types: ['minor', 'patch']
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ['*']
+        update-types: ['minor', 'patch']

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+# Auto-enable squash-merge on Dependabot PRs when the bump is low-risk:
+#   - any patch bump (semver says backwards-compatible)
+#   - dev-dep minor bumps (tooling, can't reach production)
+#   - security patch updates (CVE-driven, usually a patch anyway)
+#
+# GitHub's native auto-merge means the PR lands only after every required
+# check passes — there's no "skip CI" path. If CI goes red, the PR just
+# stays open for manual review, same as today.
+#
+# Runtime-dep minors and any major bumps never match these conditions and
+# always require explicit review.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-security' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+           steps.metadata.outputs.dependency-type == 'direct:development')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/venture/.github/workflows/dependabot-auto-merge.yml
+++ b/templates/venture/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,41 @@
+name: Dependabot auto-merge
+
+# Auto-enable squash-merge on Dependabot PRs when the bump is low-risk:
+#   - any patch bump (semver says backwards-compatible)
+#   - dev-dep minor bumps (tooling, can't reach production)
+#   - security patch updates (CVE-driven, usually a patch anyway)
+#
+# GitHub's native auto-merge means the PR lands only after every required
+# check passes — there's no "skip CI" path. If CI goes red, the PR just
+# stays open for manual review, same as today.
+#
+# Runtime-dep minors and any major bumps never match these conditions and
+# always require explicit review.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-security' ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+           steps.metadata.outputs.dependency-type == 'direct:development')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Eliminates the Dependabot PR backlog without adding a skill or an ape-in-the-loop. Two config-level changes:

1. **Auto-merge workflow** — GitHub's native auto-merge enabled for patch bumps, dev-dep minor bumps, and security patches. CI still gates every merge; if CI goes red, the PR stays open same as today.
2. **Grouping config** — related bumps collapse into one PR per ecosystem area, so 19 individual PRs become ~5.

## Why this instead of a skill

Originally pitched `/dependabot-triage` as a skill. Captain asked whether an ape needs to be in the loop. Honest answer: no, not for the ~80% of bumps where CI already tells us the bump is safe. Config-level automation is the right tool. A skill would just be a human-in-the-loop for what should be hands-off.

## What auto-merges

| Bump type | Auto-merge? |
|-----------|-------------|
| Patch (any dep) | ✅ yes |
| Minor (dev-dep only) | ✅ yes |
| Security update | ✅ yes |
| Minor (runtime dep) | ❌ needs review |
| Major (any) | ❌ needs review |

## Risks and mitigations

- **Supply-chain risk:** auto-merge trusts CI. Same trust model as manual merge — CI passing is what we rely on either way. Preview + staging catch escapes.
- **Semver liars:** some packages call breaking changes "patches." CI catches surface breaks; semantic breaks can slip but they'd slip manual review too.
- **Visibility:** merged PRs are always queryable via `gh pr list --search \"is:merged author:app/dependabot\"` — nothing vanishes, just stops requiring attention.

## Rollout

- **crane-console:** both changes applied here
- **templates/venture/:** workflow added; existing `dependabot.yml` already had groups (was actually ahead of crane-console's config — fixed that inversion)
- **Existing venture repos** (sc, dfg, dc, ke, ss, smd): follow-up PR to copy the workflow. Scope outside this PR.

## Test plan

- [x] `npm run verify` passes
- [x] Both workflow YAML files validate
- [x] Dependabot config validates (8 update streams)
- [ ] CI green
- [ ] Post-merge: next Dependabot-filed PR lands grouped; patch/dev-minor bumps auto-merge after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)