### PR TITLE
feat(fleet): unattended-upgrades security floor for Linux boxes

### DIFF
--- a/scripts/bootstrap-machine.sh
+++ b/scripts/bootstrap-machine.sh
@@ -336,6 +336,22 @@ else
     log_ok "crane-console already exists at $REPO_DIR"
 fi
 
+# ─── Step 7b: Configure unattended-upgrades (Linux only) ──────────
+#
+# Security-only floor — ensures security patches land nightly on Linux
+# fleet machines regardless of whether the Hermes-on-mini orchestrator
+# is online. See scripts/bootstrap-unattended-upgrades.sh and
+# docs/instructions/fleet-ops.md.
+
+if [ "$OS" = "linux" ] && [ -f "$REPO_DIR/scripts/bootstrap-unattended-upgrades.sh" ]; then
+    log_info "Configuring unattended-upgrades (security-only)..."
+    if sudo bash "$REPO_DIR/scripts/bootstrap-unattended-upgrades.sh" >/dev/null 2>&1; then
+        log_ok "unattended-upgrades configured"
+    else
+        log_warn "unattended-upgrades bootstrap failed — re-run manually: sudo bash scripts/bootstrap-unattended-upgrades.sh"
+    fi
+fi
+
 # ─── Step 8: Build Crane CLI ──────────────────────────────────────
 
 CRANE_MCP_DIR="$REPO_DIR/packages/crane-mcp"

--- a/scripts/bootstrap-unattended-upgrades.sh
+++ b/scripts/bootstrap-unattended-upgrades.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Bootstrap unattended-upgrades on a Linux (Debian/Ubuntu) fleet machine.
+#
+# Security-only floor. No feature upgrades. No auto-reboot.
+# This is the fallback if the Hermes-on-mini orchestrator is offline:
+# security patches land nightly regardless.
+#
+# Idempotent: re-running is safe.
+#
+# Usage:
+#   sudo bash scripts/bootstrap-unattended-upgrades.sh
+#
+# Or invoked non-interactively from bootstrap-machine.sh on Linux.
+#
+
+set -e
+set -o pipefail
+
+# Only run on Linux. macOS machines are handled by the orchestrator per-run.
+OS_RAW=$(uname -s)
+if [ "$OS_RAW" != "Linux" ]; then
+    echo "[skip] bootstrap-unattended-upgrades.sh is Linux-only (detected: $OS_RAW)"
+    exit 0
+fi
+
+# Require apt-based distro. Script is written for Debian/Ubuntu/Xubuntu.
+if ! command -v apt-get >/dev/null 2>&1; then
+    echo "[error] apt-get not found. Script supports Debian/Ubuntu only." >&2
+    exit 1
+fi
+
+# Require root (via sudo or direct).
+if [ "$(id -u)" -ne 0 ]; then
+    echo "[error] Must run as root (use sudo)." >&2
+    exit 1
+fi
+
+echo "[info] Installing unattended-upgrades and apt-listchanges..."
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+    unattended-upgrades \
+    apt-listchanges >/dev/null
+
+# Detect distro codename for the origin pattern. lsb_release is present on
+# Ubuntu/Xubuntu by default; fall back to /etc/os-release otherwise.
+if command -v lsb_release >/dev/null 2>&1; then
+    DISTRO_ID=$(lsb_release -is)
+else
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    DISTRO_ID="${ID^}"  # capitalize first letter to match lsb_release -is
+fi
+
+echo "[info] Distro detected: $DISTRO_ID"
+
+# /etc/apt/apt.conf.d/50unattended-upgrades — security origins only.
+# ${distro_codename} is expanded by unattended-upgrades at runtime.
+cat > /etc/apt/apt.conf.d/50unattended-upgrades <<EOF
+// Managed by scripts/bootstrap-unattended-upgrades.sh (crane fleet).
+// Security-only. No feature upgrades. No auto-reboot.
+// Manual edits will be overwritten on next bootstrap run.
+
+Unattended-Upgrade::Allowed-Origins {
+    "${DISTRO_ID}:\${distro_codename}-security";
+    "${DISTRO_ID}ESMApps:\${distro_codename}-apps-security";
+    "${DISTRO_ID}ESM:\${distro_codename}-infra-security";
+};
+
+Unattended-Upgrade::DevRelease "false";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::SyslogEnable "true";
+EOF
+echo "[ok] wrote /etc/apt/apt.conf.d/50unattended-upgrades"
+
+# /etc/apt/apt.conf.d/20auto-upgrades — enable the periodic job.
+cat > /etc/apt/apt.conf.d/20auto-upgrades <<'EOF'
+// Managed by scripts/bootstrap-unattended-upgrades.sh (crane fleet).
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";
+EOF
+echo "[ok] wrote /etc/apt/apt.conf.d/20auto-upgrades"
+
+# Ensure the unattended-upgrades systemd service is enabled (package default
+# on most Ubuntu releases, but re-assert for safety).
+systemctl enable unattended-upgrades.service >/dev/null 2>&1 || true
+systemctl start unattended-upgrades.service >/dev/null 2>&1 || true
+
+# Dry-run to verify the config parses and matches security-only origins.
+echo ""
+echo "[info] Dry-run verification (unattended-upgrade --dry-run):"
+if unattended-upgrade --dry-run 2>&1 | head -20; then
+    echo "[ok] unattended-upgrades configured successfully"
+else
+    echo "[warn] dry-run returned non-zero — inspect manually" >&2
+fi


### PR DESCRIPTION
## Summary

- Phase A of the fleet update orchestrator arc (#657). Ships the Linux security-patch floor independently — it provides immediate value regardless of whether the Hermes-on-mini orchestrator ever comes online.
- Security-only origins. No feature upgrades. No auto-reboot.

## Related Issues

Closes part of #657 (Phase A).

## Changes

- New `scripts/bootstrap-unattended-upgrades.sh` — idempotent, Linux-only, root-required. Installs `unattended-upgrades` + `apt-listchanges`; writes `/etc/apt/apt.conf.d/50unattended-upgrades` (security origins only, no auto-reboot) and `/etc/apt/apt.conf.d/20auto-upgrades` (enables the periodic job). Ends with `unattended-upgrade --dry-run` for verification.
- `scripts/bootstrap-machine.sh` — new Step 7b invokes the above when `OS=linux`. Placed after Step 7 (repo clone) so the script is available on disk.

## Test Plan

- [x] `bash -n` parses both scripts cleanly.
- [x] `npm run verify` passes (typecheck + format + lint + full test suite).
- [x] Script is non-destructive — writes to apt config paths only, no data changes.
- [ ] Post-merge: run manually on mini / mbp27 / think and verify `unattended-upgrade --dry-run -d` matches only `-security` origins. (Deferred to Captain per plan — requires sudo on fleet boxes.)

## Feature Impact

**Feature impact:** None. Additive only — new script, new optional step in bootstrap.

## Instruction Module Impact

**Module impact:** None for this PR. Phase D of #657 will update `docs/instructions/fleet-ops.md` to document the full orchestrator architecture.

## Deployment Notes

No deployment. Post-merge, Captain (or next bootstrap run on each Linux fleet machine) triggers `sudo bash scripts/bootstrap-unattended-upgrades.sh`. Standing up the orchestrator itself (Phases B/C/D) proceeds in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)