### PR TITLE
chore(tokens): cut v0.1.0 — graduate to latest dist-tag (Stream A10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6925,7 +6925,7 @@
     },
     "packages/tokens": {
       "name": "@venturecrane/tokens",
-      "version": "0.0.2-alpha.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "style-dictionary": "^4.1.5"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/tokens",
-  "version": "0.0.2-alpha.0",
+  "version": "0.1.0",
   "description": "Enterprise design tokens for Venture Crane ventures (W3C-DTCG + Style Dictionary)",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Bumps `@venturecrane/tokens` from `0.0.2-alpha.0` → `0.1.0`. Per the `publish-tokens.yml` workflow's dist-tag logic, a version without a `-` suffix routes to **the `latest` dist-tag** (vs `rc` for pre-releases). This is the GA cut.

## Why now

Justified by all three brownfield migrations burning in clean today:

- **SS C5** — ss-console#568 (PR A, additive import) + ss-console#570 (PR B, `@theme inline` aliases + source codemod). 78 files, smoke #9: 1634 → 0.
- **DC C3** — dc-console#517. 15 files, smoke #9: 10 → 10 (the 10 are legitimate non-token references).
- **KE C1** — ke-console#206. 9 files, smoke #9: 5 → 5 (legitimate Next.js font vars).

All three consume `@venturecrane/tokens` as the single source of truth for color primitives, using the hybrid Tailwind v4 pattern (`@theme inline {}` aliases over package `--<code>-*` tokens).

## After merge

```
git tag tokens-v0.1.0 && git push origin tokens-v0.1.0
```

`publish-tokens.yml` fires. Tarball ships all 8 ventures' compiled CSS (vc, ke, dc, dcm, ss, sc, dfg, smd) under the `latest` dist-tag. Mission-complete smoke test #1 flips green when `npm view @venturecrane/tokens versions` includes `0.1.0`.

## Test plan

- [x] `npm install` syncs lockfile
- [x] `npm run build -w @venturecrane/tokens` still emits all 8 dist CSS files (subpath glob exports cover any future ventures too)
- [ ] Post-tag: workflow run publishes `0.1.0` to `latest` dist-tag
- [ ] Post-tag: `/tmp` smoke install with `NODE_AUTH_TOKEN` pulls a tarball with all 8 venture CSS files
- [ ] Post-tag: `npm view @venturecrane/tokens dist-tags` shows `latest: 0.1.0` and `rc: 0.0.2-alpha.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)