### PR TITLE
feat(claude-design): enterprise instruction module + setup runbook

### DIFF
--- a/.agents/skills/new-venture/SKILL.md
+++ b/.agents/skills/new-venture/SKILL.md
@@ -81,6 +81,7 @@ After the script completes, walk through remaining manual steps from the checkli
 4. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
 5. **Monitoring** (Phase 4.6) - Sentry, uptime checks
 6. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
+7. **Claude Design onboarding** (Phase 3.8) - create a named design system in claude.ai/design, link the recommended subdirectory, seed with the venture's `design-spec.md`. Full steps in `docs/runbooks/claude-design-enterprise-setup.md`; context in `docs/instructions/claude-design.md`.
 
 ### Step 5: Update CLAUDE.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,20 +54,21 @@ Injected by `crane` launcher: `CRANE_ENV`, `CRANE_VENTURE_CODE`, `CRANE_VENTURE_
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module                    | Key Rule (always applies)                                                                                                       | Fetch for details                                          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `operating-ethos.md`      | Mission first. Execute. Ask if unclear, otherwise move out. No corporate theater.                                               | Captain's standing order, ethos vs. guardrails distinction |
-| `secrets.md`              | Verify secret VALUES, not just key existence                                                                                    | Infisical, vault, API keys, GitHub App                     |
-| `content-policy.md`       | Never auto-save to VCMS; agents ARE the voice                                                                                   | VCMS tags, storage rules, editorial, style                 |
-| `team-workflow.md`        | All changes through PRs; never push to main                                                                                     | Full workflow, QA grades, escalation triggers              |
-| `fleet-ops.md`            | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh                                                    | SSH, machines, Tailscale, macOS                            |
-| `creating-issues.md`      | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                                                                   | Templates, labels, target repos                            |
-| `pr-workflow.md`          | Push branch, `gh pr create`, assign QA grade - never skip the PR                                                                | Branch naming, commit format, PR template, post-merge QA   |
-| `guardrails.md`           | Never deprecate features, drop schema, or change auth without Captain directive                                                 | Protected actions, escalation format, feature manifests    |
-| `wireframe-guidelines.md` | Wireframe committed and linked before status:ready (UI stories)                                                                 | Wireframe generation, file conventions, quality bar        |
-| `design-system.md`        | Load design spec before wireframe/UI work: `crane_doc('{code}', 'design-spec.md')`                                              | Design tokens, component patterns, venture specs           |
-| `tooling.md`              | Reach for the right plugin at the right moment; Context7 before third-party APIs, Semgrep before ship on auth/webhook changes   | Plugin catalog, triggers, anti-patterns, fleet parity      |
-| `skills/governance.md`    | Every SKILL.md has full frontmatter (name, description, version, scope, owner, status); new/changed skills pass `/skill-review` | Schema, scopes, lifecycle, review gate, audit, deprecation |
+| Module                    | Key Rule (always applies)                                                                                                       | Fetch for details                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `operating-ethos.md`      | Mission first. Execute. Ask if unclear, otherwise move out. No corporate theater.                                               | Captain's standing order, ethos vs. guardrails distinction         |
+| `secrets.md`              | Verify secret VALUES, not just key existence                                                                                    | Infisical, vault, API keys, GitHub App                             |
+| `content-policy.md`       | Never auto-save to VCMS; agents ARE the voice                                                                                   | VCMS tags, storage rules, editorial, style                         |
+| `team-workflow.md`        | All changes through PRs; never push to main                                                                                     | Full workflow, QA grades, escalation triggers                      |
+| `fleet-ops.md`            | Bootstrap phases IN ORDER: Tailscale -> CLI -> bootstrap -> optimize -> mesh                                                    | SSH, machines, Tailscale, macOS                                    |
+| `creating-issues.md`      | Backlog = GitHub Issues (`gh issue create`), never VCMS notes                                                                   | Templates, labels, target repos                                    |
+| `pr-workflow.md`          | Push branch, `gh pr create`, assign QA grade - never skip the PR                                                                | Branch naming, commit format, PR template, post-merge QA           |
+| `guardrails.md`           | Never deprecate features, drop schema, or change auth without Captain directive                                                 | Protected actions, escalation format, feature manifests            |
+| `wireframe-guidelines.md` | Wireframe committed and linked before status:ready (UI stories)                                                                 | Wireframe generation, file conventions, quality bar                |
+| `design-system.md`        | Load design spec before wireframe/UI work: `crane_doc('{code}', 'design-spec.md')`                                              | Design tokens, component patterns, venture specs                   |
+| `claude-design.md`        | claude.ai/design is org-scoped and default-off for Enterprise; no API/MCP yet; link subdirectories, not monorepos               | Per-venture link paths, handoff-to-Claude-Code flow, setup runbook |
+| `tooling.md`              | Reach for the right plugin at the right moment; Context7 before third-party APIs, Semgrep before ship on auth/webhook changes   | Plugin catalog, triggers, anti-patterns, fleet parity              |
+| `skills/governance.md`    | Every SKILL.md has full frontmatter (name, description, version, scope, owner, status); new/changed skills pass `/skill-review` | Schema, scopes, lifecycle, review gate, audit, deprecation         |
 
 Fetch with: `crane_doc('global', '<module>')` (or read local `docs/skills/governance.md` directly for the skill governance module)
 

