### PR TITLE
feat(fleet): SOS partitioned Fleet Health + fleet-machine-check cadence + docs

### DIFF
--- a/docs/instructions/fleet-ops.md
+++ b/docs/instructions/fleet-ops.md
@@ -18,6 +18,31 @@
 - Safari defaults keys guarded with `2>/dev/null || true` - may differ across macOS versions.
 - Firewall signed app allowance covers Tailscale.app. Verify `tailscale ping` after enabling.
 
+## Automated fleet updates (Hermes-on-mini)
+
+**Architecture.** The fleet has two independent update-hygiene systems that meet at the same `fleet_health_findings` table:
+
+1. **`unattended-upgrades` on Linux boxes** — the always-on floor. Installed by `scripts/bootstrap-unattended-upgrades.sh` via `bootstrap-machine.sh` on mini/mbp27/think. Security-only origins, no auto-reboot, runs nightly regardless of anything else. Lands security patches even when the orchestrator is offline.
+2. **Hermes fleet_update orchestrator on `mini`** — weekly Sunday 07:20 systemd timer. Walks every machine via Tailscale SSH, classifies findings (OS updates, brew outdated, reboot-required, uptime, Xcode CLT, disk pressure), applies safe-auto fixes, files GitHub issues for needs-human findings, and posts a `source: 'machine'` snapshot to `/admin/fleet-health/ingest`. Findings surface in `crane_sos` under Fleet Health → Machines.
+
+**Host roles.**
+
+| Box               | Role                                                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------- |
+| mini              | Orchestrator host. Only box that runs the timer.                                                                     |
+| mac23             | SSH target. Permanently apply-suppressed (Captain's workstation; see `tools/hermes/fleet_update/suppressions.yaml`). |
+| mbp27, think, m16 | SSH targets. Subject to both the `unattended-upgrades` floor (Linux) and orchestrator apply (all).                   |
+
+**mac23 is not a scheduler host.** Never cron the orchestrator on mac23. The Captain's workstation is not a server and should not run unattended maintenance.
+
+**Canary rollout.** `FLEET_UPDATE_APPLY=false` by default (classify-only). Captain flips to `true` after ~2 weeks of validating that classifications match expectations. Per-machine, per-type suppressions live in `tools/hermes/fleet_update/suppressions.yaml`.
+
+**Canonical sources.** All orchestrator code lives in the crane-console repo under `tools/hermes/fleet_update/` and `tools/hermes/systemd/`. On mini, `/srv/crane-console` is a git clone that the systemd `ExecStartPre=` resets to `origin/main` on every run — edits to the canonical sources take effect the next Sunday. Stale-code drift is visible via the `extra.source_sha` field on ingested findings.
+
+**Heartbeat.** `crane_sos` renders a WARN in the Fleet Health section when the newest open machine-source finding is > 10 days old — that directly implies the timer isn't firing. Since open findings are refreshed on every successful run, staleness is a reliable stuck-timer signal.
+
+**Provisioning.** The orchestrator is NOT armed by default. See `scripts/provision-hermes-fleet-update.sh` (refuses any host other than mini) and issue #657 for the enablement checklist.
+
 ## Pending Fleet Items
 
 - **think**: offline during fleet sync. Needs `cd ~/dev/sc-console && git pull` when it comes back online. All other repos on think will self-update on next `git pull`.
@@ -26,3 +51,7 @@
 
 - `docs/infra/ssh-tailscale-access.md` - SSH and Tailscale setup
 - `docs/infra/machine-inventory.md` - Dev machine inventory
+- `docs/process/scheduled-automation-guide.md` - Timer patterns (cron, launchd, systemd, Workers, GH Actions)
+- `tools/hermes/fleet_update/SKILL.md` - Per-run orchestrator execution contract
+- `scripts/bootstrap-unattended-upgrades.sh` - Linux security-patch floor
+- `scripts/provision-hermes-fleet-update.sh` - Orchestrator provisioner (mini-only)

--- a/docs/process/scheduled-automation-guide.md
+++ b/docs/process/scheduled-automation-guide.md
@@ -383,6 +383,76 @@ async function scheduled(controller: ScheduledController, env: Env) {
 
 ---
 
+## Mechanism 4: systemd System Timer on `mini`
+
+### Overview
+
+The always-on Ubuntu Server box (`mini`) is the fleet's natural home for recurring ops workflows that need shell access to every other machine (SSH targets, local apt/brew tooling, Infisical-seeded env). The Hermes fleet_update orchestrator (#657) is the reference implementation.
+
+**Key property:** `mini` runs headless with no interactive user, so a **system** timer — not a user timer + `loginctl enable-linger` — is the right shape. User timers on headless boxes have silent-death failure modes (logind/DBUS state regenerates on cold boot). System timers just work.
+
+### Use Cases
+
+- Ops workflows that SSH into every fleet machine (fleet health audits, config drift detection, backup orchestration).
+- Long-running agent invocations that need a git checkout + ExecStartPre to pin a known source SHA.
+- Anything too heavy for a Cloudflare Worker (no SSH access) and too stateful for GitHub Actions (runner has no persistent fleet-trust relationships).
+
+### Setup
+
+Canonical sources live in the repo under `tools/hermes/systemd/*.service` and `*.timer`. A provisioner (`scripts/provision-hermes-fleet-update.sh`) installs them to `/etc/systemd/system/` — never to `~/.config/systemd/user/`, for the reason above.
+
+Minimal service shape:
+
+```ini
+[Unit]
+Description=My scheduled workflow
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=smdurgan
+Group=smdurgan
+WorkingDirectory=/srv/crane-console
+EnvironmentFile=/etc/my-workflow/my-workflow.env
+ExecStartPre=/usr/bin/git -C /srv/crane-console fetch --quiet
+ExecStartPre=/usr/bin/git -C /srv/crane-console reset --quiet --hard origin/main
+ExecStart=/home/smdurgan/.local/bin/my-command
+StandardOutput=append:/var/log/my-workflow/run.log
+StandardError=append:/var/log/my-workflow/run.log
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/srv/crane-console /var/log/my-workflow /home/smdurgan
+PrivateTmp=true
+```
+
+Timer:
+
+```ini
+[Unit]
+Description=Run my-workflow weekly Sunday 07:20 local
+
+[Timer]
+OnCalendar=Sun *-*-* 07:20:00
+RandomizedDelaySec=15min
+Unit=my-workflow.service
+
+[Install]
+WantedBy=timers.target
+```
+
+**Intentionally absent: `Persistent=true`.** For weekly workflows paired with an independent nightly safety floor (like `unattended-upgrades`), a missed fire isn't urgent enough to catch up at the next boot. Use it only if a missed run is genuinely actionable.
+
+### Drift control via `ExecStartPre` git-reset
+
+The double `ExecStartPre=` pattern (fetch then reset --hard origin/main) makes the in-repo canonical source the live source — edits committed to main take effect on the next fire, with no separate deployment. Record the SHA (`git -C /srv/crane-console rev-parse HEAD`) in whatever telemetry the workflow ingests so stale-code drift is visible if the reset fails.
+
+### Heartbeat
+
+Long-cadence jobs need an out-of-band "did it actually run?" signal. The orchestrator model: each run POSTs a full-state snapshot with a `generated_at` timestamp. The SOS then checks whether the newest open finding is stale relative to the expected cadence (for a weekly timer, > 10 days ≈ stuck). No separate heartbeat endpoint needed — the snapshot itself is the heartbeat.
+
+---
+
 ## Choosing a Mechanism
 
 | Requirement                        | Recommended                  |
@@ -391,6 +461,7 @@ async function scheduled(controller: ScheduledController, env: Env) {
 | Needs GitHub API                   | GitHub Actions               |
 | Needs D1 database                  | Cloudflare Cron              |
 | Needs to run even if laptop closed | GitHub Actions or Cloudflare |
+| Needs fleet-wide SSH               | **systemd on mini**          |
 | Complex multi-step with AI         | Cron + claude -p             |
 | Simple data operations             | Cloudflare Cron              |
 | CI/CD related                      | GitHub Actions               |
@@ -402,3 +473,5 @@ async function scheduled(controller: ScheduledController, env: Env) {
 - `team-workflow.md` - Team processes these automations support
 - `crane-relay-api.md` - Relay endpoints for automation
 - `workers/crane-context/CLAUDE.md` - Context Worker specifics
+- `../instructions/fleet-ops.md` - Hermes-on-mini orchestrator architecture
+- `../../tools/hermes/systemd/` - Canonical systemd unit sources

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -594,6 +594,15 @@ export interface DeployHeartbeatsResponse {
 
 export type FleetFindingSeverity = 'error' | 'warning' | 'info'
 export type FleetFindingStatus = 'new' | 'resolved'
+/**
+ * Source discriminator for a finding (#657). 'github' = weekly
+ * fleet-ops-health audit; 'machine' = Hermes-on-mini host-patch
+ * orchestrator. Optional because the old worker (pre-migration 0037)
+ * didn't return this field — older SOS sessions reading against an
+ * un-upgraded worker see `undefined` and treat rows as github by
+ * convention in the renderer.
+ */
+export type FleetFindingSource = 'github' | 'machine'
 
 export interface FleetHealthFinding {
   id: string
@@ -601,6 +610,7 @@ export interface FleetHealthFinding {
   repo_full_name: string
   finding_type: string
   severity: FleetFindingSeverity
+  source?: FleetFindingSource
   details_json: string
   status: FleetFindingStatus
   resolved_at: string | null
@@ -1455,6 +1465,7 @@ export class CraneApi {
     opts: {
       status?: FleetFindingStatus | 'all'
       severity?: FleetFindingSeverity
+      source?: FleetFindingSource
       repo?: string
       type?: string
       limit?: number
@@ -1463,6 +1474,7 @@ export class CraneApi {
     const params = new URLSearchParams()
     if (opts.status) params.set('status', opts.status)
     if (opts.severity) params.set('severity', opts.severity)
+    if (opts.source) params.set('source', opts.source)
     if (opts.repo) params.set('repo', opts.repo)
     if (opts.type) params.set('type', opts.type)
     if (opts.limit !== undefined) params.set('limit', String(opts.limit))

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -384,19 +384,23 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
           await maybeAutoRefreshContext(api, scheduleBriefing)
         }
 
-        // Fleet health findings (Plan §C.4). Read-only; the weekly
-        // fleet-ops-health GitHub Action writes them. Skipped in fleet
-        // mode and gracefully degraded on failure (section simply omitted).
-        // Only shown for vc (portfolio-level signal) to keep per-venture
-        // SOS focused on that venture's work.
+        // Fleet health findings (Plan §C.4 + #657 Phase D). Read-only.
+        // Two sources share this table:
+        //   - 'github'  — weekly fleet-ops-health org audit (Plan §C.4).
+        //   - 'machine' — Hermes-on-mini host-patch orchestrator (#657).
+        //
+        // We bump the list limit to 20 so the partitioned renderer can
+        // show up to 10 per source without a second API call. Summary
+        // reflects all-source totals. Skipped in fleet mode, gracefully
+        // degraded on failure. Only shown for vc (portfolio lens).
         let fleetHealthFindings: FleetHealthFinding[] = []
         let fleetHealthSummary: FleetHealthSummary | null = null
         if (!isFleet && venture.code === 'vc') {
           try {
-            const FLEET_HEALTH_DISPLAY_LIMIT = 10
+            const FLEET_HEALTH_FETCH_LIMIT = 20
             const fhResult = await api.getFleetHealthFindings({
               status: 'new',
-              limit: FLEET_HEALTH_DISPLAY_LIMIT,
+              limit: FLEET_HEALTH_FETCH_LIMIT,
             })
             fleetHealthFindings = fhResult.findings
             fleetHealthSummary = fhResult.summary
@@ -938,22 +942,27 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
     message += formatHealthCheckSection(healthCheckResults)
   }
 
-  // --- Fleet Health (Plan §C.4) ---
-  // Portfolio-level signal from the weekly fleet-ops-health audit. The
-  // audit walks the venturecrane org via GitHub API and writes findings
-  // to fleet_health_findings. Only rendered for vc (portfolio lens) and
-  // only in full mode. Empty or null summary means "section skipped."
+  // --- Fleet Health (Plan §C.4 + #657 Phase D) ---
+  // Portfolio-level signal from two independent audit pipelines sharing
+  // the fleet_health_findings table:
+  //   - source='github'  — weekly fleet-ops-health org audit (Plan §C.4).
+  //   - source='machine' — Hermes-on-mini host-patch orchestrator (#657).
   //
-  // This is separate from CI/CD alerts (which come from webhook-driven
-  // notifications). Two signal paths, two tables — Track A owns the
-  // real-time CI signal, Track C owns the weekly runtime audit.
+  // Renders for vc (portfolio lens), full mode only. Findings are
+  // partitioned by source so a dead github.com/machine/<alias> link is
+  // never emitted. Header shows combined count.
+  //
+  // Heartbeat: if any open machine-source finding's generated_at is
+  // older than 10 days, emit a WARN — open machine findings are refreshed
+  // on every successful orchestrator run, so staleness directly implies
+  // the timer isn't running.
   if (
     !isFleet &&
     venture.code === 'vc' &&
     fleetHealthSummary &&
     fleetHealthSummary.total_open > 0
   ) {
-    const FLEET_HEALTH_DISPLAY_LIMIT = 10
+    const FLEET_HEALTH_PER_SOURCE_LIMIT = 10
     message += `## Fleet Health\n\n`
 
     // Header: truthful count of total open findings + breakdown.
@@ -971,47 +980,90 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
     message += `${total_open} open finding${total_open === 1 ? '' : 's'}${breakdown} across ${open_repos} repo${open_repos === 1 ? '' : 's'}${ageLabel}\n\n`
 
     const findings = fleetHealthFindings ?? []
-    if (findings.length > 0) {
-      // Group by repo for a more scannable table. Severity-sorted within
-      // each repo (errors first) so operators see the worst ones first.
-      const sorted = [...findings].sort((a, b) => {
-        const sevRank: Record<string, number> = { error: 0, warning: 1, info: 2 }
-        const aRank = sevRank[a.severity] ?? 3
-        const bRank = sevRank[b.severity] ?? 3
-        if (aRank !== bRank) return aRank - bRank
-        return a.repo_full_name.localeCompare(b.repo_full_name)
-      })
 
-      const shown = sorted.slice(0, FLEET_HEALTH_DISPLAY_LIMIT)
+    // Partition by source. Rows from older workers (pre-#657) carry
+    // `source: undefined` and are treated as github by convention.
+    const githubFindings = findings.filter((f) => (f.source ?? 'github') === 'github')
+    const machineFindings = findings.filter((f) => f.source === 'machine')
 
+    const sevRank: Record<string, number> = { error: 0, warning: 1, info: 2 }
+    const sortBySeverityThenRepo = (a: FleetHealthFinding, b: FleetHealthFinding): number => {
+      const aRank = sevRank[a.severity] ?? 3
+      const bRank = sevRank[b.severity] ?? 3
+      if (aRank !== bRank) return aRank - bRank
+      return a.repo_full_name.localeCompare(b.repo_full_name)
+    }
+
+    const extractMessage = (f: FleetHealthFinding): string => {
+      let msg = ''
+      try {
+        const parsed = JSON.parse(f.details_json) as { message?: string }
+        msg = parsed.message || f.details_json
+      } catch {
+        msg = f.details_json
+      }
+      if (msg.length > 80) msg = msg.slice(0, 77) + '...'
+      return msg.replace(/\|/g, '\\|')
+    }
+
+    const sevLabel = (s: string): string =>
+      s === 'error' ? 'ERROR' : s === 'warning' ? 'WARN' : 'INFO'
+
+    // Stale-audit heartbeat — only fires when machine findings exist
+    // but are older than the expected weekly cadence (10 days).
+    if (machineFindings.length > 0) {
+      const newestMachine = machineFindings.reduce((acc, f) =>
+        new Date(f.generated_at) > new Date(acc.generated_at) ? f : acc
+      )
+      const ageDays = calendarDaysSince(new Date(newestMachine.generated_at))
+      if (ageDays > 10) {
+        message += `**⚠ fleet-update timer appears stuck:** newest machine snapshot is ${ageDays} days old. Check \`systemctl list-timers | grep fleet-update\` on mini, or tail \`/var/log/fleet-update/run.log\`.\n\n`
+      }
+    }
+
+    // Render the GitHub subtable (existing audit — always first).
+    if (githubFindings.length > 0) {
+      const sorted = [...githubFindings].sort(sortBySeverityThenRepo)
+      const shown = sorted.slice(0, FLEET_HEALTH_PER_SOURCE_LIMIT)
+
+      if (machineFindings.length > 0) {
+        message += `### Repos (${githubFindings.length})\n\n`
+      }
       message += `| Severity | Repo | Finding | Message |\n`
       message += `|----------|------|---------|---------|\n`
       for (const f of shown) {
-        // details_json is stored as stringified JSON; extract the message
-        // field if present, fall back to the raw string.
-        let msg = ''
-        try {
-          const parsed = JSON.parse(f.details_json) as { message?: string }
-          msg = parsed.message || f.details_json
-        } catch {
-          msg = f.details_json
-        }
-        // Truncate message to one table cell's worth
-        if (msg.length > 80) msg = msg.slice(0, 77) + '...'
-        // Strip pipe chars that would break the table
-        msg = msg.replace(/\|/g, '\\|')
-        const sevLabel =
-          f.severity === 'error' ? 'ERROR' : f.severity === 'warning' ? 'WARN' : 'INFO'
-        message += `| ${sevLabel} | ${f.repo_full_name} | ${f.finding_type} | ${msg} |\n`
+        message += `| ${sevLabel(f.severity)} | ${f.repo_full_name} | ${f.finding_type} | ${extractMessage(f)} |\n`
       }
-
-      // Truncation banner if we capped below the true total.
-      if (total_open > shown.length) {
-        const remaining = total_open - shown.length
-        message += `\nShowing ${shown.length} of ${total_open} — +${remaining} more. Full list: \`crane_fleet_health\` (once MCP tool ships) or the weekly report artifact.\n`
+      if (githubFindings.length > shown.length) {
+        const remaining = githubFindings.length - shown.length
+        message += `\nShowing ${shown.length} of ${githubFindings.length} repo finding(s) — +${remaining} more.\n`
       }
+      message += '\n'
     }
-    message += '\n'
+
+    // Render the Machines subtable — strips the `machine/` prefix so
+    // operators see clean aliases (no dead github.com links).
+    if (machineFindings.length > 0) {
+      const sorted = [...machineFindings].sort(sortBySeverityThenRepo)
+      const shown = sorted.slice(0, FLEET_HEALTH_PER_SOURCE_LIMIT)
+
+      message += `### Machines (${machineFindings.length})\n\n`
+      message += `| Severity | Machine | Finding | Message |\n`
+      message += `|----------|---------|---------|---------|\n`
+      for (const f of shown) {
+        // Strip the `machine/` convention prefix so operators see the
+        // bare alias. Source-aware branching — never emits a link.
+        const alias = f.repo_full_name.startsWith('machine/')
+          ? f.repo_full_name.slice('machine/'.length)
+          : f.repo_full_name
+        message += `| ${sevLabel(f.severity)} | ${alias} | ${f.finding_type} | ${extractMessage(f)} |\n`
+      }
+      if (machineFindings.length > shown.length) {
+        const remaining = machineFindings.length - shown.length
+        message += `\nShowing ${shown.length} of ${machineFindings.length} machine finding(s) — +${remaining} more.\n`
+      }
+      message += '\n'
+    }
   }
 
   // --- Cadence (skipped in fleet mode, actionable items first, max 5) ---

--- a/workers/crane-context/migrations/0038_fleet_machine_check_cadence.sql
+++ b/workers/crane-context/migrations/0038_fleet_machine_check_cadence.sql
@@ -1,0 +1,35 @@
+-- 0038_fleet_machine_check_cadence.sql
+--
+-- Issue #657 Phase D. Adds a schedule_items row for the Hermes-on-mini
+-- fleet update orchestrator (fleet-machine-check). Distinct from the
+-- existing fleet-health-check cadence — that one is owned by the
+-- weekly GitHub org audit (fleet-ops-health.yml). Two sources, two
+-- cadence items, no completion race.
+--
+-- Pattern: idempotent INSERT OR REPLACE on the stable id, mirroring
+-- 0033_add_skill_audit_cadence.sql.
+--
+-- The orchestrator marks this complete via
+-- POST /schedule/fleet-machine-check/complete at the end of each run
+-- (see tools/hermes/fleet_update/SKILL.md §8).
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_fleet_machine_check',
+  'fleet-machine-check',
+  'Fleet Machine Check',
+  'Weekly host-patch audit run by the Hermes-on-mini orchestrator. Walks each fleet machine via SSH, classifies findings (OS security updates, brew outdated, reboot-required, uptime, Xcode CLT, disk pressure), applies safe-auto fixes, and files GitHub issues for anything needing human judgment. Completes automatically on successful run via POST /schedule/fleet-machine-check/complete. If this item goes overdue, check systemctl list-timers on mini and tail /var/log/fleet-update/run.log.',
+  7,
+  'global',
+  2,
+  NULL,
+  NULL,
+  NULL,
+  1,
+  datetime('now'),
+  datetime('now')
+);


### PR DESCRIPTION
## Summary

- Phase D of the fleet update orchestrator arc (#657). Wires the Hermes-on-mini orchestrator's `machine`-source findings into `crane_sos` and adds the weekly cadence item the orchestrator marks complete on success.
- Closes out the code side of #657. Phases A (merged), B (#660), C (#661), D (this PR). After these land, Captain provisions mini and enables the timer.

## Related Issues

Closes #657 (code side — Captain's activation on mini tracked separately).

## Changes

**SOS renderer** — `packages/crane-mcp/src/tools/sos.ts`
- Fetch limit bumped 10 → 20 so the partitioned renderer can show up to 10 per source without a second API call.
- Fleet Health section partitions findings by `source`. "Repos" subtable (github) renders as before. "Machines" subtable renders when machine-source rows exist: columns `Severity | Machine | Finding | Message`. Strips `machine/<alias>` prefix so rendered aliases are clean — **no dead `github.com/machine/<alias>` links**.
- **Stale-audit heartbeat:** WARN banner when the newest open machine finding is > 10 days old. Open findings refresh on every successful orchestrator run, so staleness directly implies the timer isn't firing. Actionable signal, not cosmetic.
- Source is optional on `FleetHealthFinding` for back-compat with workers pre-migration 0037 — undefined is treated as `'github'` in the partition logic.
- `getFleetHealthFindings` accepts `source?: 'github' | 'machine'` filter.

**Cadence migration** — `workers/crane-context/migrations/0038_fleet_machine_check_cadence.sql`
- New `fleet-machine-check` schedule item (cadence_days=7, priority=2 NORMAL, scope=global). Idempotent INSERT OR REPLACE on stable id.
- Distinct from existing `fleet-health-check` (owned by the GitHub audit) — two sources, two cadence items, no completion race. The orchestrator marks this complete via `POST /schedule/fleet-machine-check/complete` on successful run.

**Docs**
- `docs/instructions/fleet-ops.md` — new "Automated fleet updates (Hermes-on-mini)" section: architecture (two layers — unattended-upgrades floor + Hermes orchestrator), host-role table (mac23 explicit not-a-scheduler-host rule), canary rollout (`FLEET_UPDATE_APPLY=false` default, mac23 permanently apply-suppressed), canonical-source drift control via `ExecStartPre` git-reset, heartbeat mechanism.
- `docs/process/scheduled-automation-guide.md` — new "Mechanism 4: systemd System Timer on `mini`" section alongside cron/launchd/GH-Actions/CF-Workers. Explains why system timer (not user timer + linger) on headless boxes, minimal service/timer shape, `ExecStartPre` drift control pattern, snapshot-as-heartbeat.

## Test Plan

- [x] `npm run verify` passes.
- [x] Typecheck clean — optional `source` field preserves back-compat with older workers.
- [x] Prettier normalized.
- [x] Visual inspection of partition logic: github-only input renders legacy "Repos" table unchanged (no h3 header, no partitioning overhead); mixed input renders both subtables with h3 headers and separate counts.
- [ ] Post-merge: migration 0038 applied via `cd workers/crane-context && npm run db:migrate` (staging) then `:prod`.
- [ ] Post-merge: Captain's `crane_sos(venture: 'vc')` reflects the new partition (initially only the existing "Repos" subtable renders since no machine snapshots have been ingested yet — that's correct).

## Feature Impact

**Feature impact:** None. The existing Fleet Health "Repos" subtable renders unchanged when no machine findings exist. The partition header (`### Repos (N)`) only appears when both sources have findings — single-source state keeps the legacy flat layout.

## Instruction Module Impact

**Module impact:** Updated `docs/instructions/fleet-ops.md` and `docs/process/scheduled-automation-guide.md` per plan.

## Deployment Notes

Depends on #660 (Phase B) being deployed — that's where the `source` column + scoped ingest live. Deploy order:
1. Merge + deploy #660 (migration 0037 → crane-context worker).
2. Merge + deploy this PR (migration 0038 → crane-mcp rebuild for SOS changes).
3. Merge #661 (Phase C canonical files — no deploy, sits on disk).
4. Captain: run `sudo bash /srv/crane-console/scripts/provision-hermes-fleet-update.sh` on mini after clone/refresh; populate env; smoke-test; enable timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)