### PR TITLE
chore(tokens): refactor package.json exports to subpath pattern (closes #730)

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -4,11 +4,7 @@
   "description": "Enterprise design tokens for Venture Crane ventures (W3C-DTCG + Style Dictionary)",
   "type": "module",
   "exports": {
-    "./vc.css": "./dist/vc.css",
-    "./ke.css": "./dist/ke.css",
-    "./dc.css": "./dist/dc.css",
-    "./dcm.css": "./dist/dcm.css",
-    "./ss.css": "./dist/ss.css",
+    "./*.css": "./dist/*.css",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Replaces 5 explicit per-venture entries in `packages/tokens/package.json` `exports` with a single Node.js subpath pattern:

```diff
   "exports": {
-    "./vc.css": "./dist/vc.css",
-    "./ke.css": "./dist/ke.css",
-    "./dc.css": "./dist/dc.css",
-    "./dcm.css": "./dist/dcm.css",
-    "./ss.css": "./dist/ss.css",
+    "./*.css": "./dist/*.css",
     "./package.json": "./package.json"
   }
```

Functionally equivalent for current consumers — every existing import path (`@venturecrane/tokens/vc.css`, `/ke.css`, `/dc.css`, `/dcm.css`, `/ss.css`) still resolves to its `dist/{code}.css` file. Future venture pre-stage PRs (SC, DFG, SMD) no longer need to touch this file at all; the glob auto-resolves any new `<code>.css` against `dist/<code>.css` once `src/ventures/<code>.json` lands and `npm run build` emits the corresponding CSS.

Closes #730.

## Why

During the 2026-04-25 enterprise design system rollout sprint, every concurrent venture pre-stage PR (#720 KE, #722 SS, #723 DC, #725 DCM) had to add an explicit entry to this `exports` field. Because the repo enforces "branches must be up-to-date with base," every merge invalidated the next PR's CI, producing a ~25-min serial-merge tail on top of the parallel authoring work. See memory `feedback_concurrent_merge_traffic.md` for the full friction analysis.

## Test plan

- [x] Edit applied: 5 explicit entries → 1 glob.
- [x] `npm install` (workspace re-link) → `node -e "require.resolve('@venturecrane/tokens/vc.css', ...)"` resolves to `dist/vc.css`. Same for `ke.css`, `dc.css`, `dcm.css`, `ss.css`.
- [x] Hypothetical future-venture round-trip: dropped `src/ventures/hypothetical.json`, ran `npm run build`, `dist/hypothetical.css` emitted, `require.resolve('@venturecrane/tokens/hypothetical.css', ...)` resolved correctly. Cleaned up after test.
- [x] Style Dictionary `npm run build -w @venturecrane/tokens` still emits all 5 dist CSS files unchanged.
- [x] `npm run format:check` green.
- [ ] Post-merge: SC/DFG/SMD pre-stage PRs (when Captain `/design-brief` block lands) only touch `src/ventures/{code}.json`, not `package.json`.

## Compat note

Node.js subpath patterns ([docs](https://nodejs.org/api/packages.html#subpath-patterns)) are supported since Node 16. This repo's `engines.node` is `>=22.0.0`, so the pattern is safe. If a downstream tool (e.g., a particular bundler version) struggles to resolve the pattern, fall back to the explicit form is trivial — `dist/` ships every venture's CSS regardless of the `exports` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)