### PR TITLE
fix(crane-mcp): validate repo format to prevent shell injection in fleet-status [#673]

### DIFF
--- a/packages/crane-mcp/src/tools/fleet-status.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.test.ts
@@ -332,4 +332,39 @@ describe('fleet-status tool - validation', () => {
     expect(() => fleetStatusInputSchema.parse({ machine: 'm16' })).toThrow()
     expect(() => fleetStatusInputSchema.parse({ repo: 'org/repo' })).toThrow()
   })
+
+  it('rejects repo values containing shell metacharacters', async () => {
+    const { fleetStatusInputSchema } = await getModule()
+
+    const maliciousRepos = [
+      'foo; rm -rf',
+      'org/repo; rm -rf ~',
+      'org/repo && malicious',
+      'org/repo | cat /etc/passwd',
+      'org/repo`whoami`',
+      '$(evil)/repo',
+    ]
+
+    for (const repo of maliciousRepos) {
+      expect(() => fleetStatusInputSchema.parse({ repo, issue_numbers: [1] })).toThrow()
+    }
+  })
+
+  it('accepts valid repo paths', async () => {
+    const { fleetStatusInputSchema } = await getModule()
+
+    expect(() =>
+      fleetStatusInputSchema.parse({
+        repo: 'venturecrane/crane-console',
+        issue_numbers: [42],
+      })
+    ).not.toThrow()
+
+    expect(() =>
+      fleetStatusInputSchema.parse({
+        repo: 'my-org/my.repo_name',
+        issue_numbers: [1],
+      })
+    ).not.toThrow()
+  })
 })

--- a/packages/crane-mcp/src/tools/fleet-status.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.ts
@@ -16,7 +16,11 @@ export const fleetStatusInputSchema = z
     machine: z.string().optional().describe('Target machine hostname (task mode)'),
     task_id: z.string().optional().describe('Task ID to check (task mode)'),
     // PR mode fields
-    repo: z.string().optional().describe('Full repo path org/repo (PR mode)'),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/)
+      .optional()
+      .describe('Full repo path org/repo (PR mode)'),
     issue_numbers: z
       .array(z.number())
       .optional()


### PR DESCRIPTION
## Summary

- Adds a Zod `.regex()` constraint on the `repo` parameter in `fleetStatusInputSchema`, restricting input to valid `org/repo` format: `^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$`
- Blocks crafted values like `venturecrane/crane-console; rm -rf ~` from reaching the three `execSync` template literals in `checkPrStatus`
- `issue_numbers` is already typed as `z.array(z.number())` so cannot carry shell metacharacters — no change needed there
- Adds 2 new test cases: one asserting a battery of malicious repo strings all throw Zod parse errors, one asserting valid paths still work

## Test plan

- [x] `npm test -w @venturecrane/crane-mcp` — 520 tests pass including 12 fleet-status tests (up from 10)
- [x] `npm run verify` — typecheck, format, lint, all test suites, builds all pass

Note: 4 pre-existing failures in `test/harness/notes.test.ts` are from concurrent work on issue #675 and are unrelated to this change.

Closes #673

🤖 Generated with [Claude Code](https://claude.ai/claude-code)