### PR TITLE
docs(design-system): promote SS UI-PATTERNS to enterprise scope (#703)

### DIFF
--- a/docs/design-system/current-state.md
+++ b/docs/design-system/current-state.md
@@ -25,7 +25,7 @@ sidebar:
 
 | Scope      | L1 Found | L2 Tokens | L3 Comp | L4 Patt | L5 Tmpl | L6 Guide | L7 Tool | L8 Gov |
 | ---------- | -------- | --------- | ------- | ------- | ------- | -------- | ------- | ------ |
-| Enterprise | C        | C         | A       | P       | A       | P        | C       | C      |
+| Enterprise | C        | C         | A       | C       | A       | P        | C       | C      |
 | VC         | C        | C         | C       | P       | A       | P        | C       | C      |
 | KE         | C        | C         | C       | P       | A       | P        | C       | C      |
 | DC         | C        | C         | C       | P       | A       | P        | C       | C      |
@@ -42,7 +42,7 @@ sidebar:
 
 **L3 Components — Absent.** No enterprise-wide component library. Components live per-venture.
 
-**L4 Patterns — Partial.** `docs/design-system/index.md` navigates but delegates pattern definitions to ventures. SS has the only mature pattern-library in the portfolio and is operating outside the enterprise framework (see Cross-Cutting Findings).
+**L4 Patterns — Concrete.** `docs/design-system/patterns/` contains 7 patterns promoted from SS's `docs/style/UI-PATTERNS.md` in Polaris Problem/Solution/Examples format: status-display-by-context, redundancy-ban, button-hierarchy, heading-skip-ban, typography-scale, spacing-rhythm, shared-primitives. All cite public authority. Phase 4 will add the 8th pattern (actions & menus) as the first pattern authored under the enterprise process rather than promoted from a venture.
 
 **L5 Templates — Absent.**
 
@@ -110,9 +110,9 @@ Astro (content) + Next.js (dfg-core, dfg-app). Tailwind v3 (migration to v4 pend
 
 - **All design-system layers** — A pending spec creation. Tech stack known; design identity / tokens / components still to author.
 
-### SS (ss-console) — Outside enterprise framework
+### SS (ss-console) — Rules promoted to enterprise
 
-Produces the most mature Layer 4 assets in the portfolio. Operating parallel to, not inside, the enterprise design system.
+SS authored the seven cited, enforced rules that now constitute the enterprise pattern library. SS's `docs/style/UI-PATTERNS.md` remains as the venture-local enforcement record; the patterns themselves are now canonical in [`docs/design-system/patterns/`](patterns/). Rule 7 (shared primitives) promoted with SS's `PortalListItem`/`StatusPill`/`MoneyDisplay` as the working example.
 
 - **L3** `~/dev/ss-console/src/components/portal/` — `PortalListItem`, `StatusPill`, `MoneyDisplay` (referenced in UI-PATTERNS.md) — C
 - **L4** `~/dev/ss-console/docs/style/UI-PATTERNS.md` (7 cited rules) + `~/dev/ss-console/docs/style/empty-state-pattern.md` — C
@@ -150,16 +150,16 @@ All cite public authority (Material 3, Polaris, Atlassian, Carbon, NN/g, HIG, WC
 
 ### Tooling gaps
 
-- `ui-drift-audit` skill location unverified in this scan.
-- No AST/grep rules enforce naming conventions across ventures.
-- No CI check prevents color drift (hardcoded hex instead of token).
+- `ui-drift-audit` skill verified at `~/dev/ss-console/.agents/skills/ui-drift-audit/` (v1.0.0, Python stdlib). Covers 6 of 7 rules; Rule 7 (shared primitives) detection is missing. Physical location is venture-local even though frontmatter declares enterprise scope — move planned for Phase 7.
+- No AST/grep rules enforce token naming conventions across ventures (planned Phase 7 extension of `ui-drift-audit`).
+- No CI check prevents color drift (hardcoded hex instead of token) — planned Phase 7.
 
 ## What Phase 3 Must Address
 
 Derived from the inventory above, ranked by impact:
 
 1. **Build `@venturecrane/tokens`** — W3C-DTCG JSON source compiled via Style Dictionary to per-venture CSS variable sets. Closes the "no JSON export" gap and the "no centralized token registry" gap in one artifact.
-2. **Scaffold `docs/design-system/patterns/`** — one file per pattern in Polaris's Problem / Solution / Examples format. Seed from SS's seven rules (promoted from `ss-console` — see Issue below).
+2. ~~**Scaffold `docs/design-system/patterns/`**~~ **Done.** Seven patterns promoted from SS in Polaris Problem/Solution/Examples format — see [patterns/](patterns/). Phase 4 adds the 8th (actions & menus) as the first pattern authored inside the enterprise process.
 3. **Scaffold `docs/design-system/components/`** — Atomic Design vocabulary (atoms / molecules / organisms). Start by cataloging what already exists per venture, not building new.
 4. **Token enforcement skill** — grep/AST rules for hardcoded hex/rgb/Tailwind color classes. Runs as merge gate. Either extends `ui-drift-audit` or replaces it (depends on where the current skill lives).
 5. **`docs/design-system/governance.md`** — tiered contribution model + explicit deprecation lifecycle (deprecated → hidden → removed, minimum 2 minor versions).

--- a/docs/design-system/index.md
+++ b/docs/design-system/index.md
@@ -26,3 +26,4 @@ Venture Crane runs a portfolio of products. Without a shared system, each ventur
 - **[Enterprise Scoping Brief](enterprise-scoping.md)** - Active initiative to expand the system to all eight design-system layers (foundations, tokens, components, patterns, templates, guidelines, tooling, governance).
 - **[Current State Inventory](current-state.md)** - Durable map of every venture's design-system assets against the eight-layer framework. Refreshed per phase.
 - **[Design System Proposal](proposal.md)** - Target architecture: what artifacts exist, where they live, authoring loop, deprecation lifecycle. Sized for solo operator with AI teammates.
+- **[Patterns](patterns/)** - Cross-venture UX problem/solution pairs. Seven patterns seeded from SS's cited, enforced rules; more follow as they're authored.

--- a/docs/design-system/patterns/01-status-display-by-context.md
+++ b/docs/design-system/patterns/01-status-display-by-context.md
@@ -1,0 +1,61 @@
+---
+title: 'Status display by context'
+sidebar:
+  order: 1
+---
+
+# Status display by context
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+Product surfaces display state in many places: list rows, detail pages, dashboard cards, above titles as categories. When every state uses the same visual treatment — a pill, usually — the pill loses its meaning. "Proposal" (a document category that never changes) ends up looking identical to "Signed" (a state that does change). The user can't tell which labels are actionable.
+
+Ad-hoc surfaces reinvent this rule differently on every screen. Fixing them individually doesn't compound.
+
+## Solution
+
+A status signal uses one of four treatments, chosen by **context**, not preference. Never interchanged.
+
+| Context                        | Treatment                     | Purpose                                    |
+| ------------------------------ | ----------------------------- | ------------------------------------------ |
+| **List row, dense repeating**  | Pill                          | Scan-time discrimination across many items |
+| **Category label above title** | Eyebrow (small-caps, muted)   | Document category or section kind          |
+| **Single-item dashboard card** | Dot + label OR prose          | Glanceable state without visual weight     |
+| **Detail-page headline**       | Prose in headline or subtitle | State IS the page identity                 |
+
+**Do:** pick the treatment by the row-vs-detail-vs-category distinction. A detail page about a signed document displays "Signed" in prose, not as a chip.
+
+**Don't:** reuse the pill for both "Proposal" (a non-state category) and "Signed" (an actual state) in the same surface. If pills are in play for state, eyebrows must carry the categories.
+
+## Examples
+
+**Anti-pattern — category eyebrow misused as pill.**
+
+`~/dev/ss-console/src/pages/portal/quotes/[id].astro:207-210` wraps the word "Proposal" (a document category that never changes) in a rounded-full tinted chip. The same file uses a pill for actual status 250 lines later. From the user's view, both look identical.
+
+**Correct pattern.**
+
+```astro
+<p class="text-[color:var(--color-meta)] text-label uppercase">Proposal</p>
+<h1 class="mt-3 text-display font-bold text-[color:var(--color-text-primary)]">
+  {engagementTitle}
+</h1>
+```
+
+Eyebrow for category, pill reserved for state. `text-label` is the typography token from [Pattern 05](05-typography-scale.md).
+
+## Cited authority
+
+- Material 3 — ["Chips help people enter information … don't use chips as decoration."](https://m3.material.io/components/chips/guidelines)
+- Shopify Polaris on badges — ["Use badges to indicate the status of an object. Don't use badges as a substitute for normal text."](https://polaris.shopify.com/components/feedback-indicators/badge)
+- NN/g — ["Labels and tags are scan-time affordances, not decorative categorization."](https://www.nngroup.com/articles/ui-labels/)
+
+## Detection
+
+`ui-drift-audit` Pills column cross-referenced with page archetype (list vs detail). See [tooling L7](../current-state.md#enterprise-level-assets).
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 1 (closes #703 for this pattern).

--- a/docs/design-system/patterns/02-redundancy-ban.md
+++ b/docs/design-system/patterns/02-redundancy-ban.md
@@ -1,0 +1,58 @@
+---
+title: 'Redundancy ban: one signal per fact'
+sidebar:
+  order: 2
+---
+
+# Redundancy ban: one signal per fact
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+A single fact — "this invoice is paid" — gets rendered two, three, or four times on the same surface. A pill says "Paid," a caption says "Paid in full," a subtitle says "Paid {date}." The fact is one; the renderings are noise. Cognitive load goes up without adding information.
+
+AI-generated surfaces are particularly prone to this — each generation pass adds another rendering, the earlier passes don't get removed.
+
+## Solution
+
+A single fact gets exactly one rendering. Pick the richest one.
+
+**Do:** render state in the most informative form the surface allows. A prose confirmation with a date is better than a pill, a tinted date line, and a bordered block all saying "Signed."
+
+**Don't:** place a pill next to text that states the same status in words. Don't stack confirmations.
+
+When multiple treatments are visible, apply the [context rule from Pattern 01](01-status-display-by-context.md): list rows earn pills; detail pages earn prose; don't mix within one region.
+
+## Examples
+
+**Anti-pattern — triple redundancy in invoice detail card.**
+
+`~/dev/ss-console/src/pages/portal/invoices/[id].astro:450-461` renders a "Paid" pill, a "Paid in full" caption under the amount, AND a "Paid {date}" confirmation paragraph.
+
+**Correct pattern.**
+
+```astro
+<MoneyDisplay amountCents={amountCents} size="display" />
+<p class="mt-2 text-[color:var(--color-complete)] text-caption">Paid {paidShortDate}.</p>
+```
+
+Pill removed. "Paid in full" removed (amount display carries it). Single prose confirmation with the date. The complete-tone color carries semantic, not a bordered shape.
+
+**Anti-pattern — pill over confirmation block.**
+
+`~/dev/ss-console/src/pages/portal/quotes/[id].astro:458-497` renders a "Signed" pill above a richer "Signed {date}" confirmation block. The confirmation is more informative; the pill is redundant. Fix: drop the pill when the signed state is active.
+
+## Cited authority
+
+- Shopify Polaris — ["Don't use badges as a substitute for normal text."](https://polaris.shopify.com/components/feedback-indicators/badge)
+- Atlassian on lozenges — ["Lozenges are not labels for generic metadata."](https://atlassian.design/components/lozenge/usage)
+- NN/g on redundancy — ["Repetition of the same status in multiple visual treatments increases cognitive load without adding information."](https://www.nngroup.com/articles/ui-copy/)
+
+## Detection
+
+`ui-drift-audit` Redundancy column — tinted pill whose status-keyword content is echoed in ±10 lines of surrounding prose.
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 2 (closes #703 for this pattern).

--- a/docs/design-system/patterns/03-button-hierarchy.md
+++ b/docs/design-system/patterns/03-button-hierarchy.md
@@ -1,0 +1,53 @@
+---
+title: 'Button hierarchy: one primary per view'
+sidebar:
+  order: 3
+---
+
+# Button hierarchy: one primary per view
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+A screen with two visually-primary actions is a screen showing two tasks. The user has to decide which is the real next step. Decision fatigue, misclicks, abandoned flows.
+
+AI generators emit buttons liberally — every CTA gets `bg-primary` by default. Without a hierarchy rule, every surface becomes a festival of primary buttons.
+
+## Solution
+
+Exactly one primary action is visible at a time. Secondary, tertiary, and destructive actions have distinct visual treatments. A screen that genuinely needs two primaries is showing two tasks and should be split into two screens (or two states of one screen).
+
+| Level                | Visual                                               | Usage                                          |
+| -------------------- | ---------------------------------------------------- | ---------------------------------------------- |
+| **Primary**          | Solid `bg-[color:var(--color-primary)]` + white text | The one action                                 |
+| **Secondary**        | Border + primary text color                          | Alternative actions                            |
+| **Tertiary (ghost)** | Text-only primary color                              | Low-stakes inline actions (links, "view more") |
+| **Destructive**      | Solid `bg-[color:var(--color-error)]` + white text   | Irreversible or data-loss actions              |
+
+**Do:** render one primary at a time. If the page has multiple states (Start / Continue / Submit), the SAME button slot renders different labels per state. That's one primary visible, not several.
+
+**Don't:** render two `bg-primary` CTAs co-rendered in the same top-level block without a state-branch conditional.
+
+**Legitimate exception.** State-branch conditional CTAs (the same slot rendering Start / Continue / Submit depending on state) are compliant. Only co-rendered primaries on the same screen are violations.
+
+## Examples
+
+**Correct pattern — state-branch primaries.**
+
+`~/dev/ss-console/src/pages/scorecard.astro` has four `bg-primary` occurrences (Start / Start-summary / Next / Submit). Only one renders per assessment phase. Compliant.
+
+**Violation pattern.** Two `bg-primary` buttons rendered simultaneously in the same top-level block with no `{condition ? <a/> : <b/>}` wrapping. The audit flags count-≥2 files; manual review determines whether the high count is a state branch (legitimate) or co-rendered primaries (violation).
+
+## Cited authority
+
+- Material 3 actions — ["Ensure there is only one primary button on each screen."](https://m3.material.io/components/all-buttons)
+- Apple HIG — ["Prefer one default action. Additional actions should be clearly subordinate."](https://developer.apple.com/design/human-interface-guidelines/buttons)
+
+## Detection
+
+`ui-drift-audit` Primary CTAs column counts `bg-primary` per file; manual review triages files with count ≥ 2.
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 3 (closes #703 for this pattern).

--- a/docs/design-system/patterns/04-heading-skip-ban.md
+++ b/docs/design-system/patterns/04-heading-skip-ban.md
@@ -1,0 +1,46 @@
+---
+title: 'Heading skip ban'
+sidebar:
+  order: 4
+---
+
+# Heading skip ban
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+Screen readers and scanning both rely on an unbroken heading hierarchy to convey document structure. `h1 → h3` skips a level; the reader loses the logical outline. WCAG 2.2 SC 1.3.1 flags this as a violation of Info-and-Relationships.
+
+Visual size is not heading level. Designers size headings by aesthetic; if `h2` looks too big, the temptation is to use `h3` — and now the `h2` is missing from the document.
+
+## Solution
+
+Heading levels descend in steps. `h1` → `h2` → `h3`. No `h1` → `h3`. No `h2` → `h4`. Eyebrows are NOT headings (even if they look like ones). Visual size does not imply heading level — that's what typography tokens are for (see [Pattern 05](05-typography-scale.md)).
+
+**Do:** use `h1` for the page identity, `h2` for major sections, `h3` for sub-sections. If the page has no natural `h2`, either it truly has only one section (rare), or you're missing a section label.
+
+**Don't:** skip levels because visual hierarchy suggests it. If `h2` is too big, change the `h2` styling. Don't demote to `h3`.
+
+**Eyebrows are not headings.** A small-caps label above a title is an eyebrow (typography `text-label`), not an `h3`. Eyebrows render as `<p>` or `<span>`, not as heading elements.
+
+## Examples
+
+**Correct pattern — marketing components.**
+
+SS marketing components (`Hero`, `About`, `CaseStudies`, `HowItWorks`, `Pricing`, `ProblemCards`, `WhatYouGet`, `WhoWeHelp`, `FinalCta`): `Hero` emits `h1`; all other sections emit `h2` then `h3` where nested. No skip within any component, no skip in `~/dev/ss-console/src/pages/index.astro` where they compose together.
+
+**Composed-component caveat.** Portal components (`PortalHeader`, `PortalTabs`, `ActionCard`, `ArtifactChip`, `ConsultantBlock`, `MoneyDisplay`, `TimelineEntry`) don't render headings internally, so portal page hierarchy is entirely file-local. This is verified manually whenever a new component that emits headings is added.
+
+## Cited authority
+
+- WCAG 2.2 SC 1.3.1 (Info and Relationships, Level A) — [headings must convey document structure](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html).
+- NN/g on heading hierarchy — ["Screen readers and scanning both rely on ordered heading levels to convey structure."](https://www.nngroup.com/articles/html-headings/)
+
+## Detection
+
+`ui-drift-audit` H-skips column — document-order `h{N}` → `h{N+2+}` jumps within a single file. Composed-component hierarchy requires manual verification when a component that emits headings is added.
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 4 (closes #703 for this pattern).

--- a/docs/design-system/patterns/05-typography-scale.md
+++ b/docs/design-system/patterns/05-typography-scale.md
@@ -1,0 +1,68 @@
+---
+title: 'Typography scale'
+sidebar:
+  order: 5
+---
+
+# Typography scale
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+Every inline `text-[Npx]` is a declaration that this particular instance is outside the system. When a codebase accumulates dozens of arbitrary sizes across pages, there is no consistent scale — each screen picks its own typography.
+
+SS's audit found 32 arbitrary sizes in one portal page and 27 in another. Aggregate effect: no pattern a reader can recognize.
+
+## Solution
+
+Every user-visible text node resolves to one of seven named scale tokens. Arbitrary `text-[Npx]` and raw Tailwind `text-xs/sm/base/lg/xl/...` are banned in governed contexts.
+
+| Token          | Size / LH                                | Weight | Use                           |
+| -------------- | ---------------------------------------- | ------ | ----------------------------- |
+| `text-display` | 32px / 40px                              | 700    | Page hero                     |
+| `text-title`   | 20px / 28px                              | 700    | Section heading, card title   |
+| `text-heading` | 16px / 22px                              | 600    | Sub-section heading           |
+| `text-body-lg` | 18px / 28px                              | 400    | Lead paragraph                |
+| `text-body`    | 15px / 24px                              | 400    | Default body                  |
+| `text-caption` | 13px / 18px                              | 500    | Metadata, dates, status prose |
+| `text-label`   | 12px / 16px (uppercase, 0.08em tracking) | 600    | Eyebrow, section label        |
+
+**Do:** use semantic tokens (`text-display`, `text-body`, `text-caption`) at every text node. When a new typographic need emerges, extend the scale — don't use arbitrary values as an escape hatch.
+
+**Don't:** inline `text-[18px]` or `text-lg`. Both defeat the scale — the first is arbitrary, the second is a raw Tailwind token that doesn't carry semantic meaning.
+
+## Enterprise-wide integration
+
+SS's seven tokens are the proposed enterprise scale. Phase 5's `@venturecrane/tokens` package carries them as `--{prefix}-text-size-{name}` CSS custom properties, mapped to Tailwind `@theme` utilities. Per-venture overrides are allowed at the size/LH/weight level; the _names_ are shared.
+
+## Examples
+
+**Anti-pattern.**
+
+`~/dev/ss-console/src/pages/portal/quotes/[id].astro:207-220` uses inline `text-[13px] leading-[18px]` and `text-[32px] sm:text-[42px] leading-tight` pervasively. 32 arbitrary sizes in one file.
+
+**Correct pattern.**
+
+```astro
+<p class="text-label uppercase text-[color:var(--color-meta)]">Proposal</p>
+<h1 class="mt-3 text-display font-bold text-[color:var(--color-text-primary)]">
+  {engagementTitle}
+</h1>
+<p class="mt-5 text-body-lg text-[color:var(--color-text-secondary)] max-w-2xl">
+  {engagementSubtitle}
+</p>
+```
+
+## Cited authority
+
+- [Material 3 type scale](https://m3.material.io/styles/typography/type-scale-tokens)
+- [IBM Carbon typography](https://carbondesignsystem.com/guidelines/typography/overview/)
+
+## Detection
+
+`ui-drift-audit` Typography (arbitrary / token) columns. Arbitrary values are hard violations. Raw Tailwind tokens are pre-remediation informational; once a surface is converted, ESLint/grep bans inline `text-[...]` in that surface.
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 5 (closes #703 for this pattern).

--- a/docs/design-system/patterns/06-spacing-rhythm.md
+++ b/docs/design-system/patterns/06-spacing-rhythm.md
@@ -1,0 +1,60 @@
+---
+title: 'Spacing rhythm'
+sidebar:
+  order: 6
+---
+
+# Spacing rhythm
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+Raw Tailwind spacing classes (`p-6`, `gap-3`, `py-8`) are unnamed. The drift is not "out of scale" — raw values live on a scale — it's "no rhythm names, so every card picks its own." The audit counted ~1,000 raw Tailwind spacing tokens across SS's codebase. None arbitrary, but all unnamed.
+
+Without named rhythm tokens, `p-6` means "a generous padding" to one author and "probably the right default" to another. Neither reasoning produces consistency.
+
+## Solution
+
+Vertical gaps between sibling sections and padding on cards/surfaces resolve to four named rhythm tokens. Raw `gap-*`, `py-*`, `px-*` with arbitrary integers are banned in governed contexts.
+
+| Token           | Value | Use                               |
+| --------------- | ----- | --------------------------------- |
+| `space-section` | 32px  | Gap between major page sections   |
+| `space-card`    | 24px  | Card internal padding             |
+| `space-row`     | 12px  | Gap between rows in a list        |
+| `space-stack`   | 16px  | Vertical stack of sibling content |
+
+**Do:** use semantic tokens (`p-card`, `gap-stack`, `mt-section`) where Tailwind utilities support them. Extend the scale when a clearly distinct rhythm emerges.
+
+**Don't:** use raw `p-6` or `gap-4` in governed surfaces. The rule is about vocabulary, not numeric values.
+
+## Enterprise-wide integration
+
+SS's four tokens are the proposed enterprise spacing rhythm. Phase 5's `@venturecrane/tokens` package carries them as `--{prefix}-space-{name}` CSS custom properties. Per-venture overrides are allowed at the pixel-value level; the _names_ are shared.
+
+## Examples
+
+**Anti-pattern.** A card styled with `bg-white rounded-lg border p-6 gap-3` — works, but every other card on the surface does it slightly differently. No reader recognizes the pattern.
+
+**Correct pattern.**
+
+```astro
+<div class="bg-[color:var(--color-surface)] rounded-card border p-card">
+  <h2 class="text-heading">Overview</h2>
+  <div class="mt-stack">...</div>
+</div>
+```
+
+## Cited authority
+
+- [IBM Carbon spacing](https://carbondesignsystem.com/guidelines/spacing/overview/)
+- [Material 3 layout](https://m3.material.io/foundations/layout/understanding-layout/overview)
+
+## Detection
+
+`ui-drift-audit` Spacing (arbitrary / token) columns. Same enforcement shape as [Pattern 05](05-typography-scale.md).
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 6 (closes #703 for this pattern).

--- a/docs/design-system/patterns/07-shared-primitives.md
+++ b/docs/design-system/patterns/07-shared-primitives.md
@@ -1,0 +1,93 @@
+---
+title: 'Shared primitives for repeated patterns'
+sidebar:
+  order: 7
+---
+
+# Shared primitives for repeated patterns
+
+**Status.** Active · **Authored.** 2026-04-16 (SS) · **Promoted.** 2026-04-24
+
+## Problem
+
+AI generators produce each screen in isolation. Tokens unify colors and spacing; nothing unifies element _shape_. Without a shared primitive, list-row markup diverges on every regeneration — different status pills, date formats, CTA positions — even when every surface "uses the design system."
+
+Class-reorder evasion means a "no forbidden markup string" test cannot defend against drift. The only durable contract is a named component that every surface must import.
+
+## Solution
+
+When the same visual element appears on multiple surfaces, it renders through a shared component. The component is the enforcement; prose rules about "use tokens" and "match the design system" do not survive multiple generations of AI-authored screens without a code contract behind them.
+
+**Do:** extract the first duplication into a shared component. Import it everywhere the pattern repeats. Use variants (`variant: 'status' | 'document'`) for shape differences within the same underlying primitive.
+
+**Don't:** hand-roll the markup on each new surface "for consistency" with some other screen. Tokens are necessary but not sufficient — the primitive must be a component.
+
+**Escape hatch.** An explicit allowlist of file paths that truly cannot use the primitive (e.g., "milestone rail is a vertical timeline, not a list row"). Cap: **≤3 allowlist entries per primitive globally**. Exceeding the cap means the primitive is wrong — extend its variants or split, don't allowlist around.
+
+**When to split.** A single primitive with variants is the default. Split into separate primitives only when more than ~5 conditionals key on `variant`, or when a third variant is needed. Don't pre-split.
+
+## Examples
+
+**Anti-pattern — hand-rolled list rows across portal surfaces.**
+
+```tsx
+<a href={...} class="block bg-white rounded-lg border border-slate-200 p-stack ...">
+  <div class="flex items-center justify-between gap-stack">
+    <span class={`inline-block px-2.5 py-0.5 rounded-full text-xs ${statusColorMap[status]}`}>
+      {statusLabelMap[status]}
+    </span>
+    {/* ... */}
+  </div>
+</a>
+```
+
+Each portal surface (quotes, invoices, documents) authored this independently. Different class orderings, pill tints, date formats, CTAs. A grep-based test cannot catch the divergence.
+
+**Correct pattern.**
+
+```tsx
+import PortalListItem from '../../../components/portal/PortalListItem.astro'
+import { resolveInvoiceTone, resolveInvoiceLabel } from '../../../lib/portal/status'
+
+{
+  invoices.map((inv) => (
+    <PortalListItem
+      variant="status"
+      href={`/portal/invoices/${inv.id}`}
+      tone={resolveInvoiceTone(inv.status)}
+      toneLabel={resolveInvoiceLabel(inv.status)}
+      title={typeLabel[inv.type]}
+      amountCents={Math.round(inv.amount * 100)}
+      metaCaption={resolveMetaCaption(inv)}
+    />
+  ))
+}
+```
+
+**SS-registered primitives (portal).**
+
+- [`src/components/portal/PortalListItem.astro`](https://github.com/venturecrane/ss-console/blob/main/src/components/portal/PortalListItem.astro) — card-shell list row; `variant: 'status' | 'document'`.
+- [`src/components/portal/StatusPill.astro`](https://github.com/venturecrane/ss-console/blob/main/src/components/portal/StatusPill.astro) — tone-based pill; consumes `Tone` from `status.ts`.
+- [`src/components/portal/MoneyDisplay.astro`](https://github.com/venturecrane/ss-console/blob/main/src/components/portal/MoneyDisplay.astro) — dollar-figure renderer.
+
+## Cited authority
+
+- [Shopify Polaris](https://polaris.shopify.com/) — component system as the source of truth
+- [IBM Carbon](https://carbondesignsystem.com/) — components, not tokens, are the contract
+- [Atlassian Design System](https://atlassian.design/) — named components over "match the design"
+
+## Detection
+
+**Presence test.** Every list-index page (except detail surfaces) that iterates via `.map(` must render through the shared primitive. Defeats class-reorder evasion because _presence_ is required, not absence.
+
+**No local helper redefinition.** No `const formatDate`, `const formatCurrency`, `const statusColorMap`, `const statusLabelMap`, or `const typeLabels` in governed index files. Helpers live in the shared library.
+
+Both tests auto-enroll new files. Exceptions go in an explicit allowlist with inline rationale. See SS's [`tests/forbidden-strings.test.ts`](https://github.com/venturecrane/ss-console/blob/main/tests/forbidden-strings.test.ts) for the canonical implementation.
+
+## Enterprise-wide integration
+
+Phase 6's components catalog (`docs/design-system/components/`) maps every venture's primitives. Phase 7's enforcement skill extends `ui-drift-audit` with shared-primitive detection across all ventures (Rule 7 is the 7th rule currently missing from the v1.0.0 skill).
+
+## Provenance
+
+Promoted from SS `docs/style/UI-PATTERNS.md` Rule 7 (closes #703 for this pattern).

--- a/docs/design-system/patterns/index.md
+++ b/docs/design-system/patterns/index.md
@@ -1,0 +1,36 @@
+---
+title: 'Patterns'
+sidebar:
+  order: 0
+---
+
+# Design System Patterns
+
+Cross-venture UX problem / solution pairs. Each pattern documents one recurring design decision — the shape the answer takes, the reason, and real implementations. Patterns are the Layer 4 artifact in the [eight-layer design system](../enterprise-scoping.md).
+
+## Format
+
+Every pattern follows [Shopify Polaris's structure](https://polaris-react.shopify.com/patterns): **Problem → Solution → Examples**, plus **Cited authority** (public URLs, no invented "best practices") and **Provenance** (which venture's working code seeded the pattern).
+
+## Current patterns
+
+Patterns 1-7 were promoted from [SS `docs/style/UI-PATTERNS.md`](https://github.com/venturecrane/ss-console/blob/main/docs/style/UI-PATTERNS.md) where they were authored, cited, and enforced by `ui-drift-audit`. Promotion moves them into enterprise scope; SS continues to enforce locally but now points to these as canonical.
+
+- [01 — Status display by context](01-status-display-by-context.md)
+- [02 — Redundancy ban: one signal per fact](02-redundancy-ban.md)
+- [03 — Button hierarchy: one primary per view](03-button-hierarchy.md)
+- [04 — Heading skip ban](04-heading-skip-ban.md)
+- [05 — Typography scale](05-typography-scale.md)
+- [06 — Spacing rhythm](06-spacing-rhythm.md)
+- [07 — Shared primitives for repeated patterns](07-shared-primitives.md)
+
+## Contributing a pattern
+
+Large contribution per the [governance model](../proposal.md#l8---docsdesign-systemgovernancemd):
+
+1. Open a GitHub issue with the proposed pattern. Include the recurring problem, a sketch of the solution, and at least two venture implementations that would benefit.
+2. Discuss scope and citations async.
+3. PR referencing the issue. File named `0N-{kebab-case-slug}.md`.
+4. Human review before merge.
+
+Every pattern must cite at least one public authority (Polaris, Material 3, NN/g, Carbon, Atlassian, Apple HIG, WCAG). Patterns without external citation do not belong in this library.


### PR DESCRIPTION
## Summary

Seeds \`docs/design-system/patterns/\` with **seven patterns** promoted from SS's \`docs/style/UI-PATTERNS.md\`. Each in Polaris Problem / Solution / Examples format, with public-authority citations preserved and provenance to SS's original rule numbers.

Closes #703. Unblocks Phase 4 (actions & menus pilot pattern).

## Files

- \`docs/design-system/patterns/index.md\` — pattern library landing
- \`docs/design-system/patterns/01-status-display-by-context.md\`
- \`docs/design-system/patterns/02-redundancy-ban.md\`
- \`docs/design-system/patterns/03-button-hierarchy.md\`
- \`docs/design-system/patterns/04-heading-skip-ban.md\`
- \`docs/design-system/patterns/05-typography-scale.md\` (7-token scale proposed as enterprise standard)
- \`docs/design-system/patterns/06-spacing-rhythm.md\` (4-token rhythm proposed as enterprise standard)
- \`docs/design-system/patterns/07-shared-primitives.md\`

## Matrix update

L4 Enterprise moves from **Partial** to **Concrete**. See \`docs/design-system/current-state.md\`.

## SS-side follow-up

A companion PR on \`ss-console\` will update \`docs/style/UI-PATTERNS.md\` to point to the enterprise canonical version while keeping SS's local enforcement details (tests, workflow) in place. Not blocking this PR — the promotion is complete with or without the pointer update.

## Test plan

- [ ] Docs site renders the patterns index and all 7 pattern pages
- [ ] Sidebar order (patterns/ at section level, individual patterns 1-7 within)
- [ ] All external citation links resolve
- [ ] Relative link from \`docs/design-system/index.md\` to \`patterns/\` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)