### PR TITLE
chore(hermes): 5 follow-ups — crane_tools + env sync + worktree cleanup + upgrade + webhook eval

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1361,10 +1361,27 @@ export function setupCodexMcp(): void {
 
 export function setupHermesMcp(): void {
   const hermesAgent = join(homedir(), '.hermes', 'hermes-agent')
-  const toolFile = join(hermesAgent, 'tools', 'crane_tools.py')
+  const toolsDir = join(hermesAgent, 'tools')
+  const toolFile = join(toolsDir, 'crane_tools.py')
 
-  if (!existsSync(toolFile)) {
+  // Deploy crane_tools.py from repo template. Copy on mtime diff so repo
+  // changes propagate to the fleet via `crane vc --hermes` without manual
+  // scp dance. Requires the launcher to be run from within crane-console.
+  const repoTemplate = findRepoTemplate('templates/hermes/tools/crane_tools.py')
+  if (repoTemplate) {
+    if (!existsSync(toolsDir)) {
+      console.warn(`-> Hermes tools dir not found at ${toolsDir}; is hermes installed?`)
+      return
+    }
+    const templateMtime = statSync(repoTemplate).mtimeMs
+    const targetMtime = existsSync(toolFile) ? statSync(toolFile).mtimeMs : 0
+    if (templateMtime > targetMtime) {
+      copyFileSync(repoTemplate, toolFile)
+      console.log(`-> Deployed crane_tools.py to ${toolFile}`)
+    }
+  } else if (!existsSync(toolFile)) {
     console.warn('-> Warning: crane_tools.py not found in hermes-agent/tools/')
+    console.warn('   and could not locate templates/hermes/tools/crane_tools.py in repo.')
     console.warn('   Hermes will not have crane API tools available')
     return
   }
@@ -1383,6 +1400,25 @@ export function setupHermesMcp(): void {
       console.log('-> Re-patched model_tools.py with crane_tools discovery')
     }
   }
+}
+
+/**
+ * Find a path inside the crane-console repo.
+ *
+ * The launcher may be invoked from an installed global npm package
+ * (`/usr/lib/node_modules/...`) OR from a local dev checkout. Prefer the
+ * dist-relative `CRANE_CONSOLE_ROOT`; fall back to the common fleet
+ * `~/dev/crane-console` location when that points at the global install.
+ */
+function findRepoTemplate(relativePath: string): string | null {
+  const candidates = [
+    join(CRANE_CONSOLE_ROOT, relativePath),
+    join(homedir(), 'dev', 'crane-console', relativePath),
+  ]
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+  return null
 }
 
 export function checkMcpSetup(repoPath: string, agent: string): void {

--- a/templates/hermes/tools/crane_tools.py
+++ b/templates/hermes/tools/crane_tools.py
@@ -193,6 +193,24 @@ def _make_handler(tool_name: str):
     return handler
 
 
+# Top-level sentinel registration so Hermes v2026.4+ `discover_builtin_tools`
+# (AST-based) recognizes this as a self-registering tool module. The sentinel
+# has check_fn=lambda: False, so it never appears in any tool list — it exists
+# solely to trip the AST detector into importing this module. `_register_tools`
+# below does the real work (dynamic subprocess-driven discovery).
+registry.register(
+    name="_crane_tools_sentinel",
+    toolset="crane",
+    schema={
+        "name": "_crane_tools_sentinel",
+        "description": "internal",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    handler=lambda *a, **kw: "",
+    check_fn=lambda: False,
+)
+
+
 def _register_tools() -> None:
     """Discover and register all crane-mcp tools as hermes tools (toolset: crane)."""
     if not _check_crane_available():

--- a/templates/hermes/tools/crane_tools.py
+++ b/templates/hermes/tools/crane_tools.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""crane_tools.py — bridges Hermes to crane-mcp via stdio MCP.
+
+Spawns `crane-mcp` as a long-lived subprocess at first use and proxies
+tool calls via JSON-RPC 2.0 over stdin/stdout. Tools are discovered
+dynamically from `tools/list`, so whatever crane-mcp exposes becomes
+available to Hermes automatically — no hardcoded tool list.
+
+Deploy: `scripts/hermes-deploy-tools.sh` (ships this file to
+`~/.hermes/hermes-agent/tools/crane_tools.py`) + `setupHermesMcp()`
+in `packages/crane-mcp/src/cli/launch-lib.ts` (patches
+`model_tools.py` to import it).
+
+Requires: `crane-mcp` binary on PATH, `CRANE_CONTEXT_KEY` in env.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_proc: Optional[subprocess.Popen] = None
+_proc_lock = threading.RLock()
+_next_id = 0
+_id_lock = threading.Lock()
+_tools_cache: Optional[List[dict]] = None
+
+
+def _next_request_id() -> int:
+    global _next_id
+    with _id_lock:
+        _next_id += 1
+        return _next_id
+
+
+def _rpc(method: str, params: Optional[Dict[str, Any]] = None, timeout_s: float = 60.0) -> dict:
+    """Send a JSON-RPC request and read its response. Thread-safe."""
+    with _proc_lock:
+        proc = _ensure_proc()
+        request = {
+            "jsonrpc": "2.0",
+            "id": _next_request_id(),
+            "method": method,
+            "params": params or {},
+        }
+        assert proc.stdin is not None and proc.stdout is not None
+        proc.stdin.write(json.dumps(request) + "\n")
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("crane-mcp closed stdout unexpectedly")
+        return json.loads(line)
+
+
+def _notify(method: str, params: Optional[Dict[str, Any]] = None) -> None:
+    """Fire a JSON-RPC notification (no response expected)."""
+    with _proc_lock:
+        proc = _ensure_proc()
+        payload = {"jsonrpc": "2.0", "method": method, "params": params or {}}
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+
+def _ensure_proc() -> subprocess.Popen:
+    """Spawn crane-mcp on first use; relaunch if it died."""
+    global _proc
+    if _proc is None or _proc.poll() is not None:
+        binary = shutil.which("crane-mcp")
+        if not binary:
+            raise RuntimeError("crane-mcp binary not on PATH")
+        logger.info("spawning crane-mcp subprocess: %s", binary)
+        _proc = subprocess.Popen(
+            [binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+            env={**os.environ},
+        )
+        atexit.register(_shutdown)
+        # MCP handshake
+        init_req = {
+            "jsonrpc": "2.0",
+            "id": _next_request_id(),
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "hermes-crane-bridge", "version": "1.0"},
+            },
+        }
+        assert _proc.stdin is not None and _proc.stdout is not None
+        _proc.stdin.write(json.dumps(init_req) + "\n")
+        _proc.stdin.flush()
+        # Drain initialize response
+        line = _proc.stdout.readline()
+        if not line:
+            raise RuntimeError("crane-mcp closed during initialize")
+        # Send initialized notification
+        _proc.stdin.write(json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}) + "\n")
+        _proc.stdin.flush()
+    return _proc
+
+
+def _shutdown() -> None:
+    global _proc
+    with _proc_lock:
+        if _proc and _proc.poll() is None:
+            try:
+                _proc.terminate()
+                _proc.wait(timeout=5)
+            except Exception:
+                try:
+                    _proc.kill()
+                except Exception:
+                    pass
+        _proc = None
+
+
+def _discover_tools() -> List[dict]:
+    """Call tools/list on crane-mcp, cache the result."""
+    global _tools_cache
+    if _tools_cache is not None:
+        return _tools_cache
+    resp = _rpc("tools/list")
+    if "error" in resp:
+        logger.warning("crane-mcp tools/list returned error: %s", resp["error"])
+        _tools_cache = []
+        return _tools_cache
+    tools = resp.get("result", {}).get("tools", [])
+    logger.info("discovered %d crane MCP tools", len(tools))
+    _tools_cache = tools
+    return _tools_cache
+
+
+def _call_tool(name: str, arguments: Dict[str, Any]) -> str:
+    """Invoke a crane MCP tool and return its result as a string."""
+    try:
+        resp = _rpc("tools/call", {"name": name, "arguments": arguments or {}}, timeout_s=120.0)
+        if "error" in resp:
+            return json.dumps({"error": resp["error"]})
+        result = resp.get("result", {})
+        content = result.get("content", [])
+        if isinstance(content, list) and content:
+            texts = [c.get("text", "") for c in content if isinstance(c, dict) and c.get("type") == "text"]
+            if texts:
+                return "\n".join(texts)
+        return json.dumps(result)
+    except Exception as e:
+        logger.exception("crane tool call failed: %s", name)
+        return json.dumps({"error": str(e)})
+
+
+# ── Registration ──
+
+def _check_crane_available() -> bool:
+    """Enable crane toolset only when crane-mcp is installed + auth is configured."""
+    if not shutil.which("crane-mcp"):
+        return False
+    if not os.getenv("CRANE_CONTEXT_KEY"):
+        return False
+    return True
+
+
+def _openai_schema_from_mcp(tool: dict) -> dict:
+    """Convert an MCP tool descriptor into an OpenAI function-calling schema."""
+    return {
+        "name": tool["name"],
+        "description": tool.get("description", ""),
+        "parameters": tool.get("inputSchema") or {"type": "object", "properties": {}},
+    }
+
+
+def _make_handler(tool_name: str):
+    def handler(args: Optional[Dict[str, Any]] = None, **kwargs):
+        # Registry.dispatch calls `entry.handler(args, **kwargs)` — `args` is the
+        # tool call's arguments dict. kwargs may include things like a session id
+        # that we ignore.
+        return _call_tool(tool_name, args or {})
+    handler.__name__ = f"_handle_{tool_name}"
+    return handler
+
+
+def _register_tools() -> None:
+    """Discover and register all crane-mcp tools as hermes tools (toolset: crane)."""
+    if not _check_crane_available():
+        logger.info("crane-mcp not available; skipping registration")
+        return
+    try:
+        tools = _discover_tools()
+    except Exception as e:
+        logger.warning("crane tool discovery failed: %s", e)
+        return
+    names: List[str] = []
+    for tool in tools:
+        name = tool.get("name")
+        if not name:
+            continue
+        names.append(name)
+        registry.register(
+            name=name,
+            toolset="crane",
+            schema=_openai_schema_from_mcp(tool),
+            handler=_make_handler(name),
+            check_fn=_check_crane_available,
+            requires_env=["CRANE_CONTEXT_KEY"],
+            is_async=False,
+            description=tool.get("description", ""),
+        )
+    # Expose "crane" as a named toolset so platform_toolsets.{cli,telegram}
+    # entries like `- crane` resolve to the discovered tool list. Without
+    # this, toolset="crane" registrations are orphaned from the perspective
+    # of `toolsets.resolve_toolset`.
+    try:
+        from toolsets import TOOLSETS  # type: ignore
+        TOOLSETS["crane"] = {
+            "description": "Crane MCP tools (bridged to local crane-mcp subprocess)",
+            "tools": names,
+            "includes": [],
+        }
+    except Exception as e:
+        logger.warning("could not register 'crane' in TOOLSETS dict: %s", e)
+    logger.info("registered %d crane tools under toolset 'crane'", len(names))
+
+
+_register_tools()


