### PR TITLE
chore(crane-mcp): bump version to 0.3.0 for memory tools

### DIFF
--- a/packages/crane-mcp/package.json
+++ b/packages/crane-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/crane-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server for Venture Crane development workflow",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump to 0.3.0 to unblock the publish workflow — 0.2.0 is already on the registry. Minor bump justified by 4 new MCP tools: crane_memory, crane_memory_invoked, crane_memory_usage, crane_memory_audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)