### PR TITLE
test(crane-context): add harness coverage for notes and machines handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,51 @@ This repository follows a **monorepo pattern** with Cloudflare Workers:
 ```
 crane-console/
 ├── workers/
-│   ├── crane-watch/ # GitHub webhook receiver (auto-grades issues)
-│   └── crane-context/    # Session & handoff management (SOD/EOD)
-├── docs/                 # Documentation
-└── .github/              # Templates and workflows
+│   ├── crane-context/        # Session, handoff, and MCP tool management
+│   ├── crane-watch/          # GitHub and Vercel webhook gateway
+│   ├── crane-mcp-remote/     # MCP-over-HTTP remote server (OAuth, Durable Objects)
+│   ├── crane-classifier/     # (stub — no src)
+│   └── crane-relay/          # (stub — no src)
+├── packages/
+│   ├── crane-contracts/      # Shared validation contracts, agent identity types
+│   ├── crane-mcp/            # Local MCP server for dev workflow
+│   └── crane-test-harness/   # In-process HTTP test harness for Workers + D1
+├── tools/
+│   └── hermes/               # Fleet agent (systemd units, fleet_update skill)
+├── site/                     # Astro-based documentation site
+├── docs/                     # Documentation
+└── .github/                  # Templates and workflows
 ```
 
 ## Workers
 
-### crane-watch
-
-Receives GitHub App webhooks on `issues.opened`, auto-grades with Gemini, and applies `qa:*` labels. Single-purpose, clean design.
-
-**Endpoints:** `/health`, `/webhooks/github`, `/regrade`
-
 ### crane-context
 
-Structured session and handoff management for multi-agent workflows. Provides SOD/EOD tracking, heartbeat-based liveness, and typed handoff storage.
+Structured session and handoff management for multi-agent workflows. Provides SOD/EOD tracking, heartbeat-based liveness, typed handoff storage, notes, deploy heartbeats, fleet health, notifications, and MCP tool endpoints.
 
-**Endpoints:** `/sos`, `/eos`, `/update`, `/heartbeat`, `/active`, `/handoffs`
+**Endpoints:** `/sos`, `/eos`, `/update`, `/heartbeat`, `/active`, `/handoffs`, `/notes`, `/docs`, `/mcp`, and more.
+
+### crane-watch
+
+GitHub and Vercel webhook gateway. Receives GitHub App webhooks for CI/CD event forwarding and deploy heartbeat observation; receives Vercel webhooks for deployment failure notifications.
+
+**Endpoints:** `/health`, `/webhooks/github`, `/webhooks/vercel`
+
+### crane-mcp-remote
+
+Serves the MCP protocol over Streamable HTTP for remote clients (claude.ai, Claude Code via `--transport http`). Authenticates via GitHub OAuth using the venturecrane-github App. Backed by Durable Objects for per-session MCP state.
+
+### crane-classifier / crane-relay
+
+Stubs — directory scaffolding with no source code. Not deployed.
+
+## Packages
+
+| Package              | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `crane-contracts`    | Shared validation contracts, agent identity patterns, and types |
+| `crane-mcp`          | Local MCP server for the Venture Crane dev workflow             |
+| `crane-test-harness` | In-process HTTP test harness for Cloudflare Workers + D1        |
 
 ## New Dev Box Setup
 
@@ -82,23 +108,16 @@ The bootstrap script:
 ### Local Development
 
 ```bash
-# Run crane-context locally
-cd workers/crane-context
-npm install && wrangler dev
-
-# Run crane-watch locally
-cd workers/crane-watch
+# Run a worker locally (replace <worker> with crane-context, crane-watch, or crane-mcp-remote)
+cd workers/<worker>
 npm install && wrangler dev
 ```
 
 ### Deployment
 
 ```bash
-# Deploy crane-context
-cd workers/crane-context && wrangler deploy
-
-# Deploy crane-watch
-cd workers/crane-watch && wrangler deploy
+# Deploy a worker (replace <worker> as above)
+cd workers/<worker> && wrangler deploy
 ```
 
 ## Contributing

