### PR TITLE
feat(tokens): pre-stage DC W3C-DTCG token JSON (Stream C3 prep)

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./vc.css": "./dist/vc.css",
     "./ke.css": "./dist/ke.css",
+    "./dc.css": "./dist/dc.css",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/tokens/src/ventures/dc.json
+++ b/packages/tokens/src/ventures/dc.json
@@ -1,0 +1,194 @@
+{
+  "color": {
+    "background": {
+      "$value": "#fdfcfb",
+      "$type": "color",
+      "$description": "Legacy: page background. Use surface-primary in new code."
+    },
+    "foreground": {
+      "$value": "#1c1917",
+      "$type": "color",
+      "$description": "Legacy: page text. Use text-primary in new code."
+    },
+    "text-primary": {
+      "$value": "#1c1917",
+      "$type": "color",
+      "$description": "Headings, prominent labels. 16.5:1 vs paper."
+    },
+    "text-secondary": {
+      "$value": "#44403c",
+      "$type": "color",
+      "$description": "Body text, descriptions. 9.2:1."
+    },
+    "text-muted": {
+      "$value": "#78716c",
+      "$type": "color",
+      "$description": "Captions, hints, idle labels. 4.6:1."
+    },
+    "text-placeholder": {
+      "$value": "#a8a29e",
+      "$type": "color",
+      "$description": "Input placeholders. 2.8:1 (large text only)."
+    },
+    "text-inverse": {
+      "$value": "#fdfcfb",
+      "$type": "color",
+      "$description": "Text on dark/colored backgrounds."
+    },
+    "surface-primary": {
+      "$value": "#fdfcfb",
+      "$type": "color",
+      "$description": "Writing surface, panel backgrounds."
+    },
+    "surface-secondary": {
+      "$value": "#f5f5f4",
+      "$type": "color",
+      "$description": "Dashboard bg, subtle tint."
+    },
+    "surface-tertiary": {
+      "$value": "#e7e5e4",
+      "$type": "color",
+      "$description": "Toggle tracks, hover backgrounds."
+    },
+    "surface-overlay": {
+      "$value": "rgba(28, 25, 23, 0.5)",
+      "$type": "color",
+      "$description": "Modal/dialog backdrops (warm black)."
+    },
+    "border-default": {
+      "$value": "#e7e5e4",
+      "$type": "color",
+      "$description": "Standard borders."
+    },
+    "border-subtle": {
+      "$value": "#f5f5f4",
+      "$type": "color",
+      "$description": "Dividers, separators."
+    },
+    "border-strong": {
+      "$value": "#d6d3d1",
+      "$type": "color",
+      "$description": "Emphasized borders, input outlines."
+    },
+    "border-focus": {
+      "$value": "#6b5b4b",
+      "$type": "color",
+      "$description": "Focus rings - uses primary accent."
+    },
+    "interactive-primary": {
+      "$value": "#6b5b4b",
+      "$type": "color",
+      "$description": "Primary actions, links. Warm Brown - Author's domain."
+    },
+    "interactive-primary-subtle": {
+      "$value": "#f5f2ed",
+      "$type": "color",
+      "$description": "Light warm tint backgrounds."
+    },
+    "interactive-primary-on-subtle": {
+      "$value": "#4a3f35",
+      "$type": "color",
+      "$description": "Dark text on primary-subtle."
+    },
+    "interactive-primary-hover": {
+      "$value": "#57534e",
+      "$type": "color",
+      "$description": "Hover state."
+    },
+    "interactive-primary-active": {
+      "$value": "#4a3f35",
+      "$type": "color",
+      "$description": "Active/pressed state."
+    },
+    "interactive-primary-border": {
+      "$value": "#a8a29e",
+      "$type": "color",
+      "$description": "Focus/selection borders."
+    },
+    "interactive-escalation": {
+      "$value": "#7b5b6b",
+      "$type": "color",
+      "$description": "Editor actions, AI escalation. Warm Plum - Editor's domain."
+    },
+    "interactive-escalation-subtle": {
+      "$value": "#f5f0f3",
+      "$type": "color",
+      "$description": "Light plum tint backgrounds."
+    },
+    "interactive-escalation-hover": {
+      "$value": "#6b4b5b",
+      "$type": "color",
+      "$description": "Hover state."
+    },
+    "interactive-escalation-border": {
+      "$value": "#c4a8b8",
+      "$type": "color",
+      "$description": "Focus/selection borders."
+    },
+    "interactive-destructive": {
+      "$value": "#b91c1c",
+      "$type": "color",
+      "$description": "Delete buttons, destructive actions."
+    },
+    "interactive-destructive-hover": {
+      "$value": "#991b1b",
+      "$type": "color",
+      "$description": "Hover on destructive actions."
+    },
+    "interactive-destructive-subtle": {
+      "$value": "#fef2f2",
+      "$type": "color",
+      "$description": "Light red tint backgrounds."
+    },
+    "status-error": {
+      "$value": "#b91c1c",
+      "$type": "color",
+      "$description": "Error state foreground."
+    },
+    "status-error-bg": {
+      "$value": "#fef2f2",
+      "$type": "color",
+      "$description": "Error state background."
+    },
+    "status-success": {
+      "$value": "#047857",
+      "$type": "color",
+      "$description": "Success state foreground."
+    },
+    "status-success-bg": {
+      "$value": "#ecfdf5",
+      "$type": "color",
+      "$description": "Success state background."
+    },
+    "status-success-subtle": {
+      "$value": "#ecfdf5",
+      "$type": "color",
+      "$description": "Success state subtle bg (alias of success-bg for consistency)."
+    },
+    "status-warning": {
+      "$value": "#b45309",
+      "$type": "color",
+      "$description": "Warnings, cautions."
+    },
+    "status-warning-bg": {
+      "$value": "#fffbeb",
+      "$type": "color",
+      "$description": "Warning background tint."
+    },
+    "highlight": {
+      "$value": "#fde68a",
+      "$type": "color",
+      "$description": "Text selection, AI rewrite focus (warm amber)."
+    },
+    "onboarding-dot-inactive": {
+      "$value": "#d6d3d1",
+      "$type": "color",
+      "$description": "Inactive onboarding step indicator."
+    },
+    "onboarding-backdrop": {
+      "$value": "rgba(28, 25, 23, 0.4)",
+      "$type": "color",
+      "$description": "Onboarding modal backdrop."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pre-stages `packages/tokens/src/ventures/dc.json` so the Stream C3 DC migration PR has a real seed token file to consume.

- Authored from `dc-console/web/src/app/globals.css` (Stitch V2 Warm Literary Palette).
- 38 leaf color tokens covering text tiers, surfaces, borders, interactive (primary/escalation/destructive), status, highlight, onboarding.
- Added `./dc.css` to package `exports` so the migration PR can `@import '@venturecrane/tokens/dc.css'`.
- Build emits `dist/dc.css` with `--dc-color-*` prefix (matches source convention).

## Source globals.css excerpt

From `~/dc-console/web/src/app/globals.css` (Stitch V2 — seed `#6B5B4B`, TONAL_SPOT, Stone scale):

```css
:root {
  /* Text */
  --dc-color-text-primary: #1c1917;    /* 16.5:1 vs paper */
  --dc-color-text-secondary: #44403c;  /* 9.2:1 */
  --dc-color-text-muted: #78716c;      /* 4.6:1 */

  /* Surfaces */
  --dc-color-surface-primary: #fdfcfb;
  --dc-color-surface-secondary: #f5f5f4;
  --dc-color-surface-overlay: rgba(28, 25, 23, 0.5);

  /* Interactive: Primary (Warm Brown — Author's domain) */
  --dc-color-interactive-primary: #6b5b4b;
  --dc-color-interactive-primary-hover: #57534e;

  /* Interactive: Escalation (Warm Plum — Editor's domain) */
  --dc-color-interactive-escalation: #7b5b6b;

  /* Status */
  --dc-color-status-success: #047857;
  --dc-color-status-warning: #b45309;
  --dc-color-status-error: #b91c1c;
  ...
}
```

## Built dist/dc.css excerpt

```css
:root {
  --dc-color-background: #fdfcfb;          /* Legacy */
  --dc-color-text-primary: #1c1917;
  --dc-color-surface-primary: #fdfcfb;
  --dc-color-interactive-primary: #6b5b4b;
  --dc-color-interactive-escalation: #7b5b6b;
  --dc-color-status-success: #047857;
  ...
}
```

(Plus shared base tokens: `--dc-motion-*`, `--dc-space-*`, `--dc-text-size-*`, etc., from `src/base/{motion,spacing,typography}.json`.)

## Gaps / notes for Stream C3 reviewer

1. **Alias-only tokens not seeded.** DC's globals.css defines compound tokens via `var()` references — `--dc-color-feedback-surface`, `--dc-color-onboarding-card-bg`, `--dc-color-help-accordion-bg`, etc. These are aliases over the primitives in this seed. Stream C3 will either:
   - Re-create them as DTCG references (`"$value": "{color.surface-primary}"`), or
   - Keep them in venture-local CSS as thin aliases over the imported primitives.
2. **Legacy `--background` / `--foreground` retained** (per R6 in the rollout plan). DC's Tailwind v4 `@theme inline` maps them to `--color-background` / `--color-foreground`. Description marks them as legacy with a forward-looking pointer to surface-primary / text-primary.
3. **Non-color tokens deferred.** DC's globals.css has rich spacing (`--dc-spacing-*`), radius (`--dc-radius-*`), shadow (`--dc-shadow-*`), motion (`--dc-motion-*`), z-index (`--dc-z-*`), and layout dimension tokens. Per rollout-plan instructions, only colors pre-stage here. Stream C3 decides which of these become enterprise base tokens vs venture-local.
4. **Plan called out 118 tokens.** That count is total tokens (color + spacing + typography + shadow + motion + z + layout). Color-only is 53 declarations / ~38 leaf values (the rest are aliases). All leaf colors captured.
5. **`status-success-subtle`** is included (alias of `status-success-bg` per source comment "Alias for consistency").

## Verification

- `npm run build -w @venturecrane/tokens` emits `dist/dc.css`.
- `npm run verify` from repo root passes.
- All 38 leaf color values match the source globals.css.

## Test plan

- [x] Build emits `dist/dc.css` with `--dc-color-*` prefix
- [x] Color values match source globals.css
- [x] `npm run verify` passes locally
- [x] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)