### PR TITLE
feat(anthropic-partnership): scaffold 30-day CPN + Foundations initiative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ workers/crane-context/manual-test-log.md
 
 # Generated MCP tool manifest (see scripts/snapshot-mcp-tools.ts)
 config/mcp-tool-manifest.json
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/docs/anthropic-partnership/README.md
+++ b/docs/anthropic-partnership/README.md
@@ -1,0 +1,72 @@
+# Claude Partner Network | Active Initiative
+
+**Status:** Application submitted. Cleared initial review 2026-04-09. Awaiting next broadcast from Karl Kadon (Head of Partner Experience, Anthropic).
+
+---
+
+## Current Status
+
+Venture Crane applied to the Claude Partner Network. Karl Kadon (ex-Databricks Global Leader of Partner Programs, now Head of Partner Experience at Anthropic) sent a broadcast confirming VC cleared the initial review on 2026-04-09. The program launched publicly on 2026-03-12. Next concrete steps are forthcoming from Karl.
+
+Karl's broadcast included a request to put "ten of your people through training." That language reflects a GSI onboarding template, not a published Anthropic requirement. The published CPN language states: "Any organization bringing Claude to market is eligible to join. Membership is free of charge." The "ten" question is live and worth addressing directly when Karl's next communication arrives. Qualification analysis is in `qualification.md`.
+
+---
+
+## Three Tracks in Pursuit
+
+**1. Technology Partner**
+Covers the venture portfolio - SS, DC, KE, SC, DFG, and the crane infra stack. No published headcount floor. Technology Partner explicitly admits individuals. This is the cleanest track for VC structurally. Engagements inventory is in `engagements.md`.
+
+**2. Services Partner**
+Covers smd.services (SS), the consulting arm that delivers Claude-powered operational solutions to Phoenix-area small businesses. This is where Karl's "ten" template surfaces most directly. The reframe: VC is the existence proof of Dario Amodei's one-person billion-dollar company thesis. The workforce is an agent team, not a headcount. Assessment in `qualification.md`.
+
+**3. Individual Claude Certified Architect**
+Scott Durgan pursuing the Foundations exam. Target sit date: May 20-22, 2026. This is the individual-track credential. Curriculum plan is in `curriculum.md`.
+
+---
+
+## Operating-Model Posture
+
+Transparent framing is non-negotiable. Venture Crane is one operator (Scott Durgan) with an AI agent workforce. We do not manufacture headcount. We do not pretend a human wrote the output. We are upfront about what we are.
+
+The positioning anchor is Dario Amodei's statement at Code with Claude (San Francisco, May 2025): 70-80% probability the first one-person billion-dollar company powered by AI agents arrives by 2026. VC is building toward that. The agent team produces all delivery - engineering, content, analysis. Scott directs. Agents execute.
+
+Coverage: https://www.inc.com/ben-sherry/anthropic-ceo-dario-amodei-predicts-the-first-billion-dollar-solopreneur-by-2026/91193609
+
+This framing is an asset, not a liability. Anthropic's own Dario made the prediction. VC is on-thesis.
+
+---
+
+## Directory Map
+
+| File                 | Contents                                                                                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `README.md`          | This file. Program state overview, tracks, posture, directory map, next steps.                                                                                 |
+| `qualification.md`   | Research-based assessment of VC's standing for each track. Addresses the "ten" question. Published vs. unpublished CPN requirements. Track-by-track verdict.   |
+| `engagements.md`     | Verified inventory of active Claude-powered work across the portfolio. Technology Partner and Services Partner candidates. Updated as engagements change.      |
+| `operating-model.md` | One-pager on VC's operating model for partner conversations. One operator + agent workforce. Produced by parallel agent.                                       |
+| `the-ten.md`         | Direct response to Karl's "ten of your people through training" request. How VC addresses this as an agent-workforce organization. Produced by parallel agent. |
+| `curriculum.md`      | Claude Foundations exam curriculum and study plan. Week-by-week breakdown through May 20-22 sit date. Produced by parallel agent.                              |
+| `gap-ledger.md`      | Gap analysis between current state and published CPN requirements. What's needed, what's already done. Produced by parallel agent.                             |
+| `session-notes.md`   | Running log of CPN-related session activity, Karl broadcasts, and decision points. Update after each relevant session.                                         |
+
+---
+
+## Next Step
+
+Monitor for Karl's next broadcast. When it arrives, have the following pre-work ready:
+
+- Operating-model one-pager (`operating-model.md`) - for the Services Partner reframe conversation
+- Engagements inventory (`engagements.md`) - concrete Technology Partner evidence
+- Cert curriculum (`curriculum.md`) - Individual Architect track in progress
+- The-ten response (`the-ten.md`) - direct answer to the headcount template question
+
+The 30-day push (Apr 22 - May 22) targets Foundations cert + partner readiness in parallel. Tracking issue: venturecrane/crane-console.
+
+---
+
+## Cadence
+
+Cert study and checkpoint cadence is managed as planned events. Daily study sessions (weekdays) and weekly checkpoints (Fridays) are recorded in the crane-schedule system as planned events for the Apr 22 - May 22 window.
+
+Note: crane-schedule's `planned-event-create` action supports single discrete events. Recurring automation for daily cert study is a future enhancement - flag with `crane_schedule` tooling team if this becomes a friction point.

--- a/docs/anthropic-partnership/briefs/venturecrane-site-audit.md
+++ b/docs/anthropic-partnership/briefs/venturecrane-site-audit.md
@@ -1,0 +1,122 @@
+# Venture Crane | Site Audit: Claude Attribution Gaps
+
+**Date:** 2026-04-22
+**Scope:** venturecrane.com - full site audit against the current Claude and Claude Code attribution state.
+**Purpose:** Work-item inventory for Phase 2 site editors. Pair with `venturecrane-site-positioning-pattern.md` before editing any page.
+
+---
+
+## Summary
+
+Total pages audited: 38 (homepage, 6 nav/structural pages, 31 articles, Ship Log index + 3 log entries read in full, remaining logs sampled by title).
+
+| Gap type        | Count |
+| --------------- | ----- |
+| missing         | 8     |
+| vague           | 12    |
+| already-good    | 9     |
+| conflation-risk | 2     |
+| retrofit-risk   | 1     |
+| inaccurate      | 0     |
+
+Some pages are multi-tagged.
+
+**Partnership overclaiming:** zero. No instances of "Claude Partner," "Anthropic Certified," or similar language found on the site. Appropriate given the Partner Network application is in pipeline.
+
+---
+
+## DO NOT EDIT (already-good or retrofit-risk)
+
+Editors: skip these pages. Changing them creates regression, not improvement.
+
+### Already good (accurate Claude attribution, no change needed)
+
+- `/articles/agent-context-management-system/` | names Claude Code with install commands, config paths, architecture diagrams
+- `/log/2026-02-17-three-clis-one-sprint/` | the best single commitment statement on the site: "We run Claude Code as our primary development agent"
+- `/articles/multi-agent-team-protocols/` | clean role table: Dev Agent = Claude Code, PM Agent = Claude Code, Advisor = Gemini CLI
+- `/articles/where-we-stand-agent-operations-2026/` | names Claude Code 6+ times with token efficiency benchmarks, MCP origin attribution, "Claude writes, Codex reviews" pattern
+- `/articles/what-ai-agents-actually-cost/` | Anthropic Max 20x at $200/mo, Claude Code as "the workhorse"
+- `/articles/figma-vs-stitch-design-tool-evaluation/` | honest bake-off, Claude Code named as MCP host
+- `/articles/building-mcp-server/` | Claude Code named explicitly in diagram, tool table, tech table
+- `/log/2026-04-12-killing-qa-grading-theatre/` | honest Gemini attribution; no edit warranted
+- `/log/2026-02-22-remote-mcp-browser-advisor/` | accurate claude.ai attribution
+
+### Retrofit-risk (DO NOT edit even though Claude naming is thin)
+
+- `/articles/local-llms-offline-field-development/` | already names Claude Code as the production tool these supplement. The article's framing (Ollama/Qwen/DeepSeek as offline field-compute, NOT replacing Claude) is the point. Editing would dilute the architectural honesty.
+
+### Historical inaccuracy (handle with ship-log entry, not an article edit)
+
+- `/articles/figma-vs-stitch-design-tool-evaluation/` | Stitch was retired 2026-04-17. Article describes a decision that was subsequently reversed. Do NOT edit the article. Write a one-sentence ship-log entry noting the retirement.
+
+---
+
+## EDIT: High-priority pages
+
+Highest leverage, largest credibility delta. Do these first.
+
+### Nav / methodology pages (4)
+
+These are the canonical pages linked from the homepage and Start Here. They describe VC's exact operating model without naming Claude. Single highest-leverage pattern-level gap on the site.
+
+| URL               | Current state                                                                   | Suggested treatment                                                                                                          |
+| ----------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `/` (homepage)    | Intro describes operating model; zero Claude references                         | Name Claude Code in the intro sentence. One sentence, no bolt-on paragraph. Flows into every search snippet and social card. |
+| `/the-system/`    | "AI coding CLIs" and "AI agents" throughout, no platform named                  | Name Claude Code in the Tools/primitives section; name Anthropic as the platform once.                                       |
+| `/start-here/`    | Curated reading guide, no Claude mentions                                       | Add a one-line tooling note in the intro: "Primary agent: Claude Code via Anthropic Max."                                    |
+| `/open-problems/` | Describes cross-session memory and graceful-degradation gaps, no platform named | Ground the problems: "these are challenges we encounter daily running Claude Code sessions."                                 |
+
+### High-priority articles (5)
+
+| URL                                        | Current state                                                                                | Suggested treatment                                                                                   |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `/articles/why-development-lab/`           | Origin story; zero Claude mentions despite being about the decision to build AI-native infra | One sentence in the "AI Agent Angle" section naming Claude Code as the primary agent interface.       |
+| `/articles/when-the-agent-briefing-lies/`  | Operational article referencing $741 in compute; no platform named                           | One sentence in "what directing agents actually looked like" attributing the sessions to Claude Code. |
+| `/articles/agents-building-ui-never-seen/` | 40+ agent-hours; article never names the agent                                               | Single attribution in opening context: "Claude Code agents, working from design specs."               |
+| `/articles/kill-discipline-ai-agents/`     | Mentions `CLAUDE.md file` once in passing, never names platform                              | Add "This applies directly to Claude Code sessions" in the cultural-practice section.                 |
+| `/articles/fleet-sprints-ai-agents/`       | Claude Code named in intro only, not followed through                                        | Reinforce CC CLI attribution in the mechanics description (one or two anchor sentences).              |
+
+---
+
+## EDIT: Medium-priority pages
+
+Vague language worth tightening where it appears. Work these after high-priority is complete.
+
+Pages flagged `vague` in the full audit but sampled (not fully read) by the auditor: editor should read each, apply pattern-doc guidance, add attribution where the content describes actual CC CLI work.
+
+Candidates (from audit sampling):
+
+- `/articles/cross-venture-context-agent-awareness/`
+- `/articles/forty-hours-one-auth-bug/` (MCP debugging context)
+- `/articles/tool-registration-not-integration/`
+- `/articles/zero-to-landing-page-four-days/`
+- `/articles/code-review-to-production-48-hours/`
+- `/articles/secrets-management-ai-agents/`
+- `/articles/secrets-injection-agent-launch/`
+- `/articles/fleet-management-solo/`
+- `/articles/lazy-loading-agent-context/`
+- `/articles/sessions-heartbeats-handoffs/`
+- `/articles/four-auth-vulnerabilities-one-code-review/`
+- `/articles/staging-environments-ai-agents/`
+
+Guidance per article: one or two attributions where the content concretely describes CC CLI work. Do not saturate.
+
+---
+
+## Site-wide patterns
+
+1. **Nav pages generically say "AI agents" / "AI coding CLIs" / "AI coding tools."** Three high-traffic editorial pages describe VC's exact operating model without once naming the platform. This is the single highest-leverage gap.
+
+2. **Articles use "AI coding agent," "AI agents," or "coding CLI"** without naming Claude Code when describing the primary workflow tool. Site-wide vague pattern.
+
+3. **MCP is named correctly and frequently** across technical articles. No conflation issues with MCP itself.
+
+4. **Dario Amodei one-person-billion-dollar-company framing** is cited in `where-we-stand-agent-operations-2026` but not echoed on the homepage or The System page, where it would land powerfully. Consider using the anchor sparingly on the top pages (once per page max).
+
+---
+
+## Flags
+
+- **Stitch retirement:** article describes a retired tool as current. Ship-log entry to note retirement is the correct fix, NOT an article edit.
+- **Articles sampled but not fully read:** editor should read each target article before applying guidance. Audit flagged ~12 articles as `vague` based on titles and summaries but did not fully read them.
+- **No retrofitting.** If a page's subject was NOT Claude-specific, and adding Claude references would misrepresent the original scope, do not edit.

