### PR TITLE
feat(fleet): source-scoped ingest + machine-health JSON mode

### DIFF
--- a/scripts/machine-health.sh
+++ b/scripts/machine-health.sh
@@ -1,21 +1,38 @@
 #!/bin/bash
-# Per-machine health assessment for Crane Console dev boxes
-# Runs locally or over SSH. Outputs machine-readable key=value line.
+# Per-machine health assessment for Crane Console dev boxes.
+# Runs locally or over SSH.
 #
-# Usage: bash scripts/machine-health.sh [--quick]
-#   --quick  skips preflight and git sync, only runs system checks
+# Usage:
+#   bash scripts/machine-health.sh [--quick] [--json]
+#     --quick  skip preflight and git sync (only system checks)
+#     --json   emit JSON on stdout instead of the legacy key=value line
+#
+# Legacy output (default): byte-identical single line
+#   preflight=... disk=... updates=... reboot=... crane=... infisical=... behind=... dns=...
+#
+# JSON output (--json): full object with macOS + Linux host-patch fields
+# consumed by the Hermes-on-mini fleet update orchestrator (#657):
+#   { preflight, disk, os_updates, os_security, brew_outdated, reboot_required,
+#     uptime_days, xcode_clt_outdated, crane, infisical, behind, dns }
 #
 # Exit codes: 0 = all passed, 1 = at least one failure, 2 = warnings only
 #
 # Compatible with bash 3.2+ (macOS default) and bash 5 (Linux).
-# No `timeout`, no `grep -P`, no `stat`, no `declare -A`.
+# No `timeout`, no `grep -P`, no `stat`, no `declare -A`, no `jq`.
 
 set -o pipefail
 
+# ─── Parse flags ──────────────────────────────────────────────────────
+
 QUICK=false
-if [ "$1" = "--quick" ]; then
-    QUICK=true
-fi
+JSON=false
+for arg in "$@"; do
+    case "$arg" in
+        --quick) QUICK=true ;;
+        --json)  JSON=true ;;
+        *) ;;  # ignore unknown for forward compat
+    esac
+done
 
 OS=$(uname -s)
 REPO_DIR="$HOME/dev/crane-console"
@@ -34,11 +51,19 @@ WARNINGS=0
 R_DNS="ok"
 R_PREFLIGHT="n/a"
 R_DISK="0%"
-R_UPDATES="n/a"
-R_REBOOT="n/a"
+R_UPDATES="n/a"         # legacy key=value alias for all-updates count
+R_REBOOT="n/a"           # legacy reboot flag ('yes' | 'no' | 'n/a')
 R_CRANE="ok"
 R_INFISICAL="ok"
 R_BEHIND="n/a"
+
+# Extended fields (JSON mode only, but collected in both paths).
+R_OS_UPDATES="0"           # total pending OS updates
+R_OS_SECURITY="0"          # pending security-flagged updates
+R_BREW_OUTDATED="0"        # macOS brew formulae outdated count (0 on Linux)
+R_REBOOT_REQUIRED="false"  # bool
+R_UPTIME_DAYS="0"
+R_XCODE_CLT_OUTDATED="false"  # bool; macOS only
 
 # ─── Check 1: DNS resolution ──────────────────────────────────────────
 
@@ -89,9 +114,10 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
-# ─── Check 4: System updates (Linux only) ─────────────────────────────
+# ─── Check 4: System updates (OS-specific) ────────────────────────────
 
 if [ "$OS" = "Linux" ]; then
+    # Legacy path: total count from update-notifier (unchanged).
     R_UPDATES="0"
     if [ -f /var/lib/update-notifier/updates-available ]; then
         update_count=$(grep -Eo '^[0-9]+' /var/lib/update-notifier/updates-available 2>/dev/null | head -1)
@@ -102,12 +128,105 @@ if [ "$OS" = "Linux" ]; then
             fi
         fi
     fi
+    R_OS_UPDATES="$R_UPDATES"
 
