### PR TITLE
chore(skills): /code-review ↔ /eos pointer + prettierignore worktrees

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -357,6 +357,8 @@ Top action items:
 
 Do NOT automatically commit the full report. The user may want to review it first.
 
+> At session end, `/eos` enforces commit-or-discard on this file. It cannot be left untracked across session boundaries.
+
 After displaying the summary, record the completion in the Cadence Engine:
 
 ```

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 # Local settings (user-specific, gitignored)
 .claude/settings.local.json
 
+# Worktrees created by in-process agents (gitignored; hollow dirs when EnterWorktree
+# silent-fails. Never committed, never subject to prettier check.)
+.claude/worktrees/
+
 # Starlight generated files (gitignored, but exist on disk after build)
 site/.astro/
 site/src/content/docs/


### PR DESCRIPTION
## Summary

Small follow-up to the memory system landing. Two changes:

1. **/code-review → /eos pointer.** Adds a one-line note to `.agents/skills/code-review/SKILL.md` flagging that `/eos` enforces commit-or-discard on the code-review report at session end. `/code-review`'s "do NOT auto-commit" contract stays intact; this just synchronizes the two skills so the report cannot silently leak across session boundaries (as happened today — the 2026-04-24 review report sat as untracked for hours).
2. **.prettierignore adds `.claude/worktrees/`.** When parallel agents with `isolation: "worktree"` silently fail to isolate, the harness leaves behind hollow worktree directories with content inside `.claude/worktrees/`. Prettier was picking those up and failing CI. Worktrees are already gitignored and never committed.

Both changes are plumbing. No behavior change to code, just clarity + CI hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)