--- a/docs/anthropic-partnership/briefs/venturecrane-site-positioning-pattern.md
+++ b/docs/anthropic-partnership/briefs/venturecrane-site-positioning-pattern.md
@@ -1,0 +1,151 @@
+# Venture Crane | Site Positioning Pattern & Style Guide Addendum
+
+**Date:** 2026-04-21
+**Scope:** venturecrane.com Claude / Claude Code attribution updates (Phase 2 site edits)
+**Audience:** Site editors executing page updates against the audit table
+
+---
+
+## 1. Purpose
+
+This document is the work brief for Phase 2 site editors updating venturecrane.com with accurate, consistent Claude and Claude Code attribution. It applies to every page on the audit table that is not already marked "already-good." Use it before editing any page. Do not invent framing outside what is documented here.
+
+---
+
+## 2. The Honesty Frame
+
+The goal is not marketing. The goal is accurate witness.
+
+- **Transparency is the commitment signal.** Partner Network reviewers will read the site. Vague attribution ("AI agents," "AI coding tools") reads as evasion, not humility. Naming Claude where it belongs is honest, not promotional.
+
+- **Don't retrofit history.** Articles that made their point without naming a platform should not have Claude inserted just to have Claude in the article. Attribution goes where Claude is the actual subject - in tools sections, operating model descriptions, and infrastructure overviews.
+
+- **Tool attribution is specific.** Claude Code (the CLI harness) is not the Claude API (direct HTTP inference). Neither is the Agent SDK, MCP, or claude.ai. Get the level of the stack right. Imprecise attribution undermines credibility.
+
+- **Distinguish shipping from planned.** SS lead pipelines and DFG analyst use the Claude API in production today. DC, KE, and SC are Claude Code-built at the development layer. Their product-layer Claude features exist in backlog. The canonical framing: "every venture product has Claude-powered features, shipping or in backlog." Never flatten shipping and planned into a single claim without the distinction.
+
+- **Do not overclaim partnership status.** The accurate description is: "Venture Crane is in the Claude Partner Network pipeline." Not "Claude Certified Partner." Not "Anthropic Partner." Not "official partner." The application cleared initial review on 2026-04-09. That is the verifiable fact.
+
+---
+
+## 3. Canonical Framing Sentences
+
+Editors should use these as anchors, not starting points for rewrites. Drop the right sentence at the right depth. Do not combine multiple blocks on a single page unless the page explicitly warrants that depth.
+
+**One-line intro (homepage, top-of-nav pages):**
+
+> Venture Crane is one operator and an AI agent workforce, powered by Claude Code.
+
+**Agent workforce framing (methodology pages, The System):**
+
+> Our agent workforce runs on Claude Code - the CLI harness - with Claude as the foundation model. Every session, every pull request, every pipeline runs through it.
+
+**Portfolio framing (multi-venture overview contexts):**
+
+> Every venture in the portfolio has Claude-powered features, either shipping in production or in the active backlog. SS and DFG run direct Claude API inference today. The development layer across all ventures runs through Claude Code agents.
+
+**Stack framing (technical articles, infrastructure overviews):**
+
+> Claude Code handles session-based agent work. Claude API handles production runtime inference. MCP handles tool and resource integration. These are distinct layers - the CLI, the HTTP endpoint, and the protocol. They are not interchangeable terms.
+
+**Dario anchor (methodology pages, origin story, when explicitly about the operating thesis):**
+
+> At Code with Claude in San Francisco (May 2025), Dario Amodei put 70-80% probability on the first one-person billion-dollar company powered by AI agents arriving by 2026. Venture Crane is building toward that thesis. Not as an exception to any rule. As the example he named.
+
+---
+
+## 4. Tool Attribution Lexicon
+
+| Term                                               | Definition                                                                                                                                                               | When to Use on the Site                                                                                                                                                                 | Common Conflation Errors                                                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Claude**                                         | The Anthropic foundation model family (Sonnet, Haiku, Opus checkpoints)                                                                                                  | When referring to the model doing inference - scoring leads, analyzing auction items, generating completions                                                                            | Confusing the model with the CLI harness. "We use Claude" alone is ambiguous when you mean Claude Code.       |
+| **Claude Code / CC CLI**                           | Anthropic's CLI agent harness. Agent sessions run inside it. It orchestrates tools, context, memory, and sub-agents                                                      | The correct term for the agent development environment across all VC ventures. Use "Claude Code" in full on first mention per page; subsequent references may use "the agent" naturally | Calling this "the Claude API." Claude Code uses the Claude model but the harness is its own distinct product. |
+| **Claude API**                                     | Direct HTTP calls to `api.anthropic.com/v1/messages` with an `ANTHROPIC_API_KEY`. Used in production workers for inference                                               | Use when describing SS pipelines (review-mining, job-monitor, new-business) and DFG analyst worker. These make direct API calls - not CLI sessions                                      | Calling it "Claude Code." These pipelines do not use the CLI; they call the API directly.                     |
+| **MCP / Model Context Protocol**                   | Open protocol for connecting Claude agents to tools, resources, and services. Anthropic introduced it Nov 2024; now an industry standard under the Agentic AI Foundation | Use when describing crane-mcp or crane-mcp-remote. Appropriate on infrastructure and methodology pages                                                                                  | Treating MCP as equivalent to "using Claude." MCP is the protocol layer, not the model.                       |
+| **Agent SDK**                                      | Anthropic's framework for building custom agent harnesses programmatically                                                                                               | VC does not currently use the Agent SDK. Do not attribute Agent SDK usage to VC unless confirmed.                                                                                       |                                                                                                               |
+| **Claude Managed Agents**                          | Anthropic's hosted agent infrastructure (not a product VC uses today)                                                                                                    | Do not reference on the site without confirmation of usage                                                                                                                              |                                                                                                               |
+| **claude.ai**                                      | Anthropic's web interface. crane-mcp-remote serves MCP to claude.ai clients over HTTP                                                                                    | Accurate when describing crane-mcp-remote's remote MCP capability for claude.ai sessions                                                                                                | Confusing claude.ai with Claude Code. The web interface and the CLI are different surfaces.                   |
+| **Anthropic Academy / Claude Certified Architect** | Anthropic's training and certification program. Scott Durgan pursuing the Foundations exam, target May 20-22, 2026                                                       | Use on credential or "about" contexts if referenced. Precise: "Foundations exam" is the current certification. Not yet "certified."                                                     | Claiming the certification before the exam date. Use "pursuing" until confirmed.                              |
+
+---
+
+## 5. Page-Type Playbook
+
+Work from the audit table. These are treatment rules by page type, not a sequence.
+
+**Homepage**
+Add one sentence of Claude attribution in the intro paragraph where the operating model is described. The one-line intro framing sentence is the right tool. Do not bolt on paragraphs. Do not link to a "Learn more about our Claude usage" section. One sentence, in context, done.
+
+**Methodology pages (The System, Start Here, Open Problems)**
+These pages use "AI coding CLIs" and "AI coding tools" as category-level references. Add "Claude Code" as the specific tool where those generic category terms appear, in the Tools or Primitives sections. Add one instance of "Anthropic" as platform attribution somewhere on the page - one, not every occurrence. Do not rewrite the structure of these pages. Attribution goes into existing slots; it does not require new sections.
+
+**Origin-story articles (Why We Built a Development Lab)**
+Locate the sentence or paragraph where the AI workflow or tooling decision is described. Add one sentence of Claude Code attribution at that point. The framing should read as historical fact, not insertion. "The agent workforce runs on Claude Code" as a matter-of-fact clause, not a feature announcement.
+
+**Sprint and ops articles with generic agent language (What Breaks When You Sprint with 10 AI Agents, Kill Discipline for AI Agent Teams, When the Agent Briefing Lies, Agents Building UI Never Seen)**
+Add attribution at the first mention of the agent tooling. One sentence in context. Subsequent references to "the agent" can stay natural. Do not saturate. The goal is one honest anchor per article, not product placement throughout.
+
+**Already-good articles - do NOT edit:**
+
+- How We Built an Agent Context Management System
+- Three CLIs, One Sprint, Zero Excuses Left (Ship Log)
+- Multi-Agent Team Protocols Without Chaos
+- Where We Stand: AI Agent Operations in February 2026
+- What Running Multiple Ventures with AI Agents Actually Costs
+- A Design Tool Bake-Off - Figma MCP vs Google Stitch
+- Building an MCP Server for Workflow Orchestration
+- Killing the QA Grading Theatre (Ship Log)
+- Giving the Browser Advisor Live Context Access via Remote MCP (Ship Log)
+- Multi-Model Code Review
+
+These articles earn their Claude attribution honestly through their content. Do not touch them. Do not second-guess the audit finding.
+
+**Retrofit-risk articles - do NOT edit:**
+
+- Local LLMs for Offline Field Development
+
+This article's existing framing is accurate and valuable as written. Inserting Claude attribution would distort the point. Leave it.
+
+**Historical inaccuracy (Stitch article):**
+Do not edit the Figma vs. Stitch article. The decision described in that article was subsequently reversed when Stitch was retired on 2026-04-17. Editing the article would obscure the actual history. The right treatment is a short ship-log entry noting the retirement. Draft something like: "We shipped a build log entry evaluating Figma MCP versus Google Stitch. Subsequently retired Stitch from the stack on 2026-04-17. The evaluation documented the decision as made at the time; this log entry closes the loop."
+
+---
+
+## 6. Voice Rules
+
+- **No em dashes.** Use hyphens in prose. Use pipes in page title separators. Em dashes read as AI-generated content; avoid them entirely in VC-branded text.
+
+- **"We" means the agent team directed by the operator.** It is not a royal we. It is not aspirational plurality. It is accurate: the agents produced this content under operator direction.
+
+- **Direct, not pitchy.** "The agent workforce runs on Claude Code" is a sentence. "Leveraging transformational AI-powered agent technology through the Claude ecosystem" is not. If you catch yourself writing marketing language, cut it and start again.
+
+- **Match the benchmark tone.** The tonal benchmarks are `where-we-stand-agent-operations-2026` and `what-ai-agents-actually-cost`. Both lead with specifics, name numbers, name tools, and treat the reader as capable of handling unvarnished information. Attribution additions should feel like those articles wrote them, not like a marketing insert dropped into editorial copy.
+
+- **Specificity is the voice.** "Claude Sonnet 4 scores Google reviews for operational pain signals" is better than "Claude powers our lead intelligence." Name the model, name the task, name the outcome where you have that detail.
+
+---
+
+## 7. Handoff Checklist for Phase 2 Editors
+
+**Before editing any page:**
+
+- Read this document end to end (not just the section for that page type)
+- Read `docs/anthropic-partnership/operating-model.md` for the canonical one-operator-plus-agent-workforce framing
+- Locate the target page in the audit table and confirm it is not on the already-good or retrofit-risk lists
+
+**During editing:**
+
+- Use the canonical framing sentences from Section 3 as your anchors - do not draft new framing
+- Apply the tool attribution lexicon from Section 4 to every tool reference
+- Keep the edit footprint minimal: one honest attribution anchor per page, not a rewrite
+- If the edit starts reshaping the article beyond Claude attribution, stop
+
+**After editing:**
+
+- Check every tool attribution against the lexicon: Claude Code vs. Claude API vs. MCP vs. claude.ai
+- Check for em dashes and remove them
+- Check for overclaim: does any sentence imply we are a current Claude Certified Partner or that all ventures ship Claude API today? If yes, revise
+- Read the edited section aloud against the tonal benchmarks - does it sound like VC editorial or a press release? If the latter, cut and simplify
+
+**Scope discipline:**
+If you find a legitimate issue with an already-good article during this process, note it separately for the operator. Do not fix it during Phase 2. Phase 2 scope is Claude attribution gaps in the audit table. Nothing else ships in this pass.