+    # New: security-only subset. apt list --upgradable is reliable on
+    # Ubuntu/Xubuntu; suppress stderr because the first invocation prints
+    # a "WARNING: apt does not have a stable CLI" line to stderr.
+    if command -v apt >/dev/null 2>&1; then
+        sec_count=$(apt list --upgradable 2>/dev/null | grep -c '\-security' || echo 0)
+        R_OS_SECURITY="$sec_count"
+    fi
+
+    # Reboot required (existing + bool mirror for JSON).
     if [ -f /var/run/reboot-required ]; then
         R_REBOOT="yes"
+        R_REBOOT_REQUIRED="true"
         WARNINGS=$((WARNINGS + 1))
     else
         R_REBOOT="no"
+        R_REBOOT_REQUIRED="false"
+    fi
+
+    # Uptime days from /proc/uptime (first field = seconds since boot).
+    if [ -r /proc/uptime ]; then
+        R_UPTIME_DAYS=$(awk '{print int($1/86400)}' /proc/uptime 2>/dev/null || echo 0)
+    fi
+
+elif [ "$OS" = "Darwin" ]; then
+    # macOS: softwareupdate -l lists pending updates. Parse the label
+    # lines; count is our os_updates signal. Recommended flag indicates
+    # security-critical updates — count those as os_security.
+    if command -v softwareupdate >/dev/null 2>&1; then
+        # --no-scan avoids hitting Apple's servers; returns cached state
+        # which is refreshed by Apple's background SUHelper at least
+        # weekly. Good enough for our cadence.
+        su_output=$(softwareupdate -l --no-scan 2>&1 || true)
+
+        # Total updates: count "Label:" lines.
+        total_updates=$(echo "$su_output" | grep -c '^\s*\*\?\s*Label:' 2>/dev/null || echo 0)
+        # Normalize — grep -c with no matches returns 0 but also sometimes
+        # a blank. Ensure numeric.
+        case "$total_updates" in
+            ''|*[!0-9]*) total_updates=0 ;;
+        esac
+        R_OS_UPDATES="$total_updates"
+        # Legacy R_UPDATES key mirrors the total (was n/a on macOS before).
+        R_UPDATES="$total_updates"
+        if [ "$total_updates" -gt 0 ] 2>/dev/null; then
+            WARNINGS=$((WARNINGS + 1))
+        fi
+
+        # Security-flagged updates: plain text scan for "Recommended: YES"
+        # on each block. Simpler and more portable than PlistBuddy.
+        sec_count=$(echo "$su_output" | grep -c 'Recommended: *YES' 2>/dev/null || echo 0)
+        case "$sec_count" in
+            ''|*[!0-9]*) sec_count=0 ;;
+        esac
+        R_OS_SECURITY="$sec_count"
+
+        # Xcode Command Line Tools freshness. Label contains "Command Line
+        # Tools" when an update is available.
+        if echo "$su_output" | grep -qi 'Command Line Tools'; then
+            R_XCODE_CLT_OUTDATED="true"
+            WARNINGS=$((WARNINGS + 1))
+        fi
+    fi
+
+    # Homebrew outdated count. brew outdated --quiet prints one formula
+    # per line.
+    if command -v brew >/dev/null 2>&1; then
+        R_BREW_OUTDATED=$(brew outdated --quiet 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+        case "$R_BREW_OUTDATED" in
+            ''|*[!0-9]*) R_BREW_OUTDATED=0 ;;
+        esac
+        if [ "$R_BREW_OUTDATED" -gt 20 ] 2>/dev/null; then
+            WARNINGS=$((WARNINGS + 1))
+        fi
+    fi
+
+    # macOS has no /var/run/reboot-required. We approximate reboot need
+    # from "restart required" marker in softwareupdate output.
+    if command -v softwareupdate >/dev/null 2>&1 && echo "${su_output:-}" | grep -qi 'restart'; then
+        R_REBOOT="yes"
+        R_REBOOT_REQUIRED="true"
+        WARNINGS=$((WARNINGS + 1))
+    else
+        R_REBOOT="no"
+        R_REBOOT_REQUIRED="false"
+    fi
+
+    # Uptime days from kern.boottime. Format:
+    #   { sec = 1745434567, usec = 123 } Fri Apr 18 12:36:07 2025
+    # Anchor the regex on the leading '{' so the greedy '.*' can't pull
+    # 'usec' into the capture — previously returned the usec value and
+    # computed uptimes in the tens of thousands of days.
+    if command -v sysctl >/dev/null 2>&1; then
+        boot_sec=$(sysctl -n kern.boottime 2>/dev/null | sed -E 's/^\{ sec = ([0-9]+),.*/\1/')
+        now_sec=$(date +%s 2>/dev/null)
+        if [ -n "$boot_sec" ] && [ -n "$now_sec" ] && [ "$boot_sec" -gt 0 ] 2>/dev/null; then
+            R_UPTIME_DAYS=$(( (now_sec - boot_sec) / 86400 ))
+        fi
     fi
 fi
 
