### PR TITLE
skills(ui-suite): load design-system context at dispatch (Stream A8)

### DIFF
--- a/.agents/skills/design-brief/SKILL.md
+++ b/.agents/skills/design-brief/SKILL.md
@@ -1,15 +1,26 @@
 ---
 name: design-brief
 description: Multi-Agent Design Brief Generator
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable
+depends_on:
+  files:
+    - crane-console:docs/design-system/patterns/index.md
+    - crane-console:docs/design-system/components/index.md
 ---
 
 # /design-brief - Multi-Agent Design Brief Generator
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before launching any design-round agent (Brand Strategist, Interaction Designer, Design Technologist, Target User), load the cross-venture pattern + component catalog. Pass the loaded content into `docs/design/context.md` so each round-agent works against the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> The four roles below are voices, not pattern catalogs. Concrete pattern + component decisions in their output should map back to the loaded catalog (or extend it with a clear rationale). Then load the venture's `design-spec.md` for venture-specific palette and tone.
 
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 

--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nav-spec
 description: "Authors and enforces `.design/NAVIGATION.md` — the per-venture three-layer navigation specification (IA + patterns + chrome). Anchors to NN/g, Material Design 3, Apple HIG, and Dan Brown's 8 IA principles. v3 ships as a **challenger, not a chooser**: citation-anchored disqualifier conditions (R25) refuse patterns that contradict the task model, and an authoring-direction lint (R26) prevents Sections 1–4 from ratifying shipped chrome."
-version: 3.0.0
+version: 3.0.1
 scope: global
 owner: agent-team
 status: stable
@@ -19,10 +19,19 @@ depends_on:
     - venture:.design/NAVIGATION.md
     - venture:.design/DESIGN.md
     - global:~/.agents/skills/nav-spec/validate.py
+    - crane-console:docs/design-system/patterns/index.md
+    - crane-console:docs/design-system/components/index.md
   commands: [python3]
 ---
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
 
 # /nav-spec - Nav Spec Authority (v3)
 

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-design
 description: Produces production-ready Astro/React components in a venture's own repo from the harness inputs (nav-spec, design system, UX brief). Runs a simple loop — assemble prompt from specs and existing component source → generate component → build (npm/pnpm/yarn auto-detected from lockfile) → validate.py → land. Components drop into src/components/..., pages stay hand-wired. Invoke when the Captain asks to design, generate, revise, or build product UI for any venture.
-version: 1.0.0
+version: 1.0.1
 scope: global
 owner: agent-team
 status: stable
@@ -18,10 +18,19 @@ depends_on:
     - venture:.design/NAVIGATION.md
     - venture:.design/DESIGN.md
     - global:~/.agents/skills/nav-spec/validate.py
+    - crane-console:docs/design-system/patterns/index.md
+    - crane-console:docs/design-system/components/index.md
   commands: [python3]
 ---
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
+
+> **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
 
 # /product-design — Product UI realization
 

--- a/.agents/skills/ux-brief/SKILL.md
+++ b/.agents/skills/ux-brief/SKILL.md
@@ -1,15 +1,26 @@
 ---
 name: ux-brief
 description: UX Brief Authoring
-version: 2.0.0
+version: 2.0.1
 scope: enterprise
 owner: agent-team
 status: stable
+depends_on:
+  files:
+    - crane-console:docs/design-system/patterns/index.md
+    - crane-console:docs/design-system/components/index.md
 ---
 
 # /ux-brief - UX Brief Authoring
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ux-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before Phase 1 intake — and certainly before drafting v1 — load the cross-venture pattern + component catalog. Concept proposals (timeline / archive / action-centric, etc.) and chrome decisions in the brief should anchor on the loaded catalog or explicitly note the divergence:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the venture's `design-spec.md` for venture-specific palette and tone. Anti-patterns the brief calls out should reconcile with Patterns 1–8 (status display by context, redundancy ban, button hierarchy, etc.) — those are enterprise-canonical and the brief should not contradict them silently.
 
 Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona). When the brief is approved, the skill stops. To realize the brief into screens, run `/product-design`.
 

--- a/.claude/commands/design-brief.md
+++ b/.claude/commands/design-brief.md
@@ -2,6 +2,13 @@
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
+> **Design system context.** Before launching any design-round agent (Brand Strategist, Interaction Designer, Design Technologist, Target User), load the cross-venture pattern + component catalog. Pass the loaded content into `docs/design/context.md` so each round-agent works against the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> The four roles below are voices, not pattern catalogs. Concrete pattern + component decisions in their output should map back to the loaded catalog (or extend it with a clear rationale). Then load the venture's `design-spec.md` for venture-specific palette and tone.
+
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 
 The design brief answers "how should this look and feel?" - downstream of the PRD ("what to build and why?"). It requires a PRD to exist before running.

--- a/.claude/commands/nav-spec.md
+++ b/.claude/commands/nav-spec.md
@@ -1,5 +1,12 @@
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
+> **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
+
 # /nav-spec - Nav Spec Authority (v3)
 
 You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.

--- a/.claude/commands/product-design.md
+++ b/.claude/commands/product-design.md
@@ -1,5 +1,12 @@
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
 
+> **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
+
 # /product-design — Product UI realization
 
 You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.

--- a/.claude/commands/ux-brief.md
+++ b/.claude/commands/ux-brief.md
@@ -2,6 +2,13 @@
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ux-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
+> **Design system context.** Before Phase 1 intake — and certainly before drafting v1 — load the cross-venture pattern + component catalog. Concept proposals (timeline / archive / action-centric, etc.) and chrome decisions in the brief should anchor on the loaded catalog or explicitly note the divergence:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the venture's `design-spec.md` for venture-specific palette and tone. Anti-patterns the brief calls out should reconcile with Patterns 1–8 (status display by context, redundancy ban, button hierarchy, etc.) — those are enterprise-canonical and the brief should not contradict them silently.
+
 Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona). When the brief is approved, the skill stops. To realize the brief into screens, run `/product-design`.
 
 ## Arguments


### PR DESCRIPTION
## Summary

Stream A8 of the [enterprise design system rollout](https://github.com/venturecrane/crane-console/pull/719). Wire the four UI skills to load the cross-venture pattern + component catalog before any UI generation.

For each of `nav-spec`, `design-brief`, `ux-brief`, and `product-design`:

- Added a "Design system context" directive immediately after each skill's invocation directive (in both SKILL.md and the matching `.claude/commands/*.md` dispatcher) telling agents to call `crane_doc('global', 'design-system/{patterns,components}/index.md')` before generating output.
- Bumped frontmatter `version` semver patch:
  - `nav-spec`: 3.0.0 → 3.0.1
  - `design-brief`: 1.0.0 → 1.0.1
  - `ux-brief`: 2.0.0 → 2.0.1
  - `product-design`: 1.0.0 → 1.0.1
- Added the two catalog files to each skill's `depends_on.files`, scope-prefixed `crane-console:` per the schema in `docs/skills/governance.md`. `design-brief` and `ux-brief` gained `depends_on` blocks they did not previously declare.

## Test plan

- [x] `npm run skill-review -- --all` reports 0 errors (5 violations: 4 pre-existing venture-file warnings + 1 unrelated info on `ship`)
- [x] `npm run verify` green locally (pre-push hook)
- [x] Prettier formatted
- [x] Each skill's body directive matches the dispatcher's body directive
- [x] All four skills pass per-skill `skill-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)