--- a/docs/anthropic-partnership/curriculum.md
+++ b/docs/anthropic-partnership/curriculum.md
@@ -1,0 +1,402 @@
+# Claude Certified Architect - Foundations | 30-Day Study Curriculum
+
+**Candidate:** Scott Durgan  
+**Exam window:** May 20-22, 2026  
+**Study window:** April 22 - May 19, 2026 (30 days)  
+**Produced by:** Venture Crane agent team
+
+---
+
+## Overview
+
+Four phases across 30 days. Weekdays only for scheduled sessions (flex weekends for catchup or depth extension if a phase runs long).
+
+| Phase                       | Days         | Window          | Goal                                     |
+| --------------------------- | ------------ | --------------- | ---------------------------------------- |
+| 1 - Weakness Sprint         | ~10 sessions | Apr 22 - May 5  | Close the 8 identified gaps              |
+| 2 - Lay of the Land         | ~5 sessions  | May 6 - May 12  | Surface pass across all 5 domains        |
+| 3 - Progressive Depth       | ~3 sessions  | May 13 - May 15 | Scenario walkthroughs + sample questions |
+| 4 - Practice Exam + Revisit | 2 sessions   | May 18-19       | Full mock exam, gap-ledger closeout      |
+| Exam sit                    | -            | May 20-22       | Sit at chosen slot                       |
+
+---
+
+## Working Assumptions
+
+- **Session length:** 45-60 min per weekday session.
+- **Flash-review habit:** First 2 min of every session = quick oral recall of the prior session's topic. No notes. Just reconstruct the key mechanism.
+- **Mid-phase spaced recall:** Each closed weakness item retested at 48 hours post-close, then 7 days post-close, then at end of its phase (see Spaced-Recall Schedule below).
+- **Gap ledger is live:** Update gap-ledger.md after every session. Any new gap discovered during study gets logged immediately with discovery date and a rough closure plan.
+- **Weekends are flex:** Not scheduled. Use them if you hit a week where two items proved harder than expected, or if you want to extend a depth session.
+
+---
+
+## Day-by-Day Schedule
+
+### Phase 1: Weakness Sprint (Apr 22 - May 5)
+
+**Goal:** One weakness item per session. Two sessions reserved for flash-review sweeps and ad-hoc gap closure.
+
+---
+
+**Day 1 - Tue Apr 22 | Phase 1 | Item 1: Agentic Loop Mechanics**
+
+Topic: stop_reason values ("tool_use" vs "end_turn"), the tool-result appending pattern, why text-parsing and natural-language-done-detection are anti-patterns.
+
+What to do:
+
+- Read the Anthropic "Tool use" reference (docs.anthropic.com/en/docs/build-with-claude/tool-use). Focus on the request/response cycle diagram.
+- Trace through a 3-turn agentic loop on paper: assistant emits tool_use, you append tool_result, assistant responds with end_turn. Label each stop_reason.
+- Articulate out loud why checking for the string "DONE" in the assistant response is unreliable versus reading stop_reason == "end_turn".
+
+Self-test: Explain the full loop without notes. Answer: "What is the correct termination condition for an agentic loop and what happens if you cap iterations instead?"
+
+---
+
+**Day 2 - Wed Apr 23 | Phase 1 | Item 2: Hooks as Deterministic Enforcement**
+
+Topic: PostToolUse for result normalization, tool-call interception for policy compliance, the principle that programmatic prerequisites beat prompt instructions.
+
+What to do:
+
+- Read Claude Code hooks documentation (docs.anthropic.com/en/docs/claude-code/hooks). Focus on PostToolUse lifecycle and exit-code semantics.
+- Map the customer-support scenario: "customer must be verified before refund can be issued." Sketch the hook that enforces this - not the prompt instruction that requests it.
+- Compare: prompt says "always verify customer first" vs PostToolUse hook that checks verification state and blocks if absent. Articulate why the hook is the correct architecture.
+
+Self-test: Write a 30-line pseudocode PostToolUse hook that enforces a refund-threshold policy. Explain the exit codes.
+
+---
+
+**Day 3 - Thu Apr 24 | Phase 1 | Item 3: tool_choice Semantics**
+
+Topic: "auto" vs "any" vs forced {"type":"tool","name":"..."}. When each applies. Why "any" guarantees a tool call. When to force-first a specific tool before downstream processing.
+
+What to do:
+
+- Read the tool_choice section of the Anthropic API reference (docs.anthropic.com/en/api/messages).
+- Build a decision tree: given a scenario, which tool_choice setting is correct?
+  - "auto" - Claude decides whether to use a tool
+  - "any" - Claude must use some tool (non-deterministic which one)
+  - forced - Claude must use the named tool (deterministic)
+- Identify two scenarios where forced tool_choice is necessary (e.g., structured extraction as first step before synthesis).
+
+Self-test: Given three exam-style scenarios, assign the correct tool_choice and justify. No notes.
+
+---
+
+**Day 4 - Fri Apr 25 | Phase 1 | Item 4: Structured Error Responses**
+
+Topic: isError, errorCategory (transient/validation/business/permission), isRetryable, distinguishing access-failure from valid-empty-result, partial results + attempted-query context in error payloads.
+
+What to do:
+
+- Read the MCP specification on structured errors and the Anthropic error handling docs.
+- Draft a schema for a structured MCP tool error response covering all four errorCategory values. Include an example payload for each.
+- Practice the distinction: "no results found" (valid empty result, isError=false) vs "permission denied" (isError=true, errorCategory=permission, isRetryable=false) vs "rate limit hit" (isError=true, errorCategory=transient, isRetryable=true).
+
+Self-test: Given a tool failure description, produce the correct structured error payload with all fields. Explain why isRetryable matters for orchestrator retry logic.
+
+---
+
+**Day 5 - Mon Apr 28 | Phase 1 | Item 5: Message Batches API**
+
+Topic: 50% cost savings, up to 24hr completion window, custom_id for request/response correlation, no multi-turn tool calling inside batch requests, unsuitable for blocking pre-merge checks, ideal for overnight or bulk jobs.
+
+What to do:
+
+- Read the Message Batches API docs (docs.anthropic.com/en/docs/build-with-claude/message-batches).
+- Work through the SLA math: if a batch job costs $20 at standard pricing, batches cost $10. If turnaround time is up to 24 hours, is it suitable for a pre-merge CI check? (No - CI is blocking.) Is it suitable for nightly document classification? (Yes.)
+- Map each exam scenario to "batch suitable" or "batch unsuitable" with a one-line reason.
+- Note the custom_id field: arbitrary string set by requester, echoed in response. Enables correlation when batch results arrive out of order.
+
+Self-test: Explain in 90 seconds why batches cannot support multi-turn tool calling. Identify two exam scenarios where batch processing is clearly wrong and two where it is clearly right.
+
+---
+
+**Day 6 - Tue Apr 29 | Phase 1 | Item 6: fork_session and --resume**
+
+Topic: Named session resumption, fork_session for divergent exploration branches, when to resume-with-stale-context vs start-fresh-with-summary-injection.
+
+What to do:
+
+- Read the Claude Code session management docs (docs.anthropic.com/en/docs/claude-code/memory).
+- Clarify the two operations: --resume continues a named session (same context, linear history). fork_session creates a branch from the current session state (parallel exploration, separate histories).
+- Construct a scenario: you have a session mid-way through a refactor. You want to explore two different approaches. Map the correct fork_session usage.
+- Address the stale-context tradeoff: resuming a session from yesterday may carry outdated file state. When is it better to start fresh with a summary injected as context?
+
+Self-test: Describe fork_session vs --resume in 60 seconds without notes. Answer: "If a session's context is 12 hours old, what are the failure modes of resuming vs injecting a summary?"
+
+---
+
+**Day 7 - Wed Apr 30 | Phase 1 | Flash Review + Gap Closure**
+
+Reserved session. No new material.
+
+What to do:
+
+- Oral recall of items 1-6 in sequence. 3 min per item, no notes.
+- Check gap-ledger.md. Any item where oral recall failed or felt shaky gets flagged for 48-hour retest bump.
+- If any item was harder than expected and you have documented residual gaps, use this session to address them before moving to items 7-8.
+
+Self-test: All 6 items recalled with no significant gaps. Gap ledger updated.
+
+---
+
+**Day 8 - Thu May 1 | Phase 1 | Item 7: Validation-Retry Loops**
+
+Topic: Retry with specific error feedback works for format/structural errors, fails when required info is absent from source. Pydantic-style validation. detected_pattern tracking for dismissal analysis.
+
+What to do:
+
+- Read the structured output and tool use sections of the Anthropic prompt engineering guide (docs.anthropic.com/en/docs/build-with-claude/structured-outputs).
+- Model two scenarios:
+  - Schema validation failure: Claude returns JSON missing a required field. Retry with the exact validation error message injected into next turn. This works because Claude has the information but mis-formatted it.
+  - Source-absent failure: Claude cannot extract a field because the source document does not contain it. Retrying is futile - the correct response is null/absent, not a retry loop.
+- Sketch the retry orchestrator logic: max-retries cap, error specificity in retry prompt, detected_pattern field for tracking which fields consistently fail.
+
+Self-test: Given a validation error description, classify it as "retry will help" or "retry will not help" and explain why in 30 seconds.
+
+---
+
+**Day 9 - Fri May 2 | Phase 1 | Item 8: Confidence Calibration**
+
+Topic: Field-level confidence scores, stratified sampling for error rate measurement, accuracy segmentation by document type and field, why LLM self-reported confidence is poorly calibrated for hard cases.
+
+What to do:
+
+- Read the human review and confidence calibration sections of the Anthropic reliability docs.
+- Understand the fundamental limitation: LLMs tend to be overconfident on hard cases and appropriately confident on easy ones. Self-reported confidence cannot be trusted at face value for hard documents.
+- Design a stratified sampling protocol: sample 5% of high-confidence extractions, 20% of medium-confidence, 100% of low-confidence. Measure actual error rates per stratum. Use measured error rates to recalibrate routing decisions.
+- Distinguish field-level from record-level confidence: a document may extract 8 of 10 fields with high confidence and 2 with low confidence. The correct response is partial-accept + flag for partial review, not reject-entire-record.
+
+Self-test: Describe the stratified sampling protocol and explain why 100% sampling of high-confidence results is not necessary. Explain the overconfidence failure mode in one concrete example.
+
+---
+
+**Day 10 - Mon May 5 | Phase 1 | Flash Review + Gap Closure**
+
+Reserved session. No new material.
+
+What to do:
+
+- Full oral recall sweep of all 8 items. Track which ones have residual hesitation.
+- Update gap-ledger.md: close any items that pass the self-test protocol, schedule 48h retests.
+- If 2+ items still have residual gaps, this is the last Phase 1 buffer. Flag in gap ledger. Phase 2 begins Tuesday regardless - residual Phase 1 gaps will be addressed in Phase 3 depth sessions.
+
+Self-test: 8/8 items recalled with no critical gaps. Gap ledger current.
+
+---
+
+### Phase 2: Lay of the Land (May 6 - May 12)
+
+**Goal:** One domain per session, surface-level pass. Not depth - breadth and orientation. One integration session at end.
+
+---
+
+**Day 11 - Tue May 6 | Phase 2 | Domain 1: Agentic Architecture & Orchestration**
+
+Covers: agentic loops, stop_reason, coordinator-subagent patterns, subagent context passing, multi-step workflow enforcement, Agent SDK hooks, task decomposition, fork_session, --resume.
+
+Note: Items 1, 2, and 6 from the weakness sprint map directly here. This session is consolidation and coverage of the parts not covered in the sprint (coordinator-subagent patterns, context passing, task decomposition).
+
+Self-test: Draw the coordinator-subagent architecture for the Multi-Agent Research scenario. Label context passing points.
+
+---
+
+**Day 12 - Wed May 7 | Phase 2 | Domain 2: Tool Design & MCP Integration**
+
+Covers: tool descriptions, structured MCP errors, tool distribution, tool_choice, MCP server config (.mcp.json vs settings), built-in tools.
+
+Note: Items 3 and 4 map here. Focus session on the gaps: tool description quality (what makes a description that Claude uses correctly vs incorrectly), .mcp.json vs ~/.claude.json configuration hierarchy.
+
+Self-test: Write a high-quality tool description for a hypothetical "search_customer_records" tool. Explain .mcp.json vs ~/.claude.json scope.
+
+---
+
+**Day 13 - Thu May 8 | Phase 2 | Domain 3: Claude Code Configuration & Workflows**
+
+Covers: CLAUDE.md hierarchy (user/project/directory), .claude/rules/ glob-scoped, .claude/commands/ slash commands, .claude/skills/ with context:fork + allowed-tools + argument-hint, plan mode vs direct execution, iterative refinement, CI/CD (-p flag, --output-format json, --json-schema).
+
+Note: Candidate has strong real-world experience here. Session should focus on exam-question framing (what the exam tests vs what daily usage looks like) and the CI/CD flags which are less frequently used in practice.
+
+Self-test: Describe the full CLAUDE.md precedence hierarchy. Explain -p flag and --output-format json usage in a CI context.
+
+---
+
+**Day 14 - Fri May 9 | Phase 2 | Domain 4: Prompt Engineering & Structured Output**
+
+Covers: explicit criteria, few-shot examples, tool_use + JSON schemas, validation-retry loops, Message Batches API, multi-instance review architectures.
+
+Note: Items 5, 7, and 8 map here. Session focuses on multi-instance review (separate reviewer instances vs single-model self-review) and JSON schema edge cases (nullable fields, enum+other+detail patterns).
+
+Self-test: Design a multi-instance review architecture for the Structured Data Extraction scenario. Explain when nullable vs required fields change retry behavior.
+
+---
+
+**Day 15 - Mon May 12 | Phase 2 | Domain 5 + Integration**
+
+Domain 5 covers: context preservation, escalation/ambiguity resolution, error propagation, large codebase exploration, human review workflows, multi-source synthesis provenance.
+
+Integration: Map all 5 domains to the 6 exam scenarios. Which domains are tested by which scenarios? What domain combinations appear in each scenario?
+
+Self-test: For each of the 6 scenarios, name the primary and secondary domains tested. Identify which scenario tests the most domains simultaneously.
+
+---
+
+### Phase 3: Progressive Depth (May 13 - May 15)
+
+**Goal:** Scenario walkthroughs with sample questions and variants.
+
+---
+
+**Day 16 - Tue May 13 | Phase 3 | Scenarios 1-2**
+
+Scenario 1: Customer Support Resolution Agent  
+Scenario 2: Code Generation with Claude Code
+
+For each scenario:
+
+- Read the scenario prompt.
+- Identify the domain weights it tests.
+- Answer 3 sample questions per scenario.
+- Identify variant framings (what if X was changed).
+
+Self-test: Answer all 6 questions with no notes. Flag any question where confidence was below 80%.
+
+---
+
+**Day 17 - Wed May 14 | Phase 3 | Scenarios 3-4**
+
+Scenario 3: Multi-Agent Research System  
+Scenario 4: Developer Productivity with Claude
+
+Same structure as Day 16.
+
+Self-test: Same protocol.
+
+---
+
+**Day 18 - Thu May 15 | Phase 3 | Scenarios 5-6**
+
+Scenario 5: Claude Code for Continuous Integration  
+Scenario 6: Structured Data Extraction
+
+Same structure. Note: Scenario 6 is the highest-density weakness scenario - confidence calibration, validation-retry, and batch processing all appear here. Give it extra attention.
+
+Self-test: Same protocol. Flag CI scenario specifically for the "batch is wrong for pre-merge" pattern.
+
+---
+
+### Phase 4: Practice Exam + Revisit (May 18-19)
+
+---
+
+**Day 19 - Mon May 18 | Phase 4 | Full Practice Exam**
+
+Take a timed full practice exam. 4 scenarios drawn at random (simulate this by randomly selecting 4 of the 6). Time-box to the actual exam format.
+
+Score and categorize every wrong answer by domain and weakness item.
+
+Self-test: Score above 720 scaled. Any domain below expected weight = flag for Day 20.
+
+---
+
+**Day 20 - Tue May 19 | Phase 4 | Gap Ledger Closeout**
+
+Review practice exam results. Re-close any items that surfaced in the practice exam. Update gap ledger final status. No new material.
+
+Evening: light review of the 8 weakness item core mechanisms. No cramming. 20 min max.
+
+---
+
+**Exam Window: May 20-22**
+
+Sit the exam at the chosen slot. No new study material after May 19 evening.
+
+---
+
+## Study Materials by Domain
+
+### Domain 1: Agentic Architecture & Orchestration
+
+- docs.anthropic.com/en/docs/build-with-claude/tool-use (tool-result appending, stop_reason)
+- docs.anthropic.com/en/docs/claude-code/hooks (PostToolUse, lifecycle, exit codes)
+- docs.anthropic.com/en/docs/claude-code/memory (fork_session, --resume, session naming)
+- docs.anthropic.com/en/docs/build-with-claude/agents (orchestrator/subagent patterns)
+
+### Domain 2: Tool Design & MCP Integration
+
+- docs.anthropic.com/en/docs/build-with-claude/tool-use (tool descriptions, tool_choice)
+- docs.anthropic.com/en/docs/claude-code/mcp (MCP config, .mcp.json scope)
+- modelcontextprotocol.io/docs (MCP specification, error schema)
+
+### Domain 3: Claude Code Configuration & Workflows
+
+- docs.anthropic.com/en/docs/claude-code/memory (CLAUDE.md hierarchy)
+- docs.anthropic.com/en/docs/claude-code/slash-commands (custom commands)
+- docs.anthropic.com/en/docs/claude-code/ci-cd (-p flag, --output-format, --json-schema)
+- docs.anthropic.com/en/docs/claude-code/settings (settings.json, hooks config)
+
+### Domain 4: Prompt Engineering & Structured Output
+
+- docs.anthropic.com/en/docs/build-with-claude/prompt-engineering (few-shot, explicit criteria)
+- docs.anthropic.com/en/docs/build-with-claude/structured-outputs (JSON schema, nullable fields)
+- docs.anthropic.com/en/docs/build-with-claude/message-batches (Batches API, custom_id, limits)
+
+### Domain 5: Context Management & Reliability
+
+- docs.anthropic.com/en/docs/build-with-claude/context-windows (context preservation, trimming)
+- docs.anthropic.com/en/docs/build-with-claude/agents (error propagation, escalation)
+- docs.anthropic.com/en/docs/claude-code/troubleshooting (/compact, large codebase exploration)
+
+---
+
+## Self-Test Protocol
+
+An item is "closed" when all three of the following are true:
+
+1. **Oral recall without notes** - can explain the full mechanism, the failure modes, and the correct pattern in under 90 seconds.
+2. **Unseen question performance** - can correctly answer 2 exam-style questions on the topic that were not used during study.
+3. **Code sketch** - can write a 30-50 line pseudocode or schema example demonstrating the correct pattern (applicable to items 1, 2, 3, 4, 7, 8).
+
+Items that pass criteria 1 and 2 but not 3 are marked "partially closed" in the gap ledger. They do not count as closed for retest scheduling.
+
+---
+
+## Spaced-Recall Schedule
+
+Each closed weakness item follows this retest schedule:
+
+| Retest       | Timing                          | Format                            |
+| ------------ | ------------------------------- | --------------------------------- |
+| Retest 1     | 48 hours after first-close date | Oral recall, 90 seconds, no notes |
+| Retest 2     | 7 days after first-close date   | One unseen exam-style question    |
+| Final retest | End of current phase            | Oral recall + one question        |
+
+If any retest fails, the item reverts to "in-progress" in the gap ledger. Re-close requires passing all three self-test criteria again.
+
+Items do not come off the retest cycle until 30 days post-first-close. Since the exam sits before the 30-day mark for most items, the final retest at end-of-phase serves as the graduation gate.
+
+---
+
+## Escape Hatches
+
+**If behind at end of Phase 1 (May 5):**
+
+- Compress Phase 1 flash-review sessions to 30 min.
+- Carry residual Phase 1 gaps into Phase 3 depth sessions - flag in gap ledger.
+- Do not compress Phase 2. Domain surface pass is prerequisite for Phase 3 scenario work.
+
+**If behind at end of Phase 2 (May 12):**
+
+- Use weekend May 16-17 for Phase 3 overflow.
+- Compress Phase 3 to 2 sessions (pair scenarios 1-2 on one day, 3-6 on another).
+- Do not compress Phase 4. The practice exam is non-compressible.
+
+**If practice exam score is below 720 (May 18):**
+
+- May 19 becomes targeted remediation, not gentle gap closeout.
+- Prioritize the domains where the practice exam score was worst.
+- Consider pushing the exam sit to May 22 to maximize the Day 19 remediation window.
+
+**Non-compressible:** Phase 4. The practice exam must run in full under timed conditions. Skipping it removes the only realistic calibration of readiness before the actual exam.

