### PR TITLE
ci(tokens): publish @venturecrane/tokens to GitHub Packages on tag (Stream A4)

### DIFF
--- a/.github/workflows/publish-tokens.yml
+++ b/.github/workflows/publish-tokens.yml
@@ -1,0 +1,102 @@
+name: Publish tokens
+
+# Publishes @venturecrane/tokens to GitHub Packages on tag push.
+#
+# Tag conventions:
+#   tokens-v0.1.0          → publishes 0.1.0 as 'latest'
+#   tokens-v0.1.0-rc.1     → publishes 0.1.0-rc.1 with --tag rc
+#                            (does NOT update the 'latest' tag)
+#   tokens-v0.0.1-alpha.0  → publishes 0.0.1-alpha.0 with --tag rc
+#                            (any pre-release version routes to rc dist-tag)
+#
+# The package's source is W3C-DTCG JSON files under packages/tokens/src/.
+# `npm run build` invokes Style Dictionary v4 to emit per-venture CSS files
+# into packages/tokens/dist/. The `files` field in package.json includes
+# `dist`, `src`, and `build.js`, so the published tarball ships both the
+# compiled CSS and the original DTCG source.
+#
+# After publish, runs an `npm view` smoke check to confirm the registry
+# actually has the package. If the smoke check fails, the workflow fails so
+# downstream consumers (per-venture migration PRs) get a clear signal.
+
+on:
+  push:
+    tags:
+      - 'tokens-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.1.0 or 0.0.1-alpha.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@venturecrane'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build tokens package
+        run: npm run build -w @venturecrane/tokens
+
+      - name: Determine npm dist-tag
+        id: tag
+        run: |
+          VERSION=$(node -p "require('./packages/tokens/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Publishing version $VERSION with dist-tag $(grep dist_tag $GITHUB_OUTPUT)"
+
+      - name: Publish
+        working-directory: packages/tokens
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --tag ${{ steps.tag.outputs.dist_tag }}
+
+      - name: Post-publish smoke check
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          for attempt in 1 2 3 4 5; do
+            echo "Attempt $attempt: npm view @venturecrane/tokens@$VERSION"
+            if npm view "@venturecrane/tokens@$VERSION" version 2>&1 | grep -q "$VERSION"; then
+              echo "Smoke check passed: $VERSION is on the registry."
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Smoke check failed: @venturecrane/tokens@$VERSION is not on the registry after 5 attempts."
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## tokens publish"
+            echo ""
+            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
+            echo "- Dist-tag: \`${{ steps.tag.outputs.dist_tag }}\`"
+            echo "- Registry: https://github.com/venturecrane/crane-console/pkgs/npm/tokens"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-tokens.yml`, mirroring `publish-crane-contracts.yml`. Tag-triggered (`tokens-v*`), with `workflow_dispatch` fallback.
- Reads version from `packages/tokens/package.json`; pre-release versions (containing `-`) publish to `rc` dist-tag, others to `latest`. Avoids accidentally promoting an alpha/rc to `latest`.
- Includes the same 5-attempt `npm view` smoke check used by the contracts/mcp workflows so downstream venture-migration PRs get a clear signal if registry propagation lags.

Stream A4 of the enterprise design system rollout (plan: `.claude/plans/rippling-dancing-map.md`). Unblocks A5: cut `tokens-v0.0.1-alpha.0` and verify GH Packages publish + smoke-install in `/tmp` scratch dir.

## Test plan

- [x] Local pre-push: `npm run verify` green (typecheck + format + lint + test + builds for all workspace packages including `@venturecrane/tokens`).
- [x] Local: `npm run build -w @venturecrane/tokens` emits `dist/vc.css` with `--vc-*` prefixed custom properties (Style Dictionary v4 pipeline working).
- [x] Workflow YAML formatted with Prettier.
- [ ] Post-merge (Stream A5): `git tag tokens-v0.0.1-alpha.0 && git push origin tokens-v0.0.1-alpha.0`. Workflow run should publish, smoke-check pass, and `npm view @venturecrane/tokens versions --registry=https://npm.pkg.github.com` should list `0.0.1-alpha.0` under the `rc` dist-tag.
- [ ] Post-merge (Stream A5): smoke-install in `/tmp` scratch dir to confirm the published tarball ships `dist/`, `src/`, and `build.js` per the package's `files` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)