### PR TITLE
feat(tokens): pre-stage SMD W3C-DTCG token JSON (Stream C8 prep)

### DIFF
--- a/packages/tokens/src/ventures/smd.json
+++ b/packages/tokens/src/ventures/smd.json
@@ -1,0 +1,218 @@
+{
+  "color": {
+    "chrome": {
+      "$value": "#1a1a2e",
+      "$type": "color",
+      "$description": "Primary background, header, footer. Darkest surface."
+    },
+    "surface": {
+      "$value": "#242438",
+      "$type": "color",
+      "$description": "Card backgrounds. Primary elevated surface."
+    },
+    "surface-raised": {
+      "$value": "#2a2a42",
+      "$type": "color",
+      "$description": "Founder photo background placeholder, modals. Secondary elevation."
+    },
+    "border": {
+      "$value": "#2e2e4a",
+      "$type": "color",
+      "$description": "Default border for cards, dividers, header/footer rules."
+    },
+    "text": {
+      "$value": "#e8e8f0",
+      "$type": "color",
+      "$description": "Primary text on dark surfaces."
+    },
+    "text-muted": {
+      "$value": "#a0a0b8",
+      "$type": "color",
+      "$description": "Secondary text, footer copy, nav inactive state, captions."
+    },
+    "text-inverse": {
+      "$value": "#1a1a2e",
+      "$type": "color",
+      "$description": "Text on accent backgrounds (e.g., skip-link label on accent fill)."
+    },
+    "accent": {
+      "$value": "#818cf8",
+      "$type": "color",
+      "$description": "Links, CTAs, focus rings, active nav (indigo-400)."
+    },
+    "accent-hover": {
+      "$value": "#a5b4fc",
+      "$type": "color",
+      "$description": "Hover state for accent (indigo-300)."
+    },
+    "gold": {
+      "$value": "#dbb05c",
+      "$type": "color",
+      "$description": "Premium accent. Brand-mark highlight (the S in SMDurgan), founder title, card metrics."
+    },
+    "gold-hover": {
+      "$value": "#e8c474",
+      "$type": "color",
+      "$description": "Gold hover state."
+    },
+    "error": {
+      "$value": "#f87171",
+      "$type": "color",
+      "$description": "Error state (red-400). Notice.err in contact form."
+    }
+  },
+  "font": {
+    "display": {
+      "$value": "'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Display + body. Plain system stack — no custom font load."
+    },
+    "body": {
+      "$value": "'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      "$type": "fontFamily",
+      "$description": "Body copy. Plain system stack."
+    },
+    "mono": {
+      "$value": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+      "$type": "fontFamily",
+      "$description": "Brand mark (SMDURGAN), and any precision-required data."
+    }
+  },
+  "text-size": {
+    "page-title": {
+      "$value": "2rem",
+      "$type": "dimension",
+      "$description": "32px — h1 page title, founder-info h1."
+    },
+    "form-title": {
+      "$value": "1.875rem",
+      "$type": "dimension",
+      "$description": "30px — Form-card title (Get in Touch)."
+    },
+    "brand": {
+      "$value": "1.125rem",
+      "$type": "dimension",
+      "$description": "18px — Mono brand mark in header."
+    },
+    "body": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "16px — Default body."
+    },
+    "metadata": {
+      "$value": "0.875rem",
+      "$type": "dimension",
+      "$description": "14px — Nav links, footer copy, founder title."
+    },
+    "metric": {
+      "$value": "0.85rem",
+      "$type": "dimension",
+      "$description": "14px-ish — Card metric (gold, italic feel)."
+    },
+    "label": {
+      "$value": "0.75rem",
+      "$type": "dimension",
+      "$description": "12px — Badge, label text."
+    }
+  },
+  "text-line-height": {
+    "page-title": { "$value": "1.2", "$type": "dimension" },
+    "form-title": { "$value": "1.2", "$type": "dimension" },
+    "brand": { "$value": "1.2", "$type": "dimension" },
+    "body": { "$value": "1.6", "$type": "dimension" },
+    "metadata": { "$value": "1.4", "$type": "dimension" },
+    "metric": { "$value": "1.4", "$type": "dimension" },
+    "label": { "$value": "1.3", "$type": "dimension" }
+  },
+  "text-weight": {
+    "page-title": { "$value": "700", "$type": "fontWeight" },
+    "form-title": { "$value": "700", "$type": "fontWeight" },
+    "brand": { "$value": "700", "$type": "fontWeight" },
+    "body": { "$value": "400", "$type": "fontWeight" },
+    "metadata": { "$value": "400", "$type": "fontWeight" },
+    "metric": { "$value": "400", "$type": "fontWeight" },
+    "label": { "$value": "500", "$type": "fontWeight" },
+    "nav-active": { "$value": "600", "$type": "fontWeight" }
+  },
+  "text-letter-spacing": {
+    "brand": {
+      "$value": "0.05em",
+      "$type": "dimension",
+      "$description": "Mono brand mark — uppercase tracking."
+    },
+    "label": {
+      "$value": "0.05em",
+      "$type": "dimension",
+      "$description": "Badge uppercase tracking."
+    },
+    "founder-title": {
+      "$value": "0.08em",
+      "$type": "dimension",
+      "$description": "Uppercase founder title (FOUNDER)."
+    }
+  },
+  "space": {
+    "section": {
+      "$value": "3rem",
+      "$type": "dimension",
+      "$description": "Section gap top margin (48px)."
+    },
+    "card": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Default card internal padding (16px)."
+    },
+    "card-tier-1": {
+      "$value": "1.5rem",
+      "$type": "dimension",
+      "$description": "Tier-1 portfolio card padding (24px)."
+    },
+    "form-card": {
+      "$value": "1.5rem",
+      "$type": "dimension",
+      "$description": "Form card padding mobile (24px). Desktop bumps to 2rem."
+    },
+    "form-card-lg": {
+      "$value": "2rem",
+      "$type": "dimension",
+      "$description": "Form card padding desktop ≥640px (32px)."
+    },
+    "stack": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Vertical stack of sibling content (16px)."
+    },
+    "row": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Card grid gap (16px)."
+    },
+    "container-x": {
+      "$value": "1rem",
+      "$type": "dimension",
+      "$description": "Container horizontal padding mobile (16px)."
+    },
+    "container-x-sm": {
+      "$value": "1.5rem",
+      "$type": "dimension",
+      "$description": "Container horizontal padding ≥640px (24px)."
+    }
+  },
+  "radius": {
+    "card": {
+      "$value": "0.5rem",
+      "$type": "dimension",
+      "$description": "Card and form-card radius (8px)."
+    },
+    "button": {
+      "$value": "0.25rem",
+      "$type": "dimension",
+      "$description": "Button, input, CTA, notice radius (4px). Restrained."
+    },
+    "badge": {
+      "$value": "99px",
+      "$type": "dimension",
+      "$description": "Pill-shape badge."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Pre-stages the SMDurgan (SMD) DTCG token JSON for the upcoming Stream C8 migration. Unlike SC and DFG, SMD has no `.design/DESIGN.md` — but `~/dev/smd-console/smd-web/src/styles/global.css` is a **fully concrete, prefixed-CSS-vars source of truth** (12 `--smd-*` variables, consistent visual treatment across pages). Issue #702 (closed) noted that `docs/ventures/smd/design-spec.md` was contaminated with Silicon Crane content; the live globals.css was uncontaminated and is the authoritative source for this PR.

## Source identity (extracted from `~/dev/smd-console/smd-web/src/styles/global.css` + `README.md` + `src/pages/index.astro`)

- **Brand:** SMDurgan — Venture studio building focused software products with AI-agent development teams
- **Audience:** Founder portfolio + contact form audience (visitors who want to engage with SMDurgan)
- **Theme:** Dark mode default. `chrome` `#1a1a2e` page bg, deliberately narrow 768px max-width
- **Voice:** Plainspoken, professional, restrained ("Send a message below. Typically responds within one business day.")
- **Surfaces:** chrome `#1a1a2e`, surface `#242438`, surface-raised `#2a2a42`, border `#2e2e4a`
- **Text:** primary `#e8e8f0`, muted `#a0a0b8`, inverse `#1a1a2e`
- **Accent (indigo):** `#818cf8` (links, CTAs, focus, active nav), hover `#a5b4fc`
- **Gold (premium):** `#dbb05c`, hover `#e8c474` — used for the brand-mark "S" highlight in `SMDurgan`, the FOUNDER eyebrow, and card metric coloring
- **Error:** `#f87171` (red-400) — only used in `notice.err`
- **Type:** `'Segoe UI', Roboto, Helvetica, Arial, sans-serif` for body, `ui-monospace` for the brand mark
- **Scale:** 2rem page title, 1.875rem form-card title, 1.125rem mono brand mark, 1rem body, 0.875rem nav/footer/founder-title metadata, 0.75rem badge label
- **Spacing:** 24px tier-1 card padding, 16px default, container max-width 768px (the `--smd-max-width` value)
- **Radius:** 8px cards (`0.5rem`), 4px buttons/inputs (`0.25rem`), 99px badge pills

## Resulting `dist/smd.css` excerpt (74 `--smd-*` properties)

```css
:root {
  --smd-color-chrome: #1a1a2e;
  --smd-color-surface: #242438;
  --smd-color-surface-raised: #2a2a42;
  --smd-color-border: #2e2e4a;
  --smd-color-text: #e8e8f0;
  --smd-color-text-muted: #a0a0b8;
  --smd-color-accent: #818cf8;
  --smd-color-accent-hover: #a5b4fc;
  --smd-color-gold: #dbb05c;
  --smd-color-gold-hover: #e8c474;
  --smd-color-error: #f87171;
  /* ... + 12 color tokens, 7 type roles, 9 spacing tokens, 3 radii */
}
```

## Gaps + decisions

- **Existing `docs/ventures/smd/design-spec.md` is still wrong** (issue #702 closed but file unfixed). Captain may want to either rewrite it from the brief here, or delete it and rely on the live globals.css until a `/design-brief` run authors a proper spec. This PR does not touch that file.
- **No `.design/DESIGN.md`** for SMD. The token JSON is extracted directly from globals.css (the most accurate possible source — no translation loss). A future `/design-brief` run can produce a richer spec that may add tokens; those would be additive amendments to this baseline.
- **Status colors** (success/warning) — globals.css does not establish these; `notice.ok` reuses accent indigo for success, `notice.err` uses `#f87171` red. Captured: `error` is a token; `complete`/`attention` aren't (would be additions, not extractions).
- **Segoe UI** is included in the font stack as authored. It's a Microsoft system font, not a web-loaded font — fine for a system stack but agents adopting these tokens should be aware.

## Stream C8 followups (not in this PR)

- Step (i): replace the hardcoded `:root { --smd-* }` block in `~/dev/smd-console/smd-web/src/styles/global.css` with `@import '@venturecrane/tokens/smd.css'`. Should be a 1:1 replacement since the token names match.
- Step (ii): consider whether `docs/ventures/smd/design-spec.md` needs a fresh `/design-brief` run vs. a quick rewrite from this token JSON.
- This PR only ships the token source + emitted CSS — it does not modify smd-web or the design-spec doc.

## Test plan

- [x] `npm run build -w @venturecrane/tokens` succeeds and emits `dist/smd.css`
- [x] 74 `--smd-*` properties present, all colors match the live globals.css
- [x] `npx prettier --check packages/tokens/src/ventures/smd.json` passes
- [ ] CI green