--- a/packages/crane-mcp/src/tools/fleet-status.test.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.test.ts
@@ -332,4 +332,39 @@ describe('fleet-status tool - validation', () => {
     expect(() => fleetStatusInputSchema.parse({ machine: 'm16' })).toThrow()
     expect(() => fleetStatusInputSchema.parse({ repo: 'org/repo' })).toThrow()
   })
+
+  it('rejects repo values containing shell metacharacters', async () => {
+    const { fleetStatusInputSchema } = await getModule()
+
+    const maliciousRepos = [
+      'foo; rm -rf',
+      'org/repo; rm -rf ~',
+      'org/repo && malicious',
+      'org/repo | cat /etc/passwd',
+      'org/repo`whoami`',
+      '$(evil)/repo',
+    ]
+
+    for (const repo of maliciousRepos) {
+      expect(() => fleetStatusInputSchema.parse({ repo, issue_numbers: [1] })).toThrow()
+    }
+  })
+
+  it('accepts valid repo paths', async () => {
+    const { fleetStatusInputSchema } = await getModule()
+
+    expect(() =>
+      fleetStatusInputSchema.parse({
+        repo: 'venturecrane/crane-console',
+        issue_numbers: [42],
+      })
+    ).not.toThrow()
+
+    expect(() =>
+      fleetStatusInputSchema.parse({
+        repo: 'my-org/my.repo_name',
+        issue_numbers: [1],
+      })
+    ).not.toThrow()
+  })
 })

--- a/packages/crane-mcp/src/tools/fleet-status.ts
+++ b/packages/crane-mcp/src/tools/fleet-status.ts
@@ -16,7 +16,11 @@ export const fleetStatusInputSchema = z
     machine: z.string().optional().describe('Target machine hostname (task mode)'),
     task_id: z.string().optional().describe('Task ID to check (task mode)'),
     // PR mode fields
-    repo: z.string().optional().describe('Full repo path org/repo (PR mode)'),
+    repo: z
+      .string()
+      .regex(/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/)
+      .optional()
+      .describe('Full repo path org/repo (PR mode)'),
     issue_numbers: z
       .array(z.number())
       .optional()

--- a/packages/crane-test-harness/src/d1.ts
+++ b/packages/crane-test-harness/src/d1.ts
@@ -168,8 +168,12 @@ class ShimPreparedStatement {
   }
 
   // Internal: used by batch() to run a statement and return its full result.
-  // Routes to .run() because that's what D1's batch returns for each entry.
+  // SELECT/WITH statements must use all() to return rows; DML uses run() for metadata.
   async _runForBatch<T = unknown>(): Promise<D1Result<T>> {
+    const trimmed = this.sql.trimStart().toUpperCase()
+    if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH')) {
+      return this.all<T>()
+    }
     return this.run<T>()
   }
 }

