### PR TITLE
feat(skills): add /auto-build orchestrator (plan → critique → exec)

### DIFF
--- a/.agents/skills/auto-build/SKILL.md
+++ b/.agents/skills/auto-build/SKILL.md
@@ -4,7 +4,7 @@ description: Captain-invoked rigor pass for an implementation task. Enter plan m
 version: 1.0.0
 scope: global
 owner: captain
-status: draft
+status: stable
 depends_on:
   mcp_tools:
     - crane_skill_invoked

--- a/.agents/skills/auto-build/SKILL.md
+++ b/.agents/skills/auto-build/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: auto-build
+description: Captain-invoked rigor pass for an implementation task. Enter plan mode, build the plan, run /critique to revise, gate on user approval via ExitPlanMode, then execute autonomously under Auto Mode. Captain types `/auto-build [agents]` when they want the full plan-and-vet cycle before going autonomous; harness should not auto-suggest this skill (the trigger is a Captain judgment, not a pattern).
+version: 1.0.0
+scope: global
+owner: captain
+status: draft
+depends_on:
+  mcp_tools:
+    - crane_skill_invoked
+---
+
+# /auto-build - Vetted plan-and-execute workflow
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auto-build")`. Non-blocking — if it fails, log the warning and continue.
+
+This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
+
+The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.
+
+## Arguments
+
+```
+/auto-build [agents]
+```
+
+- `agents` — number of critic agents `/critique` will spawn in Step 4. Default: **1** (Devil's Advocate). Pass through verbatim to `/critique`. The Captain knows the stakes at invocation; do not infer the count from plan content.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. Store as `AGENT_COUNT`.
+
+## Execution
+
+### Step 1: Verify Auto Mode is active (fail-closed)
+
+Scan the current system-reminder context for any of these known signals:
+
+- `Auto Mode Active` — current canonical string
+- `Auto-Accept Mode` — alternate string seen in some harness builds
+- `auto_mode: true` or similar structured field if/when one ships
+
+**If a match is found**, proceed to Step 2 silently.
+
+**If NO match is found**, do NOT assume Auto Mode is off — assume the detection is unreliable. Halt with:
+
+> `/auto-build` couldn't confirm Auto Mode is active. The skill needs autonomous execution after plan approval; without it, you'll be prompted on every tool call.
+>
+> Either: toggle Auto Mode on (Shift+Tab cycles modes) and re-run, OR reply `yes auto` to override and proceed anyway.
+
+Wait for the Captain's response. Only proceed to Step 2 if they re-invoke after toggling, or reply with the literal `yes auto` override.
+
+**Known fragility:** This is string-matching against harness output and will break if the harness changes its signal. Replace this step with a programmatic mode signal (env var, dedicated tool, structured field) when one ships. Until then, the synonym set + override is the best available.
+
+### Step 2: Enter plan mode
+
+Call `EnterPlanMode`. The harness requests Captain approval and provides a plan file path on entry. If the Captain rejects entry, the skill ends.
+
+### Step 3: Build the plan
+
+Follow the plan-mode discipline already documented in the system prompt:
+
+- **Phase 1 (Initial Understanding):** launch up to 3 Explore subagents in parallel to map the affected code. Use the minimum number needed (often 1).
+- **Phase 2 (Design):** launch up to 3 Plan subagents to design the approach.
+- **Phase 3 (Review):** read critical files identified by the agents; resolve any open questions with `AskUserQuestion`.
+- **Phase 4 (Final Plan):** write the plan to the plan file. Include Context, recommended approach (only the chosen one), critical file paths, reused functions/utilities, and a Verification section.
+
+Do not call `ExitPlanMode` yet. Step 5 owns the exit.
+
+### Step 4: Invoke `/critique`
+
+Call the `/critique` skill via the Skill tool, passing `AGENT_COUNT`:
+
+```
+/auto-build           → /critique 1   (default Devil's Advocate)
+/auto-build 3         → /critique 3   (Devil's Advocate + Simplifier + Pragmatist)
+/auto-build 6         → /critique 6   (full panel)
+```
+
+`/critique` reads the conversation, spawns critics in parallel, and returns a revised plan with `### Changes Made` and `### Critiques Acknowledged but Not Adopted` sections.
+
+**Apply the revised plan to the plan file.** Editing the plan file is allowed under plan-mode rules (it is the only writable file). The plan file is the source of truth the Captain will see at the approval gate, so it must reflect the post-critique state.
+
+If `/critique` reports "no plan identifiable," something went wrong in Step 3. Re-enter Step 3 — do not attempt to exit plan mode with an unwritten plan.
+
+### Step 5: Gate on Captain approval
+
+Call `ExitPlanMode`. The harness presents the revised plan to the Captain.
+
+- **Approved** → proceed to Step 6.
+- **Rejected** → the skill ends. The Captain re-runs `/auto-build` (or any other command) to start a fresh flow.
+
+We do not model a revise loop. ExitPlanMode rejection delivers Captain feedback as a new user turn, at which point the Captain's next message supersedes the in-progress skill — there is no reliable contract that `/auto-build` regains control with prior context intact. Re-running is cheap; pretending the loop works is dishonest.
+
+### Step 6: Execute autonomously
+
+Implement per the approved plan. Auto Mode is active (verified in Step 1), so:
+
+- No confirmation prompts on routine tool calls.
+- File edits, test runs, commits proceed without per-action approval.
+- **Destructive actions still require explicit confirmation.** Per CLAUDE.md and the Auto Mode reminder: production systems, data deletion, force-push, secret rotation, account creation, dropping schema, modifying auth, removing access controls. Auto Mode is not a license to destroy.
+- If the plan touches code in this repo, end with `npm run verify`.
+- Then commit, push, and open a PR per `pr-workflow.md`.
+
+End-of-session summary: one or two sentences (per `/own-it` rule 5).
+
+## Anti-patterns
+
+The skill must explicitly forbid these. The Captain has flagged each one in feedback memory; do not regress:
+
+1. **No deferral revisions.** When `/critique` raises an issue, fix it in the plan — do not file a follow-up ticket and call the plan done. (Per `feedback_critique_deferrals.md`, `feedback_kill_dont_file.md`.)
+2. **No "I'll figure it out during execution."** If a step is unclear after critique, revise the plan in Step 4; do not punt to runtime.
+3. **No degradation to ask-mode in Step 6.** Routine questions are yours to decide (per `/own-it` rule 1). Only stop for guardrails-gated actions (`crane_doc('global', 'guardrails.md')`).
+4. **No theater.** Plan is one scrollable screen. End-of-session summary is two sentences. No ceremonial status updates mid-step.
+
+## Notes
+
+- **Composability:** `/auto-build` ends at "PR opened, CI green, ready to merge." It does not invoke `/ship`. If the Captain wants ship-too, they invoke `/ship` after.
+- **Critique depth:** Single round per `/critique`'s own design. The Captain can re-invoke `/critique` manually if they want another round before approval.
+- **Trigger ownership:** Captain-invoked, not harness-suggested. The description field reflects this. Do not lower the bar by self-suggesting `/auto-build` in conversational responses; let the Captain decide.

--- a/.claude/commands/auto-build.md
+++ b/.claude/commands/auto-build.md
@@ -1,0 +1,104 @@
+# /auto-build - Vetted plan-and-execute workflow
+
+This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
+
+The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.
+
+## Arguments
+
+```
+/auto-build [agents]
+```
+
+- `agents` — number of critic agents `/critique` will spawn in Step 4. Default: **1** (Devil's Advocate). Pass through verbatim to `/critique`. The Captain knows the stakes at invocation; do not infer the count from plan content.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. Store as `AGENT_COUNT`.
+
+## Execution
+
+### Step 1: Verify Auto Mode is active (fail-closed)
+
+Scan the current system-reminder context for any of these known signals:
+
+- `Auto Mode Active` — current canonical string
+- `Auto-Accept Mode` — alternate string seen in some harness builds
+- `auto_mode: true` or similar structured field if/when one ships
+
+**If a match is found**, proceed to Step 2 silently.
+
+**If NO match is found**, do NOT assume Auto Mode is off — assume the detection is unreliable. Halt with:
+
+> `/auto-build` couldn't confirm Auto Mode is active. The skill needs autonomous execution after plan approval; without it, you'll be prompted on every tool call.
+>
+> Either: toggle Auto Mode on (Shift+Tab cycles modes) and re-run, OR reply `yes auto` to override and proceed anyway.
+
+Wait for the Captain's response. Only proceed to Step 2 if they re-invoke after toggling, or reply with the literal `yes auto` override.
+
+**Known fragility:** This is string-matching against harness output and will break if the harness changes its signal. Replace this step with a programmatic mode signal (env var, dedicated tool, structured field) when one ships. Until then, the synonym set + override is the best available.
+
+### Step 2: Enter plan mode
+
+Call `EnterPlanMode`. The harness requests Captain approval and provides a plan file path on entry. If the Captain rejects entry, the skill ends.
+
+### Step 3: Build the plan
+
+Follow the plan-mode discipline already documented in the system prompt:
+
+- **Phase 1 (Initial Understanding):** launch up to 3 Explore subagents in parallel to map the affected code. Use the minimum number needed (often 1).
+- **Phase 2 (Design):** launch up to 3 Plan subagents to design the approach.
+- **Phase 3 (Review):** read critical files identified by the agents; resolve any open questions with `AskUserQuestion`.
+- **Phase 4 (Final Plan):** write the plan to the plan file. Include Context, recommended approach (only the chosen one), critical file paths, reused functions/utilities, and a Verification section.
+
+Do not call `ExitPlanMode` yet. Step 5 owns the exit.
+
+### Step 4: Invoke `/critique`
+
+Call the `/critique` skill via the Skill tool, passing `AGENT_COUNT`:
+
+```
+/auto-build           → /critique 1   (default Devil's Advocate)
+/auto-build 3         → /critique 3   (Devil's Advocate + Simplifier + Pragmatist)
+/auto-build 6         → /critique 6   (full panel)
+```
+
+`/critique` reads the conversation, spawns critics in parallel, and returns a revised plan with `### Changes Made` and `### Critiques Acknowledged but Not Adopted` sections.
+
+**Apply the revised plan to the plan file.** Editing the plan file is allowed under plan-mode rules (it is the only writable file). The plan file is the source of truth the Captain will see at the approval gate, so it must reflect the post-critique state.
+
+If `/critique` reports "no plan identifiable," something went wrong in Step 3. Re-enter Step 3 — do not attempt to exit plan mode with an unwritten plan.
+
+### Step 5: Gate on Captain approval
+
+Call `ExitPlanMode`. The harness presents the revised plan to the Captain.
+
+- **Approved** → proceed to Step 6.
+- **Rejected** → the skill ends. The Captain re-runs `/auto-build` (or any other command) to start a fresh flow.
+
+We do not model a revise loop. ExitPlanMode rejection delivers Captain feedback as a new user turn, at which point the Captain's next message supersedes the in-progress skill — there is no reliable contract that `/auto-build` regains control with prior context intact. Re-running is cheap; pretending the loop works is dishonest.
+
+### Step 6: Execute autonomously
+
+Implement per the approved plan. Auto Mode is active (verified in Step 1), so:
+
+- No confirmation prompts on routine tool calls.
+- File edits, test runs, commits proceed without per-action approval.
+- **Destructive actions still require explicit confirmation.** Per CLAUDE.md and the Auto Mode reminder: production systems, data deletion, force-push, secret rotation, account creation, dropping schema, modifying auth, removing access controls. Auto Mode is not a license to destroy.
+- If the plan touches code in this repo, end with `npm run verify`.
+- Then commit, push, and open a PR per `pr-workflow.md`.
+
+End-of-session summary: one or two sentences (per `/own-it` rule 5).
+
+## Anti-patterns
+
+The skill must explicitly forbid these. The Captain has flagged each one in feedback memory; do not regress:
+
+1. **No deferral revisions.** When `/critique` raises an issue, fix it in the plan — do not file a follow-up ticket and call the plan done. (Per `feedback_critique_deferrals.md`, `feedback_kill_dont_file.md`.)
+2. **No "I'll figure it out during execution."** If a step is unclear after critique, revise the plan in Step 4; do not punt to runtime.
+3. **No degradation to ask-mode in Step 6.** Routine questions are yours to decide (per `/own-it` rule 1). Only stop for guardrails-gated actions (`crane_doc('global', 'guardrails.md')`).
+4. **No theater.** Plan is one scrollable screen. End-of-session summary is two sentences. No ceremonial status updates mid-step.
+
+## Notes
+
+- **Composability:** `/auto-build` ends at "PR opened, CI green, ready to merge." It does not invoke `/ship`. If the Captain wants ship-too, they invoke `/ship` after.
+- **Critique depth:** Single round per `/critique`'s own design. The Captain can re-invoke `/critique` manually if they want another round before approval.
+- **Trigger ownership:** Captain-invoked, not harness-suggested. The description field reflects this. Do not lower the bar by self-suggesting `/auto-build` in conversational responses; let the Captain decide.

--- a/config/global-skills.json
+++ b/config/global-skills.json
@@ -1,1 +1,1 @@
-["nav-spec", "own-it", "product-design"]
+["auto-build", "nav-spec", "own-it", "product-design"]

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -15,7 +15,8 @@
     "skill-review",
     "skill-audit",
     "skill-creator",
-    "own-it"
+    "own-it",
+    "auto-build"
   ],
   "agent-team": [
     "build-log",


### PR DESCRIPTION
## Summary

- New skill `/auto-build` codifies the manual rigor pass the Captain runs by hand for non-trivial implementation work: enter plan mode → build the plan → run `/critique` → ExitPlanMode approval gate → execute autonomously under Auto Mode.
- Thin orchestrator over existing primitives. Reuses `/critique` verbatim, harness-provided plan mode, and harness-provided Auto Mode (detect-only; the skill does not toggle modes). No reinvention.
- Single-shot. No internal revise loop — empirically `ExitPlanMode` rejection delivers the Captain's feedback as a new user turn that supersedes the in-progress skill, so a loop would be fiction. Re-running is cheap; pretending otherwise is dishonest.
- Captain-invoked, not harness-suggested. Description field reflects this so the harness doesn't lower the bar by auto-suggesting it.
- Auto Mode detection is fail-closed with a `yes auto` override path. Documented as a known fragility (string-matches harness internals) — replace with a programmatic mode signal when one ships.

## Lifecycle

Ships as `status: stable`. Originally planned as draft-then-follow-up-flip, but Gate B passed before merge — Captain confirmed first real-world non-trivial invocation worked end-to-end. The draft window existed to guard against "linter passed → marked stable → first use is the first real test"; with that risk closed, the flip is folded into this PR rather than performed via separate ceremony.

## Files

| Path | Change |
|---|---|
| `.agents/skills/auto-build/SKILL.md` | New skill body with frontmatter + invocation directive + 6-step body |
| `.claude/commands/auto-build.md` | New slash-command dispatcher (mirrors SKILL.md body, no frontmatter) |
| `config/skill-owners.json` | `auto-build` added to `captain` array |
| `config/global-skills.json` | `auto-build` added so launcher syncs to `~/.agents/skills/` |

## Plan + critique trail

Designed via the workflow it codifies: plan mode → wrote the plan → user invoked `/critique` (1 agent, Devil's Advocate) → 6 issues raised, all 6 adopted (5 in full, 1 trimmed to local fail-closed instead of filing a harness ticket per `feedback_kill_dont_file.md`) → ExitPlanMode approved → implementation. Plan file: `~/.claude/plans/full-permission-means-auto-tidy-aho.md` (local).

## Test plan

Gate A:

- [x] `npm run skill-review -- --path .agents/skills/auto-build` → 0 violations
- [x] `npm run skill-review -- --all` → no new violations from this skill
- [x] `npm run verify` → green
- [x] `auto-build` listed in `config/skill-owners.json` under `captain`
- [x] `auto-build` listed in `config/global-skills.json`
- [ ] CI green on this PR

Gate B:

- [x] Captain confirmed first real-world non-trivial invocation passed (2026-04-23)
- [x] `status: draft` → `status: stable` (commit `1a87212`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)