--- a/docs/anthropic-partnership/engagements.md
+++ b/docs/anthropic-partnership/engagements.md
@@ -1,7 +1,9 @@
 # CPN Engagements Inventory
 
-**Last updated:** 2026-04-21
-**Purpose:** Verified inventory of active Claude-powered work across the Venture Crane portfolio. Used as evidence for Technology Partner and Services Partner track applications.
+**Last updated:** 2026-04-22
+**Purpose:** Inventory of Claude-powered work across the Venture Crane portfolio. Used as evidence for Technology Partner and Services Partner track applications.
+
+**Captain's canonical position (2026-04-22):** All VC venture products have Claude-powered features, shipping or in backlog. Distinguish "shipping" from "planned" on any specific claim. Do not overstate; do not understate.
 
 ---
 
@@ -11,7 +13,7 @@
 
 The MCP server that powers every agent session across the portfolio. Implements the Model Context Protocol via `@modelcontextprotocol/sdk`. Provides Claude Code with tools for session management, context validation, handoffs, VCMS notes, scheduling, issue creation, and fleet dispatch. The `crane` CLI launcher wraps `claude` with Infisical secret injection. Every agent session in the portfolio runs through crane-mcp.
 
-**Claude usage:** Claude Code CLI is the primary client. All agent-to-infrastructure communication goes through MCP tools exposed by this package.
+**Claude usage:** Claude Code CLI is the primary client. All agent-to-infrastructure communication goes through MCP tools exposed by this package. **Shipping.**
 
 **Repo:** venturecrane/crane-console (`packages/crane-mcp`)
 
@@ -21,7 +23,7 @@ The MCP server that powers every agent session across the portfolio. Implements 
 
 Cloudflare Worker providing structured session and handoff management for multi-agent workflows. Stores sessions, heartbeats, and typed handoffs in D1. Exposes HTTP API used by crane-mcp tools (`/sos`, `/eos`, `/update`, `/heartbeat`, `/active`, `/handoffs`).
 
-**Claude usage:** Not a Claude API consumer - it is the persistence layer that Claude agents write to and read from. Enables multi-machine, multi-session agent continuity.
+**Claude usage:** Not a Claude API consumer - it is the persistence layer that Claude agents write to and read from. Enables multi-machine, multi-session agent continuity. **Shipping.**
 
 **Repo:** venturecrane/crane-console (`workers/crane-context`)
 
@@ -31,7 +33,7 @@ Cloudflare Worker providing structured session and handoff management for multi-
 
 Cloudflare Worker (Durable Object) that serves the MCP protocol over Streamable HTTP for remote clients - claude.ai and Claude Code via `--transport http`. Authenticates via GitHub OAuth using the venturecrane-github App. Enables claude.ai web clients to connect to VC's MCP infrastructure.
 
-**Claude usage:** Serves claude.ai as a remote MCP server. Claude connects to it over HTTP to access crane tools from the web interface.
+**Claude usage:** Serves claude.ai as a remote MCP server. Claude connects to it over HTTP to access crane tools from the web interface. **Shipping.**
 
 **Repo:** venturecrane/crane-console (`workers/crane-mcp-remote`)
 
@@ -41,20 +43,20 @@ Cloudflare Worker (Durable Object) that serves the MCP protocol over Streamable 
 
 Cloudflare Worker GitHub webhook receiver. Receives GitHub App webhooks for CI/CD event forwarding, deploy heartbeat observation, and Vercel deployment failure notifications. Routes events into the crane-context system.
 
-**Claude usage:** Indirect - it feeds events into crane-context which Claude agents consume. The VC product overview notes crane-watch "auto-classifies issues with QA grades via Gemini" (Gemini, not Claude, for this specific classification step).
+**Claude usage:** Indirect shipping usage - feeds events into crane-context which Claude agents consume. Current issue classification step uses Gemini Flash (cost optimization for high-volume classification). Claude-powered enrichment features planned for the roadmap. **Shipping: Gemini classification + Claude Code-agent development. Backlog: Claude-powered enrichment.**
 
 **Repo:** venturecrane/crane-console (`workers/crane-watch`)
 
 ---
 
-### SS (smd.services) - Lead Intelligence Pipelines
+### SS (smd.services) | Lead Intelligence Pipelines
 
 Four Cloudflare Worker cron jobs powering the SS new-business development pipeline:
 