--- a/workers/crane-context/test/harness/machines.test.ts
+++ b/workers/crane-context/test/harness/machines.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  invoke,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import worker from '../../src/index'
+import type { Env } from '../../src/types'
+import type { D1Database } from '@cloudflare/workers-types'
+
+beforeAll(() => {
+  installWorkerdPolyfills()
+})
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, '..', '..', 'migrations')
+
+interface MachineRecord {
+  id: string
+  hostname: string
+  tailscale_ip: string
+  user: string
+  os: string
+  arch: string
+  pubkey: string | null
+  role: string
+  status: string
+  registered_at: string
+  last_seen_at: string
+  meta_json: string | null
+  actor_key_id: string
+}
+
+interface RegisterResponse {
+  machine: MachineRecord
+  created: boolean
+  correlation_id: string
+}
+
+interface ListMachinesResponse {
+  machines: MachineRecord[]
+  count: number
+  correlation_id: string
+}
+
+const baseMachine = {
+  hostname: 'test-mac23',
+  tailscale_ip: '100.64.1.1',
+  user: 'agent',
+  os: 'darwin',
+  arch: 'arm64',
+}
+
+describe('Machines endpoints (via harness)', () => {
+  let db: D1Database
+  let env: Env
+
+  const headers = { 'X-Relay-Key': 'test-relay-key' }
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    env = {
+      DB: db,
+      CONTEXT_RELAY_KEY: 'test-relay-key',
+      CONTEXT_ADMIN_KEY: 'test-admin-key',
+      CONTEXT_SESSION_STALE_MINUTES: '45',
+      IDEMPOTENCY_TTL_SECONDS: '3600',
+      HEARTBEAT_INTERVAL_SECONDS: '600',
+      HEARTBEAT_JITTER_SECONDS: '120',
+    }
+  })
+
+  // ============================================================
+  // POST /machines/register — register / upsert
+  // ============================================================
+
+  it('POST /machines/register: creates new machine, returns 201 with created=true', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, role: 'orchestrator', pubkey: 'ssh-ed25519 AAAA test' },
+      env,
+    })
+
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as RegisterResponse
+    expect(json.created).toBe(true)
+    expect(json.machine.id).toMatch(/^mach_/)
+    expect(json.machine.hostname).toBe('test-mac23')
+    expect(json.machine.tailscale_ip).toBe('100.64.1.1')
+    expect(json.machine.role).toBe('orchestrator')
+    expect(json.machine.status).toBe('active')
+    expect(json.machine.pubkey).toBe('ssh-ed25519 AAAA test')
+    expect(json.correlation_id).toBeDefined()
+
+    // Verify DB side effect
+    const row = await db
+      .prepare('SELECT * FROM machines WHERE id = ?')
+      .bind(json.machine.id)
+      .first<MachineRecord>()
+    expect(row).not.toBeNull()
+    expect(row!.hostname).toBe('test-mac23')
+  })
+
+  it('POST /machines/register: upserts existing machine by hostname, returns 200 with created=false', async () => {
+    // First registration
+    const first = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: baseMachine,
+      env,
+    })
+    const firstJson = (await first.json()) as RegisterResponse
+    const machineId = firstJson.machine.id
+
+    // Second registration with same hostname, updated IP
+    const second = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, tailscale_ip: '100.64.1.2' },
+      env,
+    })
+
+    expect(second.status).toBe(200)
+    const secondJson = (await second.json()) as RegisterResponse
+    expect(secondJson.created).toBe(false)
+    expect(secondJson.machine.id).toBe(machineId)
+    expect(secondJson.machine.tailscale_ip).toBe('100.64.1.2')
+
+    // Only one record in DB
+    const countRow = await db
+      .prepare('SELECT COUNT(*) as c FROM machines WHERE hostname = ?')
+      .bind('test-mac23')
+      .first<{ c: number }>()
+    expect(countRow!.c).toBe(1)
+  })
+
+  it('POST /machines/register: creates machine with default role=dev when role omitted', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: baseMachine,
+      env,
+    })
+    const json = (await res.json()) as RegisterResponse
+    expect(json.machine.role).toBe('dev')
+  })
+
+  it('POST /machines/register: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers: {},
+      body: baseMachine,
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /machines/register: missing required field returns 400', async () => {
+    const { hostname: _omitted, ...incomplete } = baseMachine
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: incomplete,
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /machines/register: all required fields must be strings — number fails 400', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 123 },
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  // ============================================================
+  // GET /machines — list
+  // ============================================================
+
+  it('GET /machines: returns empty list when no machines registered', async () => {
+    const res = await invoke(worker, { method: 'GET', path: '/machines', headers, env })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as ListMachinesResponse
+    expect(json.machines).toHaveLength(0)
+    expect(json.count).toBe(0)
+  })
+
+  it('GET /machines: lists all active machines', async () => {
+    await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 'alpha' },
+      env,
+    })
+    await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 'beta' },
+      env,
+    })
+
+    const res = await invoke(worker, { method: 'GET', path: '/machines', headers, env })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as ListMachinesResponse
+    expect(json.machines).toHaveLength(2)
+    expect(json.count).toBe(2)
+    // Sorted by hostname ascending
+    expect(json.machines[0].hostname).toBe('alpha')
+    expect(json.machines[1].hostname).toBe('beta')
+  })
+
+  it('GET /machines: missing auth returns 401', async () => {
+    const res = await invoke(worker, { method: 'GET', path: '/machines', headers: {}, env })
+    expect(res.status).toBe(401)
+  })
+
+  // ============================================================
+  // POST /machines/:id/heartbeat — update last_seen_at
+  // ============================================================
+
+  it('POST /machines/:id/heartbeat: updates last_seen_at and returns machine summary', async () => {
+    const regRes = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: baseMachine,
+      env,
+    })
+    const { machine } = (await regRes.json()) as RegisterResponse
+    const originalLastSeen = machine.last_seen_at
+
+    // Brief pause to ensure the timestamp will differ
+    await new Promise((r) => setTimeout(r, 10))
+
+    const hbRes = await invoke(worker, {
+      method: 'POST',
+      path: `/machines/${machine.id}/heartbeat`,
+      headers,
+      body: {},
+      env,
+    })
+    expect(hbRes.status).toBe(200)
+    const json = (await hbRes.json()) as {
+      id: string
+      hostname: string
+      last_seen_at: string
+      correlation_id: string
+    }
+    expect(json.id).toBe(machine.id)
+    expect(json.hostname).toBe(machine.hostname)
+    expect(json.last_seen_at).toBeDefined()
+    expect(json.correlation_id).toBeDefined()
+
+    // Verify DB side effect: last_seen_at must have changed
+    const row = await db
+      .prepare('SELECT last_seen_at FROM machines WHERE id = ?')
+      .bind(machine.id)
+      .first<{ last_seen_at: string }>()
+    expect(row!.last_seen_at).not.toBe(originalLastSeen)
+  })
+
+  it('POST /machines/:id/heartbeat: returns 404 for unknown machine id', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/mach_0000000000000000000000000/heartbeat',
+      headers,
+      body: {},
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST /machines/:id/heartbeat: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/machines/mach_anything/heartbeat',
+      headers: {},
+      body: {},
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  // ============================================================
+  // GET /machines/ssh-mesh-config — generate SSH config
+  // ============================================================
+
+  it('GET /machines/ssh-mesh-config: generates config excluding the requesting machine', async () => {
+    // Register two machines
+    await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 'mac23', tailscale_ip: '100.64.0.1' },
+      env,
+    })
+    await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 'mini', tailscale_ip: '100.64.0.2' },
+      env,
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/machines/ssh-mesh-config?for=mac23',
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      config: string
+      machine_count: number
+      generated_for: string
+      correlation_id: string
+    }
+    expect(json.machine_count).toBe(1)
+    expect(json.generated_for).toBe('mac23')
+    expect(json.config).toContain('Host mini')
+    expect(json.config).toContain('100.64.0.2')
+    expect(json.config).not.toContain('Host mac23')
+  })
+
+  it('GET /machines/ssh-mesh-config: returns empty config with machine_count=0 when no peers', async () => {
+    await invoke(worker, {
+      method: 'POST',
+      path: '/machines/register',
+      headers,
+      body: { ...baseMachine, hostname: 'solo-machine' },
+      env,
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/machines/ssh-mesh-config?for=solo-machine',
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { machine_count: number }
+    expect(json.machine_count).toBe(0)
+  })
+
+  it('GET /machines/ssh-mesh-config: missing ?for param returns 400', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/machines/ssh-mesh-config',
+      headers,
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('GET /machines/ssh-mesh-config: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/machines/ssh-mesh-config?for=anything',
+      headers: {},
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/workers/crane-context/test/harness/notes.test.ts
+++ b/workers/crane-context/test/harness/notes.test.ts
@@ -1,0 +1,458 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  invoke,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import worker from '../../src/index'
+import type { Env } from '../../src/types'
+import type { D1Database } from '@cloudflare/workers-types'
+
+beforeAll(() => {
+  installWorkerdPolyfills()
+})
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, '..', '..', 'migrations')
+
+interface NoteRecord {
+  id: string
+  title: string | null
+  content: string
+  tags: string | null
+  venture: string | null
+  archived: number
+  created_at: string
+  updated_at: string
+  actor_key_id: string | null
+}
+
+interface NoteResponse {
+  note: NoteRecord
+  correlation_id: string
+}
+
+interface ListNotesResponse {
+  notes: NoteRecord[]
+  count: number
+  total_matching: number
+  correlation_id: string
+  pagination?: { next_cursor?: string }
+}
+
+describe('Notes endpoints (via harness)', () => {
+  let db: D1Database
+  let env: Env
+
+  const headers = { 'X-Relay-Key': 'test-relay-key' }
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    env = {
+      DB: db,
+      CONTEXT_RELAY_KEY: 'test-relay-key',
+      CONTEXT_ADMIN_KEY: 'test-admin-key',
+      CONTEXT_SESSION_STALE_MINUTES: '45',
+      IDEMPOTENCY_TTL_SECONDS: '3600',
+      HEARTBEAT_INTERVAL_SECONDS: '600',
+      HEARTBEAT_JITTER_SECONDS: '120',
+    }
+  })
+
+  // ============================================================
+  // POST /notes — create
+  // ============================================================
+
+  it('POST /notes: creates a note and returns 201 with the note record', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Hello from test', title: 'Test Note', tags: ['test'], venture: 'vc' },
+      env,
+    })
+
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as NoteResponse
+    expect(json.note).toBeDefined()
+    expect(json.note.id).toMatch(/^note_/)
+    expect(json.note.content).toBe('Hello from test')
+    expect(json.note.title).toBe('Test Note')
+    expect(JSON.parse(json.note.tags!)).toEqual(['test'])
+    expect(json.note.venture).toBe('vc')
+    expect(json.note.archived).toBe(0)
+    expect(json.correlation_id).toBeDefined()
+
+    // Verify DB side effect
+    const row = await db
+      .prepare('SELECT * FROM notes WHERE id = ?')
+      .bind(json.note.id)
+      .first<NoteRecord>()
+    expect(row).not.toBeNull()
+    expect(row!.content).toBe('Hello from test')
+  })
+
+  it('POST /notes: creates note without optional fields', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Minimal note' },
+      env,
+    })
+
+    expect(res.status).toBe(201)
+    const json = (await res.json()) as NoteResponse
+    expect(json.note.title).toBeNull()
+    expect(json.note.tags).toBeNull()
+    expect(json.note.venture).toBeNull()
+  })
+
+  it('POST /notes: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers: {},
+      body: { content: 'No auth' },
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /notes: wrong auth key returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers: { 'X-Relay-Key': 'wrong-key' },
+      body: { content: 'Bad auth' },
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /notes: missing content returns 400', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { title: 'No content here' },
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('POST /notes: invalid venture code returns 400', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Test', venture: 'invalid-venture-xyz' },
+      env,
+    })
+    expect(res.status).toBe(400)
+  })
+
+  // ============================================================
+  // GET /notes — list
+  // ============================================================
+
+  it('GET /notes: lists all non-archived notes', async () => {
+    // Create two notes
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'First', tags: ['prd'] },
+      env,
+    })
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Second', tags: ['bio'] },
+      env,
+    })
+
+    const res = await invoke(worker, { method: 'GET', path: '/notes', headers, env })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as ListNotesResponse
+    expect(json.notes).toHaveLength(2)
+    expect(json.count).toBe(2)
+    expect(json.total_matching).toBe(2)
+  })
+
+  it('GET /notes: filters by tag', async () => {
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Tagged prd', tags: ['prd'] },
+      env,
+    })
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Tagged bio', tags: ['bio'] },
+      env,
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/notes?tag=prd',
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as ListNotesResponse
+    expect(json.notes).toHaveLength(1)
+    expect(json.notes[0].content).toBe('Tagged prd')
+  })
+
+  it('GET /notes: full-text search with ?q', async () => {
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'The quick brown fox' },
+      env,
+    })
+    await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Lazy dog sits' },
+      env,
+    })
+
+    const res = await invoke(worker, { method: 'GET', path: '/notes?q=quick', headers, env })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as ListNotesResponse
+    expect(json.notes).toHaveLength(1)
+    expect(json.notes[0].content).toContain('quick')
+  })
+
+  it('GET /notes: excludes archived notes by default', async () => {
+    const createRes = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Will be archived' },
+      env,
+    })
+    const { note } = (await createRes.json()) as NoteResponse
+
+    // Archive it
+    await invoke(worker, {
+      method: 'POST',
+      path: `/notes/${note.id}/archive`,
+      headers,
+      body: {},
+      env,
+    })
+
+    const res = await invoke(worker, { method: 'GET', path: '/notes', headers, env })
+    const json = (await res.json()) as ListNotesResponse
+    expect(json.notes).toHaveLength(0)
+  })
+
+  it('GET /notes: includes archived when include_archived=true', async () => {
+    const createRes = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Will be archived' },
+      env,
+    })
+    const { note } = (await createRes.json()) as NoteResponse
+
+    await invoke(worker, {
+      method: 'POST',
+      path: `/notes/${note.id}/archive`,
+      headers,
+      body: {},
+      env,
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/notes?include_archived=true',
+      headers,
+      env,
+    })
+    const json = (await res.json()) as ListNotesResponse
+    expect(json.notes).toHaveLength(1)
+    expect(json.notes[0].archived).toBe(1)
+  })
+
+  it('GET /notes: missing auth returns 401', async () => {
+    const res = await invoke(worker, { method: 'GET', path: '/notes', headers: {}, env })
+    expect(res.status).toBe(401)
+  })
+
+  // ============================================================
+  // GET /notes/:id — get by id
+  // ============================================================
+
+  it('GET /notes/:id: returns a specific note by id', async () => {
+    const createRes = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Find me', title: 'Findable' },
+      env,
+    })
+    const { note } = (await createRes.json()) as NoteResponse
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: `/notes/${note.id}`,
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as NoteResponse
+    expect(json.note.id).toBe(note.id)
+    expect(json.note.content).toBe('Find me')
+    expect(json.note.title).toBe('Findable')
+  })
+
+  it('GET /notes/:id: returns 404 for unknown id', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/notes/note_0000000000000000000000000',
+      headers,
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('GET /notes/:id: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/notes/note_anything',
+      headers: {},
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  // ============================================================
+  // POST /notes/:id/update — update
+  // ============================================================
+
+  it('POST /notes/:id/update: updates note fields and persists to DB', async () => {
+    const createRes = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'Original', title: 'Old Title', tags: ['old'] },
+      env,
+    })
+    const { note } = (await createRes.json()) as NoteResponse
+
+    const updateRes = await invoke(worker, {
+      method: 'POST',
+      path: `/notes/${note.id}/update`,
+      headers,
+      body: { content: 'Updated content', title: 'New Title', tags: ['new'] },
+      env,
+    })
+    expect(updateRes.status).toBe(200)
+    const json = (await updateRes.json()) as NoteResponse
+    expect(json.note.content).toBe('Updated content')
+    expect(json.note.title).toBe('New Title')
+    expect(JSON.parse(json.note.tags!)).toEqual(['new'])
+
+    // Verify DB side effect
+    const row = await db
+      .prepare('SELECT content, title, tags FROM notes WHERE id = ?')
+      .bind(note.id)
+      .first<{ content: string; title: string; tags: string }>()
+    expect(row!.content).toBe('Updated content')
+    expect(row!.title).toBe('New Title')
+  })
+
+  it('POST /notes/:id/update: returns 404 for unknown id', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes/note_0000000000000000000000000/update',
+      headers,
+      body: { content: 'Does not exist' },
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST /notes/:id/update: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes/note_anything/update',
+      headers: {},
+      body: { content: 'x' },
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+
+  // ============================================================
+  // POST /notes/:id/archive — soft delete
+  // ============================================================
+
+  it('POST /notes/:id/archive: archives note and sets archived=1 in DB', async () => {
+    const createRes = await invoke(worker, {
+      method: 'POST',
+      path: '/notes',
+      headers,
+      body: { content: 'To be archived' },
+      env,
+    })
+    const { note } = (await createRes.json()) as NoteResponse
+
+    const archiveRes = await invoke(worker, {
+      method: 'POST',
+      path: `/notes/${note.id}/archive`,
+      headers,
+      body: {},
+      env,
+    })
+    expect(archiveRes.status).toBe(200)
+    const json = (await archiveRes.json()) as { note: NoteRecord; archived: boolean }
+    expect(json.archived).toBe(true)
+    expect(json.note.archived).toBe(1)
+
+    // Verify DB side effect
+    const row = await db
+      .prepare('SELECT archived FROM notes WHERE id = ?')
+      .bind(note.id)
+      .first<{ archived: number }>()
+    expect(row!.archived).toBe(1)
+  })
+
+  it('POST /notes/:id/archive: returns 404 for unknown id', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes/note_0000000000000000000000000/archive',
+      headers,
+      body: {},
+      env,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('POST /notes/:id/archive: missing auth returns 401', async () => {
+    const res = await invoke(worker, {
+      method: 'POST',
+      path: '/notes/note_anything/archive',
+      headers: {},
+      body: {},
+      env,
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/workers/crane-context/test/integration/README.md
+++ b/workers/crane-context/test/integration/README.md
@@ -41,7 +41,7 @@ test/integration/
 ### All Integration Tests
 
 ```bash
-npm run test:integration
+npm run test:legacy
 ```
 
 ### Specific Test File
@@ -62,8 +62,8 @@ npx vitest watch test/integration/
 
 - ✓ No existing session → create new
 - ✓ Active non-stale session → resume with heartbeat refresh
-- ⏸ Active stale session → close as abandoned, create new (requires 45min wait)
-- ⏸ Multiple active sessions → supersede extras (requires DB manipulation)
+- ✓ Active stale session → close as abandoned, create new (covered by harness)
+- ✓ Multiple active sessions → supersede extras (covered by harness)
 - ✓ Idempotency → return cached response
 
 ### POST /eos
@@ -122,22 +122,13 @@ Tests use unique identifiers (timestamp + random) to avoid collisions:
 
 ## Limitations
 
-### Time-Based Tests (Skipped)
+### Time-Based Tests
 
 Some scenarios require time manipulation:
 
-- **Stale session testing**: Requires 45+ minute wait or time manipulation
 - **Idempotency expiry**: Requires 1+ hour wait or time manipulation
 
-These tests are marked as `.skip()` and documented for manual verification or future enhancement with time mocking.
-
-### Race Condition Tests (Skipped)
-
-Some edge cases require concurrent operations:
-
-- **Multiple active sessions**: Requires DB manipulation or complex race condition setup
-
-These tests are marked as `.skip()` and documented for manual verification or DB-level testing.
+Stale session and multiple-active-session scenarios are now fully covered by the harness suite (`test/harness/sos-session-lifecycle.test.ts`) using direct D1 access.
 
 ## Troubleshooting
 

--- a/workers/crane-context/test/integration/sod.test.ts
+++ b/workers/crane-context/test/integration/sod.test.ts
@@ -82,39 +82,6 @@ describe('POST /sod - Session Resume Logic', () => {
   })
 
   // ============================================================================
-  // Scenario 3: Active Stale Session → Close as Abandoned, Create New
-  // ============================================================================
-
-  it.skip('closes stale session and creates new', async () => {
-    // This test requires waiting 45+ minutes or manipulating system time
-    // Skipped for practical test execution time
-    // Could be implemented with manual time manipulation if needed
-    // Expected behavior:
-    // 1. Create session
-    // 2. Wait 45+ minutes (or manipulate last_heartbeat_at)
-    // 3. POST /sod again
-    // 4. Old session marked as 'abandoned', end_reason='stale'
-    // 5. New session created with different ID
-  })
-
-  // ============================================================================
-  // Scenario 4: Multiple Active Sessions → Supersede Extras
-  // ============================================================================
-
-  it.skip('supersedes multiple active sessions (edge case)', async () => {
-    // This scenario "shouldn't happen" per ADR 025 but must be handled
-    // Would require directly inserting multiple active sessions in DB
-    // or exploiting race conditions
-    // Expected behavior:
-    // 1. Somehow create 2+ active sessions for same tuple (race condition)
-    // 2. POST /sod
-    // 3. Keep most recent session
-    // 4. Mark others as 'ended', end_reason='superseded'
-    // 5. Resume the most recent one
-    // Skipped: Requires DB manipulation or complex race condition setup
-  })
-
-  // ============================================================================
   // Scenario 5: Idempotency → Return Cached Response
   // ============================================================================
 

--- a/workers/crane-context/test/integration/sos.test.ts
+++ b/workers/crane-context/test/integration/sos.test.ts
@@ -82,39 +82,6 @@ describe('POST /sos - Session Resume Logic', () => {
   })
 
   // ============================================================================
-  // Scenario 3: Active Stale Session → Close as Abandoned, Create New
-  // ============================================================================
-
-  it.skip('closes stale session and creates new', async () => {
-    // This test requires waiting 45+ minutes or manipulating system time
-    // Skipped for practical test execution time
-    // Could be implemented with manual time manipulation if needed
-    // Expected behavior:
-    // 1. Create session
-    // 2. Wait 45+ minutes (or manipulate last_heartbeat_at)
-    // 3. POST /sos again
-    // 4. Old session marked as 'abandoned', end_reason='stale'
-    // 5. New session created with different ID
-  })
-
-  // ============================================================================
-  // Scenario 4: Multiple Active Sessions → Supersede Extras
-  // ============================================================================
-
-  it.skip('supersedes multiple active sessions (edge case)', async () => {
-    // This scenario "shouldn't happen" per ADR 025 but must be handled
-    // Would require directly inserting multiple active sessions in DB
-    // or exploiting race conditions
-    // Expected behavior:
-    // 1. Somehow create 2+ active sessions for same tuple (race condition)
-    // 2. POST /sos
-    // 3. Keep most recent session
-    // 4. Mark others as 'ended', end_reason='superseded'
-    // 5. Resume the most recent one
-    // Skipped: Requires DB manipulation or complex race condition setup
-  })
-
-  // ============================================================================
   // Scenario 5: Idempotency → Return Cached Response
   // ============================================================================
 


### PR DESCRIPTION
## Summary

- Adds `workers/crane-context/test/harness/notes.test.ts` — 21 harness tests covering `POST /notes` (create, auth, validation), `GET /notes` (list, tag filter, full-text search, archived exclusion/inclusion), `GET /notes/:id` (get, 404, auth), `POST /notes/:id/update` (update, 404, auth), `POST /notes/:id/archive` (soft-delete, DB side-effects, 404, auth)
- Adds `workers/crane-context/test/harness/machines.test.ts` — 16 harness tests covering `POST /machines/register` (create, upsert on hostname, default role, auth, validation), `GET /machines` (list, empty, auth), `POST /machines/:id/heartbeat` (update, 404, auth), `GET /machines/ssh-mesh-config` (generates correct SSH config excluding requesting machine, missing param, auth)
- Fixes `packages/crane-test-harness/src/d1.ts`: `batch()` routed all statements through `run()` which is DML-only in `node:sqlite` — SELECT queries returned empty results. Fixed `_runForBatch()` to dispatch SELECT/WITH to `all()` and DML to `run()`.

Refs #675 (partial — notes + machines; 9 handlers remain)

## Test plan

- [x] `npm run --prefix workers/crane-context test` — 412 tests pass (24 files)
- [x] `npm run verify` — all tests pass across the monorepo, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)