### PR TITLE
docs(design-system): Phase 3 design system proposal

### DIFF
--- a/docs/design-system/current-state.md
+++ b/docs/design-system/current-state.md
@@ -1,0 +1,172 @@
+---
+title: 'Current State Inventory'
+sidebar:
+  order: 45
+---
+
+# Current State Inventory
+
+**Purpose.** Durable map of every venture's design-system assets against the [eight-layer framework](enterprise-scoping.md). Phase 2 deliverable of the enterprise design system initiative. Kept current as assets land; the authoritative answer to "what does X venture have for layer Y?"
+
+**Layers** (abbreviated; see [scoping brief](enterprise-scoping.md) for full definitions):
+
+1. Foundations — principles, voice, a11y baseline
+2. Tokens — color, type, spacing, elevation, motion
+3. Components — atoms, molecules, organisms
+4. Patterns — recurring UX problem/solution pairs
+5. Templates — page-level compositions
+6. Guidelines — prose doctrine
+7. Tooling — drift audits, linters, codemods, generators
+8. Governance — authoring, review, versioning, deprecation
+
+**Status key.** **C** = concrete (exists, documented, enforced). **P** = partial (some of the above). **A** = absent.
+
+## Maturity Matrix
+
+| Scope      | L1 Found | L2 Tokens | L3 Comp | L4 Patt | L5 Tmpl | L6 Guide | L7 Tool | L8 Gov |
+| ---------- | -------- | --------- | ------- | ------- | ------- | -------- | ------- | ------ |
+| Enterprise | C        | C         | A       | P       | A       | P        | C       | C      |
+| VC         | C        | C         | C       | P       | A       | P        | C       | C      |
+| KE         | C        | C         | C       | P       | A       | P        | C       | C      |
+| DC         | C        | C         | C       | P       | A       | P        | C       | C      |
+| SC         | P        | A         | A       | A       | A       | A        | P       | C      |
+| DFG        | P        | P         | P       | A       | A       | A        | P       | C      |
+| SMD        | A        | A         | A       | A       | A       | A        | A       | A      |
+| SS         | A        | P         | C       | C       | A       | C        | P       | P      |
+
+## Enterprise-Level Assets
+
+**L1 Foundations — Concrete.** `docs/design-system/brand-architecture.md` defines shared visual identity, color philosophy, typography approach, crane motif, imagery, principles. `docs/design-system/overview.md` covers spec structure, maturity tiers, contribution process.
+
+**L2 Tokens — Concrete.** `docs/design-system/token-taxonomy.md` defines `--{prefix}-{category}-{variant}` naming convention with categories: `color-`, `surface-`, `text-`, `border-`, `space-`, `font-`, `text-size-`, `radius-`, `shadow-`. No centralized token registry or JSON export despite brand-architecture principle 3 promising one.
+
+**L3 Components — Absent.** No enterprise-wide component library. Components live per-venture.
+
+**L4 Patterns — Partial.** `docs/design-system/index.md` navigates but delegates pattern definitions to ventures. SS has the only mature pattern-library in the portfolio and is operating outside the enterprise framework (see Cross-Cutting Findings).
+
+**L5 Templates — Absent.**
+
+**L6 Guidelines — Partial.** `docs/design-system/overview.md` covers contribution process and maturity tiers. No detailed usage guidelines.
+
+**L7 Tooling — Concrete.** Skills: `nav-spec` (global, v3.0.0), `design-brief`, `product-design`, `ux-brief`. The `ui-drift-audit` skill is referenced from SS `docs/style/UI-PATTERNS.md` but its location has not been verified — it may live per-venture, inside `nav-spec`, or at enterprise scope.
+
+**L8 Governance — Concrete.** Per-venture `docs/ventures/{code}/design-spec.md` files (6) auto-synced to crane-context. Design maturity tiers declared in `docs/design-system/overview.md`.
+
+## Per-Venture Inventory
+
+### VC (Venture Crane) — Tier 1 Enterprise
+
+Home venture; design-system docs are authored here. Dark-only, Astro, system fonts.
+
+- **L1** `docs/ventures/vc/design-charter.md` — C
+- **L2** `docs/ventures/vc/design-spec.md` (colors, surfaces, text, spacing) — C
+- **L3** `docs/ventures/vc/design-brief.md` + inline component docs (ArticleCard, PortfolioCard, BuildLogEntry, Header, Footer, HeroSection, SkipLink, CodeBlock, TableWrapper) — C
+- **L4** WCAG 2.1 AA, skip link, focus indicators, dark-only theme — P
+- **L7** Astro, Tailwind v4, system fonts — C (stack documented in spec)
+
+### KE (Kid Expenses) — Tier 1 Enterprise
+
+Next.js 16 (App Router), Tailwind v4, Geist Sans/Mono, Clerk. Light/dark dual-theme via `prefers-color-scheme`.
+
+- **L1** `~/dev/ke-console/docs/design/charter.md` — C
+- **L2** `docs/ventures/ke/design-spec.md` (tokens, light/dark modes) — C
+- **L3** Inline component docs (ExpenseCard, StatusBadge, ExpenseForm, BottomNav, Sheet, QuestionThread) — C
+- **L4** Dual-theme, WCAG 2.1 AA, touch targets 44×44px, semantic tokens only — P
+- **L6** Explicit rule: no raw Tailwind colors in page code — C
+
+### DC (Draft Crane) — Tier 1 Enterprise
+
+Next.js 16.1.6, Tailwind v4, CSS custom properties, TipTap (ProseMirror), Clerk. iPad-first responsive, light-only.
+
+- **L1** `~/dev/dc-console/docs/design/charter.md` — C
+- **L2** `~/dev/dc-console/docs/design/brief.md`; `docs/ventures/dc/design-spec.md` (400+ token variables, semantic palette, motion system) — C
+- **L3** `~/dev/dc-console/docs/design/library-desk-spec.md`; `~/dev/dc-console/docs/design/voice-tone-help.md`; inline docs (Toolbar, Toggle Controls, Feedback Sheet, Onboarding Cards, Help Accordion, Editor Panel, Sources Panel) — C
+- **L4** `~/dev/dc-console/docs/design/contributions/` (archived contributions) — P
+
+### SC (Silicon Crane) — Tier 3 Greenfield
+
+Identity and audience defined; no implementation yet.
+
+- **L1** `docs/ventures/sc/design-spec.md` (identity, audience, brand voice) — P
+- **L2** Spec declares "No tokens implemented yet. Starting values proposed." — A
+- **L3** "No components defined yet." — A
+- **L4** "Use standard HTML5 semantic elements. As patterns emerge during development, document them here." — A
+- **L7** Astro (content), Next.js TBD (app), Tailwind v4 recommended but not yet implemented — P
+
+### DFG (Durgan Field Guide) — Tier 3 Greenfield
+
+Astro (content) + Next.js (dfg-core, dfg-app). Tailwind v3 (migration to v4 pending).
+
+- **L1** `docs/ventures/dfg/design-spec.md` (identity, audience, brand voice) — P
+- **L2** RGB-based tokens with media query dark/light toggle; motion support absent — P
+- **L3** Minimal; lists gradient backgrounds, scrollbar styling, safe area handling — P
+- **L4** Spec notes gaps: "No documented component library, no consistent card/panel pattern, no button variants, no form input system." — A
+
+### SMD (SMD Ventures) — Status contested
+
+`docs/ventures/smd/design-spec.md` **contains Silicon Crane spec content (file-copy error)**. `docs/design-system/overview.md` declares SMD Tier 2 (Established) but no verified spec exists. Tracked as a separate issue.
+
+- **All layers** — A pending spec creation
+
+### SS (ss-console) — Outside enterprise framework
+
+Produces the most mature Layer 4 assets in the portfolio. Operating parallel to, not inside, the enterprise design system.
+
+- **L3** `~/dev/ss-console/src/components/portal/` — `PortalListItem`, `StatusPill`, `MoneyDisplay` (referenced in UI-PATTERNS.md) — C
+- **L4** `~/dev/ss-console/docs/style/UI-PATTERNS.md` (7 cited rules) + `~/dev/ss-console/docs/style/empty-state-pattern.md` — C
+- **L6** Enforcement via `nav-spec/validate.py`, forbidden-strings.test.ts, merge-gate workflow — P
+- **L2** Typography scale (7 tokens) + spacing rhythm (4 tokens) embedded in UI-PATTERNS rules 5 & 6; not cross-referenced to enterprise taxonomy — P
+
+### SS's Seven UI-Pattern Rules
+
+All cite public authority (Material 3, Polaris, Atlassian, Carbon, NN/g, HIG, WCAG):
+
+1. Status display by context — pill vs eyebrow vs dot vs prose
+2. Redundancy ban — one signal per fact
+3. Button hierarchy — one primary per view
+4. Heading skip ban — h1 → h2 → h3 descending
+5. Typography scale — `text-display`, `text-title`, `text-heading`, `text-body-lg`, `text-body`, `text-caption`, `text-label`
+6. Spacing rhythm — `space-section`, `space-card`, `space-row`, `space-stack`
+7. Shared primitives — repeated elements rendered through components, not hand-rolled
+
+## Cross-Cutting Findings
+
+### Empty slots affecting every venture
+
+- **No centralized component library.** Components exist per-venture, none cross-venture.
+- **No JSON token export.** `brand-architecture.md` principle 3 states "Designs export as JSON and CSS tokens" — only CSS exists. W3C-DTCG adoption (Phase 3) closes this.
+- **No L5 Templates layer.** No venture has page-level composition docs.
+- **No automated token compliance.** Taxonomy is documented but enforcement is manual; KE's "no raw Tailwind colors" rule has no merge gate.
+
+### Duplicates and inconsistencies
+
+- **SMD/SC spec collision.** `docs/ventures/smd/design-spec.md` is a copy of SC content.
+- **SS typography/spacing tokens not mapped to enterprise taxonomy.** Is SS's `text-label` = `--{prefix}-text-size-label`? Unresolved.
+- **Dark/light divergence.** VC dark-only; KE, DFG dual via `prefers-color-scheme`; DC light-only. No enterprise decision.
+- **Component naming conventions vary.** VC PascalCase `.astro`; KE PascalCase `.tsx`; DC semantic + BEM-like. No enforced convention.
+
+### Tooling gaps
+
+- `ui-drift-audit` skill location unverified in this scan.
+- No AST/grep rules enforce naming conventions across ventures.
+- No CI check prevents color drift (hardcoded hex instead of token).
+
+## What Phase 3 Must Address
+
+Derived from the inventory above, ranked by impact:
+
+1. **Build `@venturecrane/tokens`** — W3C-DTCG JSON source compiled via Style Dictionary to per-venture CSS variable sets. Closes the "no JSON export" gap and the "no centralized token registry" gap in one artifact.
+2. **Scaffold `docs/design-system/patterns/`** — one file per pattern in Polaris's Problem / Solution / Examples format. Seed from SS's seven rules (promoted from `ss-console` — see Issue below).
+3. **Scaffold `docs/design-system/components/`** — Atomic Design vocabulary (atoms / molecules / organisms). Start by cataloging what already exists per venture, not building new.
+4. **Token enforcement skill** — grep/AST rules for hardcoded hex/rgb/Tailwind color classes. Runs as merge gate. Either extends `ui-drift-audit` or replaces it (depends on where the current skill lives).
+5. **`docs/design-system/governance.md`** — tiered contribution model + explicit deprecation lifecycle (deprecated → hidden → removed, minimum 2 minor versions).
+
+## Open Issues (Filed Separately)
+
+- **SMD design-spec file-copy error.** Restore or rewrite to actual SMD content.
+- **Promote SS UI-PATTERNS.md to enterprise scope.** Adopts SS's seven rules as enterprise patterns 1-7; required before Phase 4 pilot pattern (actions & menus) so it sits in the right directory.
+- **Verify `ui-drift-audit` skill location.** Where does it live, who owns it, does it run cross-venture today?
+
+## Refresh Cadence
+
+This doc is refreshed at the start of each design-system phase and whenever a venture lands significant new design assets. Matrix cells change state only on verified file-level evidence. When a cell moves from A to P or C, note the commit or PR that promoted it in the per-venture section.