-- **review-mining** - Discovers Phoenix-area businesses via Google Places, fetches reviews via Outscraper, and scores them with Claude (claude-sonnet-4-6) for operational pain signals. Pain score >= 7 qualifies for the Lead Inbox. Weekly cron (Mondays).
-- **job-monitor** - Searches for Phoenix-area job postings signaling operational pain, qualifies them with Claude, writes qualified leads to D1. Daily cron at 6:00 AM MST.
-- **new-business** - Fetches commercial permits from Phoenix, Scottsdale, Mesa, and Tempe open data portals. Qualifies with Claude (Haiku, ~$0.001/permit). Daily cron at 7:00 AM MST.
-- **social-listening** - Monitors Reddit for business owner operational pain signals. No Claude qualification step in this pipeline (cost optimization - pure discovery + routing via Resend digest).
+- **review-mining** - Discovers Phoenix-area businesses via Google Places, fetches reviews via Outscraper, and scores them with Claude (claude-sonnet-4-6) for operational pain signals. Pain score >= 7 qualifies for the Lead Inbox. Weekly cron (Mondays). **Shipping.**
+- **job-monitor** - Searches for Phoenix-area job postings signaling operational pain, qualifies them with Claude, writes qualified leads to D1. Daily cron at 6:00 AM MST. **Shipping.**
+- **new-business** - Fetches commercial permits from Phoenix, Scottsdale, Mesa, and Tempe open data portals. Qualifies with Claude (Haiku, ~$0.001/permit). Daily cron at 7:00 AM MST. **Shipping.**
+- **social-listening** - Monitors Reddit for business owner operational pain signals. No Claude qualification step in this pipeline (deliberate cost optimization; pure discovery + routing via Resend digest). **Shipping; non-Claude by design.**
 
 **Claude usage:** Direct Anthropic API calls (`https://api.anthropic.com/v1/messages`) with `ANTHROPIC_API_KEY`. Models confirmed: `claude-sonnet-4-6` (review scoring), Haiku-class (permit qualification).
 
@@ -62,23 +64,21 @@ Four Cloudflare Worker cron jobs powering the SS new-business development pipeli
 
 ---
 
-### DFG (durgan-field-guide) - Analyst Worker
+### DFG (durgan-field-guide) | Analyst Worker
 
 `dfg-analyst` Cloudflare Worker providing AI-powered auction item analysis. Uses Claude to evaluate acquisition opportunities with cost modeling, comp-based valuation, deal-killer detection, and margin discipline enforcement.
 
-**Claude usage:** Direct Anthropic API calls with `ANTHROPIC_API_KEY`. Model confirmed: `claude-sonnet-4-20250514` for both condition analysis and reasoning steps (two-model configuration: `CONDITION_MODEL` and `REASONING_MODEL`, both pointing to the same Sonnet 4 checkpoint).
+**Claude usage:** Direct Anthropic API calls with `ANTHROPIC_API_KEY`. Model confirmed: `claude-sonnet-4-20250514` for both condition analysis and reasoning steps (two-model configuration: `CONDITION_MODEL` and `REASONING_MODEL`, both pointing to the same Sonnet 4 checkpoint). **Shipping. Additional Claude-powered features in backlog (field-compute companion flows).**
 
 **Repo:** durganfieldguide/dfg-console (`workers/dfg-analyst`)
 
 ---
 
-### DC (Draft Crane) - dc-api AI Routes
+### DC (Draft Crane) | dc-api AI Routes
 
 `dc-api` Cloudflare Worker with AI-assisted writing routes (`/api/ai`, `/api/ai-instructions`, `/api/research`). Provides streaming completions, research queries, and AI instruction management for the book-writing workflow.
 
-**Claude usage:** dc-api uses a provider-agnostic AI interface with two tiers - "edge" (Cloudflare Workers AI, Mistral Small 3.1 24B) and "frontier" (OpenAI GPT-4o). Claude is NOT the current AI backend for DC. The writing assistant uses OpenAI/Workers AI, not Claude.
-
-**Note:** DC is Claude-assisted at the development layer (all code written by Claude Code agents) but not at the product layer. TODO: verify with Captain whether DC is intended to add Claude API usage in the roadmap.
+**Claude usage:** Current production provider is a provider-agnostic AI interface with two tiers: Cloudflare Workers AI (Mistral Small 3.1 24B, edge tier) and OpenAI GPT-4o (frontier tier). **Current shipping AI provider for DC product routes is NOT Claude.** DC is Claude-assisted at the development layer (all code written by Claude Code agents). **Claude-powered product features are in backlog;** specific migration plans under operator review.
 
 **Repo:** smdurgan-llc/dc-console (`workers/dc-api`)
 
@@ -88,7 +88,7 @@ Four Cloudflare Worker cron jobs powering the SS new-business development pipeli
 
 Expense tracking and co-parent settlement application. Next.js, Cloudflare Workers, D1.
 
-**Claude usage:** Development layer only - built by Claude Code agents. No Claude API calls found in the workers or application code. TODO: verify with Captain whether any AI features are planned or in-flight.
+**Claude usage:** Development layer | built by Claude Code agents. **No Claude API calls in current shipping product code. Claude-powered product features are in backlog.** Specific features and timeline under operator review.
 
 **Repo:** venturecrane/ke-console
 
@@ -98,7 +98,7 @@ Expense tracking and co-parent settlement application. Next.js, Cloudflare Worke
 
 Validation-as-a-Service platform. Structured 30-day sprints producing Go/Kill/Pivot decisions.
 
-**Claude usage:** Development layer only - built by Claude Code agents. No Claude API calls found in application code. TODO: verify with Captain whether SC's validation sprint tooling uses any Claude API calls for analysis or scoring.
+**Claude usage:** Development layer | built by Claude Code agents. **No Claude API calls in current shipping product code. Claude-powered product features in backlog** (validation sprint analysis, scoring, synthesis). Specific features and timeline under operator review.
 
 **Repo:** venturecrane/sc-console
 
@@ -108,16 +108,14 @@ Validation-as-a-Service platform. Structured 30-day sprints producing Go/Kill/Pi
 
 ### smd.services (SS venture)
 
-SMD Services is the consulting arm - delivers fixed-price operational consulting to Phoenix-area small businesses ($750k-$5M revenue). The core positioning: enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. AI and automation is a named capability.
+SMD Services is the consulting arm - delivers fixed-price operational consulting to Phoenix-area small businesses ($750k-$5M revenue). The core positioning: enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. Claude is the named AI platform.
 
 Active Claude-powered work:
 
-- Lead intelligence pipelines (see SS entries above) - Claude qualifies leads before human review
-- Agent-assisted engagement delivery - all consulting document production, templates, SOW generation, and operational documentation runs through Claude Code agents
+- Lead intelligence pipelines (see SS entries above) | Claude qualifies leads before human review. **Shipping.**
+- Agent-assisted engagement delivery | all consulting document production, templates, SOW generation, and operational documentation runs through Claude Code agents. **Shipping.**
 
 Current status: Prototype. Site live at smd.services. Service packaging and lead generation in progress. No closed clients confirmed at time of writing.
-
-TODO: Clarify with Captain - are there active client engagements or prospects where Claude is part of the delivery model? If yes, document them here for the Services Partner narrative.
 
 ---
 
@@ -129,7 +127,7 @@ TODO: Clarify with Captain - are there active client engagements or prospects wh
 
 ## Notes for Updating This Document
 
-- Add new engagements when Claude API usage is confirmed in a worker or application
-- Update the "Last updated" date at the top when making changes
-- Mark items "CONFIRMED" or "TODO: verify" to track verification status
-- DC and KE/SC product-layer Claude usage needs Captain input before asserting in partner conversations
+- Add new engagements when Claude API usage is confirmed in shipping code.
+- Update the "Last updated" date at the top when making changes.
+- Always distinguish "shipping" from "backlog" on specific feature claims.
+- Do not invent specific Claude features for ventures where the roadmap is not yet defined. "Claude-powered features in backlog" is the correct honest phrasing when specifics are under operator review.

--- a/docs/anthropic-partnership/engagements.md
+++ b/docs/anthropic-partnership/engagements.md
@@ -1,0 +1,135 @@
+# CPN Engagements Inventory
+
+**Last updated:** 2026-04-21
+**Purpose:** Verified inventory of active Claude-powered work across the Venture Crane portfolio. Used as evidence for Technology Partner and Services Partner track applications.
+
+---
+
+## Technology Partner Candidates
+
+### crane-mcp (`@venturecrane/crane-mcp`)
+
+The MCP server that powers every agent session across the portfolio. Implements the Model Context Protocol via `@modelcontextprotocol/sdk`. Provides Claude Code with tools for session management, context validation, handoffs, VCMS notes, scheduling, issue creation, and fleet dispatch. The `crane` CLI launcher wraps `claude` with Infisical secret injection. Every agent session in the portfolio runs through crane-mcp.
+
+**Claude usage:** Claude Code CLI is the primary client. All agent-to-infrastructure communication goes through MCP tools exposed by this package.
+
+**Repo:** venturecrane/crane-console (`packages/crane-mcp`)
+
+---
+
+### crane-context (`crane-context.automation-ab6.workers.dev`)
+
+Cloudflare Worker providing structured session and handoff management for multi-agent workflows. Stores sessions, heartbeats, and typed handoffs in D1. Exposes HTTP API used by crane-mcp tools (`/sos`, `/eos`, `/update`, `/heartbeat`, `/active`, `/handoffs`).
+
+**Claude usage:** Not a Claude API consumer - it is the persistence layer that Claude agents write to and read from. Enables multi-machine, multi-session agent continuity.
+
+**Repo:** venturecrane/crane-console (`workers/crane-context`)
+
+---
+
+### crane-mcp-remote (`crane-mcp-remote.automation-ab6.workers.dev`)
+
+Cloudflare Worker (Durable Object) that serves the MCP protocol over Streamable HTTP for remote clients - claude.ai and Claude Code via `--transport http`. Authenticates via GitHub OAuth using the venturecrane-github App. Enables claude.ai web clients to connect to VC's MCP infrastructure.
+
+**Claude usage:** Serves claude.ai as a remote MCP server. Claude connects to it over HTTP to access crane tools from the web interface.
+
+**Repo:** venturecrane/crane-console (`workers/crane-mcp-remote`)
+
+---
+
+### crane-watch
+
+Cloudflare Worker GitHub webhook receiver. Receives GitHub App webhooks for CI/CD event forwarding, deploy heartbeat observation, and Vercel deployment failure notifications. Routes events into the crane-context system.
+
+**Claude usage:** Indirect - it feeds events into crane-context which Claude agents consume. The VC product overview notes crane-watch "auto-classifies issues with QA grades via Gemini" (Gemini, not Claude, for this specific classification step).
+
+**Repo:** venturecrane/crane-console (`workers/crane-watch`)
+
+---
+
+### SS (smd.services) - Lead Intelligence Pipelines
+
+Four Cloudflare Worker cron jobs powering the SS new-business development pipeline:
+
+- **review-mining** - Discovers Phoenix-area businesses via Google Places, fetches reviews via Outscraper, and scores them with Claude (claude-sonnet-4-6) for operational pain signals. Pain score >= 7 qualifies for the Lead Inbox. Weekly cron (Mondays).
+- **job-monitor** - Searches for Phoenix-area job postings signaling operational pain, qualifies them with Claude, writes qualified leads to D1. Daily cron at 6:00 AM MST.
+- **new-business** - Fetches commercial permits from Phoenix, Scottsdale, Mesa, and Tempe open data portals. Qualifies with Claude (Haiku, ~$0.001/permit). Daily cron at 7:00 AM MST.
+- **social-listening** - Monitors Reddit for business owner operational pain signals. No Claude qualification step in this pipeline (cost optimization - pure discovery + routing via Resend digest).
+
+**Claude usage:** Direct Anthropic API calls (`https://api.anthropic.com/v1/messages`) with `ANTHROPIC_API_KEY`. Models confirmed: `claude-sonnet-4-6` (review scoring), Haiku-class (permit qualification).
+
+**Repo:** venturecrane/ss-console (`workers/review-mining`, `workers/job-monitor`, `workers/new-business`, `workers/social-listening`)
+
+---
+
+### DFG (durgan-field-guide) - Analyst Worker
+
+`dfg-analyst` Cloudflare Worker providing AI-powered auction item analysis. Uses Claude to evaluate acquisition opportunities with cost modeling, comp-based valuation, deal-killer detection, and margin discipline enforcement.
+
+**Claude usage:** Direct Anthropic API calls with `ANTHROPIC_API_KEY`. Model confirmed: `claude-sonnet-4-20250514` for both condition analysis and reasoning steps (two-model configuration: `CONDITION_MODEL` and `REASONING_MODEL`, both pointing to the same Sonnet 4 checkpoint).
+
+**Repo:** durganfieldguide/dfg-console (`workers/dfg-analyst`)
+
+---
+
+### DC (Draft Crane) - dc-api AI Routes
+
+`dc-api` Cloudflare Worker with AI-assisted writing routes (`/api/ai`, `/api/ai-instructions`, `/api/research`). Provides streaming completions, research queries, and AI instruction management for the book-writing workflow.
+
+**Claude usage:** dc-api uses a provider-agnostic AI interface with two tiers - "edge" (Cloudflare Workers AI, Mistral Small 3.1 24B) and "frontier" (OpenAI GPT-4o). Claude is NOT the current AI backend for DC. The writing assistant uses OpenAI/Workers AI, not Claude.
+
+**Note:** DC is Claude-assisted at the development layer (all code written by Claude Code agents) but not at the product layer. TODO: verify with Captain whether DC is intended to add Claude API usage in the roadmap.
+
+**Repo:** smdurgan-llc/dc-console (`workers/dc-api`)
+
+---
+
+### KE (Kid Expenses)
+
+Expense tracking and co-parent settlement application. Next.js, Cloudflare Workers, D1.
+
+**Claude usage:** Development layer only - built by Claude Code agents. No Claude API calls found in the workers or application code. TODO: verify with Captain whether any AI features are planned or in-flight.
+
+**Repo:** venturecrane/ke-console
+
+---
+
+### SC (Silicon Crane)
+
+Validation-as-a-Service platform. Structured 30-day sprints producing Go/Kill/Pivot decisions.
+
+**Claude usage:** Development layer only - built by Claude Code agents. No Claude API calls found in application code. TODO: verify with Captain whether SC's validation sprint tooling uses any Claude API calls for analysis or scoring.
+
+**Repo:** venturecrane/sc-console
+
+---
+
+## Services Partner Candidates
+
+### smd.services (SS venture)
+
+SMD Services is the consulting arm - delivers fixed-price operational consulting to Phoenix-area small businesses ($750k-$5M revenue). The core positioning: enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. AI and automation is a named capability.
+
+Active Claude-powered work:
+
+- Lead intelligence pipelines (see SS entries above) - Claude qualifies leads before human review
+- Agent-assisted engagement delivery - all consulting document production, templates, SOW generation, and operational documentation runs through Claude Code agents
+
+Current status: Prototype. Site live at smd.services. Service packaging and lead generation in progress. No closed clients confirmed at time of writing.
+
+TODO: Clarify with Captain - are there active client engagements or prospects where Claude is part of the delivery model? If yes, document them here for the Services Partner narrative.
+
+---
+
+## Individual Architect
+
+**Scott Durgan** - Pursuing Claude Certified Architect (Foundations) certification. Target sit date: May 20-22, 2026. Curriculum plan in `curriculum.md`.
+
+---
+
+## Notes for Updating This Document
+
+- Add new engagements when Claude API usage is confirmed in a worker or application
+- Update the "Last updated" date at the top when making changes
+- Mark items "CONFIRMED" or "TODO: verify" to track verification status
+- DC and KE/SC product-layer Claude usage needs Captain input before asserting in partner conversations

