### PR TITLE
ci(sync-docs): include docs/design-system/** in context-worker sync (Stream A2)

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/process/**/*.md'
       - 'docs/adr/**/*.md'
       - 'docs/infra/**/*.md'
+      - 'docs/design-system/**/*.md'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -33,12 +34,12 @@ jobs:
         run: |
           # Get list of changed markdown files in docs/process/
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manual trigger: sync all process docs
-            echo "Manual trigger - syncing all docs in docs/process/"
-            CHANGED_FILES=$(find docs/process docs/adr docs/infra -name "*.md" -type f 2>/dev/null)
+            # Manual trigger: sync all docs in covered paths
+            echo "Manual trigger - syncing all docs in docs/{process,adr,infra,design-system}/"
+            CHANGED_FILES=$(find docs/process docs/adr docs/infra docs/design-system -name "*.md" -type f 2>/dev/null)
           else
             # Automatic trigger: only sync changed docs
-            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr|infra)/.*\.md$" || true)
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr|infra|design-system)/.*\.md$" || true)
           fi
 
           if [ -z "$CHANGED_FILES" ]; then

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -86,7 +86,14 @@ if [ -z "$CRANE_ADMIN_KEY" ]; then
 fi
 
 # Extract doc name from path
-DOC_NAME=$(basename "$DOC_PATH")
+# For docs/design-system/**, preserve subfolder structure to avoid basename
+# collisions (e.g., docs/design-system/governance.md vs docs/skills/governance.md).
+# Use the path relative to docs/ as DOC_NAME.
+if [[ "$DOC_PATH" == docs/design-system/* ]]; then
+  DOC_NAME="${DOC_PATH#docs/}"
+else
+  DOC_NAME=$(basename "$DOC_PATH")
+fi
 
 # Determine scope
 if [ -n "$OVERRIDE_SCOPE" ]; then
@@ -96,12 +103,21 @@ if [ -n "$OVERRIDE_SCOPE" ]; then
 else
   # Auto-determine scope
   IS_GLOBAL=false
-  for global_doc in "${GLOBAL_DOCS[@]}"; do
-    if [ "$DOC_NAME" = "$global_doc" ]; then
-      IS_GLOBAL=true
-      break
-    fi
-  done
+
+  # Path-prefix rule: anything under docs/design-system/ is a global enterprise
+  # design-system asset (foundations, tokens taxonomy, patterns, components,
+  # governance, etc.) and should sync as scope=global.
+  if [[ "$DOC_PATH" == docs/design-system/* ]]; then
+    IS_GLOBAL=true
+  else
+    # Otherwise check basename whitelist
+    for global_doc in "${GLOBAL_DOCS[@]}"; do
+      if [ "$DOC_NAME" = "$global_doc" ]; then
+        IS_GLOBAL=true
+        break
+      fi
+    done
+  fi
 
   if [ "$IS_GLOBAL" = true ]; then
     SCOPE="global"


### PR DESCRIPTION
## Summary

Extends the docs sync workflow so \`crane_doc('global', 'design-system/...')\` resolves at runtime. Without this, every design-system doc on main is invisible to agents.

Stream A2 of the [enterprise design system full-rollout plan](https://github.com/venturecrane/crane-console/blob/main/.claude/plans/rippling-dancing-map.md).

## Changes

1. **Workflow path filter** (\`.github/workflows/sync-docs-to-context-worker.yml\`)
   - Adds \`docs/design-system/**/*.md\` to the push-trigger paths
   - Manual workflow_dispatch walks all four covered roots: process, adr, infra, design-system

2. **Upload script DOC_NAME handling** (\`scripts/upload-doc-to-context-worker.sh\`)
   - For design-system docs: use path relative to \`docs/\` as DOC_NAME (e.g., \`design-system/governance.md\`) instead of basename
   - Avoids collision between \`docs/skills/governance.md\` (whitelisted as \`governance.md\`) and \`docs/design-system/governance.md\` — without this fix, both would upload to \`global/governance.md\` and the second overwrites the first
   - Added a path-prefix rule that auto-scopes anything under \`docs/design-system/\` as \`global\` (no per-file whitelist entry needed)

## Follow-up after merge

Run \`gh workflow run sync-docs-to-context-worker.yml\` (manual workflow_dispatch) to backfill all existing design-system docs into the Context Worker D1. This is Stream A3 of the plan — completes in ~1 minute.

## Verification post-merge

\`\`\`bash
crane_doc('global', 'design-system/patterns/08-actions-and-menus.md')
\`\`\`

Should return content (currently returns 404).

## Test plan

- [ ] CI green
- [ ] Workflow_dispatch run after merge succeeds
- [ ] Verification command above returns content
- [ ] No collision with existing \`global/governance.md\` entry (from \`docs/skills/governance.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)