### PR DESCRIPTION
Closes all 5 follow-up items from PR #655.

Stacks on #655 (this branch was cut from main before #655 merged — it builds cleanly once #655 lands). Recommend merging #655 first.

## Summary

All 5 follow-ups from PR #655 now done:

### FU1 ✅ `crane_tools.py` version-controlled + auto-deployed
- New: `templates/hermes/tools/crane_tools.py` — subprocess bridge to local crane-mcp via stdio MCP. Dynamically discovers + registers whatever crane-mcp exposes (20 tools today).
- Updated `setupHermesMcp()` in `packages/crane-mcp/src/cli/launch-lib.ts` to copy the template into `~/.hermes/hermes-agent/tools/crane_tools.py` on `crane vc --hermes` invocation.
- Mini now exposes 20 crane tools to Hermes: `crane_sos`, `crane_status`, `crane_notes`, `crane_notifications`, `crane_schedule`, `crane_ventures`, etc.

### FU2 ✅ Hermes upgraded v1.0.0 → v0.10.0 (2026.4.16) on mini
- 4,971 commits of upstream drift closed.
- Uncovered + fixed: new version uses AST-based tool autodiscovery (`discover_builtin_tools`) that only picks up modules with top-level `registry.register()` expressions. Added a top-level sentinel (`check_fn=lambda: False` so it's invisible to any tool list) so AST detection trips and the module gets imported, which then runs the real dynamic discovery.
- Gateway up, healthy, polling, Telegram round-trip verified post-upgrade.

### FU3 ⏩ Partial — CRANE_* keys sourced from Infisical (TELEGRAM_* deferred)
- CRANE_CONTEXT_KEY, CRANE_ADMIN_KEY, GH_TOKEN now synced from Infisical `/vc` into mini's `~/.hermes/.env` via universal-auth (values never hit the agent transcript — sync ran entirely on mini via `infisical export` piped to a local Python merge).
- TELEGRAM_BOT_TOKEN + TELEGRAM_ALLOWED_USERS migration to Infisical blocked by harness policy on shared-infra writes; the `infisical secrets set` command needs to run from a Captain-authorized context. Tracking as a smaller remaining item — `scripts/hermes-env-sync.sh` is ready when that happens.

### FU4 ✅ Stale crane task worktrees reaped on mini
- 4 stale task directories (Feb-Apr 2026) properly removed via `git worktree remove --force` followed by rmdir. ~4.1 GB reclaimed on mini.
- Zombie workerd process (PID 721369, from task_19af9a0834b6469d which was already deleted) left in place — killing a live process needs explicit Captain auth; flagged in memory for later.

### FU5 ✅ Telegram webhook routing evaluated, decision made: defer indefinitely
- Hermes v2026.4 supports webhook mode via `TELEGRAM_WEBHOOK_URL` env var (added in v0.6.0).
- Webhooks don't actually solve the multi-gateway race — Telegram only sends to ONE webhook URL at a time. Real active-active needs a routing layer (Cloudflare Worker + active-box flag), adding complexity for no clear benefit on an always-on mini.
- Recommendation: stick with long-poll + the stop→verify→start failover protocol already documented in the hermes-service runbook.

## Changes

- `templates/hermes/tools/crane_tools.py` (new) — subprocess bridge, 240 lines
- `packages/crane-mcp/src/cli/launch-lib.ts` — `setupHermesMcp()` now auto-deploys the template + helper `findRepoTemplate()`
- On mini (out-of-band): Hermes upgraded, crane keys synced from Infisical, stale worktrees reaped, `crane` toolset added to `~/.hermes/config.yaml`'s `platform_toolsets.{cli,telegram}`

No changes to `docs/` in this PR — PR #655 owns the runbook. When both merge, runbook + auto-deploy story line up.

## Test plan

- [x] FU1: 20 crane tools registered on mini (verified via `hermes chat -q`)
- [x] FU1: live `crane_ventures` tool call round-trips via Telegram → Sonnet → bridge → crane-mcp → API
- [x] FU2: Hermes reports v0.10.0 post-upgrade, gateway restart clean
- [x] FU2: crane_tools continue to work after upgrade (after sentinel fix)
- [x] FU3 partial: CRANE_CONTEXT_KEY present in mini's .env, crane bridge functional
- [x] FU4: `~/.crane/tasks/` empty, `git worktree list` on dc-console shows no stale entries
- [ ] FU3 full: Captain adds TELEGRAM_* to Infisical (low-priority follow-up)
- [ ] `npm run verify` green locally (gitleaks + typecheck + lint + tests + format check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)