### PR TITLE
chore(tokens): bump to 0.0.1-alpha.0 for alpha-first publish (Stream A5 prep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,7 +6925,7 @@
     },
     "packages/tokens": {
       "name": "@venturecrane/tokens",
-      "version": "0.1.0",
+      "version": "0.0.1-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "style-dictionary": "^4.1.5"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/tokens",
-  "version": "0.1.0",
+  "version": "0.0.1-alpha.0",
   "description": "Enterprise design tokens for Venture Crane ventures (W3C-DTCG + Style Dictionary)",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bumps `packages/tokens/package.json` from `0.1.0` → `0.0.1-alpha.0`.
- Reserves `0.1.0` for the post-KE-proven release cut in Stream A10 (per the rollout plan's R15 mitigation: alpha-first publish, `0.1.0` only after KE proves clean).
- The Stream A4 workflow (#716, merged) reads version from this `package.json` and routes pre-release versions (containing `-`) to the `rc` dist-tag, so this publishes under `@venturecrane/tokens@rc` without touching `latest`.

## Test plan

- [x] Local pre-push: `npm run verify` green.
- [x] `node -p "require('./packages/tokens/package.json').version"` prints `0.0.1-alpha.0`.
- [x] `package-lock.json` updated to match.
- [ ] Post-merge: `git tag tokens-v0.0.1-alpha.0 && git push origin tokens-v0.0.1-alpha.0`. Workflow run should publish `0.0.1-alpha.0` to GitHub Packages under the `rc` dist-tag, smoke-check pass.
- [ ] Post-merge: `npm view @venturecrane/tokens versions --registry=https://npm.pkg.github.com` should list `0.0.1-alpha.0`.
- [ ] Post-merge: smoke-install in `/tmp` scratch dir; verify the published tarball ships `dist/`, `src/`, and `build.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)