--- a/docs/design-system/index.md
+++ b/docs/design-system/index.md
@@ -24,3 +24,4 @@ Venture Crane runs a portfolio of products. Without a shared system, each ventur
 - **[Token Taxonomy](token-taxonomy.md)** - The naming conventions and rules that govern CSS custom properties across all ventures.
 - **[Brand Architecture](brand-architecture.md)** - Shared visual identity, design principles, and the family relationships between ventures.
 - **[Enterprise Scoping Brief](enterprise-scoping.md)** - Active initiative to expand the system to all eight design-system layers (foundations, tokens, components, patterns, templates, guidelines, tooling, governance).
+- **[Current State Inventory](current-state.md)** - Durable map of every venture's design-system assets against the eight-layer framework. Refreshed per phase.

--- a/docs/design-system/index.md
+++ b/docs/design-system/index.md
@@ -25,3 +25,4 @@ Venture Crane runs a portfolio of products. Without a shared system, each ventur
 - **[Brand Architecture](brand-architecture.md)** - Shared visual identity, design principles, and the family relationships between ventures.
 - **[Enterprise Scoping Brief](enterprise-scoping.md)** - Active initiative to expand the system to all eight design-system layers (foundations, tokens, components, patterns, templates, guidelines, tooling, governance).
 - **[Current State Inventory](current-state.md)** - Durable map of every venture's design-system assets against the eight-layer framework. Refreshed per phase.
