### PR TITLE
feat(tokens): pre-stage DFG W3C-DTCG token JSON (Stream C7 prep)

### DIFF
--- a/packages/tokens/src/ventures/dfg.json
+++ b/packages/tokens/src/ventures/dfg.json
@@ -1,0 +1,249 @@
+{
+  "color": {
+    "background": {
+      "$value": "#0f172a",
+      "$type": "color",
+      "$description": "Page background. Dark slate (slate-900). Brief light variant: #f9fafb."
+    },
+    "surface": {
+      "$value": "#1f2937",
+      "$type": "color",
+      "$description": "Card backgrounds, panels (gray-800). Brief light variant: #ffffff."
+    },
+    "surface-elevated": {
+      "$value": "#374151",
+      "$type": "color",
+      "$description": "Hover/active surfaces, modals (gray-700). Brief light variant: #f3f4f6."
+    },
+    "border": {
+      "$value": "#374151",
+      "$type": "color",
+      "$description": "Standard borders (gray-700). Brief light variant: #e5e7eb."
+    },
+    "text-primary": {
+      "$value": "#f9fafb",
+      "$type": "color",
+      "$description": "Primary text on dark surfaces (gray-50). Brief light variant: #111827."
+    },
+    "text-secondary": {
+      "$value": "#d1d5db",
+      "$type": "color",
+      "$description": "Labels, descriptions (gray-300). Brief light variant: #374151."
+    },
+    "text-muted": {
+      "$value": "#9ca3af",
+      "$type": "color",
+      "$description": "Hints, captions (gray-400). Brief light variant: #6b7280."
+    },
+    "text-inverse": {
+      "$value": "#111827",
+      "$type": "color",
+      "$description": "Text on accent backgrounds. Brief light variant: #ffffff."
+    },
+    "accent": {
+      "$value": "#1f2937",
+      "$type": "color",
+      "$description": "Primary CTAs, navigation chrome (gray-800). Field Slate."
+    },
+    "accent-hover": {
+      "$value": "#111827",
+      "$type": "color",
+      "$description": "Hover state (gray-900)."
+    },
+    "accent-soft": {
+      "$value": "#e5e7eb",
+      "$type": "color",
+      "$description": "Soft accent backgrounds (gray-200)."
+    },
+    "highlight": {
+      "$value": "#3b82f6",
+      "$type": "color",
+      "$description": "Selected items, focus rings (blue-500)."
+    },
+    "highlight-subtle": {
+      "$value": "#dbeafe",
+      "$type": "color",
+      "$description": "Selected row backgrounds (blue-100)."
+    },
+    "strike-zone": {
+      "$value": "#f59e0b",
+      "$type": "color",
+      "$description": "Border/icon for high-value targets (amber-500)."
+    },
+    "verification": {
+      "$value": "#a855f7",
+      "$type": "color",
+      "$description": "Border/icon for unresolved verification gates (purple-500)."
+    },
+    "status-inbox-bg": {
+      "$value": "#dbeafe",
+      "$type": "color",
+      "$description": "New, untriaged opportunity (blue-100)."
+    },
+    "status-inbox-text": {
+      "$value": "#1e40af",
+      "$type": "color",
+      "$description": "Inbox status label (blue-800)."
+    },
+    "status-qualifying-bg": {
+      "$value": "#fef3c7",
+      "$type": "color",
+      "$description": "Qualifying / under review (amber-100)."
+    },
+    "status-qualifying-text": {
+      "$value": "#92400e",
+      "$type": "color",
+      "$description": "Qualifying status label (amber-800)."
+    },
+    "status-bid-bg": {
+      "$value": "#d1fae5",
+      "$type": "color",
+      "$description": "Active bid / Won (emerald-100)."
+    },
+    "status-bid-text": {
+      "$value": "#065f46",
+      "$type": "color",
+      "$description": "Bid/Won status label (emerald-800)."
+    },
+    "status-lost-bg": {
+      "$value": "#fee2e2",
+      "$type": "color",
+      "$description": "Outbid or abandoned (red-100)."
+    },
+    "status-lost-text": {
+      "$value": "#991b1b",
+      "$type": "color",
+      "$description": "Lost status label (red-800)."
+    },
+    "status-rejected-bg": {
+      "$value": "#f3f4f6",
+      "$type": "color",
+      "$description": "Disqualified (gray-100)."
+    },
+    "status-rejected-text": {
+      "$value": "#374151",
+      "$type": "color",
+      "$description": "Rejected status label (gray-700)."
+    }
+  },
+  "font": {
+    "display": {
+      "$value": "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Display + body. Inter loaded via next/font/google in app layout."
+    },
+    "body": {
+      "$value": "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Body copy. Inter."
+    },
+    "mono": {
+      "$value": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+      "$type": "fontFamily",
+      "$description": "Monospace for prices, lot IDs, percentages — anywhere precision matters."
+    }
+  },
+  "text-size": {
+    "page-h": {
+      "$value": "1.875rem",
+      "$type": "dimension",
+      "$description": "30px — Page H1 (text-3xl)."
+    },
+    "section-h": {
+      "$value": "1.5rem",
+      "$type": "dimension",
+      "$description": "24px — Section H2 (text-2xl)."
+    },
+    "card-title": {
+      "$value": "1.125rem",
+      "$type": "dimension",
+      "$description": "18px — Card title (text-lg)."
+    },
+    "body": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "16px — Default body (text-base)."
+    },
+    "metadata": {
+      "$value": "0.875rem",
+      "$type": "dimension",
+      "$description": "14px — Metadata (text-sm)."
+    },
+    "fine-print": {
+      "$value": "0.75rem",
+      "$type": "dimension",
+      "$description": "12px — Fine print (text-xs)."
+    }
+  },
+  "text-line-height": {
+    "page-h": { "$value": "2.25rem", "$type": "dimension" },
+    "section-h": { "$value": "2rem", "$type": "dimension" },
+    "card-title": { "$value": "1.75rem", "$type": "dimension" },
+    "body": { "$value": "1.5rem", "$type": "dimension" },
+    "metadata": { "$value": "1.25rem", "$type": "dimension" },
+    "fine-print": { "$value": "1rem", "$type": "dimension" }
+  },
+  "text-weight": {
+    "page-h": { "$value": "600", "$type": "fontWeight" },
+    "section-h": { "$value": "600", "$type": "fontWeight" },
+    "card-title": { "$value": "500", "$type": "fontWeight" },
+    "body": { "$value": "400", "$type": "fontWeight" },
+    "metadata": { "$value": "400", "$type": "fontWeight" },
+    "fine-print": { "$value": "400", "$type": "fontWeight" },
+    "label": { "$value": "500", "$type": "fontWeight" },
+    "emphasis": {
+      "$value": "700",
+      "$type": "fontWeight",
+      "$description": "Bold reserved for won/lost numeric outcomes only."
+    }
+  },
+  "space": {
+    "container-x": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Mobile container horizontal padding (px-4 = 16px)."
+    },
+    "container-x-sm": {
+      "$value": "1.5rem",
+      "$type": "dimension",
+      "$description": "Desktop container horizontal padding (sm:px-6 = 24px)."
+    },
+    "card": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Card internal padding (16px)."
+    },
+    "stack": {
+      "$value": "0.75rem",
+      "$type": "dimension",
+      "$description": "Vertical stack of sibling content — dense operator default (12px)."
+    },
+    "row": {
+      "$value": "0.5rem",
+      "$type": "dimension",
+      "$description": "Gap between table rows — dense (8px)."
+    }
+  },
+  "radius": {
+    "card": {
+      "$value": "0.5rem",
+      "$type": "dimension",
+      "$description": "Card radius (rounded-lg = 8px)."
+    },
+    "button": {
+      "$value": "0.5rem",
+      "$type": "dimension",
+      "$description": "Button radius (rounded-lg = 8px)."
+    },
+    "chip": {
+      "$value": "0.375rem",
+      "$type": "dimension",
+      "$description": "Avatar/chip radius (rounded-md = 6px)."
+    },
+    "dot": {
+      "$value": "9999px",
+      "$type": "dimension",
+      "$description": "Status dot — rounded-full."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pre-stages the Durgan Field Guide (DFG) DTCG token JSON for the upcoming Stream C7 migration. DFG's `~/dev/dfg-console/.design/DESIGN.md` already contains a confident, complete identity spec — this PR translates that spec into `packages/tokens/src/ventures/dfg.json` per the per-table mapping in `docs/design-system/adoption/design-brief-to-dtcg.md`. No `/design-brief` run was needed.

## Source identity (excerpted from `~/dev/dfg-console/.design/DESIGN.md`)

- **Brand:** Durgan Field Guide — Auction intelligence for resellers
- **Theme:** Dark mode default (operator surface is dense and read-often); `prefers-color-scheme` adapts
- **Voice:** Analytical-confident, data-first, no marketing fluff
- **Surfaces (dark / light pair):** `#0f172a` / `#f9fafb`, `#1f2937` / `#ffffff`, `#374151` / `#f3f4f6`, border `#374151` / `#e5e7eb`
- **Text (dark / light pair):** `#f9fafb` / `#111827`, `#d1d5db` / `#374151`, `#9ca3af` / `#6b7280`, inverse `#111827` / `#ffffff`
- **Accent (Steel Blue / Field Slate):** `#1f2937` (gray-800), hover `#111827`, soft `#e5e7eb`, highlight `#3b82f6` (blue-500), highlight-subtle `#dbeafe`
- **Strike Zone:** `#f59e0b` (amber-500) — high-value targets
- **Verification:** `#a855f7` (purple-500) — unresolved verification gates
- **Status (auction-domain):** Inbox/Watch (blue-100/800), Qualifying/Inspect (amber-100/800), Bid/Won (emerald-100/800), Lost (red-100/800), Rejected (gray-100/700)
- **Type:** Inter sans (loaded via `next/font/google`) + `ui-monospace` for prices/lot IDs/percentages
- **Scale:** Tailwind defaults — `text-3xl` page H1, `text-2xl` section H2, `text-lg` card title, `text-sm` metadata, `text-xs` fine print
- **Spacing:** Dense operator default — 12px stack, 8px row gap. Mobile container `px-4`, desktop `sm:px-6`
- **Radius:** `rounded-lg` (8px) cards/buttons, `rounded-md` (6px) chips, `rounded-full` status dots

## Decision: dark variant as primary

DFG's brief defines BOTH light + dark token pairs. The token JSON in this monorepo currently uses one value per role (cf. `vc.json` dark, `ss.json` light). Since DFG is "Dark mode default (operator surface is dense and read-often)," the dark variants are emitted as `$value`; the light hex pair is captured in `$description` for each surface/text token so a future light-mode strategy (CSS custom property + `[data-theme]` toggle, or `light-dark()` function) can lift them out cleanly.

## Resulting `dist/dfg.css` excerpt (82 `--dfg-*` properties)

```css
:root {
  --dfg-color-background: #0f172a;
  --dfg-color-surface: #1f2937;
  --dfg-color-surface-elevated: #374151;
  --dfg-color-border: #374151;
  --dfg-color-text-primary: #f9fafb;
  --dfg-color-accent: #1f2937;
  --dfg-color-highlight: #3b82f6;
  --dfg-color-strike-zone: #f59e0b;
  --dfg-color-verification: #a855f7;
  --dfg-color-status-bid-bg: #d1fae5;
  --dfg-color-status-bid-text: #065f46;
  /* ... + 25 color tokens, 6 type roles, dense spacing, 4 radii */
}
```

## Gaps

- **No serif type role** — brief explicitly states "Serif: none — DFG is not a literary surface." Captured by omission.
- **Light-mode token strategy** is not encoded in this PR. Captain decides how to surface light variants (separate `dfg-light.json`? `[data-theme]` selector blocks? `light-dark()` CSS function?) during the C7 migration PR.

## Stream C7 followups (not in this PR)

- Step (i): extracting hardcoded hex literals from `apps/dfg-app/tailwind.config.js` into a `@theme` block — separate PR.
- Step (ii): venture-side adoption (replace `bg-status-inbox` etc. with `bg-[var(--dfg-color-status-inbox-bg)]`) follows after the @theme migration.
- This PR only ships the token source + emitted CSS — no venture CSS modified.

## Test plan

- [x] `npm run build -w @venturecrane/tokens` succeeds and emits `dist/dfg.css`
- [x] 82 `--dfg-*` properties present, all colors match the source brief
- [x] `npx prettier --check packages/tokens/src/ventures/dfg.json` passes
- [ ] CI green