### PR TITLE
chore(skills): promote 7 ss-console-only commands to canonical

### DIFF
--- a/.claude/commands/analytics.md
+++ b/.claude/commands/analytics.md
@@ -1,0 +1,157 @@
+# /analytics - Site Traffic Report
+
+Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
+
+## Usage
+
+```
+/analytics              # Today + 7-day trend
+/analytics 30           # Last 30 days
+/analytics 2026-02-01   # Specific date
+```
+
+## Arguments
+
+Parse the argument:
+
+- If empty, default to **today + 7-day trend**
+- If a number (e.g., `30`), show the **last N days**
+- If a date (e.g., `2026-02-01`), show that **specific date**
+
+## Constants
+
+These do not change:
+
+- **Account ID:** `ab6cc9362f7e51ba9a610aec1fc3a833`
+- **API Token env var:** `CLOUDFLARE_API_TOKEN`
+- **GraphQL endpoint:** `https://api.cloudflare.com/client/v4/graphql`
+- **Analytics type:** Account-level RUM (Web Analytics), NOT zone-level httpRequests
+
+Zone-level analytics (`httpRequests1dGroups`) will fail with a permissions error. Always use account-level `rumPageloadEventsAdaptiveGroups`.
+
+## Pre-flight
+
+Check that `CLOUDFLARE_API_TOKEN` is set:
+
+```bash
+[ -z "$CLOUDFLARE_API_TOKEN" ] && echo "CLOUDFLARE_API_TOKEN not set" && exit 1
+```
+
+If not set, stop: "CLOUDFLARE_API_TOKEN is not in the environment. Launch with `crane vc` to inject secrets."
+
+## Execution
+
+### 1. Daily Trend (broken out by site)
+
+Query `rumPageloadEventsAdaptiveGroups` at the account level for the date range, grouped by `requestHost` and `date`:
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { rumPageloadEventsAdaptiveGroups(limit: 500, filter: { date_geq: \"START_DATE\", date_leq: \"END_DATE\" }, orderBy: [date_ASC]) { count dimensions { date requestHost } } } } }"
+  }'
+```
+
+Replace `START_DATE` and `END_DATE` based on the parsed argument.
+
+Group the results by `requestHost`. Each unique host gets its own trend section. If there is only one host, display it without the grouping header.
+
+### 2. Top Pages, Referrers, Countries (for the most recent date in the range)
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { topPages: rumPageloadEventsAdaptiveGroups(limit: 15, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost requestPath } } topReferrers: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost refererHost } } topCountries: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost countryName } } } } }"
+  }'
+```
+
+Run both queries in parallel (two Bash tool calls in one message).
+
+Group results by `requestHost`. If only one host exists, omit the grouping header.
+
+### 3. Format Output
+
+**Single site** (omit site header when only one host):
+
+```
+== venturecrane.com Traffic ==
+
+Pageloads (7-day trend):
+  Feb 10:    2
+  Feb 11:    9
+  Feb 12:    0
+  Feb 13:    4
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+  16  /articles/agent-context-management-system/
+   9  /portfolio/
+   ...
+
+Referrers (today):
+  99  venturecrane.com (internal)
+  50  (direct)
+   1  bing.com
+
+Countries (today):
+ 145  US
+   2  SG
+   1  PL
+   ...
+```
+
+**Multiple sites** (group by host with clear separation):
+
+```
+== Venture Crane Traffic ==
+
+--- venturecrane.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+   ...
+
+--- kidexpenses.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   12
+  Feb 15:   18
+  Feb 16:    9  <-- today
+
+Top Pages (today):
+   5  /
+   3  /dashboard/
+   ...
+
+--- Totals ---
+
+  Feb 14:   86
+  Feb 15:  248
+  Feb 16:  159  <-- today
+```
+
+Right-align the numbers for scannability. Flag days with zero traffic (missing from API response) as `0`.
+
+When multiple sites exist, include a **Totals** section at the bottom summing all sites.
+
+## Notes
+
+- Read-only query. RUM data from JavaScript beacon (no bot traffic, but includes operator browsing).
+- Days missing from API response = zero pageloads. Fill as `0` in trend output.
+- Data may lag a few hours for current day. If API errors, show raw error message.
+- Account-level query - new sites with the beacon appear automatically.
+- Fleet machines block the beacon via /etc/hosts. Fleet traffic is not collected.

--- a/.claude/commands/docs-refresh.md
+++ b/.claude/commands/docs-refresh.md
@@ -1,0 +1,48 @@
+# /docs-refresh - Enterprise Docs Refresh
+
+Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+
+## Arguments
+
+```
+/docs-refresh [scope]
+```
+
+- No argument: Audit mode - lists stale pages, does NOT modify files
+- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
+- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
+- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+
+## Execution
+
+### Step 1: Audit
+
+Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+
+**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+
+### Step 2: Gather Data
+
+For pages in scope, pull from:
+
+- **Overviews**: `config/ventures.json` + `docs/design/ventures/{code}/design-spec.md` + VCMS exec summaries
+- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
+- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+
+### Step 3: Draft
+
+Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+
+### Step 4: Approve
+
+Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+
+### Step 5: PR
+
+Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+
+## Notes
+
+- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
+- After merge, Vercel auto-rebuilds the site
+- Quality bar: 0 unjustified TBDs, 20+ lines, real data

--- a/.claude/commands/go-live.md
+++ b/.claude/commands/go-live.md
@@ -1,0 +1,110 @@
+# /go-live - Venture Go-Live Process
+
+Launch a venture to production with mandatory secret rotation and readiness checks.
+
+```
+/go-live dc           # launch Draft Crane
+/go-live ke           # launch Kid Expenses
+```
+
+**Do NOT follow `docs/process/secrets-rotation-runbook.md`** - it references decommissioned tooling.
+
+## Step 1: Parse & Validate
+
+Parse `$ARGUMENTS` for a venture code. Then:
+
+1. Read `config/ventures.json`
+2. Find the venture by `code`
+3. If not found, stop: "Unknown venture code. Available: {list codes with status}"
+4. If `portfolio.status` is `"launched"`, stop: "Already launched."
+5. If no argument provided, stop with usage: "/go-live {venture-code}"
+
+## Step 2: Pre-flight Checks (automated)
+
+Run these checks without user input. Report pass/fail for each.
+
+1. **Golden Path compliance** - Read `docs/standards/golden-path.md` compliance dashboard row for this venture. Note Sentry, CI/CD, Monitoring, Docs status. If the venture is missing from the dashboard, flag it as a gap.
+2. **Infisical prod secrets** - Run `infisical secrets --path /{venture} --env prod --silent 2>/dev/null | grep '│' | grep -v 'SECRET NAME' | grep -v '├\|┌\|└' | sed 's/│/|/g' | cut -d'|' -f2 | sed 's/^ *//;s/ *$//'` to extract key names only. **NEVER run bare `infisical secrets` - it displays values in the transcript.**
+3. **Infisical dev secrets** - Same key-names-only extraction for `--env dev`.
+4. **Production worker health** - If the venture has a known health endpoint, `curl` it and confirm 200.
+5. **DNS/custom domain** - If `portfolio.url` is set in ventures.json, verify DNS resolves.
+
+Present results as a checklist. If any critical check fails (no prod secrets, no worker health), stop: "Fix these before proceeding."
+
+## Step 3: Secret Inventory
+
+Agent pulls and displays key names only (NEVER values):
+
+1. Extract key names from Infisical (reuse the key-names-only command from Step 2 - NEVER display values).
+2. Read the **Shared Credentials** table from `docs/infra/secrets-management.md`.
+3. Read the **Revocation Behavior by Type** table from `docs/infra/secrets-management.md`.
+4. Cross-reference: flag any shared credentials and note rotation impact.
+5. Categorize each secret by revocation behavior (immediate vs dual-key vs self-generated).
+
+Present the full inventory, then ask via AskUserQuestion:
+
+**Question:** "Rotate all {N} secrets at their sources, update Infisical (prod AND dev), then confirm."
+
+Include in the question context:
+
+- Shared credentials and which ventures they affect
+- Immediate-revocation secrets (test each one right after rotating)
+- Dual-key/self-generated secrets (can batch)
+
+**Options:**
+
+1. "All rotated and updated in Infisical" - proceed to push
+2. "Skip rotation" - launch without rotating (for ventures where secrets were never exposed in transcripts)
+3. "Cancel" - abort go-live
+
+If cancelled, stop.
+
+## Step 4: Push to Workers (agent-safe)
+
+Push secrets to Cloudflare Workers without exposing values:
+
+```bash
+cd {venture-worker-dir}
+infisical export --format=json --path /{venture} --env prod | npx wrangler secret bulk
+```
+
+No secret values appear in the transcript. If the venture has multiple workers, push to each.
+
+## Step 5: Smoke Test
+
+Run these checks and report pass/fail:
+
+1. **Health endpoint** - `curl` the production health endpoint
+2. **Auth flow** - venture-specific auth check (describe what to test based on the venture's tech stack)
+3. **Sentry** - verify Sentry project exists and is receiving events (if integrated)
+4. **Uptime monitor** - confirm external monitoring is configured
+
+If any fail: "Smoke test failures above. Fix before continuing. Old credentials have NOT been revoked yet."
+
+If all pass, ask via AskUserQuestion:
+
+**Question:** "Smoke tests passed. Revoke old credentials at their source consoles now. Self-generated tokens (like ENCRYPTION_KEY) don't need revocation - rotation was the control."
+
+**Options:**
+
+1. "Old credentials revoked" - proceed to ship
+2. "Cancel" - abort (new credentials remain active, no rollback needed)
+
+## Step 6: Ship
+
+1. Update `config/ventures.json`:
+   - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.showInPortfolio` to `true` (this enables venture name usage in published articles and build logs per terminology.md)
+   - Set `portfolio.url` if provided by user (ask if not already set)
+   - Update `bvmStage` if appropriate
+2. Commit with message: `feat: launch {venture name}`
+3. Run `/portfolio-review` to sync the venture to vc-web's portfolio page
+4. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+
+Report: "{Venture Name} is live. ventures.json updated, portfolio synced, handoff saved."
+
+## Important Notes
+
+- **Transcript cleanup is optional hygiene.** Rotation already invalidated any exposed values. Old transcripts in ~/.claude/ contain dead credentials after rotation.
+- **If smoke tests fail after rotating an immediate-revocation secret** (like OAuth client secrets), the old value is already dead. Fix the issue with the new credential - don't try to rollback.
+- **Shared credentials require coordination.** If GOOGLE_CLIENT_SECRET is rotated for /dc, the old value dies immediately for /ke too. Push to all consuming ventures before revoking.

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -1,0 +1,140 @@
+# /heartbeat - Keep Session Alive
+
+Send a heartbeat to prevent your session from timing out.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Updates the `last_heartbeat_at` timestamp
+3. Prevents 45-minute session timeout
+4. Shows when next heartbeat is recommended
+
+## When to Use
+
+- Working on long tasks (>30 minutes)
+- Want to keep session active while reading/researching
+- Need to maintain "active" status visibility
+
+**Not needed if:** You're actively using `/sos`, `/update`, or `/eos` - those all refresh heartbeat automatically.
+
+## Usage
+
+```bash
+/heartbeat
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Send Heartbeat
+
+```bash
+# Build request body
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  '{
+    session_id: $session_id
+  }')
+
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/heartbeat" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Heartbeat failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 3. Display Results
+
+```bash
+LAST_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.last_heartbeat_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "💓 Heartbeat sent"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Last heartbeat: $LAST_HEARTBEAT"
+echo "Next heartbeat in: ~$MINUTES minutes"
+echo ""
+echo "Your session will stay active for 45 minutes from this heartbeat."
+```
+
+## Notes
+
+- Automatic heartbeats: `/sos`, `/update`, `/eos` all refresh heartbeat
+- Manual heartbeat needed when working >30 minutes without those commands
+- Recommended interval: every 10-15 minutes during long tasks
+- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sos` creates new session)
+- Requires active session and CRANE_CONTEXT_KEY
+- Safe to call frequently (idempotent)

--- a/.claude/commands/skill-deprecate.md
+++ b/.claude/commands/skill-deprecate.md
@@ -1,0 +1,29 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,78 @@
+# /status - Show Session Status
+
+Display current session state, tasks, and git status for situational awareness.
+
+## What to Show
+
+### 1. Session Information
+
+Query crane-context for current session (if available):
+
+- Session ID
+- Session age (how long since /sos)
+- Last heartbeat time
+- Venture context
+
+If no session exists, note: "No active session. Run /sos to start."
+
+### 2. Active Tasks
+
+Use TaskList to show current task state:
+
+- Pending tasks (not started)
+- In-progress tasks (being worked on)
+- Recently completed tasks
+
+### 3. Git Status
+
+Show current repository state:
+
+- Current branch
+- Uncommitted changes (staged and unstaged)
+- Commits ahead/behind remote
+
+### 4. Context Summary
+
+- Current working directory
+- Repository name
+- Machine name (hostname)
+
+## Output Format
+
+```
+== Session Status ==
+Session: [ID or "None"]
+Age: [duration or "N/A"]
+Venture: [venture name or "Unknown"]
+
+== Tasks ==
+In Progress: [count]
+  - [task subject]
+Pending: [count]
+  - [task subject]
+Completed (recent): [count]
+
+== Git ==
+Branch: [branch name]
+Changes: [staged] staged, [unstaged] unstaged
+Remote: [ahead/behind status]
+
+== Context ==
+Repo: [repo name]
+Dir: [current directory]
+Machine: [hostname]
+```
+
+## Implementation Steps
+
+1. Check for active session by querying crane-context /session endpoint
+2. Call TaskList to get task state
+3. Run `git status --porcelain` and `git branch -vv` for git info
+4. Get hostname and current directory from environment
+5. Format and display results
+
+## Notes
+
+- This is a read-only status check - it should not modify anything
+- If crane-context is unavailable, show what information is available locally
+- Keep output concise and scannable

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,197 @@
+# /update - Update Session Context
+
+Update your session with current branch, commit, and work metadata.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Auto-detects current git branch and commit
+3. Updates session with current work context
+4. Refreshes heartbeat (keeps session alive)
+5. Provides visibility: "Agent X is on branch Y working on issue #123"
+
+## When to Use
+
+- Started working on a new issue
+- Switched branches
+- Made significant progress (checkpoint)
+- Want to update team visibility
+
+**Tip:** Call this when you start work on an issue and after major milestones.
+
+## Usage
+
+```bash
+# Auto-detect branch/commit
+/update
+
+# With issue number
+/update 123
+
+# With custom metadata
+/update --meta '{"issue": 123, "priority": "P0"}'
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Detect Current Work Context
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Get current commit
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+
+# Parse arguments for issue number or metadata
+ISSUE_NUMBER=""
+META_JSON=""
+
+# If first arg is a number, it's an issue
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  ISSUE_NUMBER="$1"
+  META_JSON=$(jq -n --argjson issue "$ISSUE_NUMBER" '{issue: $issue}')
+fi
+
+# If --meta flag provided, use that
+if [[ "$1" == "--meta" && -n "$2" ]]; then
+  META_JSON="$2"
+fi
+
+echo "## 📝 Updating Session"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo "Issue: #$ISSUE_NUMBER"
+fi
+echo ""
+```
+
+### 3. Build Update Request
+
+```bash
+# Build request body with current context
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$COMMIT" \
+  --argjson meta "${META_JSON:-null}" \
+  '{
+    session_id: $session_id,
+    branch: $branch,
+    commit_sha: $commit
+  } + (if $meta != null then {meta: $meta} else {} end)')
+```
+
+### 4. Call Context Worker /update
+
+```bash
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/update" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Update failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 5. Display Results
+
+```bash
+UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updated_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "✅ Session updated"
+echo ""
+echo "Updated at: $UPDATED_AT"
+echo "Next heartbeat: ~$MINUTES minutes"
+echo ""
+echo "Your session context is now visible to other agents."
+```
+
+## What Gets Updated
+
+- `branch`, `commit_sha`, `last_heartbeat_at` (always)
+- `meta` (optional freeform JSON: issue, priority, tags, etc.)
+- Venture, repo, track are set at session creation (not updated)
+
+## Notes
+
+- Auto-detects git branch and commit
+- Requires active session (run `/sos` first) and CRANE_CONTEXT_KEY
+- Refreshes heartbeat (prevents timeout)
+- Safe to call frequently
+- The `meta` field is freeform JSON - use it for whatever context helps your workflow


### PR DESCRIPTION
## Summary

Promotes 7 commands that lived only in \`ss-console/.claude/commands/\` but are pure cross-venture infrastructure with no ss-specific references.

| Command | What it does |
|---|---|
| \`analytics.md\` | Cloudflare RUM rollup across all VC sites |
| \`docs-refresh.md\` | Updates \`crane-console.vercel.app\` enterprise docs |
| \`go-live.md\` | Orchestrates any venture launch (\`/go-live dc\`, \`/go-live ke\`) |
| \`heartbeat.md\` | Generic Context Worker session keep-alive |
| \`skill-deprecate.md\` | Captain-gated skill deprecation flow |
| \`status.md\` | Generic session status display |
| \`update.md\` | Generic Context Worker session context update |

## Verification

Grepped each file for \`smd.services\`, \`ss-console\`, \`portal.smd\`, \`admin.smd\`, \`venture: ss\` — zero matches across all 7. They're all general-purpose; the ss-console placement was historical accident.

## Companion PR

[ss-console#573](https://github.com/venturecrane/ss-console/pull/573) gitignores \`.agents/skills/\`. A follow-on PR to ss-console will delete all 10 ss-only commands (these 7 + 3 confirmed-retired: \`stitch-design\`, \`stitch-ux-brief\`, \`work-plan\`) once this lands and \`syncClaudeAssets\` repopulates them on next \`crane ss\` launch.

## Known anomaly (not addressed here, surface for /skill-audit)

\`skill-deprecate.md\` carries skill-style frontmatter (\`scope: enterprise\`, \`owner: captain\`) on a command file. Per \`docs/skills/governance.md\` the frontmatter belongs on a \`SKILL.md\`. Moving as-is preserves current behavior; promotion to a full skill (with \`.agents/skills/skill-deprecate/SKILL.md\` + thin command dispatcher) is a separate concern.

## Test plan

- [ ] CI passes (typecheck, lint, format, all 25 test projects)
- [ ] After merge: run \`crane ss\` (or any venture launch); confirm \`syncClaudeAssets\` propagates the 7 new commands
- [ ] Verify \`/go-live dc\`, \`/heartbeat\`, etc. resolve in any venture context

🤖 Generated with [Claude Code](https://claude.com/claude-code)