+- **[Design System Proposal](proposal.md)** - Target architecture: what artifacts exist, where they live, authoring loop, deprecation lifecycle. Sized for solo operator with AI teammates.

--- a/docs/design-system/proposal.md
+++ b/docs/design-system/proposal.md
@@ -1,0 +1,244 @@
+---
+title: 'Design System Proposal'
+sidebar:
+  order: 48
+---
+
+# Design System Proposal
+
+**Purpose.** Defines the target shape of Venture Crane's enterprise design system: what documents exist, where they live, how they're authored and reviewed, and how they evolve. Phase 3 deliverable. Derived from the [scoping brief](enterprise-scoping.md) (direction), the [Phase 1 research](../research/enterprise-design-system-survey.md) (what to adopt from established systems), and the [current-state inventory](current-state.md) (what we have to build on).
+
+**Sizing principle.** The proposal is sized for one operator with AI teammates, not a 50-designer org. Every heavy-process primitive from the surveyed systems (federated design councils, RFC cycles, dedicated system teams) has been reduced to its smallest functional equivalent.
+
+## Target Architecture
+
+Eight layers. For each, one or two concrete artifacts. Each artifact has a file path, a format, and a change cadence.
+
+| #   | Layer       | Artifact(s)                                                    | Location                              | Format                                       | Cadence               |
+| --- | ----------- | -------------------------------------------------------------- | ------------------------------------- | -------------------------------------------- | --------------------- |
+| 1   | Foundations | `brand-architecture.md`, `overview.md`                         | `docs/design-system/` (existing)      | Prose                                        | Annual review         |
+| 2   | Tokens      | `@venturecrane/tokens` package + `token-taxonomy.md`           | package: repo TBD; doc: existing      | W3C-DTCG JSON → Style Dictionary → CSS       | Semver on package     |
+| 3   | Components  | `docs/design-system/components/` catalog; per-venture source   | catalog: crane-console; src: venture  | Markdown catalog entries                     | Dated, not versioned  |
+| 4   | Patterns    | `docs/design-system/patterns/` library                         | crane-console                         | Problem / Solution / Examples (Polaris)      | Dated, not versioned  |
+| 5   | Templates   | `docs/design-system/templates/` (future; empty until Phase 5+) | crane-console                         | Page-level composition docs                  | Dated, not versioned  |
+| 6   | Guidelines  | Absorbed into L1/L3/L4 entries; `governance.md` covers process | crane-console                         | Inline prose                                 | With parent artifact  |
+| 7   | Tooling     | `ui-drift-audit` skill (or replacement) + CI gate              | `.agents/skills/` (location TBD #704) | Skill spec + CI workflow                     | Bug-fix as discovered |
+| 8   | Governance  | `docs/design-system/governance.md`                             | crane-console                         | Prose: contributions + deprecation lifecycle | As process evolves    |
+
+### Why no separate L6 Guidelines artifact
+
+Enterprise systems typically ship a Guidelines layer as prose (writing, IA, a11y). Our foundations, component catalog, and patterns are prose-first and carry their own guidelines inline — a separate file would duplicate. The `governance.md` doc handles process-level prose that doesn't fit elsewhere.
+
+## Artifact Details
+
+### L2 — `@venturecrane/tokens` package
+
+**What.** Single source of truth for every design token across every venture. W3C-DTCG JSON in one tree; Style Dictionary v4 compiles to per-venture CSS variable sets.
+
+**Source structure (sketch):**
+
+```
+packages/tokens/src/
+  base/
+    color.json      # neutral ramps, shared semantic colors
+    typography.json # families, weights, scale
+    spacing.json    # base unit, scale
+    motion.json     # durations, easings
+  ventures/
+    vc.json         # overrides for vc prefix
+    ke.json
+    dc.json
+    smd.json
+    sc.json
+    dfg.json
+```
+
+**Build output (per venture):**
+
+```
+packages/tokens/dist/
+  vc.css      # --vc-color-accent, --vc-surface-chrome, ...
+  ke.css
+  ...
+```
+
+**Publish target.** Decide during Phase 3 execution: npm under `@venturecrane/tokens` or consumable via path from crane-console. Default: npm, so each venture consumes a versioned dependency and drift is visible in `package.json`.
+
+**Migration from current state.** Each venture's existing `--{prefix}-*` tokens move from `globals.css` into the JSON tree as overrides of base tokens where possible, or as leaf values where not. Expected coverage after migration: VC, KE, DC at 90%+ (tokens already systematic); SC, DFG build from base tokens; SMD defined as part of its spec fix (#702).
+
+**Validator.** Lives in the enforcement skill (L7). Fails builds on raw hex/rgb values, un-tokenized spacing, raw Tailwind color classes.
+
+### L3 — `docs/design-system/components/`
+
+**What.** Markdown catalog of existing components across ventures, classified by [Atomic Design](https://atomicdesign.bradfrost.com/chapter-2/) vocabulary. **The catalog does not ship components** — ventures continue to maintain their own source. The catalog surfaces duplicates, enables deduplication decisions, and gives Phase 4+ patterns a vocabulary.
+
+**Structure:**
+
+```
+docs/design-system/components/
+  atoms/
+    button.md      # list of per-venture implementations + cross-refs
+    input.md
+    icon.md
+  molecules/
+    status-pill.md
+    money-display.md
+  organisms/
+    portal-list-item.md
+    expense-card.md
+```
+
+**Per-component entry template:**
+
+```markdown
+# Button
+
+**Classification.** Atom.
+
+## Implementations
+
+- VC: `src/components/Button.astro`
+- KE: `src/components/ui/Button.tsx`
+- DC: `src/components/ui/Button.tsx`
+- SS: `src/components/portal/Button.tsx`
+
+## Consolidation status
+
+Non-shared; each venture implements its own. Patterns enforce hierarchy (see `../patterns/button-hierarchy.md`).
+
+## Cross-references
+
+- Pattern: `../patterns/button-hierarchy.md`
+```
+
+No "implementation spec." Source code is the spec.
+
+### L4 — `docs/design-system/patterns/`
+
+**What.** The pattern library. Each file documents one recurring UX problem / solution pair in [Polaris's format](https://polaris-react.shopify.com/patterns). Seeded from SS's seven rules (via #703), extended per phase.
+
+**Structure:**
+
+```
+docs/design-system/patterns/
+  01-status-display-by-context.md
+  02-redundancy-ban.md
+  03-button-hierarchy.md
+  04-heading-skip-ban.md
+  05-typography-scale.md
+  06-spacing-rhythm.md
+  07-shared-primitives.md
+  08-actions-and-menus.md  # Phase 4 pilot
+```
+
+**Per-pattern template:**
+
+```markdown
+# Actions and Menus
+
+**Status.** Active · **Authored.** YYYY-MM-DD · **Last revised.** YYYY-MM-DD
+
+## Problem
+
+Short framing: what UX problem recurs, where it shows up, why ad-hoc solutions fail.
+
+## Solution
+
+Named recommendation. Specific. Dos and don'ts.
+
+## Examples
+
+1. Real implementation in venture X: file path.
+2. Real implementation in venture Y: file path.
+3. Anti-example (optional): what drift looks like.
+
+## Cited authority
+
+Links to the external pattern(s) this adapts (Polaris, Material 3, NN/g, etc).
+```
+
+### L7 — Enforcement skill
+
+**What.** A skill (either an extended `ui-drift-audit` or a replacement — pending #704) that runs against any venture's source tree and reports:
+
+- Raw hex / rgb / hsl values in places that should use tokens
+- Raw Tailwind color classes in places where semantic tokens exist
+- Spacing numbers outside the token scale
+- Components that duplicate catalog entries (potential consolidation candidates)
+
+**CI integration.** A GitHub Action wraps the skill, runs on PR, comments on violations, blocks merge above a threshold. Threshold calibrated per-venture: Tier 1 = zero tolerance; Tier 2 = warn only; Tier 3 = count and report.
+
+### L8 — `docs/design-system/governance.md`
+
+**What.** Two things:
+
+1. **Contribution model (tiered).** Based on Curtis's [contribution vs participation](https://medium.com/eightshapes-llc/defining-design-system-contributions-eb48e00e8898) framing.
+   - **Small contributions** — token value changes within an existing category, bug fixes, catalog entries for existing components, pattern example additions. PR + passing tests + maintainer review from any agent. No pre-discussion required.
+   - **Large contributions** — new token categories, new patterns, breaking token changes, deprecations. GitHub issue first with proposal, then PR referencing the issue. At least one human review before merge.
+
+2. **Deprecation lifecycle.** Copied from [Atlassian's token lifecycle](https://developer.atlassian.com/platform/forge/design-tokens-and-theming/), compressed.
+   - **Deprecated.** Token/component/pattern is kept but flagged in source with a deprecation comment linking to the replacement. Stays in this state for at least one minor version.
+   - **Hidden.** Removed from catalog and documentation surface. Source remains for consumers on old versions. At least one minor version.
+   - **Removed.** Deleted entirely. Minor version bump. Consumers on older versions can pin.
+
+## Authoring and Review Loop
+
+Not a separate doc — lives in `governance.md`. Here's the shape:
+
+```
+Small contribution
+  → branch from main
+  → edit
+  → PR
+  → any agent reviews
+  → merge when green
+
+Large contribution
+  → open issue with proposal (problem, proposed artifact, layer(s) affected)
+  → discussion (async)
+  → approval
+  → branch from main
+  → PR referencing issue
+  → human review
+  → merge
+```
+
+**Tiered means different defaults.** Agents can ship small contributions without human review; large contributions gate on Captain's eye. The skill-review / skill-audit precedent already works this way and is the functional analog.
+
+## Adoption Coverage Metrics
+
+The current-state inventory's maturity matrix is the primary tracking tool — when a cell moves from A to P or C, the matrix updates, and the change is dated in the per-venture section.
+
+**Leading indicator** (tracked per venture): fraction of CSS hex/rgb/hsl values replaced by token references. Computed by the enforcement skill. Goal: Tier 1 ventures at ≥95%; Tier 2 at ≥80%; Tier 3 growing over time.
+
+**Trailing indicator** (tracked enterprise-wide): enforcement skill violations per 1k lines of CSS/TSX. Goal: monotonically decreasing; investigate any quarter-over-quarter increase.
+
+No dashboards, no separate tracking system. The matrix and the enforcement-skill output are the dashboard.
+
+## Phase Roadmap
+
+The numbered artifacts above map to implementation phases:
+
+- **Phase 3** (this doc) — proposal; no artifacts shipped.
+- **Phase 4** — pilot pattern: actions & menus (`docs/design-system/patterns/08-actions-and-menus.md`). Prerequisites: SS rules promoted (#703). First pattern authored under this process; proves the Polaris Problem/Solution/Examples format fits VC.
+- **Phase 5** — `@venturecrane/tokens` package. Migration from per-venture CSS to compiled output. Prerequisites: resolve SMD (#702), clarify `ui-drift-audit` location (#704).
+- **Phase 6** — `docs/design-system/components/` catalog. Walks every venture, classifies what exists, surfaces duplicates. No consolidation decisions yet — just mapping.
+- **Phase 7** — `governance.md` + enforcement skill. Closes the loop so subsequent contributions flow through the process this doc describes.
+
+Each phase is one session. Each phase produces one PR. Each phase's merge commit updates `current-state.md`'s matrix.
+
+## What This Proposal Does Not Do
+
+- **Does not mandate a component library.** Ventures keep their own source. The catalog is a map, not a substitute.
+- **Does not centralize design decisions.** Foundations + tokens are shared; patterns are shared; visual identity per venture remains that venture's call.
+- **Does not add a design council or RFC process.** The tiered contribution model is the entire process. If it proves too permissive, we revisit.
+- **Does not version components or patterns.** Only tokens carry a semver. Components and patterns are dated. Breaking changes happen through deprecation cycles, not version pins.
+- **Does not target 100% coverage on day one.** Coverage grows per-phase. Tier 3 ventures (SC, DFG) are expected to carry A / P cells in the matrix for months; that's the correct state, not a failure.
+
+## Open Decisions (Resolve in Phase 4+)
+
+Not blocking Phase 3 approval.
+
+- `@venturecrane/tokens` — npm package or path-consumed from crane-console? Phase 5 decides, after seeing the migration cost.
+- Token-enforcement strictness per tier — "warn only" for Tier 2/3 is default, but Phase 4 may find a tighter setting works for patterns adoption.
+- Whether to add L5 Templates as an empty directory during Phase 3 or wait until first template lands. Currently planned for whenever Phase 5+ has its first real template.


### PR DESCRIPTION
## Summary

Adds \`docs/design-system/proposal.md\` — target architecture for the enterprise design system. Phase 3 of the initiative scoped in #689 (merged).

## Derivation

- **Direction.** Scoping brief at \`docs/design-system/enterprise-scoping.md\` (#689)
- **Adopt/adapt/skip verdicts.** Research brief at \`docs/research/enterprise-design-system-survey.md\` (#691)
- **What we have.** Current-state inventory at \`docs/design-system/current-state.md\` (#701)

## Key decisions

| Layer | Artifact | Format | Cadence |
|---|---|---|---|
| L2 Tokens | \`@venturecrane/tokens\` package | W3C-DTCG JSON → Style Dictionary → CSS | Semver |
| L3 Components | \`docs/design-system/components/\` catalog | Markdown entries, Atomic Design vocabulary | Dated |
| L4 Patterns | \`docs/design-system/patterns/\` library | Polaris Problem/Solution/Examples | Dated |
| L7 Tooling | Enforcement skill + CI gate | Skill spec + workflow | Bug-fix |
| L8 Governance | \`docs/design-system/governance.md\` | Tiered contribution + deprecation lifecycle | As needed |

## Phase roadmap

Each phase = one session, one PR:

- **Phase 4** — pilot pattern (actions & menus). Prerequisites: SS rules promoted (#703).
- **Phase 5** — \`@venturecrane/tokens\` package. Prerequisites: SMD fix (#702), ui-drift-audit location confirmed (#704).
- **Phase 6** — components catalog.
- **Phase 7** — governance.md + enforcement skill.

## Design principles

- Sized for solo operator + AI teammates (no design council, no RFC cycles)
- Ventures keep their own source (catalog is a map, not a substitute)
- Visual identity per venture remains that venture's call
- Only tokens carry a semver; components and patterns are dated
- Coverage grows per-phase — Tier 3 ventures carrying A/P cells is correct state

## Depends on

- #701 (Phase 2 current-state — now merged)
- Relative link to \`current-state.md\` resolves once #701 lands on main

## Test plan

- [ ] Docs site renders proposal page
- [ ] Sidebar order (48) places it between current-state (45) and any future artifacts
- [ ] Links to \`enterprise-scoping.md\`, \`../research/enterprise-design-system-survey.md\`, \`current-state.md\` all resolve
- [ ] Markdown tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)