### PR TITLE
test(ci): verify Security Summary blocks merge [WILL NOT MERGE]

### DIFF
--- a/scripts/semgrep-canary.ts
+++ b/scripts/semgrep-canary.ts
@@ -1,0 +1,19 @@
+// scripts/semgrep-canary.ts
+//
+// THROWAWAY PR — verifies that the required status check on main
+// actually blocks merge when Semgrep goes red. Never merged.
+// See docs/ci-verification/semgrep-initial-canary.md.
+
+import { execSync, spawn } from 'child_process'
+
+export function canaryChildProcessExec(userName: string): string {
+  return execSync(`echo hello ${userName}`).toString()
+}
+
+export function canaryChildProcessSpawn(cmd: string): void {
+  spawn(cmd)
+}
+
+export function canaryExecThird(venture: string): void {
+  execSync(`gh repo list ${venture}`)
+}


### PR DESCRIPTION
## Purpose

Post-merge verification that the `Security Summary` required status check added in #639 actually blocks merge when Semgrep goes red.

**This PR will NOT be merged.** Closing without merging after the CI+enforcement checks are captured.

## Expected

- Semgrep job turns red (3 findings from the canary file)
- Security Summary aggregates to red
- GitHub's merge button is disabled because `Security Summary` is listed as a required status check on main (ruleset ID 15383940)

## If the merge button is enabled anyway

Ruleset didn't apply correctly. Investigate `gh api /repos/venturecrane/crane-console/rulesets/15383940`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)