### PR TITLE
feat(skills): add Claude attribution checks to /edit-article and /edit-log

### DIFF
--- a/.agents/skills/edit-article/SKILL.md
+++ b/.agents/skills/edit-article/SKILL.md
@@ -114,6 +114,10 @@ Read the article line by line. Check every line against the rules below. Report 
 
 **Founder-voice fabrication** - any sentence that puts words in the founder's mouth or manufactures a personal anecdote
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (should fix)
 
 - Public venture names per the tag-dependent rules above (suggest genericizing for focus where no matching tag exists)
@@ -122,6 +126,7 @@ Read the article line by line. Check every line against the rules below. Report 
 - Throat-clearing openers ("In this article, we will...", "Today we're going to...")
 - Marketing language (superlatives, hype, "revolutionary", "game-changing", etc.)
 - Register mismatch (article should be analytical/explanatory, not terse build-log voice)
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the article's title or H1 describe a Claude Code capability, workflow, or session? (2) Does the article already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### Output Format
 

--- a/.agents/skills/edit-log/SKILL.md
+++ b/.agents/skills/edit-log/SKILL.md
@@ -118,6 +118,10 @@ For each blocking issue, provide:
 - venturecrane org -> Omit or "example-org"
 - Specific counts -> "multiple ventures" or "several projects"
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (report but don't auto-fix)
 
 - Public venture names per the tag-dependent rules above (not auto-fixed; suggest genericizing for focus)
@@ -125,6 +129,7 @@ For each blocking issue, provide:
 - Article-register voice: flag analytical or explanatory tone that reads like an article rather than an operational log. Build logs should feel like a field report, not an essay.
 - Numbers that might go stale: specific counts, percentages, or metrics that will become wrong over time
 - Article overlap: search the article index for keyword overlap with the log's content. If found, surface: "This log discusses [topic]. An article on this topic exists at [slug]. Verify consistency."
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the log's title describe a Claude Code capability, workflow, or session? (2) Does the log already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### NOT checked (explicitly out of scope)
 


### PR DESCRIPTION
## Summary

Companion to venturecrane/vc-web#95 which adds the `Claude Attribution` section to `docs/content/terminology.md`. Both editorial skills already read that file as source of truth; this PR teaches them to act on the new section.

Three new checks added to each skill:

### BLOCKING (both skills)

- **Partnership-relationship form.** Canonical-form match against the positive whitelist in terminology.md Section 1. "in the Claude Partner Network" / "pursuing Partner Network status" / "applied to the Claude Partner Network" pass; anything else flagged with a rewrite proposal. No auto-fix; rewrites need human judgment on surrounding context.
- **Tool attribution conflation.** Lexicon match (terminology.md Section 2) plus venture-to-integration mapping (Section 3). Catches "Claude Code" naming an HTTP API call, "Claude" naming a specific SS or DFG pipeline, MCP used as if it were an agent. Auto-fix only when the mapping yields an unambiguous target.

### ADVISORY (both skills)

- **Generic AI-agent language.** Two-question retrofit heuristic from terminology.md Section 4. Mechanical checklist, not judgment call. If the title describes Claude Code work OR the content already names Claude Code, flag the generic reference as advisory. Otherwise suppress (retrofit exception). Never auto-fixed.

## Graceful Degradation

Skills read `terminology.md` at pre-flight. If this PR merges before vc-web#95 (and the terminology.md update), the editor agents will find rule references pointing to sections that don't exist. Result: the agents treat missing sections as "no applicable rule" and existing checks continue to work unchanged. The two PRs can merge in either order.

## Verification (once both PRs merge)

Three deterministic smoke tests:

1. `/edit-article ~/dev/vc-web/docs/test-fixtures/edit-skill-claude-attribution-fixture.md` | expect exactly **3 findings**: 2 BLOCKING (overclaim + conflation) + 1 ADVISORY (generic AI-agent, retrofit exception does not apply).
2. `/edit-article` on `src/content/articles/where-we-stand-agent-operations-2026.md` (audit-marked already-good) | expect **zero** findings from the new checks.
3. `/edit-log` on `src/content/logs/2026-04-17-stitch-retirement.md` (authored earlier today, Claude Code named correctly throughout) | expect **zero** findings from the new checks.

The fixture is committed in the vc-web PR, so all three tests are reproducible without any run-time fixture creation.

## Out of scope

- Pre-existing em dashes in the skill files (1 in each) were left as-is. Those are unrelated to this change; fixing them belongs in a separate voice-rule cleanup.
- No change to the two-agent vs one-agent architecture of the skills.
- No change to fact-checker (Agent 2 in `/edit-article`); the new checks are style/compliance concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>