### PR TITLE
chore(workers): remove empty crane-classifier and crane-relay stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ crane-console/
 ├── workers/
 │   ├── crane-context/        # Session, handoff, and MCP tool management
 │   ├── crane-watch/          # GitHub and Vercel webhook gateway
-│   ├── crane-mcp-remote/     # MCP-over-HTTP remote server (OAuth, Durable Objects)
-│   ├── crane-classifier/     # (stub — no src)
-│   └── crane-relay/          # (stub — no src)
+│   └── crane-mcp-remote/     # MCP-over-HTTP remote server (OAuth, Durable Objects)
 ├── packages/
 │   ├── crane-contracts/      # Shared validation contracts, agent identity types
 │   ├── crane-mcp/            # Local MCP server for dev workflow
@@ -46,10 +44,6 @@ GitHub and Vercel webhook gateway. Receives GitHub App webhooks for CI/CD event 
 ### crane-mcp-remote
 
 Serves the MCP protocol over Streamable HTTP for remote clients (claude.ai, Claude Code via `--transport http`). Authenticates via GitHub OAuth using the venturecrane-github App. Backed by Durable Objects for per-session MCP state.
-
-### crane-classifier / crane-relay
-
-Stubs — directory scaffolding with no source code. Not deployed.
 
 ## Packages
 

--- a/docs/process/CONTEXT-WORKER-SETUP.md
+++ b/docs/process/CONTEXT-WORKER-SETUP.md
@@ -149,10 +149,10 @@ cd workers/crane-context
 echo "$NEW_KEY" | npx wrangler secret put CONTEXT_RELAY_KEY
 ```
 
-**Crane Relay:**
+**Crane Relay** (external repo — `venturecrane/crane-relay`):
 
 ```bash
-cd workers/crane-relay
+# Clone or cd into venturecrane/crane-relay, then:
 echo "$NEW_KEY" | npx wrangler secret put RELAY_SHARED_SECRET
 ```
 


### PR DESCRIPTION
## Summary

Removes `workers/crane-classifier/` and `workers/crane-relay/` from the monorepo. Both directories contained only `node_modules` — no `src/`, no `wrangler.toml`, no `package.json`. Neither was wired into `typecheck`, `test`, or `verify`.

**Decision rationale:**
- `crane-classifier`: No external repo exists. Directory removed.
- `crane-relay`: The real Cloudflare Worker lives in the external repo `venturecrane/crane-relay` (last pushed 2026-01-14). The empty stub in this monorepo is removed. All references to the external repo and its live deployed worker (`crane-relay.automation-ab6.workers.dev`) are intentionally kept:
  - `workers/crane-context/src/deploy-heartbeats-github.ts` — `INFRA_REPOS` still monitors `venturecrane/crane-relay` (the real repo)
  - `site/src/content/docs/process/team-workflow.md` — curl examples reference the live deployed worker

**Doc fix included:** `docs/process/CONTEXT-WORKER-SETUP.md` — updated the crane-relay key-rotation step to clarify secrets are managed in the external `venturecrane/crane-relay` repo, not `workers/crane-relay`.

Closes #678

## Test plan

- [ ] `npm run verify` passes (nothing in verify chain referenced the stub directories)
- [ ] `workers/crane-classifier/` and `workers/crane-relay/` no longer exist in the repo
- [ ] `INFRA_REPOS` in `deploy-heartbeats-github.ts` still includes `venturecrane/crane-relay`

🤖 Generated with [Claude Code](https://claude.com/claude-code)