### PR TITLE
chore(tokens): bump to 0.0.2-alpha.0 (ship ke/dc/dcm/ss CSS, closes #732)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,7 +6925,7 @@
     },
     "packages/tokens": {
       "name": "@venturecrane/tokens",
-      "version": "0.0.1-alpha.0",
+      "version": "0.0.2-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "style-dictionary": "^4.1.5"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/tokens",
-  "version": "0.0.1-alpha.0",
+  "version": "0.0.2-alpha.0",
   "description": "Enterprise design tokens for Venture Crane ventures (W3C-DTCG + Style Dictionary)",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Bumps `packages/tokens` from `0.0.1-alpha.0` → `0.0.2-alpha.0` so a fresh tag publishes a tarball containing all 5 brownfield ventures' compiled CSS.

## Why

Yesterday's `tokens-v0.0.1-alpha.0` was tagged when only `vc.json` existed. The published tarball ships only `dist/vc.css`. Verified 2026-04-25 with a `/tmp` smoke install using `NODE_AUTH_TOKEN`:

```
$ npm install '@venturecrane/tokens@rc'
added 1 package, ...
$ ls node_modules/@venturecrane/tokens/dist/
vc.css
```

KE/DC/DCM/SS token JSONs (#720, #722, #723, #725) all merged after the alpha tag. Without a re-tag, KE C1's migration PR `@import '@venturecrane/tokens/ke.css'` would 404.

## After merge

```
git tag tokens-v0.0.2-alpha.0 && git push origin tokens-v0.0.2-alpha.0
```

publish-tokens.yml fires. Pre-release version routes to `rc` dist-tag (no `latest` movement). Smoke check confirms registry ships 5 dist CSS files.

Closes #732.

## Test plan

- [x] `npm install` syncs lockfile (single line: `0.0.1-alpha.0` → `0.0.2-alpha.0`)
- [x] Local `npm run build -w @venturecrane/tokens` still emits all 5 dist CSS files
- [ ] Post-tag: workflow run publishes 0.0.2-alpha.0 with all 5 CSS files in tarball
- [ ] Post-tag: `/tmp` smoke install pulls a tarball that contains `dist/{vc,ke,dc,dcm,ss}.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)