--- a/docs/instructions/claude-design.md
+++ b/docs/instructions/claude-design.md
@@ -1,0 +1,79 @@
+# Claude Design
+
+Enterprise instructions for using [Claude Design](https://claude.ai/design) across the Venture Crane portfolio.
+
+## What It Is
+
+Claude Design is an Anthropic Labs product (launched 2026-04-17, powered by Claude Opus 4.7) that lets you collaborate with Claude to produce polished visual work — designs, interactive prototypes, slides, one-pagers — from a chat + canvas UI. It is included with Pro, Max, Team, and Enterprise plans and uses subscription limits.
+
+**Verified facts** (from [Anthropic's announcement](https://www.anthropic.com/news/claude-design-anthropic-labs) and [Get started](https://support.claude.com/en/articles/14604416-get-started-with-claude-design)):
+
+- Claude Design is **default OFF for Enterprise plans** — a workspace admin must enable it.
+- Design systems are **organization-scoped**. A workspace can maintain **more than one** design system; every new project inherits the system selected at creation.
+- Onboarding ingests a linked code repository plus uploaded design files. **Link a specific subdirectory, not a full monorepo** — linking large repos causes lag and browser issues (official guidance).
+- Handoff path: "Send to local coding agent" (Claude Code on your box) or "Send to Claude Code Web." Claude Design packages the work into a bundle and Claude Code completes the build from a single instruction.
+- **No public API or MCP server yet.** Anthropic says integrations are "coming weeks." Do not plan automation that depends on a Claude Design API that does not exist.
+
+## When To Use Claude Design (vs. Our Existing Tools)
+
+| Situation                                                        | Tool                                                            |
+| ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| Brand-new venture, no design system yet                          | `/design-brief` → produce `design-spec.md` first                |
+| Generating production-aligned screens for an established venture | **Claude Design** (picks up the onboarded system automatically) |
+| Token refresh or spec-only changes                               | Edit `docs/ventures/{code}/design-spec.md` directly             |
+| Implementing a design into code                                  | `/product-design` → `/react-components` → PR                    |
+| Sharing a static mockup in-browser quickly                       | **Claude Design** (export to PPTX/PDF/Canva)                    |
+
+Claude Design **supplements** `/design-brief` and `/product-design`; it does not replace them. The charter and spec remain the source of truth for tokens.
+
+## Portfolio Setup Model
+
+The rollout has three layers. Layers 1 and 2 are performed by the Captain in the browser at [claude.ai/design](https://claude.ai/design); Layer 3 is what this module and the `/new-venture` skill give you.
+
+1. **Workspace enablement** (one-time) — admin toggles Claude Design ON for the Anthropic workspace.
+2. **Per-venture design system** (once per venture) — create a named system, link the recommended subdirectory, upload the venture's `design-spec.md` to seed identity.
+3. **Instruction + scaffold** (this module) — agents know Claude Design exists, when to recommend it, and what the handoff flow looks like; the `/new-venture` skill includes Claude Design onboarding as a standard step.
+
+Full step-by-step: `docs/runbooks/claude-design-enterprise-setup.md`.
+
+## Per-Venture Link Paths
+
+When linking a venture's code to its Claude Design system, point at the **smallest subdirectory** that contains the design tokens (`globals.css` or equivalent) and the component library. Avoid linking the repo root.
+
+| Venture            | Code  | Repo                           | Recommended link path               | `globals.css`             |
+| ------------------ | ----- | ------------------------------ | ----------------------------------- | ------------------------- |
+| Venture Crane      | `vc`  | `venturecrane/vc-web`          | `src/components/`                   | confirm on vc-web clone   |
+| Kid Expenses       | `ke`  | `kidexpenses/ke-console`       | `app/src/components/`               | `app/src/app/globals.css` |
+| Draft Crane        | `dc`  | `draftcrane/dc-console`        | `web/src/components/`               | `web/src/app/globals.css` |
+| Silicon Crane      | `sc`  | `siliconcrane/sc-console`      | select the active app under `apps/` | confirm at link time      |
+| Durgan Field Guide | `dfg` | `durganfieldguide/dfg-console` | `apps/dfg-app/src/components/`      | confirm at link time      |
+| SMD Services       | `ss`  | `smdservices/ss-console`       | `src/components/`                   | confirm at link time      |
+| SMD Ventures       | `smd` | pending install                | TBD after install                   | TBD                       |
+
+If you add a venture, add its row here and in the runbook in the same PR that adds it to `config/ventures.json`.
+
+## Handoff to Claude Code
+
+When a design is ready to build:
+
+1. In Claude Design, open the design and choose **Send to local coding agent** (Claude Code on your box) or **Send to Claude Code Web**.
+2. Claude Design bundles the design artifacts and passes a single instruction to Claude Code.
+3. In the Claude Code session, verify the venture context (`/sos` if not active) and confirm the target branch before Claude Code begins implementation.
+4. All resulting work goes through the normal PR flow. Do not bypass `/ship`, pre-push verify, or the PR Completion Rule.
+
+## What Agents Must NOT Assume
+
+- **No CLI.** There is no `claude design` CLI command to script against. Do not invent one.
+- **No MCP server.** Do not add a Claude Design MCP server to `.mcp.json` or claim one exists.
+- **No per-repo install.** Claude Design is not a plugin you install in a venture's repo — the linkage lives in the Anthropic workspace.
+- **No silent design-spec drift.** If Claude Design produces tokens that diverge from `design-spec.md`, update the spec (and the PR referencing it) — do not let the canvas and the spec disagree.
+
+If a user asks you to "integrate Claude Design," first read this module and the runbook. If the ask exceeds what the current product supports (e.g., programmatic design generation), say so plainly and route to `/product-design` for the automatable path.
+
+## References
+
+- Anthropic announcement: https://www.anthropic.com/news/claude-design-anthropic-labs
+- Get started: https://support.claude.com/en/articles/14604416-get-started-with-claude-design
+- Runbook: `docs/runbooks/claude-design-enterprise-setup.md`
+- Design-system module: `docs/instructions/design-system.md`
+- Skill: `.agents/skills/new-venture/SKILL.md`

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -95,6 +95,8 @@ When adding new tokens during implementation:
 
 Design generation now via `/product-design` — see that skill for the workflow.
 
+For interactive design work in the browser (chat + canvas), use [Claude Design](https://claude.ai/design). Each onboarded venture has its own named design system there, seeded from this spec. See `docs/instructions/claude-design.md` for when to reach for Claude Design vs. `/product-design`/`/design-brief`, and `docs/runbooks/claude-design-enterprise-setup.md` for the per-venture setup procedure.
+
 ### File Placement Rules
 
 | File              | Location                | Repo                      |

--- a/docs/process/new-venture-setup-checklist.md
+++ b/docs/process/new-venture-setup-checklist.md
@@ -36,6 +36,7 @@ Most of this checklist can be automated using `scripts/setup-new-venture.sh`.
 | Get installation ID             | From post-install URL                                        |
 | Seed venture documentation      | Content is venture-specific                                  |
 | Define venture design system    | Creative decisions, needs context                            |
+| Claude Design onboarding        | Browser UI at claude.ai/design; no API/MCP yet               |
 | PWA setup                       | Framework-specific, needs branding                           |
 
 ### Quick Start (After Manual Prerequisites)
@@ -348,6 +349,33 @@ For a full design definition, run `/design-brief`.
 ```
 
 - [ ] Design spec uploaded to crane-context (`crane_doc('{code}', 'design-spec.md')` returns content)
+
+---
+
+## Phase 3.8: Claude Design Onboarding
+
+Create a named design system for the venture in [claude.ai/design](https://claude.ai/design) so the Captain (and collaborators) can generate on-brand designs without rebuilding identity context each session. Claude Design is organization-scoped — workspace admin must have already enabled it per Phase 1 of `docs/runbooks/claude-design-enterprise-setup.md`.
+
+### 3.8.1 Create the Design System
+
+1. Open https://claude.ai/design and enter the Design System setup flow.
+2. Name it `{Venture Display Name} — {code}` (e.g., `Kid Expenses — ke`).
+3. Link the **smallest subdirectory** that contains the venture's tokens + component library (not the whole repo — official guidance warns against linking monorepos).
+
+- [ ] Design system created with canonical name
+- [ ] Subdirectory linked (recorded in `docs/instructions/claude-design.md` table)
+
+### 3.8.2 Seed With `design-spec.md`
+
+- [ ] `design-spec.md` uploaded to the Claude Design system as a reference document
+- [ ] Any venture brand PDF (logo guide, identity doc) uploaded
+
+### 3.8.3 Verify
+
+- [ ] Token view matches `--{code}-*` tokens in the spec (chrome, surface, text, border, accent)
+- [ ] Smoke test: generate one card using venture tokens and confirm it reads as the venture
+
+Full procedure + rollback steps: `docs/runbooks/claude-design-enterprise-setup.md`.
 
 ---
 

--- a/docs/runbooks/claude-design-enterprise-setup.md
+++ b/docs/runbooks/claude-design-enterprise-setup.md
@@ -1,0 +1,106 @@
+# Runbook: Claude Design Enterprise Setup
+
+Captain-executed runbook for enabling [Claude Design](https://claude.ai/design) across the Venture Crane portfolio. Sourced from the official [Get started](https://support.claude.com/en/articles/14604416-get-started-with-claude-design) guide and Anthropic's [launch announcement](https://www.anthropic.com/news/claude-design-anthropic-labs).
+
+> **Context for agents:** This runbook describes browser/admin work the Captain performs. Do not attempt to automate it — there is no public API or MCP server for Claude Design as of this writing. Background: `docs/instructions/claude-design.md`.
+
+## Prerequisites
+
+- Anthropic workspace on a Pro, Max, Team, or Enterprise plan.
+- Workspace admin access (required for Enterprise plans — Claude Design is default off).
+- Each venture's `design-spec.md` uploaded to crane-context (`crane_doc('{code}', 'design-spec.md')` returns content).
+- The venture's repo cloned locally (for confirming the link subdirectory before linking).
+
+## Phase 1 — Workspace Enablement (one-time)
+
+1. Sign in to [claude.ai](https://claude.ai) as a workspace admin.
+2. Open the workspace admin panel → **Labs / Claude Design**.
+3. Toggle **Claude Design** to **ON** for the workspace.
+4. Verify: as a non-admin member, load `claude.ai/design` and confirm the product renders the chat + canvas UI.
+
+Record the date of enablement in the portfolio note (Captain's call) so future audits know when the clock starts on usage limits.
+
+## Phase 2 — Per-Venture Design System
+
+Run this phase once per venture. Repeat for every currently-active venture (`vc`, `ke`, `dc`, `sc`, `dfg`, `ss`, and `smd` post-install) and for every future venture as part of `/new-venture`.
+
+### 2.1 Create the Design System
+
+1. Open [claude.ai/design](https://claude.ai/design).
+2. Enter the **Design System** setup flow.
+3. Name the system exactly `{Venture Display Name} — {code}` (e.g., `Kid Expenses — ke`). Consistent naming lets agents reference systems unambiguously.
+4. Select the venture's active repo and **link the subdirectory from the table below**, not the repo root. Linking whole monorepos causes lag (official guidance).
+
+| Venture            | Code  | Repo                           | Link path                      |
+| ------------------ | ----- | ------------------------------ | ------------------------------ |
+| Venture Crane      | `vc`  | `venturecrane/vc-web`          | `src/components/`              |
+| Kid Expenses       | `ke`  | `kidexpenses/ke-console`       | `app/src/components/`          |
+| Draft Crane        | `dc`  | `draftcrane/dc-console`        | `web/src/components/`          |
+| Silicon Crane      | `sc`  | `siliconcrane/sc-console`      | active app under `apps/`       |
+| Durgan Field Guide | `dfg` | `durganfieldguide/dfg-console` | `apps/dfg-app/src/components/` |
+| SMD Services       | `ss`  | `smdservices/ss-console`       | `src/components/`              |
+| SMD Ventures       | `smd` | pending install                | fill in after install          |
+
+If Claude Design offers multiple directory granularities, always pick the tightest subdirectory that still contains the tokens file (`globals.css` or equivalent) and the primary component library.
+
+### 2.2 Seed With `design-spec.md`
+
+Claude Design reads uploaded design files during onboarding. Seed the system with the venture's spec so brand/identity is correct from project one.
+
+1. Locally render the venture's spec:
+   ```bash
+   crane_doc('{code}', 'design-spec.md')
+   ```
+2. Export the spec to a file (save as `{code}-design-spec.md`).
+3. In the Claude Design onboarding flow, upload that file when prompted for existing design work. Also upload any brand PDFs (logo guide, visual identity doc) the venture maintains.
+
+### 2.3 Verify the Generated System
+
+After Claude Design finishes ingesting:
+
+1. Open the system's token view and confirm:
+   - Colors match the `--{code}-*` tokens in the spec (chrome, surface, text, border, accent).
+   - Typography matches the spec's font stacks.
+   - Component examples look like the venture's actual components.
+2. If tokens diverge, edit the system in Claude Design to match the spec. Do **not** "adopt" drifted tokens — the spec is the source of truth.
+3. Create one test project ("Smoke test") inside the system, ask Claude to generate a simple card using the venture's tokens, and confirm the rendered output reads as the venture (not a generic AI look).
+
+### 2.4 Document Linkage
+
+Add a row to the per-venture table in `docs/instructions/claude-design.md` with the confirmed link path. If you created a fallback path (e.g., sc/dfg whose active app changed), update both this runbook and the instruction module in the same PR.
+
+## Phase 3 — Handoff Workflow (per design)
+
+Whenever a design is ready to implement:
+
+1. In Claude Design, open the design and click **Send to local coding agent** (Claude Code on your box) or **Send to Claude Code Web**.
+2. Claude Design passes a bundle + a single instruction to Claude Code.
+3. In the receiving Claude Code session, confirm venture context (`/sos` if not active), confirm the branch is not `main`, and let Claude Code implement.
+4. Ship via normal PR flow — never bypass `/ship`, pre-push verify, or the PR Completion Rule.
+
+## Audit / Health Checks
+
+Monthly, during `/portfolio-review` or `/skill-audit`:
+
+- [ ] Workspace still has Claude Design enabled.
+- [ ] Every installed venture has a named design system.
+- [ ] Link paths in `docs/instructions/claude-design.md` still exist in their repos.
+- [ ] Token drift check: spot-check one venture's Claude Design system against its `design-spec.md`.
+- [ ] Capture any Claude Design product changes Anthropic has shipped (new export targets, MCP/API availability) and update `docs/instructions/claude-design.md`.
+
+## Rollback
+
+If a venture's Claude Design system misbehaves (bad tokens, wrong components, hallucinated brand):
+
+1. In Claude Design, archive the broken system (do not delete — keep a record).
+2. Rerun Phase 2 with a narrower link path and a fresh `design-spec.md` upload.
+3. If Anthropic-side bugs block recovery, file in `docs/notes/issues.md` and fall back to `/product-design` until resolved.
+
+## References
+
+- https://claude.ai/design
+- https://www.anthropic.com/news/claude-design-anthropic-labs
+- https://support.claude.com/en/articles/14604416-get-started-with-claude-design
+- `docs/instructions/claude-design.md`
+- `docs/instructions/design-system.md`
+- `.agents/skills/new-venture/SKILL.md`


### PR DESCRIPTION
## Summary

- Standardizes **Claude Design** (claude.ai/design, Anthropic Labs, launched 2026-04-17) as a portfolio-wide tool available to every current and future venture.
- Adds a new instruction module (`docs/instructions/claude-design.md`) with per-venture link-path table and what-not-to-assume guidance (no CLI, no MCP, no per-repo install).
- Adds a Captain-executed runbook (`docs/runbooks/claude-design-enterprise-setup.md`) covering workspace enablement, per-venture design-system creation, seeding, verification, and rollback.
- Wires Claude Design onboarding into `/new-venture` (Phase 3.8) so future ventures inherit it automatically.

## Context

Claude Design is org-scoped (one Anthropic workspace → multiple design systems, one per venture) and **default off for Enterprise plans** — admin must enable it. Official guidance: link subdirectories, not monorepos. No public API/MCP yet (Anthropic says "coming weeks"); handoff to Claude Code is via the "Send to local coding agent" flow with a bundle + single instruction.

Sources:
- https://www.anthropic.com/news/claude-design-anthropic-labs
- https://support.claude.com/en/articles/14604416-get-started-with-claude-design

## Captain Action Items (out of PR — browser UI)

- [ ] **Layer 1:** Enable Claude Design in the Anthropic workspace admin panel (default off on Enterprise).
- [ ] **Layer 2:** For each installed venture (vc, ke, dc, sc, dfg, ss), create a named design system in claude.ai/design, link the recommended subdirectory per the table, and seed with the venture's `design-spec.md`.
- [ ] Update the per-venture table in `docs/instructions/claude-design.md` with any corrections after actually linking (especially sc/dfg fallback paths and vc-web).

## Test plan

- [x] `npm run verify` passes locally (typecheck + format + lint + test)
- [x] New module registered in CLAUDE.md Instruction Modules table
- [x] Cross-reference added from `design-system.md`
- [x] `/new-venture` SKILL.md + setup checklist updated with Phase 3.8
- [ ] Post-merge: Captain executes Layer 1 + Layer 2 per runbook; confirms smoke test per venture
- [ ] Next `/new-venture` run includes Phase 3.8 naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)