### PR TITLE
chore(crane-context): remove legacy skip tests now covered by harness

### DIFF
--- a/workers/crane-context/test/integration/README.md
+++ b/workers/crane-context/test/integration/README.md
@@ -41,7 +41,7 @@ test/integration/
 ### All Integration Tests
 
 ```bash
-npm run test:integration
+npm run test:legacy
 ```
 
 ### Specific Test File
@@ -62,8 +62,8 @@ npx vitest watch test/integration/
 
 - ✓ No existing session → create new
 - ✓ Active non-stale session → resume with heartbeat refresh
-- ⏸ Active stale session → close as abandoned, create new (requires 45min wait)
-- ⏸ Multiple active sessions → supersede extras (requires DB manipulation)
+- ✓ Active stale session → close as abandoned, create new (covered by harness)
+- ✓ Multiple active sessions → supersede extras (covered by harness)
 - ✓ Idempotency → return cached response
 
 ### POST /eos
@@ -122,22 +122,13 @@ Tests use unique identifiers (timestamp + random) to avoid collisions:
 
 ## Limitations
 
-### Time-Based Tests (Skipped)
+### Time-Based Tests
 
 Some scenarios require time manipulation:
 
-- **Stale session testing**: Requires 45+ minute wait or time manipulation
 - **Idempotency expiry**: Requires 1+ hour wait or time manipulation
 
-These tests are marked as `.skip()` and documented for manual verification or future enhancement with time mocking.
-
-### Race Condition Tests (Skipped)
-
-Some edge cases require concurrent operations:
-
-- **Multiple active sessions**: Requires DB manipulation or complex race condition setup
-
-These tests are marked as `.skip()` and documented for manual verification or DB-level testing.
+Stale session and multiple-active-session scenarios are now fully covered by the harness suite (`test/harness/sos-session-lifecycle.test.ts`) using direct D1 access.
 
 ## Troubleshooting
 

--- a/workers/crane-context/test/integration/sod.test.ts
+++ b/workers/crane-context/test/integration/sod.test.ts
@@ -82,39 +82,6 @@ describe('POST /sod - Session Resume Logic', () => {
   })
 
   // ============================================================================
-  // Scenario 3: Active Stale Session → Close as Abandoned, Create New
-  // ============================================================================
-
-  it.skip('closes stale session and creates new', async () => {
-    // This test requires waiting 45+ minutes or manipulating system time
-    // Skipped for practical test execution time
-    // Could be implemented with manual time manipulation if needed
-    // Expected behavior:
-    // 1. Create session
-    // 2. Wait 45+ minutes (or manipulate last_heartbeat_at)
-    // 3. POST /sod again
-    // 4. Old session marked as 'abandoned', end_reason='stale'
-    // 5. New session created with different ID
-  })
-
-  // ============================================================================
-  // Scenario 4: Multiple Active Sessions → Supersede Extras
-  // ============================================================================
-
-  it.skip('supersedes multiple active sessions (edge case)', async () => {
-    // This scenario "shouldn't happen" per ADR 025 but must be handled
-    // Would require directly inserting multiple active sessions in DB
-    // or exploiting race conditions
-    // Expected behavior:
-    // 1. Somehow create 2+ active sessions for same tuple (race condition)
-    // 2. POST /sod
-    // 3. Keep most recent session
-    // 4. Mark others as 'ended', end_reason='superseded'
-    // 5. Resume the most recent one
-    // Skipped: Requires DB manipulation or complex race condition setup
-  })
-
-  // ============================================================================
   // Scenario 5: Idempotency → Return Cached Response
   // ============================================================================
 

--- a/workers/crane-context/test/integration/sos.test.ts
+++ b/workers/crane-context/test/integration/sos.test.ts
@@ -82,39 +82,6 @@ describe('POST /sos - Session Resume Logic', () => {
   })
 
   // ============================================================================
-  // Scenario 3: Active Stale Session → Close as Abandoned, Create New
-  // ============================================================================
-
-  it.skip('closes stale session and creates new', async () => {
-    // This test requires waiting 45+ minutes or manipulating system time
-    // Skipped for practical test execution time
-    // Could be implemented with manual time manipulation if needed
-    // Expected behavior:
-    // 1. Create session
-    // 2. Wait 45+ minutes (or manipulate last_heartbeat_at)
-    // 3. POST /sos again
-    // 4. Old session marked as 'abandoned', end_reason='stale'
-    // 5. New session created with different ID
-  })
-
-  // ============================================================================
-  // Scenario 4: Multiple Active Sessions → Supersede Extras
-  // ============================================================================
-
-  it.skip('supersedes multiple active sessions (edge case)', async () => {
-    // This scenario "shouldn't happen" per ADR 025 but must be handled
-    // Would require directly inserting multiple active sessions in DB
-    // or exploiting race conditions
-    // Expected behavior:
-    // 1. Somehow create 2+ active sessions for same tuple (race condition)
-    // 2. POST /sos
-    // 3. Keep most recent session
-    // 4. Mark others as 'ended', end_reason='superseded'
-    // 5. Resume the most recent one
-    // Skipped: Requires DB manipulation or complex race condition setup
-  })
-
-  // ============================================================================
   // Scenario 5: Idempotency → Return Cached Response
   // ============================================================================
 


### PR DESCRIPTION
## Summary

- Deleted four `it.skip()` bodies in `test/integration/sos.test.ts` and `test/integration/sod.test.ts` (Scenarios 3 & 4) — both scenarios are now fully covered by `test/harness/sos-session-lifecycle.test.ts` via direct D1 access
- Fixed `test/integration/README.md` line 44: `npm run test:integration` → `npm run test:legacy` (consistent with line 21)
- Updated README coverage checklist and Limitations section to reflect harness coverage

Closes #677

## Test plan

- [ ] `npm run --prefix workers/crane-context test` passes (375 tests, 0 skipped)
- [ ] `npm run verify` passes at root
- [ ] No `it.skip` blocks remain in `test/integration/sos.test.ts` or `test/integration/sod.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)