--- a/docs/anthropic-partnership/gap-ledger.md
+++ b/docs/anthropic-partnership/gap-ledger.md
@@ -1,0 +1,98 @@
+# CCA Foundations | Gap Ledger
+
+**Candidate:** Scott Durgan  
+**Opened:** April 22, 2026  
+**Exam window:** May 20-22, 2026  
+**Produced by:** Venture Crane agent team
+
+This is a living document. Update after every study session. Do not batch updates.
+
+---
+
+## Active Gaps
+
+| #   | Item                               | Status  | First-Close Date | Retest-48h Date | Retest-7d Date | Final-Retest Date | Residual Notes |
+| --- | ---------------------------------- | ------- | ---------------- | --------------- | -------------- | ----------------- | -------------- |
+| 1   | Agentic loop mechanics             | pending | -                | -               | -              | -                 | -              |
+| 2   | Hooks as deterministic enforcement | pending | -                | -               | -              | -                 | -              |
+| 3   | tool_choice semantics              | pending | -                | -               | -              | -                 | -              |
+| 4   | Structured error responses         | pending | -                | -               | -              | -                 | -              |
+| 5   | Message Batches API                | pending | -                | -               | -              | -                 | -              |
+| 6   | fork_session and --resume          | pending | -                | -               | -              | -                 | -              |
+| 7   | Validation-retry loops             | pending | -                | -               | -              | -                 | -              |
+| 8   | Confidence calibration             | pending | -                | -               | -              | -                 | -              |
+
+**Status values:** pending | in-progress | partially-closed | closed
+
+"Partially-closed" = passes oral recall and unseen-question criteria but not the code-sketch criterion. Does not trigger the retest schedule.
+
+---
+
+## Closed Gaps
+
+_Empty on day 1. Items move here after passing all three self-test criteria (oral recall + unseen questions + code sketch). Include first-close date and any notes on what finally resolved the gap._
+
+---
+
+## New Gaps Discovered
+
+_Empty on day 1. When study surfaces a concept not on the original weakness list, log it here immediately. Include discovery date, which session surfaced it, and a brief closure plan._
+
+| Discovery Date | Item | Surfaced During | Domain | Closure Plan |
+| -------------- | ---- | --------------- | ------ | ------------ |
+| -              | -    | -               | -      | -            |
+
+---
+
+## Scenario-Specific Gaps
+
+_Reserved for Phase 3 (May 13-15). One subsection per scenario. Populated during depth sessions._
+
+### Scenario 1: Customer Support Resolution Agent
+
+_(Not yet populated)_
+
+### Scenario 2: Code Generation with Claude Code
+
+_(Not yet populated)_
+
+### Scenario 3: Multi-Agent Research System
+
+_(Not yet populated)_
+
+### Scenario 4: Developer Productivity with Claude
+
+_(Not yet populated)_
+
+### Scenario 5: Claude Code for Continuous Integration
+
+_(Not yet populated)_
+
+### Scenario 6: Structured Data Extraction
+
+_(Not yet populated)_
+
+---
+
+## Maintenance Protocol
+
+**When to update:**
+
+- After every study session: update status column for items touched that session.
+- When an item first-closes: fill first-close date, compute and fill retest-48h date (first-close + 2 calendar days) and retest-7d date (first-close + 7 calendar days).
+- When a retest is completed: fill the retest date with the actual date. Note pass/fail in residual notes.
+- When a retest fails: revert item status to in-progress. Clear the retest dates. Re-close requires passing all three criteria again from scratch.
+- When new gaps are discovered: add to New Gaps Discovered immediately with discovery date and session name.
+- After Phase 3 sessions: populate the relevant scenario subsection.
+
+**Closing an item:**
+The closer (the study session) confirms retention by passing all three self-test criteria. Do not mark closed based on "felt comfortable" - run the oral recall, the unseen question, and the code sketch. If any criterion fails, mark partially-closed and log what failed in residual notes.
+
+**Retest cycle:**
+Items do not leave the retest cycle until 30 days post-first-close. Given the exam sits May 20-22 and Phase 1 opens April 22, most items will not reach 30 days before the exam. The final-retest date (end of current phase) serves as the exam-readiness gate for each item.
+
+**Moving to Closed Gaps section:**
+When an item passes its final retest, cut the row from the Active Gaps table and paste it into the Closed Gaps section. Preserve all dates and residual notes.
+
+**Practice exam integration (May 18):**
+After the practice exam, re-open any item that produced a wrong answer in the exam. Even if the item was previously closed. Log it in Active Gaps with a note "re-opened: practice exam [date]" and re-run the close process.

--- a/docs/anthropic-partnership/operating-model.md
+++ b/docs/anthropic-partnership/operating-model.md
@@ -47,6 +47,6 @@ Note: DC, KE, and SC are built by Claude Code agents at the development layer bu
 
 ## What We Need from the Program
 
-Enrollment that recognizes the operator-plus-agent-workforce model. The "ten of your people through training" framing fits a GSI onboarding template - appropriate for Accenture, not appropriate for the operating model Dario described at Code with Claude. We propose training enrollment that admits agent-identity workforces alongside human teams, and partner engagement patterns for non-traditional shapes.
+Enrollment that recognizes the operator-plus-agent-workforce model. The Learning Path Complete form currently requires ten individuals with company-domain emails completing four Anthropic Academy courses. That gate fits a traditional-consulting shape. We propose training enrollment that also admits agent-identity workforces, and partner engagement patterns for non-traditional shapes.
 
 Venture Crane is a forward signal, not an edge case. The program benefits from having the reference example in the room.

--- a/docs/anthropic-partnership/operating-model.md
+++ b/docs/anthropic-partnership/operating-model.md
@@ -1,0 +1,52 @@
+# Venture Crane | Operating Model
+
+Venture Crane is a one-operator enterprise powered by an AI agent workforce.
+
+---
+
+## The Shape
+
+**The operator.** Scott Durgan holds strategy, architecture-of-record, and the Captain's chair. Customer relationships, decisions carrying reputational or legal weight, and final architectural calls belong to the operator. Scott directs; the agents produce.
+
+**The agent workforce.** Engineering, content production, delivery, analysis, and operations are handled by AI agents across all ventures and all engagements. This is not humans using AI tools - the agents are the workforce, structured through session-based operation, memory persistence, multi-agent orchestration, and handoff protocols that ensure continuity across sessions and machines. Every pull request, every pipeline, every client document: produced by the agent team under operator direction.
+
+**How engagements get staffed.** For a client engagement under smd.services, agent roles are assigned with defined accountabilities - project lead, delivery, QA, review. The operator provides oversight at decision boundaries: scope calls, client-facing commitments, anything requiring the accountable human. Between those boundaries, the agent team runs the work. Scale means more agent instances, not more human hires.
+
+---
+
+## Why This Shape
+
+The thesis is that AI agents are the workforce, not a force multiplier on top of a human workforce. Quality comes from the operating environment - structured sessions, memory persistence, multi-agent orchestration, editorial review pipelines, automated verification (type checking, linting, test suites). The rigor is in the architecture of the operating environment. This is a different model from "AI-assisted human work."
+
+---
+
+## Anchored to Anthropic's Own Direction
+
+At Code with Claude (San Francisco, May 2025), Dario Amodei assigned 70-80% probability to the arrival of the first one-person billion-dollar company powered by AI agents by 2026. Venture Crane is building toward that thesis - not requesting an exception to any rule. We are an existence proof of what Anthropic's own CEO described.
+
+Coverage: Inc. Magazine - https://www.inc.com/ben-sherry/anthropic-ceo-dario-amodei-predicts-the-first-billion-dollar-solopreneur-by-2026/91193609
+
+---
+
+## What We Bring to the Claude Partner Network
+
+**Services track - smd.services.** Fixed-price operational consulting for Phoenix-area small businesses. Delivery is AI-agent-executed: documentation, SOW production, analysis, and templates are produced by the agent team. Claude powers the delivery engine. Current status: prototype and active lead generation; no closed clients confirmed at this writing.
+
+**Technology track - Claude-powered product footprint.**
+
+- _SS pipelines._ Three active cron workers calling the Anthropic API directly: review-mining (Claude Sonnet 4 scores Google reviews for operational pain signals), job-monitor (Claude qualifies job postings as lead signals, daily), new-business (Claude Haiku qualifies commercial permit data from four Phoenix metro municipalities, daily).
+- _DFG analyst._ Worker using Claude Sonnet 4 for auction item analysis - condition scoring, comp valuation, deal-killer detection.
+- _crane-mcp._ MCP server powering every agent session in the portfolio. Gives Claude Code agents tools for session management, handoffs, memory, and fleet dispatch.
+- _crane-mcp-remote._ Cloudflare Durable Object serving MCP over Streamable HTTP to claude.ai and Claude Code remote clients.
+
+Note: DC, KE, and SC are built by Claude Code agents at the development layer but do not call the Claude API in their product code at this time. Scope stated accurately.
+
+**Individual credential.** Scott Durgan pursuing Claude Certified Architect - Foundations. Target sit date: May 20-22, 2026.
+
+---
+
+## What We Need from the Program
+
+Enrollment that recognizes the operator-plus-agent-workforce model. The "ten of your people through training" framing fits a GSI onboarding template - appropriate for Accenture, not appropriate for the operating model Dario described at Code with Claude. We propose training enrollment that admits agent-identity workforces alongside human teams, and partner engagement patterns for non-traditional shapes.
+
+Venture Crane is a forward signal, not an edge case. The program benefits from having the reference example in the room.

--- a/docs/anthropic-partnership/outbound/partner-support-initial-question.md
+++ b/docs/anthropic-partnership/outbound/partner-support-initial-question.md
@@ -1,0 +1,36 @@
+---
+to: partner-support@anthropic.com
+from: smdurgan@venturecrane.com
+subject: 'Learning Path form: question from a one-person operation'
+drafted: 2026-04-22
+status: draft (awaiting Captain send)
+---
+
+# Partner Support: Initial Question
+
+## Context
+
+Drafted on 2026-04-22 after the Captain located the Claude Partner Network Learning Path Complete form (Google Forms URL in chat history) and confirmed the "ten individuals with company-domain emails" gate is a published program requirement for Services Partner enrollment, not reviewer template friction.
+
+Captain's posture: option 3 from the routing discussion - ask partner-support up front rather than submit a form with agent emails without knowing whether that is welcomed. Transparent framing, above-board operation, willing to accept "not aligned" as a valid answer.
+
+## Email body
+
+Hi,
+
+Our Partner Network application cleared initial review on April 9 via Karl Kadon's team. Thanks for the early note.
+
+Quick bit of background before the ask. Venture Crane is one human and an AI agent workforce. I'm the human. Operator and architect, handling the decisions that need a person. The agents do the engineering, content, analysis, and delivery. It's a deliberate setup, and honestly not that different from what Dario described at Code with Claude last year. We document the work openly at venturecrane.com if you're curious.
+
+On the Claude side, we're active on both product delivery (a portfolio of Claude-powered ventures) and service delivery (smd.services, the implementation entity for client work).
+
+Which brings me to the Learning Path Complete form. It asks for ten people, each completing the four Anthropic Academy courses with company-domain emails. I'm one person. I've started the coursework myself and will finish it regardless, the material is directly useful. The other nine is where I'd like your guidance before submitting anything.
+
+Rather than guess, I'd rather just ask: given our shape, how would you want us to approach this? And if we're not aligned with the program as it stands, better to know now.
+
+This is an above-board operation. Happy to hop on a call if that's easier.
+
+Thanks,
+Scott Durgan
+Founder, Venture Crane
+smdurgan@venturecrane.com