@@ -156,7 +275,32 @@ fi
 
 # ─── Output ───────────────────────────────────────────────────────────
 
-echo "preflight=$R_PREFLIGHT disk=$R_DISK updates=$R_UPDATES reboot=$R_REBOOT crane=$R_CRANE infisical=$R_INFISICAL behind=$R_BEHIND dns=$R_DNS"
+if [ "$JSON" = true ]; then
+    # Hand-crafted JSON to avoid requiring jq on fleet machines.
+    # Keep keys stable — consumed by the Hermes-on-mini orchestrator.
+    # String fields are always quoted; numeric/bool emitted bare.
+    printf '{"os":"%s","preflight":"%s","disk":"%s","os_updates":%s,"os_security":%s,"brew_outdated":%s,"reboot":"%s","reboot_required":%s,"uptime_days":%s,"xcode_clt_outdated":%s,"crane":"%s","infisical":"%s","behind":"%s","dns":"%s","failures":%s,"warnings":%s}\n' \
+        "$OS" \
+        "$R_PREFLIGHT" \
+        "$R_DISK" \
+        "$R_OS_UPDATES" \
+        "$R_OS_SECURITY" \
+        "$R_BREW_OUTDATED" \
+        "$R_REBOOT" \
+        "$R_REBOOT_REQUIRED" \
+        "$R_UPTIME_DAYS" \
+        "$R_XCODE_CLT_OUTDATED" \
+        "$R_CRANE" \
+        "$R_INFISICAL" \
+        "$R_BEHIND" \
+        "$R_DNS" \
+        "$FAILURES" \
+        "$WARNINGS"
+else
+    # Legacy key=value line — byte-identical to the pre-#657 format.
+    # Do not add keys here; use --json for new fields.
+    echo "preflight=$R_PREFLIGHT disk=$R_DISK updates=$R_UPDATES reboot=$R_REBOOT crane=$R_CRANE infisical=$R_INFISICAL behind=$R_BEHIND dns=$R_DNS"
+fi
 
 # ─── Exit code ────────────────────────────────────────────────────────
 

