### PR TITLE
fix(sync-docs): flatten design-system path separators for context-worker doc_name

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -88,9 +88,21 @@ fi
 # Extract doc name from path
 # For docs/design-system/**, preserve subfolder structure to avoid basename
 # collisions (e.g., docs/design-system/governance.md vs docs/skills/governance.md).
-# Use the path relative to docs/ as DOC_NAME.
+# Use the path relative to docs/ with `/` replaced by `.` so it satisfies the
+# Context Worker's doc_name regex (alphanumeric + ._-, .md/.json extension).
+# Example: docs/design-system/patterns/08-actions-and-menus.md
+#       -> design-system.patterns.08-actions-and-menus.md
 if [[ "$DOC_PATH" == docs/design-system/* ]]; then
-  DOC_NAME="${DOC_PATH#docs/}"
+  REL_PATH="${DOC_PATH#docs/}"
+  REL_DIR=$(dirname "$REL_PATH")
+  REL_FILE=$(basename "$REL_PATH")
+  if [ "$REL_DIR" = "." ]; then
+    DOC_NAME="$REL_FILE"
+  else
+    # Replace path separators with dots so the worker accepts the name
+    FLATTENED_DIR="${REL_DIR//\//.}"
+    DOC_NAME="${FLATTENED_DIR}.${REL_FILE}"
+  fi
 else
   DOC_NAME=$(basename "$DOC_PATH")
 fi


### PR DESCRIPTION
## Summary

Fixes the A2 backfill failure: 24 of 62 docs in the sync \`workflow_dispatch\` failed because the Context Worker's \`/admin/docs\` endpoint validates \`doc_name\` against the regex \`^[a-zA-Z0-9._-]+\\.(md|json)\$\` — which doesn't allow \`/\`.

A2 (#714) introduced path-prefixed DOC_NAMEs like \`design-system/governance.md\` to avoid basename collision with \`docs/skills/governance.md\`. The collision-avoidance is correct; the separator wasn't.

## Fix

Replace \`/\` with \`.\` in design-system doc names:

\`\`\`
docs/design-system/governance.md                  → design-system.governance.md
docs/design-system/patterns/08-actions-and-menus  → design-system.patterns.08-actions-and-menus.md
\`\`\`

\`.\` is in the worker's allowed character class. No worker code change needed.

## After merge

Re-run the sync workflow_dispatch to backfill the previously-failed design-system docs:

\`\`\`bash
gh workflow run sync-docs-to-context-worker.yml --repo venturecrane/crane-console
\`\`\`

## Future cleanup

Could extend the worker regex to allow \`/\` so paths stay literal:

\`\`\`ts
// workers/crane-context/src/endpoints/admin-docs.ts:153
if (!/^[a-zA-Z0-9._/-]+\\.(md|json)\$/.test(body.doc_name)) {
\`\`\`

Filing as a follow-up issue, not blocking this fix.

## Test plan

- [ ] CI green
- [ ] Re-run sync workflow_dispatch after merge
- [ ] All 62 docs upload successfully (was 38 succeeded / 24 failed)
- [ ] \`crane_doc('global', 'design-system.patterns.08-actions-and-menus.md')\` returns content

🤖 Generated with [Claude Code](https://claude.com/claude-code)