### PR TITLE
ci(template): add Semgrep + nosemgrep-audit + Security Summary to venture template

### DIFF
--- a/templates/venture/.github/workflows/security.yml
+++ b/templates/venture/.github/workflows/security.yml
@@ -73,3 +73,153 @@ jobs:
 
       - name: Run Gitleaks
         run: ./gitleaks detect --source . --verbose --no-git --config .gitleaks.toml
+
+  typescript:
+    name: TypeScript Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+  semgrep:
+    name: Static Analysis (Semgrep)
+    runs-on: ubuntu-latest
+    container:
+      # Pinned container tag. Dependabot watches returntocorp/semgrep in
+      # .github/dependabot.yml so pin bumps land as PRs (auto-merged by
+      # .github/workflows/dependabot-auto-merge.yml when safe).
+      image: returntocorp/semgrep:1.157.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        # POSIX-compatible shell script — the returntocorp/semgrep container
+        # uses Alpine ash, not bash, so ${PIPESTATUS[n]} is unavailable.
+        # We redirect to a file, capture $? directly, then cat for both the
+        # CI log and (on failure) $GITHUB_STEP_SUMMARY.
+        run: |
+          echo "## Static Analysis (Semgrep)" >> "$GITHUB_STEP_SUMMARY"
+          # `--error` fails on findings. Pinned packs prevent silent rule
+          # drift; if a derivative venture needs different packs, override
+          # locally rather than editing the template.
+          set +e
+          semgrep scan \
+            --error \
+            --metrics=off \
+            --config=p/typescript \
+            --config=p/javascript \
+            --config=p/security-audit \
+            --config=p/owasp-top-ten \
+            --exclude=node_modules --exclude=dist --exclude='**/*.test.ts' \
+            > semgrep-output.txt 2>&1
+          rc=$?
+          set -e
+          cat semgrep-output.txt
+          if [ "$rc" -ne 0 ]; then
+            {
+              echo '### Findings'
+              echo '```'
+              cat semgrep-output.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit "$rc"
+          fi
+
+  nosemgrep-audit:
+    name: nosemgrep Justification Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require substantive justification on every nosemgrep
+        # Every `// nosemgrep` annotation must be followed by ` — ` or `: ` and
+        # at least 20 characters of justification prose. Without this audit,
+        # the gate degrades over time as agents silently silence findings by
+        # appending a bare `// nosemgrep` comment.
+        run: |
+          set -e
+          bad=$(grep -rnP --include='*.ts' --include='*.js' \
+            '//[[:space:]]*nosemgrep(:[^[:space:]]+)?[[:space:]]*(?:[—:][[:space:]]*.{0,19})?[[:space:]]*$' \
+            . \
+            --exclude-dir=node_modules --exclude-dir=dist || true)
+          if [ -n "$bad" ]; then
+            echo "nosemgrep annotations require ≥20 chars of justification after ' — ' or ': ':"
+            echo "$bad"
+            exit 1
+          fi
+          block=$(grep -rnzP --include='*.ts' --include='*.js' \
+            '/\*[^*]*nosemgrep[^*]*\*/' \
+            . \
+            --exclude-dir=node_modules --exclude-dir=dist || true)
+          if [ -n "$block" ]; then
+            echo "Block-comment nosemgrep not supported; use inline // nosemgrep:"
+            echo "$block"
+            exit 1
+          fi
+          disabled=$(grep -rn --include='*.ts' --include='*.js' 'semgrep-disable' . --exclude-dir=node_modules --exclude-dir=dist || true)
+          if [ -n "$disabled" ]; then
+            echo "'semgrep-disable' is banned; use rule-specific nosemgrep:"
+            echo "$disabled"
+            exit 1
+          fi
+
+  summary:
+    name: Security Summary
+    runs-on: ubuntu-latest
+    needs: [audit, gitleaks, typescript, semgrep, nosemgrep-audit]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          echo "## Security Check Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.audit.result }}" == "success" ]; then
+            echo "- NPM Audit: PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- NPM Audit: FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.gitleaks.result }}" == "success" ]; then
+            echo "- Secret Detection: PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Secret Detection: FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.typescript.result }}" == "success" ]; then
+            echo "- TypeScript: PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- TypeScript: FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.semgrep.result }}" == "success" ]; then
+            echo "- Static Analysis (Semgrep): PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Static Analysis (Semgrep): FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.nosemgrep-audit.result }}" == "success" ]; then
+            echo "- nosemgrep Justification Audit: PASSED" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- nosemgrep Justification Audit: FAILED" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Fail if any check failed
+          if [ "${{ needs.audit.result }}" != "success" ] || \
+             [ "${{ needs.gitleaks.result }}" != "success" ] || \
+             [ "${{ needs.typescript.result }}" != "success" ] || \
+             [ "${{ needs.semgrep.result }}" != "success" ] || \
+             [ "${{ needs.nosemgrep-audit.result }}" != "success" ]; then
+            echo ""
+            echo "One or more security checks failed."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Mirrors the canonical pattern in `.github/workflows/security.yml` (added by #639) into `templates/venture/.github/workflows/security.yml`, so future ventures scaffolded from this template inherit the full Semgrep CI gate at scaffolding time rather than post-hoc.

Closes #643. Companion to the in-flight venture mirroring (#642) and ruleset application (#644) work.

## Changes

- `templates/venture/.github/workflows/security.yml`: add `typescript`, `semgrep`, `nosemgrep-audit`, and `summary` jobs. Existing `audit` and `gitleaks` jobs preserved verbatim. The Security Summary aggregator now requires all 5 sub-jobs.

## Notes

- Drops the `--exclude=packages/crane-test-harness/dist` line from the canonical pattern (template ventures don't have this monorepo path).
- Drops the per-worker matrix from `audit` and `typescript` (template ventures default to flat single-package; monorepo ventures will add their own matrix when cloning).
- Container pin matches canonical: `returntocorp/semgrep:1.157.0`.

## Verification

The template file is not executed; it's copied during `new-venture` scaffolding. The runtime verification of this pattern is the canonical workflow in `.github/workflows/security.yml`, already proven via PR #639's canary process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)