### PR TITLE
feat(tokens): pre-stage DCM W3C-DTCG token JSON (Stream C4 prep)

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -7,6 +7,7 @@
     "./vc.css": "./dist/vc.css",
     "./ke.css": "./dist/ke.css",
     "./dc.css": "./dist/dc.css",
+    "./dcm.css": "./dist/dcm.css",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/tokens/src/ventures/dcm.json
+++ b/packages/tokens/src/ventures/dcm.json
@@ -1,0 +1,114 @@
+{
+  "color": {
+    "brand-50": {
+      "$value": "#f0f7ff",
+      "$type": "color",
+      "$description": "Brand scale 50. Lightest tint."
+    },
+    "brand-100": {
+      "$value": "#e0effe",
+      "$type": "color",
+      "$description": "Brand scale 100."
+    },
+    "brand-200": {
+      "$value": "#b9dffd",
+      "$type": "color",
+      "$description": "Brand scale 200."
+    },
+    "brand-300": {
+      "$value": "#7cc5fc",
+      "$type": "color",
+      "$description": "Brand scale 300."
+    },
+    "brand-400": {
+      "$value": "#36a9f8",
+      "$type": "color",
+      "$description": "Brand scale 400."
+    },
+    "brand-500": {
+      "$value": "#0c8ee9",
+      "$type": "color",
+      "$description": "Brand scale 500. Default brand color, focus rings."
+    },
+    "brand-600": {
+      "$value": "#0070c7",
+      "$type": "color",
+      "$description": "Brand scale 600. Skip-link background."
+    },
+    "brand-700": {
+      "$value": "#0159a1",
+      "$type": "color",
+      "$description": "Brand scale 700."
+    },
+    "brand-800": {
+      "$value": "#064c85",
+      "$type": "color",
+      "$description": "Brand scale 800."
+    },
+    "brand-900": {
+      "$value": "#0b406e",
+      "$type": "color",
+      "$description": "Brand scale 900."
+    },
+    "brand-950": {
+      "$value": "#072849",
+      "$type": "color",
+      "$description": "Brand scale 950. Darkest shade."
+    },
+    "slate-50": {
+      "$value": "#f8fafc",
+      "$type": "color",
+      "$description": "Neutral scale 50."
+    },
+    "slate-100": {
+      "$value": "#f1f5f9",
+      "$type": "color",
+      "$description": "Neutral scale 100."
+    },
+    "slate-200": {
+      "$value": "#e2e8f0",
+      "$type": "color",
+      "$description": "Neutral scale 200."
+    },
+    "slate-300": {
+      "$value": "#cbd5e1",
+      "$type": "color",
+      "$description": "Neutral scale 300."
+    },
+    "slate-400": {
+      "$value": "#94a3b8",
+      "$type": "color",
+      "$description": "Neutral scale 400."
+    },
+    "slate-500": {
+      "$value": "#64748b",
+      "$type": "color",
+      "$description": "Neutral scale 500."
+    },
+    "slate-600": {
+      "$value": "#475569",
+      "$type": "color",
+      "$description": "Neutral scale 600."
+    },
+    "slate-700": {
+      "$value": "#334155",
+      "$type": "color",
+      "$description": "Neutral scale 700."
+    },
+    "slate-800": {
+      "$value": "#1e293b",
+      "$type": "color",
+      "$description": "Neutral scale 800. Default body text color."
+    },
+    "slate-900": {
+      "$value": "#0f172a",
+      "$type": "color",
+      "$description": "Neutral scale 900."
+    },
+    "slate-950": {
+      "$value": "#020617",
+      "$type": "color",
+      "$description": "Neutral scale 950."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pre-stages `packages/tokens/src/ventures/dcm.json` so the Stream C4 DCM (DraftCrane marketing) migration PR has a real seed token file to consume.

- Authored from `dc-marketing/src/styles/global.css` (Astro + Tailwind v4 site, draftcrane.com).
- 22 color tokens: brand scale (50-950, 11 stops) + slate neutral scale (50-950, 11 stops).
- Added `./dcm.css` to package `exports`.
- Build emits `dist/dcm.css` with `--dcm-color-*` prefix (the source uses unprefixed `--color-brand-*` / `--color-slate-*` inside `@theme {}`; this seed adopts enterprise-tokens prefixed convention).

## Source globals.css excerpt

From `~/dev/dc-marketing/src/styles/global.css` (Astro `@theme` block):

```css
@theme {
  /* Brand colors - derived from DraftCrane app palette */
  --color-brand-50:  #f0f7ff;
  --color-brand-500: #0c8ee9;  /* default focus rings */
  --color-brand-600: #0070c7;  /* skip-link bg */
  --color-brand-950: #072849;

  /* Neutral palette */
  --color-slate-50:  #f8fafc;
  --color-slate-800: #1e293b;  /* default body text */
  --color-slate-950: #020617;
}
```

## Built dist/dcm.css excerpt

```css
:root {
  --dcm-color-brand-50:  #f0f7ff;
  --dcm-color-brand-500: #0c8ee9;
  --dcm-color-brand-600: #0070c7;
  --dcm-color-slate-800: #1e293b;
  ...
}
```

(Plus shared base tokens: `--dcm-motion-*`, `--dcm-space-*`, `--dcm-text-size-*`, etc., from `src/base/{motion,spacing,typography}.json`.)

## Gaps / notes for Stream C4 reviewer

1. **Tailwind v4 utility class consumption is heavy.** DCM components use ~80 occurrences of `bg-brand-500`, `text-slate-700`, etc. across `src/`. The migration PR will need to either:
   - Re-introduce a Tailwind v4 `@theme inline` block that maps `--color-brand-*` → `--dcm-color-brand-*` (preserving existing utility class names), OR
   - Codemod components to use `bg-dcm-brand-500` style class names against a venture-prefixed `@theme` block.
2. **Plan-noted coordination with DC console.** Plan calls for "same dc.css import or separate dcm.css layer." DCM's palette (sky-derived brand + slate neutrals) is structurally different from DC console's Warm Literary Palette (warm brown #6b5b4b primary + stone surfaces). Recommend a separate `dcm.css` layer (delivered here) rather than sharing `dc.css`.
3. **Typography deferred.** DCM's `@theme` also sets `--font-serif: Georgia, ...` and `--font-sans: -apple-system, ...`. Not in this seed (per "skip motion/spacing/typography per venture" instruction). Migration PR decides whether to keep venture-local or extend `src/base/typography.json` with a `font-stack` token group.
4. **No semantic aliases in source.** DCM uses primitive scale directly (`var(--color-brand-500)`, `var(--color-slate-800)`). Migration PR may introduce semantic aliases (`--dcm-text-default`, `--dcm-link-color`) over the imported primitives at adoption time.
5. **DCM clone freshness.** `~/dev/dc-marketing` last touched at commit `38d1122` (OG default image); not refreshed. Source globals.css scope is small enough that drift risk is low, but reviewer should re-check at merge time.

## Verification

- `npm run build -w @venturecrane/tokens` emits `dist/dcm.css` (alongside dc/ke/vc).
- `npm run verify` from repo root passes.
- All 22 color values match the source globals.css.

## Test plan

- [x] Build emits `dist/dcm.css` with `--dcm-color-*` prefix
- [x] Color values match source globals.css
- [x] `npm run verify` passes locally
- [x] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)