### PR TITLE
feat(skills): warn on orphan entries in skill mirrors (home + venture)

### DIFF
--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -62,6 +62,14 @@ depends_on:
 | `global`         | `~/.agents/skills/<name>/`              | Mirrored from `crane-console/.agents/skills/<name>/` to home via `config/global-skills.json` + launcher `syncGlobalSkills()` (see PR #528) |
 | `venture:<code>` | `<venture-repo>/.agents/skills/<name>/` | Venture-specific. Not synced from crane-console. Example: a skill only useful in ss-console                                                |
 
+### Canonical-only invariant for `~/.agents/skills/`
+
+`~/.agents/skills/` is a mirror, not a store. Every directory there MUST correspond to an entry in `config/global-skills.json` whose canonical content lives at `crane-console/.agents/skills/<name>/`. Anything else is an orphan.
+
+`syncGlobalSkills()` enforces this passively: on every `crane <venture>` launch, it logs a `Warning: ~/.agents/skills/ contains N non-canonical entries` for any directory not declared in the config. The launcher does NOT delete orphans automatically — removal is a Captain-directive action per `guardrails.md`. The warning is the prompt; the operator decides whether to canonicalize the orphan (move into `crane-console/.agents/skills/` and add to `config/global-skills.json`) or remove it.
+
+This invariant exists because the audit and review tooling assumes a single source of truth. Hand-placed `~/.agents/skills/<name>/` content never appears in `git log` and never goes through `/skill-review`, so it accumulates schema drift, broken references, and zero-usage detritus that the audit can't fix.
+
 ## Lifecycle: draft → stable → removed
 
 ```

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -56,19 +56,31 @@ depends_on:
 
 ## Scopes — where do skills live?
 
-| Scope            | On-disk location                        | Distribution mechanism                                                                                                                     |
-| ---------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `enterprise`     | `crane-console/.agents/skills/<name>/`  | Primary — loaded directly when Claude Code runs in crane-console. Follow-up work will mirror to venture repos                              |
-| `global`         | `~/.agents/skills/<name>/`              | Mirrored from `crane-console/.agents/skills/<name>/` to home via `config/global-skills.json` + launcher `syncGlobalSkills()` (see PR #528) |
-| `venture:<code>` | `<venture-repo>/.agents/skills/<name>/` | Venture-specific. Not synced from crane-console. Example: a skill only useful in ss-console                                                |
+| Scope            | On-disk location                        | Distribution mechanism                                                                                                                                                                             |
+| ---------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enterprise`     | `crane-console/.agents/skills/<name>/`  | Mirrored from canon to every venture repo via launcher `syncVentureSkills()` on every `crane <venture>` launch. Each repo's `.agents/skills/<name>/` is rewritten if the source is newer           |
+| `global`         | `~/.agents/skills/<name>/`              | Mirrored from `crane-console/.agents/skills/<name>/` to home via `config/global-skills.json` + launcher `syncGlobalSkills()` (see PR #528)                                                         |
+| `venture:<code>` | `<venture-repo>/.agents/skills/<name>/` | Venture-specific. Lives in the venture repo only; the launcher detects this scope on canonical SKILL.md and skips mirroring to non-matching ventures. Example: a skill only useful in `ss-console` |
 
-### Canonical-only invariant for `~/.agents/skills/`
+### Canonical-only invariant (both mirrors)
 
-`~/.agents/skills/` is a mirror, not a store. Every directory there MUST correspond to an entry in `config/global-skills.json` whose canonical content lives at `crane-console/.agents/skills/<name>/`. Anything else is an orphan.
+Both `~/.agents/skills/` (the home mirror) and `<venture-repo>/.agents/skills/` (the venture mirror) are mirrors of canon, not stores. Every directory there is either:
 
-`syncGlobalSkills()` enforces this passively: on every `crane <venture>` launch, it logs a `Warning: ~/.agents/skills/ contains N non-canonical entries` for any directory not declared in the config. The launcher does NOT delete orphans automatically — removal is a Captain-directive action per `guardrails.md`. The warning is the prompt; the operator decides whether to canonicalize the orphan (move into `crane-console/.agents/skills/` and add to `config/global-skills.json`) or remove it.
+- **Mirrored from canon** — appears in `crane-console/.agents/skills/<name>/`, OR
+- **Legitimately venture-scoped** — has `scope: venture:<this-venture>` frontmatter (venture mirrors only).
 
-This invariant exists because the audit and review tooling assumes a single source of truth. Hand-placed `~/.agents/skills/<name>/` content never appears in `git log` and never goes through `/skill-review`, so it accumulates schema drift, broken references, and zero-usage detritus that the audit can't fix.
+Anything else is an orphan. Hand-placed content there never goes through `/skill-review` and never appears in `git log`, so it accumulates schema drift, broken references, and zero-usage detritus that the audit can't reach.
+
+The launcher enforces this passively on every launch:
+
+- **Home mirror**: `syncGlobalSkills()` logs `Warning: ~/.agents/skills/ contains N non-canonical entries` for any directory not declared in `config/global-skills.json`.
+- **Venture mirror**: `syncVentureSkills()` logs `Warning: <venture>/.agents/skills/ contains N non-canonical entries` for any directory not in canon and not scoped to this venture.
+
+The launcher does NOT delete orphans automatically — removal is a Captain-directive action per `guardrails.md`. The warning is the prompt; the operator decides whether to canonicalize (move into `crane-console/.agents/skills/`), scope correctly, or remove.
+
+### Recommended: gitignore venture mirrors
+
+Because the launcher mirrors canonical content into each venture repo on every launch, tracking `.agents/skills/` in a venture repo's git history creates a recurring "dirty working tree" any time canon updates. Add `.agents/skills/` to each venture repo's `.gitignore` and `git rm -r --cached .agents/skills/` to drop it from tracking. The on-disk content stays; only the version-control bookkeeping changes. Fresh clones populate from canon on the first `crane <venture>` launch.
 
 ## Lifecycle: draft → stable → removed
 
@@ -172,9 +184,8 @@ If `CRANE_CONTEXT_KEY` is not set, the tool returns immediately with a warning. 
 
 ## Deferred (not yet implemented)
 
-The following governance features are planned but not in this session's landing:
+The following governance features are planned but not yet implemented:
 
-- **Venture-repo skill sync** — the launcher currently syncs `.claude/commands/` (via `syncClaudeAssets`) and global skills to `~/.agents/skills/` (via `syncGlobalSkills`). Extending this to mirror `.agents/skills/` to venture repos requires a reconcile pass for ss-console's 16 hand-ported skills; that work is tracked separately.
-<!-- CI is already blocking; this item has shipped. Kept here as a historical note for future lifecycle entries. -->
+- **Per-venture `.gitignore` rollout** — the launcher's `syncVentureSkills()` mirrors canonical content into each venture repo on every launch; the recommended cleanup is to gitignore `.agents/skills/` in each venture and `git rm -r --cached .agents/skills/` to drop tracked copies. This is a per-venture PR (one each for ss-console, dc-console, ke-console, sc-console, dfg-console, smd-console) and is not yet rolled out.
 
 See `docs/skills/deprecated.md` for the deprecation log.

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -1502,6 +1502,219 @@ describe('syncVentureSkills', () => {
     // venture-scoped skill skipped (unknown venture code)
     expect(copyFileSync).not.toHaveBeenCalled()
   })
+
+  it('warns when venture/.agents/skills/ contains a directory not in canon', () => {
+    // Source has [sos]; venture target has [sos, orphan-skill]
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) return true
+      if (s.endsWith('/ke-console/.agents/skills')) return true
+      if (s.endsWith('/sos')) return true
+      if (s.endsWith('/orphan-skill')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) {
+        return [dirent('sos', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/ke-console/.agents/skills')) {
+        return [dirent('sos', true), dirent('orphan-skill', true)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (s.endsWith('/sos')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('ventures.json')) {
+        return JSON.stringify({ ventures: [{ code: 'ke' }] })
+      }
+      // SKILL.md content (canon SOS = enterprise; orphan SKILL.md missing/unscoped)
+      return '---\nscope: enterprise\n---\n'
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncVentureSkills('/home/user/ke-console')
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(1)
+    expect(String(orphanWarnings[0][0])).toContain('orphan-skill')
+    consoleSpy.mockRestore()
+  })
+
+  it('does not warn for skills legitimately scoped to this venture', () => {
+    // Source has nothing; venture has [ss-special] scoped venture:ss
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) return true
+      if (s.endsWith('/ss-console/.agents/skills')) return true
+      if (s.endsWith('/ss-special/SKILL.md')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) {
+        return [] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/ss-console/.agents/skills')) {
+        return [dirent('ss-special', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('ventures.json')) {
+        return JSON.stringify({ ventures: [{ code: 'ss' }] })
+      }
+      return '---\nscope: "venture:ss"\n---\n'
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncVentureSkills('/home/user/ss-console')
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('warns for skills scoped to a different venture (leaked)', () => {
+    // ke-console has a skill scoped venture:ss — leaked
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) return true
+      if (s.endsWith('/ke-console/.agents/skills')) return true
+      if (s.endsWith('/ss-leaked/SKILL.md')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) {
+        return [] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/ke-console/.agents/skills')) {
+        return [dirent('ss-leaked', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('ventures.json')) {
+        return JSON.stringify({ ventures: [{ code: 'ke' }, { code: 'ss' }] })
+      }
+      return '---\nscope: "venture:ss"\n---\n'
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncVentureSkills('/home/user/ke-console')
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(1)
+    expect(String(orphanWarnings[0][0])).toContain('ss-leaked')
+    consoleSpy.mockRestore()
+  })
+
+  it('does not warn when canonical mirrored skills are the only entries', () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) return true
+      if (s.endsWith('/ke-console/.agents/skills')) return true
+      if (s.endsWith('/sos')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) {
+        return [dirent('sos', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/ke-console/.agents/skills')) {
+        return [dirent('sos', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/sos')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('ventures.json')) {
+        return JSON.stringify({ ventures: [{ code: 'ke' }] })
+      }
+      return '---\nscope: enterprise\n---\n'
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncVentureSkills('/home/user/ke-console')
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('lists all orphans when multiple are present', () => {
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) return true
+      if (s.endsWith('/ke-console/.agents/skills')) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('crane-console') && s.endsWith('.agents/skills')) {
+        return [] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/ke-console/.agents/skills')) {
+        return [
+          dirent('drift-a', true),
+          dirent('drift-b', true),
+          dirent('drift-c', true),
+        ] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.includes('ventures.json')) {
+        return JSON.stringify({ ventures: [{ code: 'ke' }] })
+      }
+      return ''
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncVentureSkills('/home/user/ke-console')
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(1)
+    const message = String(orphanWarnings[0][0])
+    expect(message).toContain('drift-a')
+    expect(message).toContain('drift-b')
+    expect(message).toContain('drift-c')
+    expect(message).toContain('3 non-canonical entries')
+    consoleSpy.mockRestore()
+  })
 })
 
 describe('extractPassthroughArgs', () => {

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -1062,6 +1062,153 @@ describe('syncGlobalSkills', () => {
 
     expect(copyFileSync).toHaveBeenCalledTimes(2)
   })
+
+  it('warns when ~/.agents/skills/ contains a directory not in config', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return ''
+    })
+
+    const targetRoot = join(homedir(), '.agents', 'skills')
+    vi.mocked(existsSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s.endsWith('/.agents/skills/nav-spec') && !s.startsWith(targetRoot)) return true
+      if (s === targetRoot) return true
+      return false
+    })
+
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s === targetRoot) {
+        return [dirent('nav-spec', true), dirent('orphan-skill', true)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncGlobalSkills()
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(1)
+    expect(String(orphanWarnings[0][0])).toContain('orphan-skill')
+    consoleSpy.mockRestore()
+  })
+
+  it('does not warn when home directory exactly matches config', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return 'same'
+    })
+
+    vi.mocked(existsSync).mockReturnValue(true)
+
+    const targetRoot = join(homedir(), '.agents', 'skills')
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s === targetRoot) {
+        return [dirent('nav-spec', true)] as unknown as ReturnType<typeof readdirSync>
+      }
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncGlobalSkills()
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('ignores plain files when scanning for orphans', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify(['nav-spec'])
+      return 'same'
+    })
+
+    vi.mocked(existsSync).mockReturnValue(true)
+
+    const targetRoot = join(homedir(), '.agents', 'skills')
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      const s = String(p)
+      if (s === targetRoot) {
+        return [dirent('nav-spec', true), dirent('.DS_Store', false)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      if (s.endsWith('/.agents/skills/nav-spec')) {
+        return [dirent('SKILL.md', false)] as unknown as ReturnType<typeof readdirSync>
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncGlobalSkills()
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
+
+  it('warns about all orphans when config is empty but home has content', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify([])
+      return ''
+    })
+
+    const targetRoot = join(homedir(), '.agents', 'skills')
+    vi.mocked(existsSync).mockImplementation((p) => String(p) === targetRoot)
+    vi.mocked(readdirSync).mockImplementation((p) => {
+      if (String(p) === targetRoot) {
+        return [dirent('orphan-a', true), dirent('orphan-b', true)] as unknown as ReturnType<
+          typeof readdirSync
+        >
+      }
+      return [] as unknown as ReturnType<typeof readdirSync>
+    })
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncGlobalSkills()
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(1)
+    expect(String(orphanWarnings[0][0])).toContain('orphan-a')
+    expect(String(orphanWarnings[0][0])).toContain('orphan-b')
+    consoleSpy.mockRestore()
+  })
+
+  it('skips orphan check entirely when home directory does not exist', () => {
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (String(p).includes('global-skills.json')) return JSON.stringify([])
+      return ''
+    })
+
+    vi.mocked(existsSync).mockReturnValue(false)
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    syncGlobalSkills()
+
+    const orphanWarnings = consoleSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('non-canonical')
+    )
+    expect(orphanWarnings).toHaveLength(0)
+    consoleSpy.mockRestore()
+  })
 })
 
 describe('parseSkillScope', () => {

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1063,26 +1063,59 @@ function mirrorDirectoryTree(sourceDir: string, targetDir: string): number {
  *
  * Runs on every `crane <venture>` launch (via checkMcpSetup). Fast no-op when
  * everything is already current (identical files skipped by content compare).
+ *
+ * Also flags orphan directories — entries in ~/.agents/skills/ that are not in
+ * config/global-skills.json. These are typically leftovers from retired skills
+ * or pre-canonical hand-placed content; the warning prompts the operator to
+ * either canonicalize them in crane-console or remove them.
  */
 export function syncGlobalSkills(): void {
   const skills = loadGlobalSkills()
-  if (skills.length === 0) return
-
-  const sourceRoot = join(CRANE_CONSOLE_ROOT, '.agents', 'skills')
   const targetRoot = join(homedir(), '.agents', 'skills')
 
-  let totalSynced = 0
-  for (const skill of skills) {
-    const sourceDir = join(sourceRoot, skill)
-    const targetDir = join(targetRoot, skill)
-    totalSynced += mirrorDirectoryTree(sourceDir, targetDir)
+  if (skills.length > 0) {
+    const sourceRoot = join(CRANE_CONSOLE_ROOT, '.agents', 'skills')
+    let totalSynced = 0
+    for (const skill of skills) {
+      const sourceDir = join(sourceRoot, skill)
+      const targetDir = join(targetRoot, skill)
+      totalSynced += mirrorDirectoryTree(sourceDir, targetDir)
+    }
+
+    if (totalSynced > 0) {
+      console.log(
+        `-> Synced ${totalSynced} global skill file${totalSynced > 1 ? 's' : ''} to ~/.agents/skills/`
+      )
+    }
   }
 
-  if (totalSynced > 0) {
-    console.log(
-      `-> Synced ${totalSynced} global skill file${totalSynced > 1 ? 's' : ''} to ~/.agents/skills/`
-    )
+  warnOrphanGlobalSkills(targetRoot, skills)
+}
+
+/**
+ * Warn about directories in ~/.agents/skills/ that are not declared in
+ * config/global-skills.json. Pure read; never mutates the filesystem.
+ */
+function warnOrphanGlobalSkills(targetRoot: string, expected: string[]): void {
+  if (!existsSync(targetRoot)) return
+
+  const expectedSet = new Set(expected)
+  const orphans: string[] = []
+  for (const entry of readdirSync(targetRoot, { withFileTypes: true })) {
+    if (entry.isDirectory() && !expectedSet.has(entry.name)) {
+      orphans.push(entry.name)
+    }
   }
+
+  if (orphans.length === 0) return
+
+  const noun = orphans.length === 1 ? 'entry' : 'entries'
+  console.log(
+    `-> Warning: ~/.agents/skills/ contains ${orphans.length} non-canonical ${noun}: ${orphans.join(', ')}`
+  )
+  console.log(
+    '-> Add to config/global-skills.json (and place under crane-console/.agents/skills/) or remove. See docs/skills/governance.md.'
+  )
 }
 
 /**

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -1175,6 +1175,10 @@ export function parseSkillScope(skillMdPath: string): string | null {
  *  3. Target-only preservation: files/dirs that exist in the venture repo but NOT
  *     in crane-console are never deleted.
  *
+ * After mirroring, flags orphan directories — entries in the venture repo that
+ * are neither mirrored from canon nor legitimately venture-scoped to this repo.
+ * These typically indicate hand-ported content that's drifted from canonical.
+ *
  * On first run for a venture repo that has zero skills, all non-excluded skills
  * propagate. The count appears in launcher output; the Captain can review the diff.
  *
@@ -1200,11 +1204,13 @@ export function syncVentureSkills(repoPath: string): void {
   const ventureCode = resolveVentureCodeFromPath(repoPath)
 
   let totalSynced = 0
+  const canonicalNames = new Set<string>()
 
   for (const entry of readdirSync(sourceRoot, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
 
     const skillName = entry.name
+    canonicalNames.add(skillName)
     const sourceSkillDir = join(sourceRoot, skillName)
     const skillMdPath = join(sourceSkillDir, 'SKILL.md')
 
@@ -1225,6 +1231,59 @@ export function syncVentureSkills(repoPath: string): void {
       `-> Synced ${totalSynced} venture skill file${totalSynced > 1 ? 's' : ''} to ${repoPath}/.agents/skills/`
     )
   }
+
+  warnOrphanVentureSkills(targetRoot, canonicalNames, ventureCode)
+}
+
+/**
+ * Warn about directories in <venture>/.agents/skills/ that are neither mirrored
+ * from canon nor scoped to this venture. Pure read; never mutates the filesystem.
+ *
+ * An entry is an orphan when ALL of:
+ *  - It's a directory (loose files like .DS_Store are ignored)
+ *  - It does NOT appear in crane-console/.agents/skills/
+ *  - Its SKILL.md (if any) is NOT scope: venture:<this-venture>
+ *
+ * Orphans typically come from hand-ported skill content that's drifted from
+ * canonical. Removing them is a Captain-directive action; this function only
+ * surfaces the drift.
+ */
+function warnOrphanVentureSkills(
+  targetRoot: string,
+  canonicalNames: Set<string>,
+  ventureCode: string | null
+): void {
+  if (!existsSync(targetRoot)) return
+
+  const orphans: string[] = []
+  for (const entry of readdirSync(targetRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue
+    if (canonicalNames.has(entry.name)) continue
+
+    // Allow legitimate venture-scoped skills that don't exist in canon
+    const skillMdPath = join(targetRoot, entry.name, 'SKILL.md')
+    const scope = parseSkillScope(skillMdPath)
+    if (
+      scope !== null &&
+      scope.startsWith('venture:') &&
+      ventureCode !== null &&
+      scope.slice('venture:'.length) === ventureCode
+    ) {
+      continue
+    }
+
+    orphans.push(entry.name)
+  }
+
+  if (orphans.length === 0) return
+
+  const noun = orphans.length === 1 ? 'entry' : 'entries'
+  console.log(
+    `-> Warning: ${targetRoot} contains ${orphans.length} non-canonical ${noun}: ${orphans.join(', ')}`
+  )
+  console.log(
+    `-> Either canonicalize in crane-console/.agents/skills/, scope as venture:${ventureCode ?? '<code>'}, or remove. See docs/skills/governance.md.`
+  )
 }
 
 export function setupGeminiMcp(repoPath: string): void {


### PR DESCRIPTION
## Summary

Adds passive orphan-detection guards to both skill mirrors maintained by the launcher:

- `~/.agents/skills/` (home mirror, populated by `syncGlobalSkills()`)
- `<venture-repo>/.agents/skills/` (venture mirror, populated by `syncVentureSkills()`)

In each, an entry is an orphan when it isn't backed by canon and isn't legitimately scoped to live there. The launcher logs a `Warning: ... contains N non-canonical entries` line with the offending names. Removal stays a Captain-directive action per `guardrails.md` — the launcher only surfaces drift.

## Why

A recurring "dirty working tree" pattern kept hitting venture repos: agents would see 50+ files modified in `<venture>/.agents/skills/`, get confused about source-of-truth, and either propose `git reset --hard` (data loss) or defer to a stash (kicks the can). Triaging one such case (ss-console, 2026-04-25) surfaced two compounding problems:

1. **3 Stitch-era orphan global skills** in `~/.agents/skills/` (`enhance-prompt`, `react-components`, `skill-creator`) — never canonicalized, zero-usage, dead content. Captain authorized retirement; cleanup ran out-of-band on this machine.
2. **Governance.md line 169** marked the venture-repo mirror as deferred, but `syncVentureSkills()` had actually been built. The doc was lying about reality, so agents kept misreading the situation.

This PR adds the orphan guard that prevents drift accumulation in both mirrors, and updates governance to reflect that the launcher mechanism exists today.

## Changes

- `syncGlobalSkills()` and `syncVentureSkills()` both gain an `warnOrphan*` companion that scans the target dir post-sync and logs orphans.
- `docs/skills/governance.md`:
  - Scopes table updated (line 61: enterprise scope now mirrored to every venture, not "follow-up work").
  - New "Canonical-only invariant" section covering both mirrors.
  - New "Recommended: gitignore venture mirrors" section explaining the per-venture cleanup that closes the dirty-working-tree pattern.
  - "Deferred" section pivots from "venture-repo skill sync" (already shipped) to "per-venture .gitignore rollout" (the actual next step).
- 10 new unit tests (5 per mirror): orphan detected, no-orphan happy path, venture-scoped skill respected, file entries ignored, multiple orphans listed.

## Test plan

- [x] `npx vitest run src/cli/launch-lib.test.ts` — 74/74 passing (64 existing + 10 new)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (30 pre-existing warnings, none in changed files)
- [x] `npx prettier --check` — clean
- [ ] CI verify
- [ ] Next `crane vc` launch shows no orphan warnings (after this machine's home-mirror cleanup)
- [ ] Next `crane ss` launch flags ss-console's hand-ported skills as orphans (until the per-venture gitignore PR lands)

## Out of scope (intentionally)

- **Per-venture `.gitignore` PRs** — `git rm -r --cached .agents/skills/` + add to `.gitignore` in each of: ss-console, dc-console, ke-console, sc-console, dfg-console, smd-console. One PR per repo. Documented in governance.md "Deferred" section.

## Pre-push note

Pushed with `--no-verify` (Captain-authorized). Pre-push hook tripped on 4 pre-existing failures in `workers/crane-context/test/harness/notes.test.ts` that fail identically on clean `main` while CI is green — tracked in #744.