### PR TITLE
docs(design-system): canonical CLAUDE.md snippet (Stream A7)

### DIFF
--- a/docs/design-system/adoption/claude-md-snippet.md
+++ b/docs/design-system/adoption/claude-md-snippet.md
@@ -1,0 +1,65 @@
+---
+title: 'CLAUDE.md Snippet'
+sidebar:
+  order: 51
+---
+
+# Canonical CLAUDE.md Snippet
+
+The block below is the canonical instruction every venture's `CLAUDE.md` carries after design-system adoption. Step 5 of the [adoption runbook](../adoption-runbook.md) wires this in.
+
+The snippet tells venture agents **when** to load the cross-venture pattern + component catalog and **how** to fetch each surface via `crane_doc`. It supplements the venture's own `design-spec.md` reference (kept in place); it does not replace it.
+
+## Scope
+
+Add this block under the existing "Instruction Modules" section in the venture's `CLAUDE.md`, alongside the row that already references the venture's design spec. Do not delete the per-venture design-spec row — both layers are needed: the catalog is the cross-venture vocabulary, the spec is the venture's specific palette and tone.
+
+## What goes in CLAUDE.md
+
+```markdown
+## Design System
+
+Load the enterprise pattern + component catalog before any UI work — design briefs, wireframes, component generation, design-related PR review:
+
+- Patterns (cross-venture UX problem/solution pairs): `crane_doc('global', 'design-system/patterns/index.md')`
+- Components (per-venture catalog of atoms, molecules, organisms): `crane_doc('global', 'design-system/components/index.md')`
+
+Then load this venture's spec for palette and tone: `crane_doc('{code}', 'design-spec.md')`.
+
+The catalog is the shared vocabulary across all eight ventures — eight named patterns (status display by context, redundancy ban, button hierarchy, heading skip ban, typography scale, spacing rhythm, shared primitives, actions and menus) plus the components map (atoms / molecules / organisms with per-venture implementations). The catalog is a map, not a library — each venture maintains its own source. Cite a pattern by its file slug (`patterns/03-button-hierarchy.md`, etc.) when referencing it in PRs and skill output.
+```
+
+## Pattern set reference
+
+The catalog ships eight patterns at the time this runbook was authored. Quick reference:
+
+| File                                    | Topic                     |
+| --------------------------------------- | ------------------------- |
+| `patterns/01-status-display-by-context` | Status display by context |
+| `patterns/02-redundancy-ban`            | Redundancy ban            |
+| `patterns/03-button-hierarchy`          | Button hierarchy          |
+| `patterns/04-heading-skip-ban`          | Heading-skip ban          |
+| `patterns/05-typography-scale`          | Typography scale          |
+| `patterns/06-spacing-rhythm`            | Spacing rhythm            |
+| `patterns/07-shared-primitives`         | Shared primitives         |
+| `patterns/08-actions-and-menus`         | Actions and menus         |
+
+The components catalog is organized by Atomic Design vocabulary — `components/atoms/*`, `components/molecules/*`, `components/organisms/*`. Component entries are not implementation specs; they map per-venture source files so duplicates surface and shared vocabulary holds across ventures.
+
+## Three-line elevator version
+
+If the venture's `CLAUDE.md` is tight on real estate, use the abbreviated form:
+
+```markdown
+**Design system.** Before UI work, load patterns: `crane_doc('global', 'design-system/patterns/index.md')` and components: `crane_doc('global', 'design-system/components/index.md')`. Then load this venture's spec: `crane_doc('{code}', 'design-spec.md')`.
+```
+
+The abbreviated form is acceptable when the venture's `CLAUDE.md` already references the design spec elsewhere; otherwise prefer the full block above.
+
+## Why both layers
+
+The catalog gives agents the cross-venture invariants (status pills always derive from a venture-prefixed token; one primary action per view; menu vs. inline-action affordance rules). The venture spec gives the venture-specific values (the actual hex for `--ke-color-accent`, KE's heading scale, KE's empty-state voice). An agent loading only one layer ships generic patterns or invents tokens; loading both gives consistent UX with venture-specific tone.
+
+## Ownership
+
+This snippet is enterprise-scoped and propagates by copy. When the catalog adds a pattern or the snippet wording changes materially, the change lands here first; ventures pick it up by re-copying on their next adoption-runbook revisit (or as a small contribution per [governance](../governance.md)).

