### PR TITLE
feat(fleet): Hermes fleet_update skill + systemd units + provisioner

### DIFF
--- a/scripts/provision-hermes-fleet-update.sh
+++ b/scripts/provision-hermes-fleet-update.sh
@@ -143,25 +143,53 @@ mkdir -p /var/log/fleet-update /etc/fleet-update
 chown "$TARGET_USER:$TARGET_USER" /var/log/fleet-update
 chmod 755 /var/log/fleet-update
 
-# Substitute HERMES_CMD into the service file if overridden.
+# Resolve the absolute path to `hermes` on THIS host as the target user,
+# so the runtime PATH (pip install --user, /usr/local/bin, etc.) is
+# respected. systemd requires an absolute path in ExecStart.
 service_src="$SOURCE_REPO/tools/hermes/systemd/fleet-update.service"
 timer_src="$SOURCE_REPO/tools/hermes/systemd/fleet-update.timer"
 
-if [ "${HERMES_CMD}" != "hermes chat --skill fleet_update --non-interactive" ]; then
-    # Rewrite ExecStart line with the overridden command. Path-qualify the
-    # first word so systemd accepts it.
+hermes_bin=$(sudo -u "$TARGET_USER" bash -lc 'command -v hermes' 2>/dev/null || true)
+if [ -z "$hermes_bin" ]; then
+    for candidate in /usr/local/bin/hermes "$TARGET_HOME/.local/bin/hermes" /usr/bin/hermes; do
+        if [ -x "$candidate" ]; then
+            hermes_bin="$candidate"
+            break
+        fi
+    done
+fi
+
+if [ -z "$hermes_bin" ]; then
+    echo "[error] could not locate hermes binary on this host." >&2
+    echo "        install first: sudo -u $TARGET_USER pip install hermes-agent" >&2
+    exit 1
+fi
+echo "[info] resolved hermes binary: $hermes_bin"
+
+# Determine the ExecStart command. HERMES_CMD overrides the entire
+# invocation; otherwise use the template's default subcommand form
+# with the resolved binary path.
+if [ -n "${HERMES_CMD:-}" ]; then
     first_word="${HERMES_CMD%% *}"
     rest_words="${HERMES_CMD#* }"
     if [[ "$first_word" == /* ]]; then
-        abs_hermes="$first_word"
+        # Already absolute — trust the override verbatim.
+        resolved_exec="$HERMES_CMD"
+    elif [ "$first_word" = "hermes" ]; then
+        # Bare `hermes` — swap in the resolved binary path.
+        resolved_exec="$hermes_bin $rest_words"
     else
-        abs_hermes="$TARGET_HOME/.local/bin/$first_word"
+        # Some other binary name — assume the user knows what they're doing.
+        resolved_exec="$hermes_bin $HERMES_CMD"
     fi
-    sed "s|^ExecStart=.*|ExecStart=$abs_hermes $rest_words|" "$service_src" \
-        > /etc/systemd/system/fleet-update.service
 else
-    cp "$service_src" /etc/systemd/system/fleet-update.service
+    resolved_exec="$hermes_bin chat --skill fleet_update --non-interactive"
 fi
+
+echo "[info] ExecStart=$resolved_exec"
+
+sed "s|^ExecStart=.*|ExecStart=$resolved_exec|" "$service_src" \
+    > /etc/systemd/system/fleet-update.service
 cp "$timer_src" /etc/systemd/system/fleet-update.timer
 chmod 644 /etc/systemd/system/fleet-update.service /etc/systemd/system/fleet-update.timer
 

--- a/scripts/provision-hermes-fleet-update.sh
+++ b/scripts/provision-hermes-fleet-update.sh
@@ -24,9 +24,9 @@
 #
 # Environment overrides:
 #   HERMES_CMD    Override the hermes invocation used by the service.
-#                 Default: "hermes chat --skill fleet_update --non-interactive"
-#                 Set this if the installed hermes-agent build uses a
-#                 different command form (e.g. "hermes skill run fleet_update").
+#                 Default: `hermes chat -q "..." -s fleet_update -Q` (verified
+#                 against hermes CLI on mini, 2026-04-23). Set this if the
+#                 installed build ever changes its flags.
 #
 # Idempotent: re-running is safe. Does NOT arm the timer until the
 # Captain explicitly enables it (see the Next Steps output).
@@ -60,7 +60,9 @@ if [ ! -d "$SOURCE_REPO/tools/hermes/fleet_update" ]; then
     exit 1
 fi
 
-HERMES_CMD="${HERMES_CMD:-hermes chat --skill fleet_update --non-interactive}"
+# HERMES_CMD left unset here — the real default is constructed later
+# using the resolved absolute binary path (see resolved_exec below).
+HERMES_CMD="${HERMES_CMD:-}"
 TARGET_USER="smdurgan"
 TARGET_HOME="/home/$TARGET_USER"
 CANONICAL_REPO="/srv/crane-console"
@@ -183,7 +185,10 @@ if [ -n "${HERMES_CMD:-}" ]; then
         resolved_exec="$hermes_bin $HERMES_CMD"
     fi
 else
-    resolved_exec="$hermes_bin chat --skill fleet_update --non-interactive"
+    # Default invocation form verified against hermes CLI on mini
+    # (2026-04-23). See tools/hermes/systemd/fleet-update.service
+    # header for the flag semantics.
+    resolved_exec="$hermes_bin chat -q \"Run the fleet_update skill for this week's scheduled maintenance cycle. Follow the execution contract in SKILL.md exactly.\" -s fleet_update -Q"
 fi
 
 echo "[info] ExecStart=$resolved_exec"

--- a/scripts/provision-hermes-fleet-update.sh
+++ b/scripts/provision-hermes-fleet-update.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+#
+# Provision the Hermes fleet_update skill and its systemd timer on `mini`.
+#
+# Installs from the canonical in-repo sources under
+# tools/hermes/{fleet_update,systemd}/ into:
+#   ~/.hermes/hermes-agent/skills/fleet_update/
+#   ~/.hermes/hermes-agent/tools/fleet_update_tools.py
+#   /etc/systemd/system/fleet-update.{service,timer}
+#   /etc/fleet-update/fleet-update.env  (scaffolded if missing)
+#   /var/log/fleet-update/               (created with smdurgan ownership)
+#   /srv/crane-console                   (git clone of this repo; ExecStartPre
+#                                         keeps it at origin/main every run)
+#
+# Patches ~/.hermes/hermes-agent/model_tools.py to discover
+# tools.fleet_update_tools (mirrors the pattern in
+# packages/crane-mcp/src/cli/launch-lib.ts:1362-1386).
+#
+# **Refuses to run on any host other than mini.** mac23 is not a
+# scheduler host — see ~/.claude/plans/cuddly-riding-sifakis.md (#657).
+#
+# Usage:
+#   sudo bash scripts/provision-hermes-fleet-update.sh
+#
+# Environment overrides:
+#   HERMES_CMD    Override the hermes invocation used by the service.
+#                 Default: "hermes chat --skill fleet_update --non-interactive"
+#                 Set this if the installed hermes-agent build uses a
+#                 different command form (e.g. "hermes skill run fleet_update").
+#
+# Idempotent: re-running is safe. Does NOT arm the timer until the
+# Captain explicitly enables it (see the Next Steps output).
+
+set -e
+set -o pipefail
+
+# ─── Refuse non-mini hosts ────────────────────────────────────────────
+HOST=$(hostname | tr '[:upper:]' '[:lower:]' | sed 's/\.local$//')
+if [ "$HOST" != "mini" ]; then
+    echo "[error] this script is mini-only (hostname=$HOST)." >&2
+    echo "        mac23 is the Captain's workstation, not a scheduler host." >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "[error] must run as root (use sudo)." >&2
+    exit 1
+fi
+
+# ─── Locate repo sources ──────────────────────────────────────────────
+# The script may be invoked from a local repo clone or via ssh. Either
+# way, determine SOURCE_REPO from $0 and ensure /srv/crane-console exists
+# as a canonical always-fresh checkout the systemd unit uses.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -d "$SOURCE_REPO/tools/hermes/fleet_update" ]; then
+    echo "[error] expected tools/hermes/fleet_update at $SOURCE_REPO — is this a crane-console checkout?" >&2
+    exit 1
+fi
+
+HERMES_CMD="${HERMES_CMD:-hermes chat --skill fleet_update --non-interactive}"
+TARGET_USER="smdurgan"
+TARGET_HOME="/home/$TARGET_USER"
+CANONICAL_REPO="/srv/crane-console"
+
+echo "[info] Provisioning fleet_update skill on $HOST (user $TARGET_USER)"
+
+# ─── 1. Canonical checkout at /srv/crane-console ──────────────────────
+if [ ! -d "$CANONICAL_REPO/.git" ]; then
+    echo "[info] Cloning canonical repo to $CANONICAL_REPO..."
+    mkdir -p "$(dirname "$CANONICAL_REPO")"
+    # Use the local source repo as origin, then convert to github origin.
+    # Alternative: direct clone from github if gh is authenticated.
+    if command -v gh >/dev/null 2>&1 && sudo -u "$TARGET_USER" gh auth status >/dev/null 2>&1; then
+        sudo -u "$TARGET_USER" gh repo clone venturecrane/crane-console "$CANONICAL_REPO"
+    else
+        git clone "$SOURCE_REPO" "$CANONICAL_REPO"
+        git -C "$CANONICAL_REPO" remote set-url origin "git@github.com:venturecrane/crane-console.git" || true
+    fi
+    chown -R "$TARGET_USER:$TARGET_USER" "$CANONICAL_REPO"
+fi
+echo "[ok] /srv/crane-console exists and is git-tracked"
+
+# ─── 2. Hermes skill + tool install ───────────────────────────────────
+HERMES_ROOT="$TARGET_HOME/.hermes/hermes-agent"
+if [ ! -d "$HERMES_ROOT" ]; then
+    echo "[error] hermes-agent not found at $HERMES_ROOT" >&2
+    echo "        install first: sudo -u $TARGET_USER pip install hermes-agent" >&2
+    exit 1
+fi
+
+SKILL_DIR="$HERMES_ROOT/skills/fleet_update"
+TOOLS_DIR="$HERMES_ROOT/tools"
+sudo -u "$TARGET_USER" mkdir -p "$SKILL_DIR" "$TOOLS_DIR"
+
+echo "[info] Rsyncing fleet_update skill + tools..."
+rsync -a --delete \
+    "$SOURCE_REPO/tools/hermes/fleet_update/" \
+    "$SKILL_DIR/"
+cp "$SOURCE_REPO/tools/hermes/fleet_update/fleet_update_tools.py" \
+   "$TOOLS_DIR/fleet_update_tools.py"
+chown -R "$TARGET_USER:$TARGET_USER" "$SKILL_DIR" "$TOOLS_DIR/fleet_update_tools.py"
+echo "[ok] skill + tools installed"
+
+# ─── 3. Patch model_tools.py to discover tools.fleet_update_tools ────
+MODEL_TOOLS="$HERMES_ROOT/model_tools.py"
+if [ -f "$MODEL_TOOLS" ]; then
+    if ! grep -q "tools.fleet_update_tools" "$MODEL_TOOLS"; then
+        echo "[info] Patching model_tools.py to include fleet_update_tools..."
+        # Best-effort: append a discovery entry. Mirrors the logic in
+        # packages/crane-mcp/src/cli/launch-lib.ts:1362-1386.
+        python3 - "$MODEL_TOOLS" <<'PYEOF'
+import re, sys
+path = sys.argv[1]
+src = open(path).read()
+if "tools.fleet_update_tools" in src:
+    sys.exit(0)
+# Look for a TOOLS or DISCOVERY list and append our module.
+m = re.search(r'(TOOLS|DISCOVERY|MODEL_TOOLS|tools)\s*=\s*\[([^\]]*)\]', src, re.DOTALL)
+if m:
+    updated = src.replace(m.group(0), m.group(0).rstrip("]").rstrip() + ',\n    "tools.fleet_update_tools",\n]')
+    open(path, "w").write(updated)
+else:
+    # Append at end of file as a fallback.
+    with open(path, "a") as fh:
+        fh.write("\n# Added by provision-hermes-fleet-update.sh (#657)\n")
+        fh.write('import importlib\n')
+        fh.write('try: importlib.import_module("tools.fleet_update_tools")\n')
+        fh.write('except Exception as _e: pass\n')
+PYEOF
+        chown "$TARGET_USER:$TARGET_USER" "$MODEL_TOOLS"
+    fi
+    echo "[ok] model_tools.py has tools.fleet_update_tools discovery"
+else
+    echo "[warn] $MODEL_TOOLS missing — skill will still run if hermes auto-discovers ~/tools/*.py"
+fi
+
+# ─── 4. Systemd service + timer ──────────────────────────────────────
+echo "[info] Installing systemd units..."
+mkdir -p /var/log/fleet-update /etc/fleet-update
+chown "$TARGET_USER:$TARGET_USER" /var/log/fleet-update
+chmod 755 /var/log/fleet-update
+
+# Substitute HERMES_CMD into the service file if overridden.
+service_src="$SOURCE_REPO/tools/hermes/systemd/fleet-update.service"
+timer_src="$SOURCE_REPO/tools/hermes/systemd/fleet-update.timer"
+
+if [ "${HERMES_CMD}" != "hermes chat --skill fleet_update --non-interactive" ]; then
+    # Rewrite ExecStart line with the overridden command. Path-qualify the
+    # first word so systemd accepts it.
+    first_word="${HERMES_CMD%% *}"
+    rest_words="${HERMES_CMD#* }"
+    if [[ "$first_word" == /* ]]; then
+        abs_hermes="$first_word"
+    else
+        abs_hermes="$TARGET_HOME/.local/bin/$first_word"
+    fi
+    sed "s|^ExecStart=.*|ExecStart=$abs_hermes $rest_words|" "$service_src" \
+        > /etc/systemd/system/fleet-update.service
+else
+    cp "$service_src" /etc/systemd/system/fleet-update.service
+fi
+cp "$timer_src" /etc/systemd/system/fleet-update.timer
+chmod 644 /etc/systemd/system/fleet-update.service /etc/systemd/system/fleet-update.timer
+
+# Scaffold the env file (idempotent — never overwrite Captain's real secrets).
+if [ ! -f /etc/fleet-update/fleet-update.env ]; then
+    cat > /etc/fleet-update/fleet-update.env <<'EOF'
+# Fleet update orchestrator environment (#657).
+# Managed by Captain — do not commit real secrets to the repo.
+#
+# FLEET_UPDATE_APPLY=false is the canary default. Flip to true after
+# ~2 weeks of classify-only runs and manual validation of the findings.
+
+FLEET_UPDATE_APPLY=false
+
+# Pulled from Infisical / Bitwarden by Captain and pasted here:
+# CRANE_ADMIN_KEY=...
+# CRANE_CONTEXT_KEY=...
+# GH_TOKEN=...
+
+CRANE_CONTEXT_BASE=https://crane-context.automation-ab6.workers.dev
+EOF
+    chmod 600 /etc/fleet-update/fleet-update.env
+    echo "[ok] scaffolded /etc/fleet-update/fleet-update.env — populate secrets before arming"
+else
+    echo "[ok] /etc/fleet-update/fleet-update.env already exists"
+fi
+
+systemctl daemon-reload
+echo "[ok] systemd units installed; daemon reloaded"
+
+# ─── 5. Next steps (do NOT arm automatically) ────────────────────────
+
+cat <<EOF
+
+──────────────────────────────────────────────────────────────────────
+Provisioning complete. Units installed but timer NOT enabled.
+
+To arm the weekly timer:
+  1. Populate secrets in /etc/fleet-update/fleet-update.env:
+       CRANE_ADMIN_KEY, CRANE_CONTEXT_KEY, GH_TOKEN
+  2. Verify mini can SSH to every fleet target as scottdurgan:
+       for alias in mac23 mbp27 think m16; do
+         ssh -o BatchMode=yes scottdurgan@\$alias 'echo ok' || echo "\$alias FAIL"
+       done
+  3. Confirm the hermes command form by running a dry execution:
+       sudo systemctl start fleet-update.service
+       tail /var/log/fleet-update/run.log
+  4. When satisfied, enable:
+       sudo systemctl enable --now fleet-update.timer
+       systemctl list-timers | grep fleet-update
+
+Canary: FLEET_UPDATE_APPLY=false for ~2 weeks. Set to true only after
+validating classifications. mac23 is permanently suppressed per
+tools/hermes/fleet_update/suppressions.yaml.
+──────────────────────────────────────────────────────────────────────
+EOF

--- a/tools/hermes/fleet_update/SKILL.md
+++ b/tools/hermes/fleet_update/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: fleet_update
+description: Walk the Crane fleet, assess host health, apply safe updates, and file issues for anything needing human judgment. Runs weekly on mini via a systemd timer (see tools/hermes/systemd/). Posts a machine-source snapshot to crane-context's fleet_health_findings table (the same ingest pipeline the weekly GitHub-state audit uses).
+version: 1.0.0
+scope: enterprise
+owner: fleet-ops
+status: active
+---
+
+# fleet_update — Crane Fleet Update Orchestrator
+
+You are the fleet update orchestrator. Your job is to SSH into every
+crane dev machine, classify what's pending, apply the safe fixes, and
+file GitHub issues for anything that needs human judgment.
+
+**Canonical plan:** `~/.claude/plans/cuddly-riding-sifakis.md` (#657 in
+`venturecrane/crane-console`).
+
+## When this runs
+
+Systemd timer `fleet-update.timer` fires this skill weekly (Sunday 07:20
+local, ±15min jitter) on the `mini` box only. You can also trigger
+manually with `systemctl start fleet-update.service`.
+
+## Inputs
+
+Read from `/etc/fleet-update/fleet-update.env`:
+
+- `FLEET_UPDATE_APPLY` (bool, **default `false`**) — apply-gate. False =
+  classify only, don't execute. Two-week canary period after initial
+  rollout. Captain flips to `true` after validating classifications.
+- `CRANE_ADMIN_KEY` — X-Admin-Key for `POST /admin/fleet-health/ingest`.
+- `CRANE_CONTEXT_BASE` — e.g. `https://crane-context.automation-ab6.workers.dev`.
+- `GH_TOKEN` — scoped PAT for `gh issue create|edit` in `venturecrane/crane-console`.
+
+Repo state: the systemd unit `ExecStartPre=` has already done
+`git fetch && git reset --hard origin/main` on `/srv/crane-console`, so
+the orchestrator tools, suppression list, and `machine-health.sh` on
+disk are exactly `origin/main`. Record the SHA via
+`git -C /srv/crane-console rev-parse HEAD` and put it in every finding's
+`extra.source_sha` so stale-code drift is visible in the ingested data.
+
+## Execution contract (one run per invocation)
+
+### 1. Load fleet registry
+
+The machine list + SSH users is in `scripts/setup-ssh-mesh.sh`
+(lines 75–82) or `tools/hermes/fleet_update/machines.yaml` if present.
+Fields you need per machine: `alias`, `tailscale_ip`, `ssh_user`, `role`.
+
+`mini` itself runs commands locally (no SSH). All others use Tailscale
+SSH. The canonical cross-user pairing is `smdurgan@mini` (executor) →
+`scottdurgan@<alias>` (targets).
+
+### 2. Load suppressions
+
+Read `tools/hermes/fleet_update/suppressions.yaml`. Format:
+
+```yaml
+- machine: mac23
+  types: ['*'] # never auto-apply anything on mac23
+  reason: 'captain workstation'
+- machine: mbp27
+  types: ['brew-outdated']
+  reason: 'manually managed tooling'
+```
+
+Wildcard `*` applies to every finding type. Classification still runs
+and findings still ingest — only `apply` is gated.
+
+### 3. For each reachable machine
+
+Run `machine-health.sh --quick --json` (locally for mini, over SSH for
+others). Wrap SSH with `bash -lc` so macOS targets load `.zprofile` for
+`brew` PATH:
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=10 scottdurgan@<alias> \
+    'bash -lc "~/dev/crane-console/scripts/machine-health.sh --quick --json"'
+```
+
+Parse the JSON. Fields of interest: `os_security`, `os_updates`,
+`brew_outdated`, `reboot_required`, `uptime_days`, `xcode_clt_outdated`,
+`disk` (string like `"87%"`).
+
+If a machine is unreachable, emit a single `preflight-fail` finding and
+move on. Do not retry within a run.
+
+### 4. Classify each finding
+
+Every non-zero signal becomes a candidate finding. Classify as
+**safe-auto** vs **needs-human**:
+
+| Finding type                                | Default classification |
+| ------------------------------------------- | ---------------------- |
+| `os-security-patches` (Linux security-only) | safe-auto              |
+| `brew-outdated` (≤ 20 formulae, no casks)   | safe-auto              |
+| `os-feature-updates` (macOS feature/major)  | needs-human            |
+| `reboot-required`                           | needs-human            |
+| `xcode-clt-outdated`                        | needs-human            |
+| `uptime-high` (> 30 days)                   | needs-human            |
+| `disk-pressure` (> 90%)                     | needs-human            |
+| `preflight-fail` / unreachable              | needs-human            |
+
+Classification can use judgment. Prefer **needs-human** when ambiguous.
+Never auto-apply anything that could require a reboot.
+
+### 5. Apply gate
+
+For each candidate **safe-auto** finding:
+
+- If `FLEET_UPDATE_APPLY=false`: skip apply, keep classification.
+- If `suppressions.yaml` matches this (machine, type) or (machine, `*`):
+  skip apply, note `auto_applied: false, apply_skipped: "suppressed:<reason>"`.
+- Otherwise apply:
+  - Linux security: `ssh <user>@<alias> 'sudo unattended-upgrade -d'`
+    (quiet success expected — `unattended-upgrades` package is the floor
+    and this just nudges it).
+  - macOS brew: `ssh <user>@<alias> 'bash -lc "brew upgrade --quiet"'`
+    — no casks, no `--greedy`.
+
+Record per finding: `extra.auto_applied` (bool), `extra.apply_exit_code`,
+`extra.apply_output_tail` (last ~20 lines).
+
+### 6. Build the ingest payload
+
+One POST per run, not per machine:
+
+```json
+{
+  "org": "venturecrane",
+  "timestamp": "<ISO8601 now>",
+  "status": "pass|fail",
+  "source": "machine",
+  "findings": [
+    {
+      "repo": "machine/mini",
+      "rule": "os-security-patches",
+      "severity": "warning",
+      "message": "3 security updates pending (applied)",
+      "extra": {
+        "classification": "safe-auto",
+        "auto_applied": true,
+        "apply_exit_code": 0,
+        "apply_output_tail": "...",
+        "source_sha": "<git SHA>",
+        "apply_mode": "apply"
+      }
+    }
+  ]
+}
+```
+
+POST to `${CRANE_CONTEXT_BASE}/admin/fleet-health/ingest` with header
+`X-Admin-Key: ${CRANE_ADMIN_KEY}`. Expect HTTP 200. Non-200 is a hard
+failure — log and exit non-zero; do not retry within the run (next
+week's run reconciles).
+
+**The `source: "machine"` discriminator is load-bearing.** Without it,
+the ingest endpoint would auto-resolve open GitHub findings using this
+snapshot. See migration 0037 and `ingestFleetHealth` (workers/crane-
+context/src/fleet-health.ts) for the scoped-resolve contract.
+
+### 7. File/update GitHub issues
+
+For each **needs-human** finding, upsert a GitHub issue in
+`venturecrane/crane-console`:
+
+- Deterministic title: `[fleet] <alias>: <finding_type>`
+  (e.g. `[fleet] mac23: reboot-required`).
+- Labels: `fleet:<alias>`, `type:patch`.
+- Body: finding message, classification, machine state summary, git SHA.
+- If issue exists open → edit (update body only, do not re-label).
+- If issue exists closed → reopen with a comment noting the finding
+  re-surfaced.
+- If a previously-filed `[fleet] <alias>: <type>` issue is no longer in
+  the current snapshot, close it with a comment ("resolved by next
+  snapshot at `<timestamp>`"). Match by title to avoid touching issues
+  the Captain filed manually.
+
+### 8. Complete the cadence item
+
+POST to `${CRANE_CONTEXT_BASE}/schedule/fleet-machine-check/complete`
+(X-Relay-Key auth) with a one-line summary. Makes SOS's Cadence block
+show a fresh `last_completed_at`.
+
+### 9. Emit a one-line result to stdout
+
+Format: `fleet-update: N machines, K applied, M issues, P failures`.
+systemd captures this in `/var/log/fleet-update/run.log`.
+
+## Failure modes & recovery
+
+- **One machine unreachable:** emit `preflight-fail`, continue.
+- **All machines unreachable:** ingest an empty-findings machine snapshot
+  anyway (this auto-resolves prior machine findings correctly via
+  full-snapshot semantics) and exit non-zero.
+- **Ingest endpoint 5xx:** exit non-zero; next week's run reconciles.
+- **gh auth expired:** emit the finding, skip issue upsert, exit non-zero.
+- **Apply failure on a safe-auto:** classify as needs-human for the next
+  run by including `extra.apply_failed=true` and filing the issue.
+
+## What you are NOT for
+
+- Config drift (dotfiles, zshrc) — different skill.
+- Code deploys — Captain-directed only.
+- Cross-venture repo audits — that's the GitHub source of `fleet_health`.
+- Anything destructive (reboots, format, uninstall) — never.
+
+## Related modules
+
+- `crane_doc('global', 'fleet-ops.md')` — fleet architecture + safety rules.
+- `workers/crane-context/src/fleet-health.ts` — ingest DAL.
+- `scripts/machine-health.sh` — per-machine data collection (JSON mode).
+- `scripts/bootstrap-unattended-upgrades.sh` — Linux security floor (Phase A).

--- a/tools/hermes/fleet_update/fleet_update_tools.py
+++ b/tools/hermes/fleet_update/fleet_update_tools.py
@@ -1,0 +1,800 @@
+"""Fleet update orchestrator helpers for the Hermes agent.
+
+This module is provisioned onto mini's Hermes install by
+``scripts/provision-hermes-fleet-update.sh`` and registered in
+``~/.hermes/hermes-agent/model_tools.py`` alongside ``crane_tools``.
+The SKILL.md beside this file drives the per-run flow; these helpers
+are the building blocks it calls.
+
+Design notes:
+    - stdlib only (json, subprocess, urllib, ssl, os, time, datetime,
+      pathlib, logging, typing) plus PyYAML — which hermes-agent
+      already requires.
+    - No retries inside a single run. Weekly cadence reconciles.
+    - Every tool is side-effect-minimal; side effects (ssh, apply,
+      POST) are explicit so the skill can reason about them.
+
+Canonical source: ``tools/hermes/fleet_update/fleet_update_tools.py``
+in ``venturecrane/crane-console``. Do not edit the deployed copy on
+mini — it's overwritten by the provisioner on every systemd run via
+``ExecStartPre=git reset --hard origin/main``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError as exc:  # pragma: no cover - deployment error
+    raise RuntimeError(
+        "PyYAML is required for fleet_update_tools. "
+        "Install with: pip install pyyaml"
+    ) from exc
+
+
+log = logging.getLogger("hermes.fleet_update")
+
+
+# ─── Data types ──────────────────────────────────────────────────────
+
+
+@dataclass
+class Machine:
+    """Single fleet machine the orchestrator visits."""
+
+    alias: str
+    tailscale_ip: str
+    ssh_user: str
+    role: str = "dev"
+
+    @property
+    def is_self(self) -> bool:
+        """True if this is the executor host (mini). Local, no SSH."""
+        return self.alias == "mini"
+
+
+@dataclass
+class Finding:
+    """One classified finding ready for ingest + issue upsert.
+
+    ``repo`` follows the convention ``machine/<alias>`` so the SOS
+    renderer can branch on source to avoid emitting dead github.com
+    links.
+    """
+
+    machine: str
+    rule: str
+    severity: str
+    message: str
+    classification: str  # "safe-auto" | "needs-human"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_ingest_payload(self) -> dict[str, Any]:
+        return {
+            "repo": f"machine/{self.machine}",
+            "rule": self.rule,
+            "severity": self.severity,
+            "message": self.message,
+            "extra": {
+                **self.extra,
+                "classification": self.classification,
+            },
+        }
+
+
+# ─── Constants & classification rules ────────────────────────────────
+
+
+# Safe-auto candidates. Everything else is needs-human by default.
+SAFE_AUTO_RULES = frozenset(
+    {
+        "os-security-patches",
+        "brew-outdated",
+    }
+)
+
+
+DEFAULT_CRANE_CONTEXT_BASE = "https://crane-context.automation-ab6.workers.dev"
+
+
+# ─── Registry loading ────────────────────────────────────────────────
+
+
+def load_suppressions(suppressions_path: str | Path) -> dict[str, set[str]]:
+    """Return {machine_alias: set(suppressed finding_types | "*")}.
+
+    Missing file → empty suppressions (permissive). Parse errors raise
+    so a malformed YAML never silently disables safety rules.
+    """
+    path = Path(suppressions_path)
+    if not path.exists():
+        log.warning("suppressions file not found at %s — empty set", path)
+        return {}
+
+    data = yaml.safe_load(path.read_text()) or []
+    out: dict[str, set[str]] = {}
+    for entry in data:
+        machine = entry.get("machine")
+        types = entry.get("types") or []
+        if not machine:
+            continue
+        out.setdefault(machine, set()).update(types)
+    return out
+
+
+def load_machine_registry(mesh_script_path: str | Path) -> list[Machine]:
+    """Parse scripts/setup-ssh-mesh.sh machine lines.
+
+    The mesh script uses a single-source-of-truth table whose rows look
+    like ``alias|tailscale_ip|ssh_user|role``. We tolerate commented
+    rows and blanks. Missing file returns a hard-coded fleet list so
+    the orchestrator still functions if the mesh script is ever
+    renamed.
+    """
+    path = Path(mesh_script_path)
+    machines: list[Machine] = []
+
+    if path.exists():
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # Match lines like: "mini|100.105.134.85|smdurgan|remote"
+            if "|" not in line or line.count("|") < 3:
+                continue
+            parts = [p.strip().strip('"') for p in line.split("|")]
+            if len(parts) < 4:
+                continue
+            alias, ts_ip, ssh_user, role = parts[0], parts[1], parts[2], parts[3]
+            # Filter non-ip rows (headers, continuation lines)
+            if not ts_ip.count(".") == 3:
+                continue
+            machines.append(Machine(alias=alias, tailscale_ip=ts_ip, ssh_user=ssh_user, role=role))
+
+    if not machines:
+        # Hard-coded fallback matching scripts/setup-ssh-mesh.sh at the
+        # time #657 Phase C was written. Keep in sync when fleet changes.
+        log.warning("falling back to hard-coded machine registry")
+        machines = [
+            Machine("mac23", "100.71.110.46", "scottdurgan"),
+            Machine("mbp27", "100.66.43.51", "scottdurgan"),
+            Machine("mini", "100.105.134.85", "smdurgan"),
+            Machine("think", "100.75.35.43", "scottdurgan"),
+            Machine("m16", "100.125.113.8", "scottdurgan"),
+        ]
+
+    return machines
+
+
+# ─── Remote execution ────────────────────────────────────────────────
+
+
+def run_health_check(machine: Machine, repo_dir: str = "/srv/crane-console") -> dict[str, Any]:
+    """Execute ``machine-health.sh --quick --json`` on the machine.
+
+    Returns the parsed JSON. Local execution for ``mini``; Tailscale
+    SSH otherwise with ``bash -lc`` wrapping so macOS brew PATH loads.
+
+    Raises ``RuntimeError`` on unreachable / non-zero / malformed JSON.
+    The caller should convert those to preflight-fail findings rather
+    than letting them abort the whole run.
+    """
+    script = f"{repo_dir if machine.is_self else '~/dev/crane-console'}/scripts/machine-health.sh"
+    cmd_str = f'bash -lc "{script} --quick --json"'
+
+    if machine.is_self:
+        cmd = ["bash", "-lc", f"{script} --quick --json"]
+    else:
+        cmd = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            f"{machine.ssh_user}@{machine.tailscale_ip}",
+            cmd_str,
+        ]
+
+    log.info("health check: %s", machine.alias)
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    # Exit 0/2 are both success-ish (2 = warnings, meaningful to us);
+    # exit 1 means at least one hard failure (DNS, preflight, crane-mcp).
+    # We still parse the JSON — the fields carry the signal either way.
+    if not proc.stdout.strip():
+        raise RuntimeError(
+            f"{machine.alias}: empty output (exit={proc.returncode}, "
+            f"stderr={proc.stderr[:200]!r})"
+        )
+
+    try:
+        return json.loads(proc.stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"{machine.alias}: unparseable JSON: {exc} (raw={proc.stdout[:200]!r})"
+        ) from exc
+
+
+# ─── Classification ──────────────────────────────────────────────────
+
+
+def classify_findings(machine: Machine, health: dict[str, Any]) -> list[Finding]:
+    """Translate a per-machine health JSON into zero or more Findings.
+
+    A Finding per non-zero signal. No Findings at all = machine is fully
+    current (green snapshot → prior findings auto-resolve on ingest).
+    """
+    findings: list[Finding] = []
+
+    def needs_human(rule: str, severity: str, msg: str, **extra: Any) -> None:
+        findings.append(
+            Finding(
+                machine=machine.alias,
+                rule=rule,
+                severity=severity,
+                message=msg,
+                classification="needs-human",
+                extra=extra,
+            )
+        )
+
+    def safe_auto(rule: str, severity: str, msg: str, **extra: Any) -> None:
+        findings.append(
+            Finding(
+                machine=machine.alias,
+                rule=rule,
+                severity=severity,
+                message=msg,
+                classification="safe-auto",
+                extra=extra,
+            )
+        )
+
+    # Security patches — Linux safe-auto; macOS needs-human (major OS
+    # updates shouldn't auto-apply because they often require reboot).
+    sec_count = int(health.get("os_security", 0) or 0)
+    if sec_count > 0:
+        if health.get("os", "").lower() == "linux":
+            safe_auto(
+                "os-security-patches",
+                "warning",
+                f"{sec_count} security updates pending",
+                count=sec_count,
+            )
+        else:
+            needs_human(
+                "os-security-patches",
+                "warning",
+                f"{sec_count} security updates pending (macOS — manual review)",
+                count=sec_count,
+            )
+
+    # Non-security OS updates — feature updates, always needs-human.
+    total = int(health.get("os_updates", 0) or 0)
+    feature_count = max(total - sec_count, 0)
+    if feature_count > 0:
+        needs_human(
+            "os-feature-updates",
+            "info",
+            f"{feature_count} non-security OS updates pending",
+            count=feature_count,
+        )
+
+    # Brew outdated — safe-auto in bounded volume, needs-human above
+    # threshold to avoid multi-hour apply times and surprise regressions.
+    brew = int(health.get("brew_outdated", 0) or 0)
+    if brew > 0:
+        if brew <= 20:
+            safe_auto(
+                "brew-outdated",
+                "info",
+                f"{brew} brew formulae outdated",
+                count=brew,
+            )
+        else:
+            needs_human(
+                "brew-outdated",
+                "warning",
+                f"{brew} brew formulae outdated — review manually (>20 threshold)",
+                count=brew,
+            )
+
+    # Reboot required — always needs-human. Never auto-reboot any box.
+    if health.get("reboot_required"):
+        needs_human(
+            "reboot-required",
+            "warning",
+            "Machine needs a reboot to complete pending updates",
+        )
+
+    # Uptime — flag long-running boxes as needs-human so Captain can
+    # coordinate a reboot window.
+    uptime_days = int(health.get("uptime_days", 0) or 0)
+    if uptime_days > 30:
+        needs_human(
+            "uptime-high",
+            "info",
+            f"Uptime is {uptime_days} days (>30 — consider reboot)",
+            uptime_days=uptime_days,
+        )
+
+    # Xcode CLT on macOS.
+    if health.get("xcode_clt_outdated"):
+        needs_human(
+            "xcode-clt-outdated",
+            "info",
+            "Xcode Command Line Tools update available",
+        )
+
+    # Disk pressure — warn early, fail at 95%.
+    disk_str = str(health.get("disk", "0%")).rstrip("%")
+    try:
+        disk_pct = int(disk_str)
+    except ValueError:
+        disk_pct = 0
+    if disk_pct >= 95:
+        needs_human(
+            "disk-pressure",
+            "error",
+            f"Disk is {disk_pct}% full",
+            disk_pct=disk_pct,
+        )
+    elif disk_pct >= 90:
+        needs_human(
+            "disk-pressure",
+            "warning",
+            f"Disk is {disk_pct}% full",
+            disk_pct=disk_pct,
+        )
+
+    # Preflight failure — crane-mcp / infisical / DNS issues. Always
+    # needs-human; the orchestrator can't self-heal these.
+    if health.get("preflight") == "fail":
+        needs_human(
+            "preflight-fail",
+            "error",
+            "preflight-check.sh failed",
+            preflight=health.get("preflight"),
+        )
+
+    return findings
+
+
+# ─── Apply gate ──────────────────────────────────────────────────────
+
+
+def should_apply(
+    finding: Finding,
+    *,
+    apply_enabled: bool,
+    suppressions: dict[str, set[str]],
+) -> tuple[bool, str]:
+    """Return ``(will_apply, reason_if_not)``.
+
+    Rules (first-match):
+        1. classification != 'safe-auto' → don't apply.
+        2. FLEET_UPDATE_APPLY=false → "canary:report-only".
+        3. suppressions matches machine + ('*' or type) → "suppressed:<reason>".
+        4. otherwise apply.
+    """
+    if finding.classification != "safe-auto":
+        return False, f"classification:{finding.classification}"
+
+    if not apply_enabled:
+        return False, "canary:report-only"
+
+    sup_types = suppressions.get(finding.machine, set())
+    if "*" in sup_types or finding.rule in sup_types:
+        return False, "suppressed"
+
+    return True, ""
+
+
+def apply_safe_auto(
+    machine: Machine,
+    finding: Finding,
+) -> dict[str, Any]:
+    """Execute the fix for a safe-auto finding. Never on mac23.
+
+    Returns ``{auto_applied, apply_exit_code, apply_output_tail}`` for
+    inclusion in ``finding.extra``. Caller updates ``finding.extra``
+    before ingest.
+    """
+    if finding.rule == "os-security-patches":
+        # Linux only — unattended-upgrade is the kernel of our floor,
+        # triggering it here just accelerates the pending patches.
+        remote = 'sudo unattended-upgrade -d'
+    elif finding.rule == "brew-outdated":
+        # macOS brew — bash -lc picks up .zprofile so /opt/homebrew/bin
+        # is on PATH for non-interactive SSH sessions.
+        remote = 'bash -lc "brew upgrade --quiet"'
+    else:
+        raise ValueError(f"apply_safe_auto not implemented for rule={finding.rule!r}")
+
+    if machine.is_self:
+        cmd = ["bash", "-lc", remote]
+    else:
+        cmd = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            f"{machine.ssh_user}@{machine.tailscale_ip}",
+            remote,
+        ]
+
+    log.info("apply %s on %s", finding.rule, machine.alias)
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=900,  # 15 min ceiling — brew can be slow
+            check=False,
+        )
+        output_tail = "\n".join((proc.stdout + proc.stderr).strip().splitlines()[-20:])
+        return {
+            "auto_applied": proc.returncode == 0,
+            "apply_exit_code": proc.returncode,
+            "apply_output_tail": output_tail,
+            "apply_mode": "apply",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "auto_applied": False,
+            "apply_exit_code": -1,
+            "apply_output_tail": "(timed out after 900s)",
+            "apply_mode": "apply",
+            "apply_failed": True,
+        }
+
+
+# ─── Ingest + GitHub ─────────────────────────────────────────────────
+
+
+def _http_post_json(url: str, payload: dict[str, Any], headers: dict[str, str]) -> tuple[int, str]:
+    """Minimal HTTPS POST via ``curl`` subprocess.
+
+    We shell out to curl rather than use ``urllib.request.urlopen`` so
+    the tool cannot be tricked into reading local files via ``file://``
+    if ``CRANE_CONTEXT_BASE`` is ever poisoned — curl is HTTP-only by
+    default and we additionally validate the ``https://`` prefix.
+
+    Returns (status_code, response_body). Raises RuntimeError on curl
+    transport failure (DNS, connection refused, TLS error, etc.).
+    """
+    if not url.startswith("https://"):
+        raise ValueError(
+            f"refusing non-https URL: {url!r} "
+            "(fleet_update_tools only posts to crane-context)"
+        )
+
+    body = json.dumps(payload)
+    cmd = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--max-time",
+        "30",
+        "--proto",
+        "=https",  # defense-in-depth: reject any non-https protocol at curl's own layer
+        "--request",
+        "POST",
+        "--header",
+        "Content-Type: application/json",
+    ]
+    for k, v in headers.items():
+        cmd.extend(["--header", f"{k}: {v}"])
+    cmd.extend(["--data", body, "--write-out", "\n%{http_code}", url])
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=45, check=False)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"curl timed out to {url}") from exc
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"curl failed (exit {proc.returncode}) to {url}: {proc.stderr[:200]!r}"
+        )
+
+    # Response body is everything except the last line; status_code is
+    # the last line (from --write-out "\n%{http_code}").
+    lines = proc.stdout.rsplit("\n", 1)
+    if len(lines) != 2:
+        raise RuntimeError(f"unexpected curl output shape: {proc.stdout[:200]!r}")
+    resp_body, status_line = lines[0], lines[1].strip()
+    try:
+        status = int(status_line)
+    except ValueError as exc:
+        raise RuntimeError(f"curl status not integer: {status_line!r}") from exc
+    return status, resp_body
+
+
+def ingest_snapshot(
+    findings: list[Finding],
+    *,
+    source_sha: str,
+    crane_context_base: str | None = None,
+    admin_key: str | None = None,
+) -> dict[str, Any]:
+    """POST a full machine-source snapshot to crane-context.
+
+    Load-bearing: ``source: "machine"`` — without it, the ingest endpoint
+    auto-resolves open GitHub findings via the pre-load query. See
+    migration 0037 and ``ingestFleetHealth`` in ``workers/crane-context/
+    src/fleet-health.ts``.
+    """
+    base = crane_context_base or os.environ.get(
+        "CRANE_CONTEXT_BASE", DEFAULT_CRANE_CONTEXT_BASE
+    )
+    key = admin_key or os.environ.get("CRANE_ADMIN_KEY")
+    if not key:
+        raise RuntimeError("CRANE_ADMIN_KEY required for ingest_snapshot")
+
+    # Annotate each finding with source_sha so stale-code drift is
+    # visible in the ingested data (e.g. if ExecStartPre fails).
+    payload_findings = []
+    for f in findings:
+        payload = f.to_ingest_payload()
+        payload["extra"]["source_sha"] = source_sha
+        payload_findings.append(payload)
+
+    body = {
+        "org": "venturecrane",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": "fail" if any(f.severity == "error" for f in findings) else "pass",
+        "source": "machine",
+        "findings": payload_findings,
+    }
+
+    status, resp_text = _http_post_json(
+        f"{base.rstrip('/')}/admin/fleet-health/ingest",
+        body,
+        {"X-Admin-Key": key},
+    )
+    if status != 200:
+        raise RuntimeError(f"ingest failed: HTTP {status}: {resp_text[:500]}")
+    return json.loads(resp_text)
+
+
+def complete_cadence(
+    *,
+    summary: str,
+    crane_context_base: str | None = None,
+    relay_key: str | None = None,
+) -> None:
+    """Mark fleet-machine-check complete so SOS's Cadence block refreshes."""
+    base = crane_context_base or os.environ.get(
+        "CRANE_CONTEXT_BASE", DEFAULT_CRANE_CONTEXT_BASE
+    )
+    key = relay_key or os.environ.get("CRANE_CONTEXT_KEY")
+    if not key:
+        log.warning("CRANE_CONTEXT_KEY missing — skipping cadence completion")
+        return
+
+    status, resp = _http_post_json(
+        f"{base.rstrip('/')}/schedule/fleet-machine-check/complete",
+        {"summary": summary},
+        {"X-Relay-Key": key},
+    )
+    if status != 200:
+        log.warning("cadence completion returned HTTP %s: %s", status, resp[:200])
+
+
+def gh_issue_upsert(
+    finding: Finding,
+    *,
+    source_sha: str,
+    repo: str = "venturecrane/crane-console",
+) -> dict[str, Any]:
+    """Upsert a `[fleet] <alias>: <type>` issue for this needs-human finding.
+
+    Uses `gh` CLI. Caller must have GH_TOKEN in env (set by systemd
+    EnvironmentFile). Returns ``{action: "created"|"updated"|"reopened",
+    issue_number: N}`` or ``{skipped: reason}`` on gh failure.
+    """
+    title = f"[fleet] {finding.machine}: {finding.rule}"
+    body = _build_issue_body(finding, source_sha)
+    labels = [f"fleet:{finding.machine}", "type:patch"]
+
+    # Search for an existing issue by exact title (open or closed).
+    search_cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--search",
+        f'in:title "{title}"',
+        "--state",
+        "all",
+        "--json",
+        "number,state,title",
+        "--limit",
+        "10",
+    ]
+    try:
+        proc = subprocess.run(search_cmd, capture_output=True, text=True, check=True, timeout=30)
+        matches = [m for m in json.loads(proc.stdout) if m["title"] == title]
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        return {"skipped": f"gh_search_failed:{exc}"}
+
+    if not matches:
+        create_cmd = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--body",
+            body,
+        ]
+        for label in labels:
+            create_cmd.extend(["--label", label])
+        try:
+            proc = subprocess.run(create_cmd, capture_output=True, text=True, check=True, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            return {"skipped": f"gh_create_failed:{exc.stderr[:200]}"}
+        # gh returns "https://github.com/owner/repo/issues/N" on stdout
+        issue_num = proc.stdout.strip().rstrip("/").rsplit("/", 1)[-1]
+        return {"action": "created", "issue_number": int(issue_num)}
+
+    # Take the newest match.
+    target = sorted(matches, key=lambda m: -m["number"])[0]
+    num = target["number"]
+
+    if target["state"] == "CLOSED":
+        subprocess.run(
+            ["gh", "issue", "reopen", str(num), "--repo", repo, "--comment", "Finding re-surfaced in fleet-update snapshot."],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        subprocess.run(
+            ["gh", "issue", "edit", str(num), "--repo", repo, "--body", body],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        return {"action": "reopened", "issue_number": num}
+
+    subprocess.run(
+        ["gh", "issue", "edit", str(num), "--repo", repo, "--body", body],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    return {"action": "updated", "issue_number": num}
+
+
+def gh_issue_close_stale(
+    active_titles: set[str],
+    *,
+    source_sha: str,
+    repo: str = "venturecrane/crane-console",
+) -> list[int]:
+    """Close fleet:* issues whose title is not in the active snapshot.
+
+    Matches by title prefix ``[fleet] `` so Captain-filed issues with
+    different title shapes are left alone.
+    """
+    search_cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--search",
+        'in:title "[fleet]"',
+        "--state",
+        "open",
+        "--json",
+        "number,title",
+        "--limit",
+        "100",
+    ]
+    try:
+        proc = subprocess.run(search_cmd, capture_output=True, text=True, check=True, timeout=30)
+        existing = json.loads(proc.stdout)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return []
+
+    closed: list[int] = []
+    for issue in existing:
+        title = issue["title"]
+        if not title.startswith("[fleet] ") or title in active_titles:
+            continue
+        comment = (
+            f"Finding no longer present in fleet-update snapshot at "
+            f"{datetime.now(timezone.utc).isoformat()} (SHA {source_sha[:7]}). "
+            "Closing automatically — reopen if the finding re-surfaces."
+        )
+        subprocess.run(
+            ["gh", "issue", "close", str(issue["number"]), "--repo", repo, "--comment", comment],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        closed.append(issue["number"])
+    return closed
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+
+def _build_issue_body(finding: Finding, source_sha: str) -> str:
+    extra_lines = "\n".join(f"- `{k}`: {v}" for k, v in sorted(finding.extra.items()))
+    return (
+        f"Fleet update orchestrator found a **needs-human** finding on `{finding.machine}`.\n\n"
+        f"## Finding\n\n"
+        f"- **Type:** `{finding.rule}`\n"
+        f"- **Severity:** `{finding.severity}`\n"
+        f"- **Classification:** `{finding.classification}`\n"
+        f"- **Message:** {finding.message}\n\n"
+        f"## Context\n\n"
+        f"{extra_lines}\n\n"
+        f"## Source\n\n"
+        f"- Crane-console: `{source_sha}`\n"
+        f"- Timestamp: `{datetime.now(timezone.utc).isoformat()}`\n"
+        f"- This issue is upserted by `tools/hermes/fleet_update/fleet_update_tools.py` "
+        f"and will close automatically when the finding disappears from the next snapshot.\n\n"
+        f"See plan: `~/.claude/plans/cuddly-riding-sifakis.md` (#657)."
+    )
+
+
+def current_source_sha(repo_dir: str = "/srv/crane-console") -> str:
+    """Return the HEAD SHA of the canonical checkout on mini."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", repo_dir, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        return proc.stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+__all__ = [
+    "Finding",
+    "Machine",
+    "SAFE_AUTO_RULES",
+    "apply_safe_auto",
+    "classify_findings",
+    "complete_cadence",
+    "current_source_sha",
+    "gh_issue_close_stale",
+    "gh_issue_upsert",
+    "ingest_snapshot",
+    "load_machine_registry",
+    "load_suppressions",
+    "run_health_check",
+    "should_apply",
+]

--- a/tools/hermes/fleet_update/suppressions.yaml
+++ b/tools/hermes/fleet_update/suppressions.yaml
@@ -1,0 +1,25 @@
+# Fleet update apply-gate suppression list.
+#
+# Machines listed here will NOT have auto-apply run against them —
+# classification still happens and findings still ingest, but the
+# safe-auto apply step is skipped. needs-human findings still file
+# GitHub issues as normal.
+#
+# Managed in-repo; the Hermes skill at tools/hermes/fleet_update/
+# SKILL.md reads this via the provisioner's rsync into
+# ~/.hermes/hermes-agent/skills/fleet_update/ on mini.
+#
+# Format:
+#   - machine: <alias>        # must match machine alias in setup-ssh-mesh.sh
+#     types: ["type1", "*"]   # "*" = every finding type
+#     reason: "..."            # short human-readable justification
+#
+# ─────────────────────────────────────────────────────────────────────
+
+- machine: mac23
+  types: ['*']
+  reason: >-
+    mac23 is the Captain's workstation — never auto-apply anything.
+    Classification still runs and issues get filed, but the orchestrator
+    does not touch brew/softwareupdate on this box. The Captain applies
+    updates on their own schedule to avoid interrupting in-flight work.

--- a/tools/hermes/systemd/fleet-update.service
+++ b/tools/hermes/systemd/fleet-update.service
@@ -30,12 +30,14 @@ ExecStartPre=/usr/bin/git -C /srv/crane-console reset --quiet --hard origin/main
 
 # The provisioner resolves the absolute path to `hermes` on the target
 # host via `which hermes` (as smdurgan) and rewrites this ExecStart. The
-# path below is the /usr/local/bin default (systemd requires an absolute
-# path). Override the subcommand form via HERMES_CMD if the installed
-# build expects something different, e.g.:
-#   HERMES_CMD='hermes skill run fleet_update' \
-#   sudo bash scripts/provision-hermes-fleet-update.sh
-ExecStart=/usr/local/bin/hermes chat --skill fleet_update --non-interactive
+# path below is a /usr/local/bin default (systemd requires an absolute
+# path). The invocation form is `hermes chat -q ... -s fleet_update -Q`:
+#   -q  single-query non-interactive mode
+#   -s  preload skill(s); comma-separated if multiple
+#   -Q  quiet (suppress banner/spinner — programmatic use)
+# Verified against hermes CLI surface on mini (2026-04-23).
+# Override with HERMES_CMD env var if needed.
+ExecStart=/usr/local/bin/hermes chat -q "Run the fleet_update skill for this week's scheduled maintenance cycle. Follow the execution contract in SKILL.md exactly." -s fleet_update -Q
 
 # One rolling log. Captured by systemd-journald anyway; the file is for
 # easy Captain-tailing after a run.

--- a/tools/hermes/systemd/fleet-update.service
+++ b/tools/hermes/systemd/fleet-update.service
@@ -1,0 +1,53 @@
+# Fleet update orchestrator — runs the Hermes fleet_update skill.
+#
+# Canonical source: tools/hermes/systemd/fleet-update.service in
+# venturecrane/crane-console. Installed on mini by
+# scripts/provision-hermes-fleet-update.sh (refuses to run on any other
+# host). Paired with fleet-update.timer.
+#
+# See SKILL.md at tools/hermes/fleet_update/ and the plan at
+# ~/.claude/plans/cuddly-riding-sifakis.md (#657).
+
+[Unit]
+Description=Crane fleet update orchestrator (Hermes)
+Documentation=https://github.com/venturecrane/crane-console/tree/main/tools/hermes/fleet_update
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=smdurgan
+Group=smdurgan
+WorkingDirectory=/srv/crane-console
+Environment="PATH=/home/smdurgan/.local/bin:/usr/local/bin:/usr/bin:/bin"
+EnvironmentFile=/etc/fleet-update/fleet-update.env
+
+# Pin the repo checkout to origin/main on every run so edits in the
+# canonical source take effect immediately and stale code is visible
+# via the extra.source_sha field in ingested findings.
+ExecStartPre=/usr/bin/git -C /srv/crane-console fetch --quiet
+ExecStartPre=/usr/bin/git -C /srv/crane-console reset --quiet --hard origin/main
+
+# Invocation form depends on the installed hermes-agent build. The
+# provisioner substitutes ${HERMES_CMD} when installing if the env var
+# is set; otherwise the default below is used. If the installed build
+# does not support --skill / --non-interactive, override with:
+#   HERMES_CMD='hermes skill run fleet_update' \
+#   sudo bash scripts/provision-hermes-fleet-update.sh
+ExecStart=/home/smdurgan/.local/bin/hermes chat --skill fleet_update --non-interactive
+
+# One rolling log. Captured by systemd-journald anyway; the file is for
+# easy Captain-tailing after a run.
+StandardOutput=append:/var/log/fleet-update/run.log
+StandardError=append:/var/log/fleet-update/run.log
+
+# Hardening — we're running shell commands and SSH so a full sandbox
+# is impractical, but prevent the service from gaining privileges or
+# writing outside its expected surfaces.
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/srv/crane-console /var/log/fleet-update /home/smdurgan
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/hermes/systemd/fleet-update.service
+++ b/tools/hermes/systemd/fleet-update.service
@@ -19,7 +19,7 @@ Type=oneshot
 User=smdurgan
 Group=smdurgan
 WorkingDirectory=/srv/crane-console
-Environment="PATH=/home/smdurgan/.local/bin:/usr/local/bin:/usr/bin:/bin"
+Environment="PATH=/usr/local/bin:/home/smdurgan/.local/bin:/usr/bin:/bin"
 EnvironmentFile=/etc/fleet-update/fleet-update.env
 
 # Pin the repo checkout to origin/main on every run so edits in the
@@ -28,13 +28,14 @@ EnvironmentFile=/etc/fleet-update/fleet-update.env
 ExecStartPre=/usr/bin/git -C /srv/crane-console fetch --quiet
 ExecStartPre=/usr/bin/git -C /srv/crane-console reset --quiet --hard origin/main
 
-# Invocation form depends on the installed hermes-agent build. The
-# provisioner substitutes ${HERMES_CMD} when installing if the env var
-# is set; otherwise the default below is used. If the installed build
-# does not support --skill / --non-interactive, override with:
+# The provisioner resolves the absolute path to `hermes` on the target
+# host via `which hermes` (as smdurgan) and rewrites this ExecStart. The
+# path below is the /usr/local/bin default (systemd requires an absolute
+# path). Override the subcommand form via HERMES_CMD if the installed
+# build expects something different, e.g.:
 #   HERMES_CMD='hermes skill run fleet_update' \
 #   sudo bash scripts/provision-hermes-fleet-update.sh
-ExecStart=/home/smdurgan/.local/bin/hermes chat --skill fleet_update --non-interactive
+ExecStart=/usr/local/bin/hermes chat --skill fleet_update --non-interactive
 
 # One rolling log. Captured by systemd-journald anyway; the file is for
 # easy Captain-tailing after a run.

--- a/tools/hermes/systemd/fleet-update.timer
+++ b/tools/hermes/systemd/fleet-update.timer
@@ -1,0 +1,22 @@
+# Fleet update orchestrator timer — weekly Sunday morning.
+#
+# Canonical source: tools/hermes/systemd/fleet-update.timer in
+# venturecrane/crane-console. Installed on mini by
+# scripts/provision-hermes-fleet-update.sh.
+#
+# Persistent=false is intentional: unattended-upgrades is landing
+# security patches nightly on Linux boxes regardless. A missed weekly
+# machine-source snapshot isn't urgent enough to catch up on reboot.
+# A missing snapshot for >10 days surfaces as a heartbeat warning in
+# SOS (see packages/crane-mcp/src/tools/sos.ts, Phase D).
+
+[Unit]
+Description=Weekly fleet update orchestrator run (Sunday 07:20 local)
+
+[Timer]
+OnCalendar=Sun *-*-* 07:20:00
+RandomizedDelaySec=15min
+Unit=fleet-update.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Phase C of the fleet update orchestrator arc (#657). Ships the in-repo canonical sources for the Hermes-on-mini orchestrator.
- **Does NOT arm on mini.** The provisioner explicitly refuses to enable the timer — Captain provisions + enables separately after verifying the exact `hermes` invocation form of the installed build and cross-user SSH trust from `smdurgan@mini` to `scottdurgan@{mac23,mbp27,think,m16}`.
- Canary default: `FLEET_UPDATE_APPLY=false`. mac23 permanently apply-suppressed regardless of that flag (Captain's workstation).

## Related Issues

Part of #657 (Phase C).

## Changes

**Skill** — `tools/hermes/fleet_update/`
- `SKILL.md` — full per-run execution contract. Reads env, loads registry + suppressions, walks machines via `machine-health.sh --quick --json`, classifies, applies (when gate open), POSTs `source: 'machine'` snapshot to `/admin/fleet-health/ingest`, upserts deterministic-title GH issues, completes `fleet-machine-check` cadence.
- `fleet_update_tools.py` — stdlib + PyYAML only. Types (`Machine`, `Finding`), `load_suppressions`, `load_machine_registry` (parses `scripts/setup-ssh-mesh.sh` with hard-coded fallback), `run_health_check`, `classify_findings`, `should_apply`, `apply_safe_auto`, `ingest_snapshot`, `complete_cadence`, `gh_issue_upsert`, `gh_issue_close_stale`, `current_source_sha`.
- `suppressions.yaml` — declarative apply-gate exclusions. mac23 is `types: ['*']` (permanent).

**Systemd units** — `tools/hermes/systemd/`
- `fleet-update.service` — `Type=oneshot`, `User=smdurgan`, `WorkingDirectory=/srv/crane-console`, `ExecStartPre` git fetch + reset to `origin/main` (so the in-repo canonical source is the live source), `ExecStart=hermes chat --skill fleet_update --non-interactive` (overridable via `HERMES_CMD` env at provision time). Hardened with `NoNewPrivileges`, `ProtectSystem=strict`, `ReadWritePaths` restricted.
- `fleet-update.timer` — `OnCalendar=Sun *-*-* 07:20:00`, `RandomizedDelaySec=15min`, no `Persistent=true` (`unattended-upgrades` is the nightly floor).

**Provisioner** — `scripts/provision-hermes-fleet-update.sh`
- Hostname gate: `[[ "$(hostname)" == "mini" ]] || die`.
- Clones/refreshes `/srv/crane-console` as the canonical checkout.
- rsyncs skill + tools into `~/.hermes/hermes-agent/`.
- Patches `model_tools.py` to discover `tools.fleet_update_tools` (mirrors `setupHermesMcp` at `packages/crane-mcp/src/cli/launch-lib.ts:1362-1386`).
- Installs systemd units to `/etc/systemd/system/`, scaffolds `/etc/fleet-update/fleet-update.env` (600 perms) with `FLEET_UPDATE_APPLY=false`.
- **Does NOT enable the timer.** Prints a Next Steps checklist.

## Security notes

- HTTPS POST goes through `curl` subprocess (scheme-pinned via `--proto =https`) rather than `urllib.request.urlopen` — sidesteps the `file://` scheme class of attacks on dynamic URL input.
- SSH uses `-o BatchMode=yes` and explicit `StrictHostKeyChecking=accept-new` on first contact.
- Issue upserts scoped by deterministic title prefix `[fleet]` — will not touch Captain-filed issues with different title shapes.

## Test Plan

- [x] `npm run verify` passes.
- [x] Python `ast.parse()` on `fleet_update_tools.py` — syntactically valid.
- [x] Both systemd unit files parse-clean by inspection (no `systemd-analyze verify` locally — runs in Phase C activation).
- [x] Provisioner `bash -n` syntax-checks clean; hostname guard verified by inspection.
- [ ] **Post-merge (Captain)**: run provisioner on mini; populate secrets; smoke-test with `sudo systemctl start fleet-update.service` (FLEET_UPDATE_APPLY=false — classify only); verify log. Enable timer only after canary satisfies.
- [ ] **Post-merge (depends on #660)**: the ingest endpoint must accept `source: 'machine'` — that's Phase B PR #660. Phase C code runs correctly against the pre-#660 worker but the `source` field will be silently dropped and rows ingest as `source='github'` (since the DAL still defaults unscoped). Safe to merge C first, but activation on mini should wait for #660 deploy.

## Feature Impact

**Feature impact:** None. All new files. No modifications to existing paths.

## Instruction Module Impact

**Module impact:** None for this PR. Phase D updates `docs/instructions/fleet-ops.md` to document the complete orchestrator architecture.

## Deployment Notes

Nothing deploys from this PR alone — the skill code sits dormant until provisioned on mini. Captain's Phase C activation sequence, in order:
1. Merge + wait for main-branch sync.
2. Merge & deploy #660 (Phase B). Migration 0037 must land before Phase C runs, else `source: 'machine'` is dropped silently.
3. SSH to mini: `sudo bash /srv/crane-console/scripts/provision-hermes-fleet-update.sh` (or adjust source path if mini hasn't cloned yet).
4. Populate `/etc/fleet-update/fleet-update.env` secrets from Infisical/Bitwarden.
5. Dry-run: `sudo systemctl start fleet-update.service`; tail `/var/log/fleet-update/run.log`.
6. Verify findings ingested with `source='machine'` (via `curl ".../fleet-health/findings?source=machine"`).
7. After ~2 weeks of classify-only canary: flip `FLEET_UPDATE_APPLY=true`, enable timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)