--- a/docs/anthropic-partnership/qualification.md
+++ b/docs/anthropic-partnership/qualification.md
@@ -1,6 +1,6 @@
 # CPN Qualification Assessment
 
-**Bottom line:** Venture Crane is not structurally blocked from any CPN track. The "ten" question is template friction from a GSI-shaped onboarding form, not a published gate. An agent-workforce framing anchored to Dario's own thesis is the correct response.
+**Bottom line:** Venture Crane is not structurally blocked from any CPN track. The Learning Path Complete form ("ten individuals") is a real published gate for Services Partner enrollment but does not block Technology Partner (explicit individual admission) or Individual Architect. The correct response to the Services Partner gate is a direct question to partner-support, not headcount manufacturing.
 
 ---
 
@@ -8,8 +8,8 @@
 
 The Claude Partner Network launched publicly on 2026-03-12. Two tracks per the official announcement:
 
-- **Technology Partners** - Organizations building with Claude APIs and SDKs. The announcement explicitly states individuals are eligible. No published headcount floor.
-- **Services Partners** - Organizations implementing Claude for clients. This is where most of the "ten" friction originates.
+- **Technology Partners** | Organizations and individuals building with Claude APIs and SDKs. The announcement explicitly states individuals are eligible. No published headcount floor.
+- **Services Partners** | Organizations implementing Claude for clients. Gated through the Learning Path Complete form described below.
 
 Official sources:
 
@@ -20,16 +20,17 @@ Official sources:
 
 ## The "Ten" Question
 
-Karl Kadon's broadcast included a request to put "ten of your people through training." This framing appears in two places outside official Anthropic docs:
+Karl Kadon's April 9 broadcast included a request to put "ten of your people through training." This is enforced at the form level for Services Partner enrollment: the Claude Partner Network Learning Path Complete form explicitly requires "10 or more individuals from my organization [who] have each completed all required Anthropic Academy courses" with matching company-domain emails. Form enforcement language: "if we find fewer than 10 fully completed, we'll return the submission."
 
-1. Karl's onboarding broadcast (internal, GSI template language)
-2. A third-party blog post at lowcode.agency (not an Anthropic source)
+This is a published, programmatically-enforced gate, not reviewer template friction. Karl's ex-Databricks Global Leader of Partner Programs background is the likely source of the GSI-shaped form design.
 
-The "ten" language does NOT appear in Anthropic's published CPN requirements. This matters.
+Key interpretation points:
 
-A solo agency has already been accepted into CPN. The Indie Hackers post at https://www.indiehackers.com/post/anthropic-accepted-my-solo-agency-into-their-partner-network-heres-what-i-built-to-get-in-and-what-s-next-b5db4075ad documents a single-person operation clearing the review and getting in. This is the clearest signal that the "ten" is template friction, not a hard gate.
+1. **The gate is Services Partner-specific.** Technology Partner admits individuals per the public announcement; no "ten" requirement there.
+2. **Solo-agency precedent exists.** An Indie Hackers post documents a one-person agency that cleared CPN review: https://www.indiehackers.com/post/anthropic-accepted-my-solo-agency-into-their-partner-network-heres-what-i-built-to-get-in-and-what-s-next-b5db4075ad. The entry track (Technology Partner vs. Services Partner) and any reviewer accommodation are not public.
+3. **Transparent framing is non-negotiable.** VC's operating model is one operator + AI agent workforce. Manufacturing nine humans to satisfy the form is off the table per Captain directive. See `the-ten.md` for the decision record.
 
-The correct response is not to manufacture headcount or apologize for the operating model. It is to reframe with Dario's own thesis and let the agent workforce speak for itself.
+The correct response is the partner-support inquiry drafted at `outbound/partner-support-initial-question.md` - ask before submitting.
 
 ---
 
@@ -39,9 +40,9 @@ Dario Amodei at Code with Claude (San Francisco, May 2025) gave a 70-80% probabi
 
 Additional signals that Anthropic is moving toward agent-native structures:
 
-- **Agent SDK rename** (2026-04) - The Agents SDK was rebranded, signaling commitment to the agentic use case as a first-class pattern.
-- **Claude Managed Agents launch** (2026-04-08) - Anthropic launched managed agent infrastructure, validating the agent-workforce model.
-- **Anthropic Economic Index direction** - Anthropic's own research tracks how AI reshapes labor. The one-person-enterprise thesis is consistent with that direction.
+- **Agent SDK rename** (2026-04) | The Agents SDK was rebranded, signaling commitment to the agentic use case as a first-class pattern.
+- **Claude Managed Agents launch** (2026-04-08) | Anthropic launched managed agent infrastructure, validating the agent-workforce model.
+- **Anthropic Economic Index direction** | Anthropic's own research tracks how AI reshapes labor. The one-person-enterprise thesis is consistent with that direction.
 
 VC is not an edge case. It is an on-thesis proof point. The right framing with Karl is not "we're an exception" but "we're the example Dario described."
 
@@ -51,9 +52,9 @@ VC is not an edge case. It is an on-thesis proof point. The right framing with K
 
 Karl Kadon is Head of Partner Experience at Anthropic. Previously Global Leader of Partner Programs at Databricks. LinkedIn: https://www.linkedin.com/in/karlkadon/
 
-His "ten of your people through training" template reflects Databricks-ecosystem thinking - GSI partner programs where partners certify a bench of practitioners as proof of commitment and delivery capacity. Databricks certifications and partner tiers are built around that model.
+His partner-program design reflects Databricks-ecosystem thinking | GSI partner programs where partners certify a bench of practitioners as proof of commitment and delivery capacity. Databricks certifications and partner tiers are built around that model.
 