--- a/docs/design-system/index.md
+++ b/docs/design-system/index.md
@@ -29,3 +29,5 @@ Venture Crane runs a portfolio of products. Without a shared system, each ventur
 - **[Patterns](patterns/)** - Cross-venture UX problem/solution pairs. Eight patterns currently: seven seeded from SS's cited, enforced rules and one authored directly in enterprise scope (actions and menus).
 - **[Components](components/)** - Catalog of per-venture component implementations, classified by Atomic Design vocabulary. The catalog is a map, not a library.
 - **[Governance](governance.md)** - Tiered contribution model (small / large) and deprecation lifecycle. How the system evolves.
+- **[Adoption Runbook](adoption-runbook.md)** - Per-venture migration playbook: prerequisites, token JSON pre-stage, globals.css migration, screenshot sweep, CLAUDE.md + audit-workflow wire-in.
+- **[CLAUDE.md Snippet](adoption/claude-md-snippet.md)** - Canonical block every venture copies into its `CLAUDE.md` so agents load the patterns + components catalog by default.

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -4,13 +4,25 @@ Enterprise design system instructions for all Venture Crane agents.
 
 ## When to Load Design Context
 
-Load the venture's design spec before:
+Load the enterprise patterns + components catalog **and** the venture's design spec before:
 
 - **Wireframe generation** - tokens, surfaces, and component patterns inform the prototype
 - **UI implementation** - use venture-prefixed tokens, never hardcoded values
 - **Design-related PR review** - verify new code uses the token system correctly
+- **Design briefs and `/design-brief` runs** - the catalog is the cross-venture vocabulary the brief snaps to
+
+The catalog is a map, not a library — it lives in `docs/design-system/` and surfaces shared patterns + per-venture component implementations. The venture's design spec carries the venture-specific palette and tone. Load both: catalog for shared vocabulary, spec for venture identity.
 
 ## How to Load
+
+The pattern + component catalog (cross-venture, always loaded before UI work):
+
+```
+crane_doc('global', 'design-system/patterns/index.md')
+crane_doc('global', 'design-system/components/index.md')
+```
+
+Then the venture's spec (palette, tone, accessibility floor):
 
 ```
 crane_doc('{venture_code}', 'design-spec.md')
@@ -23,6 +35,8 @@ For Venture Crane's governance document (VC-specific):
 ```
 crane_doc('vc', 'design-charter.md')
 ```
+
+The canonical CLAUDE.md snippet — the block ventures copy into their own `CLAUDE.md` so their agents load the catalog by default — lives at [`docs/design-system/adoption/claude-md-snippet.md`](../design-system/adoption/claude-md-snippet.md). See the [adoption runbook](../design-system/adoption-runbook.md) Step 5 for the wire-in procedure.
 
 ## What You Get
 


### PR DESCRIPTION
## Summary

Stream A7 of the [enterprise design system rollout](https://github.com/venturecrane/crane-console/pull/719) — the canonical CLAUDE.md snippet ventures copy in.

- New file: `docs/design-system/adoption/claude-md-snippet.md` — the canonical block (~10-15 lines plus reference table) every venture's CLAUDE.md gets after design-system adoption. Tells agents when to load the cross-venture patterns + components catalog and when to load the per-venture spec.
- Updated `docs/instructions/design-system.md` — directs agents to load the patterns + components catalog before the venture spec; links the new snippet doc as the canonical wire-in source.
- Updated `docs/design-system/index.md` — surfaces the new adoption-runbook + claude-md-snippet alongside governance.

The Stream A6 adoption runbook already linked `adoption/claude-md-snippet.md` (the link is now resolvable on merge). No A6 file edits required.

## Test plan

- [x] `npm run verify` green locally (pre-push hook)
- [x] Prettier formatted
- [x] Snippet >= 50 lines (65)
- [x] Instructions module updated to point at patterns + components catalog
- [x] A6 link to the snippet now resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)