--- a/workers/crane-context/migrations/0037_fleet_health_add_source.sql
+++ b/workers/crane-context/migrations/0037_fleet_health_add_source.sql
@@ -1,0 +1,38 @@
+-- 0037_fleet_health_add_source.sql
+--
+-- Issue #657 (Phase B). The fleet_health_findings table was built for the
+-- weekly GitHub-state audit (.github/workflows/fleet-ops-health.yml →
+-- POST /admin/fleet-health/ingest). We're extending it to also carry
+-- findings from the host-patch orchestrator (Hermes-on-mini), which
+-- posts a different kind of snapshot (OS updates, brew outdated,
+-- reboot-required, uptime, etc.) keyed by machine alias.
+--
+-- Key design constraint (from plan critique): the auto-resolve tuple
+-- MUST include `source`, and the ingestFleetHealth pre-load query MUST
+-- scope by source. Otherwise a machine-only snapshot would sweep every
+-- open GitHub finding into resolved, and vice-versa. The new index
+-- backs that lookup.
+--
+-- Convention for machine findings: repo_full_name = 'machine/<alias>'
+-- (e.g. 'machine/mini'). This overloads a column name whose semantics
+-- are "GitHub repo" but avoids a parallel table with duplicate schema
+-- and lifecycle logic. SOS renderer branches on `source` before URL
+-- generation so no dead github.com/machine/* links are emitted.
+
+-- Add nullable column for back-compat with existing rows. SQLite's
+-- ALTER TABLE ADD COLUMN does not support NOT NULL without a default,
+-- and defaulting to 'github' is fine semantically — every existing row
+-- was posted by the GitHub audit.
+ALTER TABLE fleet_health_findings ADD COLUMN source TEXT;
+
+-- Back-fill existing rows to 'github'. New machine rows will be written
+-- with source='machine' by the orchestrator.
+UPDATE fleet_health_findings SET source = 'github' WHERE source IS NULL;
+
+-- Auto-resolve lookup — "find the open finding for this
+-- (source, repo, type)". This is the index ingestFleetHealth uses for
+-- its pre-load query. Keeping the older idx_fleet_findings_match for
+-- compatibility with any direct (repo, type) queries, but the new
+-- source-scoped index is the primary hot path.
+CREATE INDEX IF NOT EXISTS idx_fleet_findings_match_src
+  ON fleet_health_findings(source, repo_full_name, finding_type, status);

--- a/workers/crane-context/src/endpoints/fleet-health.ts
+++ b/workers/crane-context/src/endpoints/fleet-health.ts
@@ -31,6 +31,7 @@ import {
 import type {
   FleetFindingInput,
   FleetFindingSeverity,
+  FleetFindingSource,
   FleetFindingStatus,
   FleetHealthIngestRequest,
 } from '../fleet-health'
@@ -43,6 +44,12 @@ interface IngestBody {
   org?: string
   timestamp?: string
   status?: 'pass' | 'fail'
+  /**
+   * Source of this snapshot. Defaults to 'github' for back-compat with
+   * the existing fleet-ops-health GitHub audit. The Hermes-on-mini host
+   * orchestrator posts 'machine' explicitly (#657).
+   */
+  source?: string
   findings?: Array<{
     repo?: string
     rule?: string
@@ -67,6 +74,9 @@ export async function handleIngestFleetHealth(request: Request, env: Env): Promi
     if (!body.timestamp) errors.push({ field: 'timestamp', message: 'Required ISO8601' })
     if (!body.status || (body.status !== 'pass' && body.status !== 'fail')) {
       errors.push({ field: 'status', message: "Required: 'pass' | 'fail'" })
+    }
+    if (body.source !== undefined && body.source !== 'github' && body.source !== 'machine') {
+      errors.push({ field: 'source', message: "Optional: 'github' | 'machine' (default 'github')" })
     }
     if (!Array.isArray(body.findings)) {
       errors.push({ field: 'findings', message: 'Required array' })
@@ -99,6 +109,7 @@ export async function handleIngestFleetHealth(request: Request, env: Env): Promi
       org: body.org as string,
       timestamp: body.timestamp as string,
       status: body.status as 'pass' | 'fail',
+      source: (body.source as FleetFindingSource | undefined) ?? 'github',
       findings,
     }
 
@@ -108,6 +119,7 @@ export async function handleIngestFleetHealth(request: Request, env: Env): Promi
       {
         ok: true,
         org: req.org,
+        source: req.source,
         generated_at: result.generated_at,
         inserted: result.inserted,
         updated: result.updated,
@@ -141,6 +153,7 @@ export async function handleListFleetHealthFindings(request: Request, env: Env):
     const severity = url.searchParams.get('severity') as FleetFindingSeverity | null
     const repo = url.searchParams.get('repo')
     const findingType = url.searchParams.get('type')
+    const sourceParam = url.searchParams.get('source')
     const limitStr = url.searchParams.get('limit')
     const limit = limitStr ? parseInt(limitStr, 10) : undefined
 
@@ -157,6 +170,10 @@ export async function handleListFleetHealthFindings(request: Request, env: Env):
       severity:
         severity === 'error' || severity === 'warning' || severity === 'info'
           ? severity
+          : undefined,
+      source:
+        sourceParam === 'github' || sourceParam === 'machine'
+          ? (sourceParam as FleetFindingSource)
           : undefined,
       repo_full_name: repo || undefined,
       finding_type: findingType || undefined,

--- a/workers/crane-context/src/fleet-health.ts
+++ b/workers/crane-context/src/fleet-health.ts
@@ -26,12 +26,26 @@ export type FleetFindingStatus = 'new' | 'resolved'
 export type FleetFindingResolveReason = 'auto_snapshot' | 'manual'
 
 /**
- * Stable enum of finding types emitted by scripts/fleet-ops-health.sh.
- * Kept as a string (not strict enum) so new finding types don't require
- * a schema change — the ingest endpoint validates against this list but
- * unknown types are logged and stored anyway (forward-compat).
+ * Source discriminator for a finding. Distinct audit pipelines share
+ * this table but never resolve each other's rows.
+ *
+ *   'github'  — weekly fleet-ops-health audit (GitHub org state).
+ *   'machine' — host-patch orchestrator (Hermes-on-mini; #657).
+ *
+ * Rows written before migration 0037 are back-filled to 'github'.
+ */
+export type FleetFindingSource = 'github' | 'machine'
+
+/**
+ * Stable enum of finding types. Kept as a string (not strict enum) so
+ * new finding types don't require a schema change — the ingest endpoint
+ * stores unknowns for forward-compat.
+ *
+ * GitHub-source types come from scripts/fleet-ops-health.sh.
+ * Machine-source types come from the fleet-update orchestrator.
  */
 export const KNOWN_FINDING_TYPES = [
+  // GitHub-source (fleet-ops-health.sh)
   'archived',
   'template',
   'stale-push',
@@ -41,6 +55,15 @@ export const KNOWN_FINDING_TYPES = [
   'dependabot-stale',
   'secret-missing',
   'security-workflow-failed',
+  // Machine-source (Hermes-on-mini, #657)
+  'os-security-patches',
+  'os-feature-updates',
+  'brew-outdated',
+  'reboot-required',
+  'uptime-high',
+  'xcode-clt-outdated',
+  'disk-pressure',
+  'preflight-fail',
 ] as const
 export type KnownFindingType = (typeof KNOWN_FINDING_TYPES)[number]
 
@@ -49,6 +72,7 @@ export interface FleetHealthFinding {
   generated_at: string
   repo_full_name: string
   finding_type: string
+  source: FleetFindingSource
   severity: FleetFindingSeverity
   details_json: string
   status: FleetFindingStatus
@@ -72,6 +96,12 @@ export interface FleetHealthIngestRequest {
   org: string
   timestamp: string
   status: 'pass' | 'fail'
+  /**
+   * Source of this snapshot. Defaults to 'github' for back-compat with
+   * the existing fleet-ops-health ingest. Machine-source snapshots must
+   * pass 'machine' explicitly.
+   */
+  source?: FleetFindingSource
   findings: FleetFindingInput[]
 }
 
@@ -83,7 +113,9 @@ export interface FleetHealthIngestResult {
 }
 
 export interface FleetHealthListOptions {
-  /** Filter by repo full name (owner/repo). */
+  /** Filter by source (github | machine). Omit to return both. */
+  source?: FleetFindingSource
+  /** Filter by repo full name (owner/repo) — or 'machine/<alias>' for machine rows. */
   repo_full_name?: string
   /** Filter by finding type. */
   finding_type?: string
@@ -142,12 +174,26 @@ export async function ingestFleetHealth(
   const generated_at = req.timestamp
   const now = nowIso()
 
-  // Load current open findings so we can compute the delta: which ones
-  // to upsert (still present) vs which ones to auto-resolve (gone).
+  // Default source to 'github' for back-compat with the pre-#657
+  // fleet-ops-health ingest payload shape. Machine-source snapshots
+  // must pass source='machine' explicitly.
+  const source: FleetFindingSource = req.source ?? 'github'
+
+  // Load current open findings FOR THIS SOURCE so we can compute the
+  // delta: which ones to upsert (still present) vs which ones to
+  // auto-resolve (gone).
+  //
+  // CRITICAL: this query is scoped by source. Without it, a
+  // machine-source snapshot would auto-resolve every open GitHub
+  // finding (and vice-versa). Plan critique Issue #1 — see
+  // `~/.claude/plans/cuddly-riding-sifakis.md`.
   const openRows = await db
     .prepare(
-      `SELECT id, repo_full_name, finding_type FROM fleet_health_findings WHERE status = 'new'`
+      `SELECT id, repo_full_name, finding_type
+       FROM fleet_health_findings
+       WHERE status = 'new' AND source = ?`
     )
+    .bind(source)
     .all<{ id: string; repo_full_name: string; finding_type: string }>()
 
   const openByKey = new Map<string, { id: string }>()
@@ -200,16 +246,17 @@ export async function ingestFleetHealth(
         db
           .prepare(
             `INSERT INTO fleet_health_findings (
-               id, generated_at, repo_full_name, finding_type,
+               id, generated_at, repo_full_name, finding_type, source,
                severity, details_json, status, resolved_at, resolve_reason,
                created_at, updated_at
-             ) VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, ?, ?)`
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, 'new', NULL, NULL, ?, ?)`
           )
           .bind(
             id,
             generated_at,
             finding.repo,
             finding.rule,
+            source,
             finding.severity,
             detailsJson,
             now,
@@ -271,6 +318,10 @@ export async function listFleetHealthFindings(
     clauses.push(`status = ?`)
     binds.push(status)
   }
+  if (opts.source) {
+    clauses.push(`source = ?`)
+    binds.push(opts.source)
+  }
   if (opts.repo_full_name) {
     clauses.push(`repo_full_name = ?`)
     binds.push(opts.repo_full_name)
@@ -286,7 +337,7 @@ export async function listFleetHealthFindings(
 
   const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : ''
   const sql = `
-    SELECT id, generated_at, repo_full_name, finding_type, severity,
+    SELECT id, generated_at, repo_full_name, finding_type, source, severity,
            details_json, status, resolved_at, resolve_reason,
            created_at, updated_at
     FROM fleet_health_findings

--- a/workers/crane-context/test/fleet-health.test.ts
+++ b/workers/crane-context/test/fleet-health.test.ts
@@ -264,6 +264,166 @@ describe('ingestFleetHealth', () => {
   })
 })
 
+describe('ingestFleetHealth — cross-source isolation (#657)', () => {
+  // Plan critique Issue #1: before migration 0037, a machine-source snapshot
+  // would sweep every open GitHub finding into resolved because the
+  // pre-load query was unscoped. These tests pin that invariant.
+
+  it('machine snapshot does not auto-resolve github findings', async () => {
+    const db = await setupDb()
+
+    // Seed two github-source findings (default — no source passed)
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(0),
+      status: 'fail',
+      findings: [
+        { repo: 'venturecrane/smd-web', rule: 'ci-failed', severity: 'error', message: 'broken' },
+        {
+          repo: 'venturecrane/dc-marketing',
+          rule: 'stale-push',
+          severity: 'warning',
+          message: 'stale',
+        },
+      ],
+    })
+
+    // Now ingest a DIFFERENT source (machine) — it must not touch the github rows.
+    const result = await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(60),
+      status: 'fail',
+      source: 'machine',
+      findings: [
+        {
+          repo: 'machine/mini',
+          rule: 'os-security-patches',
+          severity: 'warning',
+          message: '3 security updates pending',
+        },
+      ],
+    })
+
+    expect(result.inserted).toBe(1)
+    expect(result.updated).toBe(0)
+    expect(result.resolved).toBe(0)
+
+    // Both github findings still open, one machine finding also open.
+    const githubOpen = await listFleetHealthFindings(db, { status: 'new', source: 'github' })
+    expect(githubOpen).toHaveLength(2)
+
+    const machineOpen = await listFleetHealthFindings(db, { status: 'new', source: 'machine' })
+    expect(machineOpen).toHaveLength(1)
+    expect(machineOpen[0].repo_full_name).toBe('machine/mini')
+    expect(machineOpen[0].source).toBe('machine')
+  })
+
+  it('github snapshot does not auto-resolve machine findings', async () => {
+    const db = await setupDb()
+
+    // Seed a machine finding first
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(0),
+      status: 'fail',
+      source: 'machine',
+      findings: [
+        {
+          repo: 'machine/mini',
+          rule: 'reboot-required',
+          severity: 'warning',
+          message: 'kernel update requires reboot',
+        },
+      ],
+    })
+
+    // Now ingest a github snapshot — it must not touch the machine row.
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(60),
+      status: 'fail',
+      findings: [
+        { repo: 'venturecrane/smd-web', rule: 'ci-failed', severity: 'error', message: 'broken' },
+      ],
+    })
+
+    const machineOpen = await listFleetHealthFindings(db, { status: 'new', source: 'machine' })
+    expect(machineOpen).toHaveLength(1)
+    expect(machineOpen[0].resolve_reason).toBeNull()
+    expect(machineOpen[0].status).toBe('new')
+
+    // And the github finding landed as expected
+    const githubOpen = await listFleetHealthFindings(db, { status: 'new', source: 'github' })
+    expect(githubOpen).toHaveLength(1)
+    expect(githubOpen[0].source).toBe('github')
+  })
+
+  it('auto-resolves only within its own source when a finding goes away', async () => {
+    const db = await setupDb()
+
+    // Seed a github and a machine finding with the same logical repo key
+    // (impossible in practice — 'venturecrane/mini' is not a real repo —
+    // but the purpose is to prove that (source, repo, rule) is the unique
+    // resolve tuple, not (repo, rule)).
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(0),
+      status: 'fail',
+      findings: [{ repo: 'machine/mini', rule: 'ci-failed', severity: 'error', message: 'x' }],
+    })
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(30),
+      status: 'fail',
+      source: 'machine',
+      findings: [{ repo: 'machine/mini', rule: 'ci-failed', severity: 'error', message: 'y' }],
+    })
+
+    // Two open rows now (same repo+rule, different source).
+    const beforeOpen = await listFleetHealthFindings(db, { status: 'new' })
+    expect(beforeOpen).toHaveLength(2)
+
+    // Resolve just the machine one by posting an empty machine snapshot.
+    const result = await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(60),
+      status: 'pass',
+      source: 'machine',
+      findings: [],
+    })
+    expect(result.resolved).toBe(1)
+
+    // Github row remains open; machine row is resolved.
+    const afterGithubOpen = await listFleetHealthFindings(db, {
+      status: 'new',
+      source: 'github',
+    })
+    expect(afterGithubOpen).toHaveLength(1)
+
+    const afterMachineOpen = await listFleetHealthFindings(db, {
+      status: 'new',
+      source: 'machine',
+    })
+    expect(afterMachineOpen).toHaveLength(0)
+  })
+
+  it('back-compat: omitting source defaults to github', async () => {
+    const db = await setupDb()
+
+    await ingestFleetHealth(db, {
+      org: 'venturecrane',
+      timestamp: ts(0),
+      status: 'fail',
+      findings: [
+        { repo: 'venturecrane/smd-web', rule: 'ci-failed', severity: 'error', message: 'x' },
+      ],
+    })
+
+    const [finding] = await listFleetHealthFindings(db, { status: 'new' })
+    expect(finding.source).toBe('github')
+  })
+})
+
 describe('getFleetHealthSummary', () => {
   it('counts only open findings, grouped by severity', async () => {
     const db = await setupDb()


### PR DESCRIPTION
## Summary

- Phase B of the fleet update orchestrator arc (#657). Extends the existing `fleet_health_findings` pipeline to support a second source (the Hermes-on-mini host-patch orchestrator, shipping in Phases C/D) without breaking the existing GitHub audit.
- **Critical scoping fix (plan critique Issue #1):** `ingestFleetHealth`'s pre-load query now filters by `source`. Without this, a machine-source snapshot would sweep every open GitHub finding into resolved, and vice-versa. Four new tests pin the cross-source isolation invariant.
- `machine-health.sh` gets a `--json` mode and macOS coverage. Legacy key=value output is preserved byte-identical when `--json` is absent.

## Related Issues

Part of #657 (Phase B).

## Changes

**Schema** — `workers/crane-context/migrations/0037_fleet_health_add_source.sql`
- `ALTER TABLE fleet_health_findings ADD COLUMN source TEXT;`
- Back-fill existing rows to `source='github'`.
- New index `idx_fleet_findings_match_src (source, repo_full_name, finding_type, status)` backs the scoped auto-resolve lookup.

**Worker** — `workers/crane-context/src/fleet-health.ts`
- `FleetFindingSource = 'github' | 'machine'` type.
- `FleetHealthIngestRequest.source?` defaults to `'github'` for back-compat.
- `ingestFleetHealth` pre-load query: `WHERE status='new' AND source=?` — **the critical fix**.
- `INSERT` statement carries `source`.
- `listFleetHealthFindings` accepts `source` filter; SELECT returns it.
- Added 8 new machine-source `finding_type` values to `KNOWN_FINDING_TYPES` (os-security-patches, os-feature-updates, brew-outdated, reboot-required, uptime-high, xcode-clt-outdated, disk-pressure, preflight-fail).

**Endpoint** — `workers/crane-context/src/endpoints/fleet-health.ts`
- `IngestBody.source?: 'github' | 'machine'`, validated, defaults `'github'`.
- Source echoed back in ingest response.
- `GET /fleet-health/findings` accepts `?source=<value>` query param.

**Tests** — `workers/crane-context/test/fleet-health.test.ts`
- New `describe('ingestFleetHealth — cross-source isolation (#657)')` with 4 tests:
  1. Machine snapshot does NOT auto-resolve GitHub findings.
  2. GitHub snapshot does NOT auto-resolve machine findings.
  3. Same (repo, rule) under different sources → resolving one doesn't touch the other.
  4. Back-compat: omitting `source` still defaults to `'github'`.

**Script** — `scripts/machine-health.sh`
- `--json` flag emits classified JSON (16 fields) for the Hermes orchestrator. Includes OS, preflight, disk, os_updates, os_security, brew_outdated, reboot_required (bool), uptime_days, xcode_clt_outdated (bool), crane, infisical, behind, dns, failures, warnings.
- Legacy `key=value` output **byte-identical** when `--json` is not passed (preserves existing `fleet-health.sh` consumer contract).
- macOS coverage: `softwareupdate -l --no-scan`, `brew outdated`, uptime from `kern.boottime` (anchored regex fixes greedy-sed bug that previously returned tens-of-thousands of days), Xcode CLT detection, restart-required marker.
- Linux coverage: security-only subset via `apt list --upgradable | grep -c '\-security'`.

## Test Plan

- [x] `npm run verify` passes — 375 tests (was 371, +4 new).
- [x] Legacy key=value output confirmed byte-identical shape on macOS (only values changed where we now have real data where we had `n/a` before).
- [x] JSON output validates via `python3 -m json.tool`.
- [x] Uptime regex fix verified (was reporting 20558 days → now 9 days on this box).
- [ ] Post-merge: run migration 0037 in staging + production. `source` back-fill is idempotent.

## Feature Impact

**Feature impact:** None. Additive only. Existing `fleet-ops-health.yml` workflow continues to work unchanged — its payload omits `source`, which defaults to `'github'`.

## Instruction Module Impact

**Module impact:** None for this PR. Phase D of #657 updates `docs/instructions/fleet-ops.md` to document the full orchestrator architecture.

## Deployment Notes

Post-merge:
1. `cd workers/crane-context && npm run db:migrate` (staging).
2. Verify: `wrangler d1 execute crane-context-db-staging --remote --command "SELECT COUNT(*) FROM fleet_health_findings WHERE source IS NULL"` — should be 0.
3. `npm run db:migrate:prod` (production) after staging verification.
4. Deploy worker to staging, then prod, via standard `npm run deploy` / `deploy:prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)