-That model fits Accenture. It does not fit a one-operator agent enterprise. Karl cleared VC through initial review, which means he is not operating as a rigid gatekeeper. The onboarding conversation is the right moment to establish what "ten trained practitioners" means for an agent-workforce org.
+That model fits Accenture. It does not fit a one-operator agent enterprise. Karl cleared VC through initial review, which means he is not operating as a rigid gatekeeper. The onboarding conversation (once we have partner-support's response) is the right moment to establish what the Learning Path Complete form means for an agent-workforce org.
 
 ---
 
@@ -73,22 +74,18 @@ Tribe AI and Turing are both outside the standard GSI mold. There is documented 
 ## Track-by-Track Assessment
 
 **Individual Architect (Claude Certified Architect - Foundations)**
-Assessment: Clean. This is a standard professional certification track. No headcount requirement. Scott sits the exam May 20-22, 2026. No blockers.
+Assessment: Clean. No headcount requirement. Scott sits the exam May 20-22, 2026. No blockers.
 
 **Technology Partner**
-Assessment: Clean. The portfolio - SS, DC, KE, SC, DFG, crane-mcp, crane-context, crane-mcp-remote - represents multiple active Claude-powered products and infrastructure components. No published headcount floor for Technology Partner. VC's engagements inventory (`engagements.md`) is ready.
+Assessment: Clean. No published headcount floor. The portfolio | SS, DC, KE, SC, DFG, crane-mcp, crane-context, crane-mcp-remote | represents multiple Claude-powered products and infrastructure components across shipping and backlog features. Engagements inventory (`engagements.md`) is ready.
 
 **Services Partner (smd.services)**
-Assessment: Needs the reframe conversation, not a structural fix. smd.services is delivering Claude-powered operational consulting to small businesses with active AI pipelines (lead qualification, review scoring, permit analysis). The question is how to frame "ten trained practitioners" for an agent-workforce delivery model. The Dario anchor and the solo-agency precedent are the tools for that conversation.
+Assessment: Gated at the Learning Path Complete form. Awaiting partner-support guidance on how the program accommodates the operator + agent workforce model. If the gate is strict and waiver-free, route around via Technology Partner + Individual Architect; revisit Services Partner when the program accommodates different shapes. Do not manufacture headcount.
 
 ---
 
 ## Open Questions
 
-Two items require verification against CPN's internal portal rather than the public announcement:
-
-1. **Karl's exact enrollment criteria** - The public announcement and the onboarding broadcast may surface different requirements. The internal partner portal may show fields or checkboxes not visible on the public page. Status: unknown until Karl's next broadcast.
-
-2. **Internal portal vs. public announcement** - Whether CPN's portal surfaces additional gates (minimum revenue, minimum clients, insurance requirements, etc.) is not confirmed from public sources. Status: unknown.
-
-These are worth asking about directly when Karl's next communication arrives. Neither is a reason to delay pre-work.
+1. **Partner-support's answer on the form.** Email drafted at `outbound/partner-support-initial-question.md`. Awaiting Captain send and Anthropic response. Shapes Services Partner path.
+2. **Karl's exact enrollment criteria beyond the form.** The public announcement and the onboarding broadcast may surface different requirements. Status: unknown until further communication.
+3. **Internal portal vs. public announcement.** Whether CPN's portal surfaces additional gates (minimum revenue, minimum clients, insurance requirements, etc.) is not confirmed from public sources. Status: unknown.

--- a/docs/anthropic-partnership/qualification.md
+++ b/docs/anthropic-partnership/qualification.md
@@ -1,0 +1,94 @@
+# CPN Qualification Assessment
+
+**Bottom line:** Venture Crane is not structurally blocked from any CPN track. The "ten" question is template friction from a GSI-shaped onboarding form, not a published gate. An agent-workforce framing anchored to Dario's own thesis is the correct response.
+
+---
+
+## Program Structure (Published)
+
+The Claude Partner Network launched publicly on 2026-03-12. Two tracks per the official announcement:
+
+- **Technology Partners** - Organizations building with Claude APIs and SDKs. The announcement explicitly states individuals are eligible. No published headcount floor.
+- **Services Partners** - Organizations implementing Claude for clients. This is where most of the "ten" friction originates.
+
+Official sources:
+
+- https://www.anthropic.com/news/claude-partner-network
+- https://claude.com/partners
+
+---
+
+## The "Ten" Question
+
+Karl Kadon's broadcast included a request to put "ten of your people through training." This framing appears in two places outside official Anthropic docs:
+
+1. Karl's onboarding broadcast (internal, GSI template language)
+2. A third-party blog post at lowcode.agency (not an Anthropic source)
+
+The "ten" language does NOT appear in Anthropic's published CPN requirements. This matters.
+
+A solo agency has already been accepted into CPN. The Indie Hackers post at https://www.indiehackers.com/post/anthropic-accepted-my-solo-agency-into-their-partner-network-heres-what-i-built-to-get-in-and-what-s-next-b5db4075ad documents a single-person operation clearing the review and getting in. This is the clearest signal that the "ten" is template friction, not a hard gate.
+
+The correct response is not to manufacture headcount or apologize for the operating model. It is to reframe with Dario's own thesis and let the agent workforce speak for itself.
+
+---
+
+## AI-Native Signal
+
+Dario Amodei at Code with Claude (San Francisco, May 2025) gave a 70-80% probability that the first one-person billion-dollar company powered by AI agents arrives by 2026. Venture Crane is building toward exactly that thesis.
+
+Additional signals that Anthropic is moving toward agent-native structures:
+
+- **Agent SDK rename** (2026-04) - The Agents SDK was rebranded, signaling commitment to the agentic use case as a first-class pattern.
+- **Claude Managed Agents launch** (2026-04-08) - Anthropic launched managed agent infrastructure, validating the agent-workforce model.
+- **Anthropic Economic Index direction** - Anthropic's own research tracks how AI reshapes labor. The one-person-enterprise thesis is consistent with that direction.
+
+VC is not an edge case. It is an on-thesis proof point. The right framing with Karl is not "we're an exception" but "we're the example Dario described."
+
+---
+
+## Karl Kadon Context
+
+Karl Kadon is Head of Partner Experience at Anthropic. Previously Global Leader of Partner Programs at Databricks. LinkedIn: https://www.linkedin.com/in/karlkadon/
+
+His "ten of your people through training" template reflects Databricks-ecosystem thinking - GSI partner programs where partners certify a bench of practitioners as proof of commitment and delivery capacity. Databricks certifications and partner tiers are built around that model.
+
+That model fits Accenture. It does not fit a one-operator agent enterprise. Karl cleared VC through initial review, which means he is not operating as a rigid gatekeeper. The onboarding conversation is the right moment to establish what "ten trained practitioners" means for an agent-workforce org.
+
+---
+
+## Partner Cohort Shape
+
+Published CPN members include a mix that confirms this is not a Big-4-only club:
+
+- **Enterprise SIs:** Accenture, Deloitte, PwC, KPMG, Cognizant
+- **Technology partners:** Microsoft, Snowflake
+- **Boutique/specialist:** Slalom, Tribe AI
+- **Non-traditional:** Turing (AI-staffing model, not a traditional consulting firm)
+
+Tribe AI and Turing are both outside the standard GSI mold. There is documented room for unusual shapes.
+
+---
+
+## Track-by-Track Assessment
+
+**Individual Architect (Claude Certified Architect - Foundations)**
+Assessment: Clean. This is a standard professional certification track. No headcount requirement. Scott sits the exam May 20-22, 2026. No blockers.
+
+**Technology Partner**
+Assessment: Clean. The portfolio - SS, DC, KE, SC, DFG, crane-mcp, crane-context, crane-mcp-remote - represents multiple active Claude-powered products and infrastructure components. No published headcount floor for Technology Partner. VC's engagements inventory (`engagements.md`) is ready.
+
+**Services Partner (smd.services)**
+Assessment: Needs the reframe conversation, not a structural fix. smd.services is delivering Claude-powered operational consulting to small businesses with active AI pipelines (lead qualification, review scoring, permit analysis). The question is how to frame "ten trained practitioners" for an agent-workforce delivery model. The Dario anchor and the solo-agency precedent are the tools for that conversation.
+
+---
+
+## Open Questions
+
+Two items require verification against CPN's internal portal rather than the public announcement:
+
+1. **Karl's exact enrollment criteria** - The public announcement and the onboarding broadcast may surface different requirements. The internal partner portal may show fields or checkboxes not visible on the public page. Status: unknown until Karl's next broadcast.
+
+2. **Internal portal vs. public announcement** - Whether CPN's portal surfaces additional gates (minimum revenue, minimum clients, insurance requirements, etc.) is not confirmed from public sources. Status: unknown.
+
+These are worth asking about directly when Karl's next communication arrives. Neither is a reason to delay pre-work.

--- a/docs/anthropic-partnership/the-ten.md
+++ b/docs/anthropic-partnership/the-ten.md
@@ -1,0 +1,54 @@
+# The Ten | Decision Record
+
+**Date:** 2026-04-21
+**Status:** Decision closed. Not revisiting without the trigger described below.
+
+---
+
+## The Situation
+
+Karl Kadon's April 9 broadcast confirming VC's clearance of initial CPN review included a request to put "ten of your people through training." Venture Crane does not have ten people. It has one operator and an AI agent workforce.
+
+---
+
+## The Decision
+
+We do not manufacture ten.
+
+We do not recruit nine humans to present the appearance of a traditional consulting firm. We do not claim agent roles as "people" to satisfy a headcount gate. We do not perform our way past a template requirement that does not apply to our shape.
+
+---
+
+## Why
+
+Transparent framing is non-negotiable for the VC operating thesis. The entire thesis is that AI agents are the workforce - not a layer on top of human labor, not a tool humans use. Padding a human bench to satisfy a headcount gate would contradict the thesis that makes the partnership worth pursuing in the first place.
+
+"If that is the limiting factor, we find out honestly rather than perform our way past it."
+
+---
+
+## The Reframe
+
+The "ten" requirement is Karl's Databricks GSI template applied reflexively - a model built for firms like Accenture, not a one-operator agent enterprise.
+
+What applies instead:
+
+1. The "ten" language does not appear in Anthropic's published CPN requirements. Published language: "Any organization bringing Claude to market is eligible to join. Membership is free of charge."
+2. A solo agency has already cleared CPN review. The precedent is documented.
+3. Dario Amodei publicly predicted this operating model at Code with Claude (May 2025): 70-80% probability the first one-person billion-dollar company powered by AI agents arrives by 2026. We are the example he named.
+
+The posture with Karl is not "we're an exception" - it is "we're the example Dario described."
+
+---
+
+## If Anthropic Pushes Back
+
+Route around. Technology Partner admits individuals per published language; no headcount gate published. Individual Claude Certified Architect is available to Scott independently. Services Partner conversation continues on our framing.
+
+---
+
+## What Changes This Decision
+
+One thing: an explicit, written Anthropic program requirement that mandates ten humans for Services Partner enrollment.
+
+Not Karl's broadcast. Not template friction. Not a third-party blog post. An actual published gate. Until that exists: closed.

--- a/docs/anthropic-partnership/the-ten.md
+++ b/docs/anthropic-partnership/the-ten.md
@@ -1,7 +1,7 @@
 # The Ten | Decision Record
 
-**Date:** 2026-04-21
-**Status:** Decision closed. Not revisiting without the trigger described below.
+**Date:** 2026-04-21 (original) | 2026-04-22 (updated with form-gate finding)
+**Status:** Decision holds. Partner-support inquiry drafted to determine whether VC's model is accommodated.
 
 ---
 
@@ -15,40 +15,58 @@ Karl Kadon's April 9 broadcast confirming VC's clearance of initial CPN review i
 
 We do not manufacture ten.
 
-We do not recruit nine humans to present the appearance of a traditional consulting firm. We do not claim agent roles as "people" to satisfy a headcount gate. We do not perform our way past a template requirement that does not apply to our shape.
+We do not recruit nine humans to present the appearance of a traditional consulting firm. We do not claim agent roles as "people" to satisfy a headcount gate. We do not perform our way past a gate that does not apply to our shape.
 
 ---
 
 ## Why
 
-Transparent framing is non-negotiable for the VC operating thesis. The entire thesis is that AI agents are the workforce - not a layer on top of human labor, not a tool humans use. Padding a human bench to satisfy a headcount gate would contradict the thesis that makes the partnership worth pursuing in the first place.
+Transparent framing is non-negotiable for the VC operating thesis. The entire thesis is that AI agents are the workforce | not a layer on top of human labor, not a tool humans use. Padding a human bench to satisfy a headcount gate would contradict the thesis that makes the partnership worth pursuing in the first place.
 
 "If that is the limiting factor, we find out honestly rather than perform our way past it."
 
 ---
 
-## The Reframe
+## Update (2026-04-22): The Form Is A Published Gate
 
-The "ten" requirement is Karl's Databricks GSI template applied reflexively - a model built for firms like Accenture, not a one-operator agent enterprise.
+On 2026-04-22 we located the Claude Partner Network Learning Path Complete form. It explicitly requires ten individuals with company-domain emails each completing the four Anthropic Academy courses. Form enforcement language: "if we find fewer than 10 fully completed, we'll return the submission."
 
-What applies instead:
+This is not Karl's template alone. It is a published program gate for Services Partner enrollment specifically. The finding updates our prior framing that "ten" was only internal broadcast language.
 
-1. The "ten" language does not appear in Anthropic's published CPN requirements. Published language: "Any organization bringing Claude to market is eligible to join. Membership is free of charge."
-2. A solo agency has already cleared CPN review. The precedent is documented.
-3. Dario Amodei publicly predicted this operating model at Code with Claude (May 2025): 70-80% probability the first one-person billion-dollar company powered by AI agents arrives by 2026. We are the example he named.
+What this changes about the decision: nothing. We still do not manufacture ten. Transparent framing still holds.
 
-The posture with Karl is not "we're an exception" - it is "we're the example Dario described."
+What this changes about the approach: we now have a specific, documented gate to reference when asking partner-support how the program accommodates operating models that do not fit ten-humans-with-company-domain-emails. The partner-support inquiry is drafted at `outbound/partner-support-initial-question.md` and awaits Captain send.
+
+What this does NOT change:
+
+- **Technology Partner track** has no such published headcount gate. Explicit individual admission per public language.
+- **Individual Architect credential** is available to Scott regardless of any Services Partner outcome.
+- **Solo-agency precedent** is documented. One-person operations have cleared CPN review (track unknown).
 
 ---
 
-## If Anthropic Pushes Back
+## The Reframe
 
-Route around. Technology Partner admits individuals per published language; no headcount gate published. Individual Claude Certified Architect is available to Scott independently. Services Partner conversation continues on our framing.
+The "ten" gate fits a GSI onboarding model | built for firms like Accenture, not a one-operator agent enterprise.
+
+What applies instead:
+
+1. Published CPN announcement language: "Any organization bringing Claude to market is eligible to join. Membership is free of charge." This is the top-of-funnel eligibility; the form gate is a specific Services Partner step within that eligibility.
+2. A solo agency has already cleared CPN review. The precedent is documented (Indie Hackers).
+3. Dario Amodei publicly predicted this operating model at Code with Claude (May 2025): 70-80% probability the first one-person billion-dollar company powered by AI agents arrives by 2026. We are the example he named.
+
+The posture with Karl and partner-support is not "we're an exception" | it is "we're the example Dario described. How does the program accommodate?"
+
+---
+
+## If Anthropic Says Services Partner Is Closed To Our Shape
+
+Route around. Technology Partner admits individuals per published language; no headcount gate published. Individual Claude Certified Architect is available to Scott independently. Services Partner waits until the program accommodates operator + agent workforce shapes.
 
 ---
 
 ## What Changes This Decision
 
-One thing: an explicit, written Anthropic program requirement that mandates ten humans for Services Partner enrollment.
+Only one thing would reverse the "no manufactured ten" posture: Anthropic partner-support telling us directly that filling the form with nine agent identities under venturecrane.com domain accounts is the program's preferred accommodation. Without that explicit written signal, we do not enroll nine agent identities in coursework designed for humans.
 
-Not Karl's broadcast. Not template friction. Not a third-party blog post. An actual published gate. Until that exists: closed.
+Everything else (Karl's broadcast, template friction, third-party blog posts, ambiguous guidance) leaves the decision closed.


### PR DESCRIPTION
## Summary

Scaffolds a mission-critical, multi-week Venture Crane program around the Claude Partner Network (CPN) application and the Foundations exam. All seven documents written this turn by three parallel agents; this PR is the review gate before the program goes live.

- Seven markdown files in `docs/anthropic-partnership/`:
  - `README.md` | program state, three tracks, posture, directory map
  - `qualification.md` | research-based standing assessment; bottom line: not structurally blocked
  - `engagements.md` | accurate Claude-powered work inventory (see inventory note below)
  - `operating-model.md` | partner-facing one-pager; Dario Amodei's Code with Claude quote as anchor
  - `the-ten.md` | internal decision record on why we don't manufacture headcount
  - `curriculum.md` | 30-day study plan, Apr 22 - May 19; exam sit window May 20-22
  - `gap-ledger.md` | living weakness tracker with spaced-recall schedule
- Sibling artifacts (not in this commit): VCMS exec-summary note, tracking issue #645, 22 cadence events covering daily cert-study (Mon-Fri) + weekly Fri checkpoints through exam window
- Memory updated with transparent-framing directive, broadcast-vs-personal-comms rule, and project state including Dario anchor

## Key inventory finding (honest scope)

The Technology Partner product footprint is narrower than the ambient framing suggested. Confirmed Claude-powered at the product layer:

- SS pipelines | review-mining, job-monitor, new-business (Claude Sonnet 4 + Haiku)
- DFG analyst | auction item analysis (Claude Sonnet 4)
- crane-mcp | MCP server powering every agent session
- crane-mcp-remote | Cloudflare Durable Object serving MCP over Streamable HTTP

Claude-built at dev layer but NOT calling the Claude API in product code: DC, KE, SC, crane-watch. smd.services is in prototype / lead-gen phase with no closed clients confirmed. All of this is stated plainly in `engagements.md` and `operating-model.md` rather than papered over.

## Why draft

Positioning content (operating-model.md, the-ten.md) may be shared with Anthropic downstream. Captain reviews before the draft flips to ready.

## Test plan

- [ ] Captain reads `operating-model.md` and confirms partner-facing tone
- [ ] Captain reads `the-ten.md` and confirms internal framing
- [ ] Spot-check `curriculum.md` day-by-day against exam sit window
- [ ] Verify tracking issue #645 phase breakdown
- [ ] `npm run verify` (pre-push hook hit a flaky heartbeat-jitter test; second push attempt passed)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>