### PR TITLE
feat(product-design): wire frontend-design into greenfield branch (v1.1.0)

### DIFF
--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-design
-description: Produces production-ready Astro/React components in a venture's own repo from the harness inputs (nav-spec, design system, UX brief). Runs a simple loop — assemble prompt from specs and existing component source → generate component → build (npm/pnpm/yarn auto-detected from lockfile) → validate.py → land. Components drop into src/components/..., pages stay hand-wired. Invoke when the Captain asks to design, generate, revise, or build product UI for any venture.
-version: 1.0.1
+description: Produces production-ready Astro/React components in a venture's own repo from the harness inputs (nav-spec, design system, UX brief). Runs a simple loop — assemble prompt from specs and existing component source → generate component → build (npm/pnpm/yarn auto-detected from lockfile) → validate.py → land. On greenfield surfaces (no file at target component path, no `--revise`), first invokes the `frontend-design` plugin to produce a per-surface composition reference within the venture's locked design language; the reference is appended to prompt-assembly as block 7-bis. Components drop into src/components/..., pages stay hand-wired. Invoke when the Captain asks to design, generate, revise, or build product UI for any venture.
+version: 1.1.0
 scope: global
 owner: agent-team
 status: stable
@@ -86,6 +86,9 @@ Five steps. Every generation follows this shape. Do not add steps without Captai
 
 1. **Assemble prompt.** See [references/prompt-assembly.md](references/prompt-assembly.md) for exactly what goes into the prompt and in what order. Inputs: nav-spec surface-class appendix, DESIGN.md or @theme tokens, UX brief section for this surface, five-tag classification (`surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`), adapter template, **raw source of every file under the venture's `src/components/**`\*\*. No registry. No AST. Let Claude read the component source directly.
 2. **Generate code.** Use the Write tool to produce the component file at its target path in the venture repo.
+
+   **Greenfield branch.** If no file exists at the target component path AND `--revise` was not passed, the workflow first invokes `Skill(frontend-design:frontend-design)` to produce a per-surface composition reference within the venture's locked design language (no new fonts, colors, or spacing — just composition exploration). The reference is captured as HTML and appended to the prompt-assembly as block 7-bis ("Aesthetic reference"); the in-loop generator then produces the Astro component as usual. Existing files and `--revise` invocations skip this branch entirely. See [references/frontend-design-handoff.md](references/frontend-design-handoff.md) for the seed prompt and constraints.
+
 3. **Build check.** Run the venture's build command (detected from lockfile — see package-manager note above). If it fails: read the compile errors, append to the prompt, regenerate. Max one retry.
 4. **Structural validate.** If a preview route is wired for this surface, extract the rendered HTML and run `~/.agents/skills/nav-spec/validate.py --file <html> --surface <tag> --archetype <tag> --viewport <tag> --task <tag> --pattern <tag> --spec <path-to-NAVIGATION.md>`. If structural violations: append to prompt, regenerate. Max one retry. If no preview route exists for this surface yet, skip — validator runs after the Captain promotes.
 5. **Land.** The component file is in place. Report to the Captain: file path, how to preview (the venture's dev command → `/design-preview/<surface>`), and anything you iterated on. Done.
@@ -123,6 +126,7 @@ If a preview route for the requested surface doesn't exist yet, the skill create
 - `design-brief` — PRD → design charter (upstream)
 - `nav-spec` — IA + patterns + chrome authority (sibling; structural authority)
 - `ux-brief` — three-reviewer surface-level UX brief (upstream)
+- `frontend-design` (Anthropic plugin) — per-surface composition reference generator on greenfield runs (sibling; aesthetic exploration within locked design language)
 
 ## Known limits (v1)
 

--- a/.agents/skills/product-design/references/frontend-design-handoff.md
+++ b/.agents/skills/product-design/references/frontend-design-handoff.md
@@ -1,0 +1,126 @@
+# Frontend-design handoff
+
+How the `/product-design` workflow invokes the Anthropic `frontend-design:frontend-design` plugin on greenfield surfaces, and what constraints govern its output.
+
+## When this fires
+
+Step 2.5 of [../workflows/generate-single-surface.md](../workflows/generate-single-surface.md). Only on greenfield invocations:
+
+- Target component path does not yet exist, AND
+- `--revise` was not passed
+
+Existing files and explicit revisions skip this step entirely. Cost: one frontend-design call per net-new surface.
+
+## What frontend-design produces (calibration result)
+
+Verified against existing output on disk at `ss-console/.design/frontend-design-output/exploration-v2/` (three HTML files, 410 lines each, generated 2026-04-19):
+
+- **Self-contained HTML files.** No `.astro`, no `.tsx`. A single `<html>` document with inline `<style>` blocks defining their own `:root` CSS variables.
+- **Raw hex values in CSS.** ~9 raw `#hexcode` values per file inside the `<style>` block. Zero Tailwind classes. Zero `--{venture}-*` token references. Zero `@theme` blocks.
+- **Composition over framework.** The plugin produces aesthetic exploration HTML you can iterate on visually, not framework-bound components you can drop into a build.
+
+This is intentional plugin behavior. It is why the handoff treats frontend-design output as a **reference**, not as the final component.
+
+## The seed prompt
+
+Built from a subset of the prompt-assembly blocks. The new prompt is sent to `frontend-design:frontend-design` via the Skill tool:
+
+```
+You are producing a composition exploration for a single surface within an existing,
+locked design language. This is NOT an identity exploration. The colors, fonts, and
+spacing below are the venture's authoritative design tokens — use them, do not
+substitute.
+
+## Surface
+
+{venture-name} — {surface-name} ({archetype}, {viewport})
+
+## Locked design language (do not introduce new tokens)
+
+{verbatim paste of .design/DESIGN.md, or the extracted @theme block}
+
+## Surface intent (from UX brief)
+
+{the section of .design/<target>-ux-brief.md covering this surface only}
+
+## Nav contract
+
+{the surface-class appendix from NAVIGATION.md, plus shared a11y / states /
+anti-patterns. Same content the in-loop generator receives.}
+
+## Your task
+
+Produce a single HTML file showing a distinctive composition for this specific
+surface, using ONLY the colors, fonts, and spacing from the locked design language
+above. Express your "BOLD aesthetic direction" through composition, hierarchy,
+density, layout asymmetry, motion, and surprise — not through new typography or
+new color families.
+
+Save the output. Do NOT introduce:
+
+- New display or body fonts. Use the venture's declared families verbatim.
+- New color families or accent hues. The palette is closed.
+- Spacing values outside the declared scale.
+
+The HTML will be used as a composition reference, not as a final component.
+```
+
+The seed deliberately reframes frontend-design's "BOLD aesthetic direction" guidance toward composition rather than identity. This narrows its trained creative pressure to the dimensions where the venture pipeline still has degrees of freedom.
+
+## Output handling
+
+1. Capture the full HTML response to `/tmp/pd-fdref-<surface>.html`.
+2. Run a drift check (grep) against the captured HTML:
+
+   ```
+   # Color drift
+   grep -oE '#[0-9a-fA-F]{6}' /tmp/pd-fdref-<surface>.html | sort -u
+   ```
+
+   Compare against the venture's declared palette (DESIGN.md or `@theme`). Any value not in the declared palette is drift.
+
+   ```
+   # Font drift
+   grep -oE 'font-family:\s*[^;]+' /tmp/pd-fdref-<surface>.html | sort -u
+   ```
+
+   Compare against declared families. Any new family is drift.
+
+3. **If drift is detected**, regenerate once with the specific contradiction explicit in the seed prompt (e.g., "The previous run introduced `Space Grotesk`. The venture uses `Crimson Pro` for display and `Public Sans` for body. Use only these.").
+4. **If the second attempt also drifts**, drop the reference entirely and proceed to step 3 of the workflow with normal blocks 1–8 only. Never let frontend-design override the venture's identity. Log the drop in the report to the Captain.
+
+## How the reference flows into the in-loop generator
+
+The captured HTML is appended to the prompt-assembly as **block 7-bis**, between block 7 (existing component source) and block 8 (revision context, which is empty for greenfield anyway).
+
+The in-loop generator's instructions for block 7-bis are explicit: this is a composition reference, NOT a copy target. The generator translates layout, hierarchy, density, and visual rhythm into Astro using the venture's tokens. It does not lift raw values from the reference.
+
+## Retry policy (greenfield, all paths)
+
+Total budget: 2 calls (unchanged from non-greenfield).
+
+| Failure type                         | Retry against                       | Reasoning                                                                                              |
+| ------------------------------------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Build check fails                    | In-loop generator                   | The build error is about Astro / TypeScript / imports — frontend-design's HTML output cannot fix that. |
+| Validator fails                      | In-loop generator                   | Validator violations are NAVIGATION-spec contracts; frontend-design has no knowledge of them.          |
+| Drift check fails (block 7-bis only) | Frontend-design                     | Targeted regeneration of the reference with the contradiction made explicit.                           |
+| Drift check fails twice              | Drop reference, continue without it | Better to ship a tokens-clean component than fight the plugin.                                         |
+| Both build + validator fail          | Stop, report to Captain             | Same as today. No third call.                                                                          |
+
+## Why composition-only, not identity exploration
+
+The venture's design language was already extracted from frontend-design output once via `/design-brief --extract-identity`. DESIGN.md is the codified identity. Running frontend-design again at the per-surface level for _identity_ exploration would re-open a closed decision and invite drift across surfaces (each surface getting a slightly different "interpretation" of the brand).
+
+What's still useful per-surface is the plugin's training on **distinctive composition**: unexpected layouts, asymmetry, density choices, motion ideas, hover surprises. The seed prompt narrows it to that. The in-loop generator then materializes those ideas in the venture's locked design language.
+
+This is the truthful interpretation of "wire frontend-design into the greenfield run" given what the plugin actually produces. Path A (output is the component) and Path B (rewrite raw values) are both incompatible with frontend-design's HTML-only output shape.
+
+## Cost
+
+One frontend-design call per net-new surface. Existing surfaces and revisions are unaffected. Routine ship work — refining shipped surfaces, fixing bugs, iterating on layout — pays zero additional API cost.
+
+## See also
+
+- [../workflows/generate-single-surface.md](../workflows/generate-single-surface.md) — the workflow that calls this handoff
+- [prompt-assembly.md](prompt-assembly.md) — block ordering, including block 7-bis
+- [../adapters/astro-component.md](../adapters/astro-component.md) — output shape constraints the in-loop generator enforces

--- a/.agents/skills/product-design/references/prompt-assembly.md
+++ b/.agents/skills/product-design/references/prompt-assembly.md
@@ -75,6 +75,27 @@ This is the biggest block. For ss-console with ~24 components it's a few thousan
 
 Header: `## Existing components (reuse these, do not reinvent)`
 
+### 7-bis. Aesthetic reference (greenfield only)
+
+If this is a greenfield surface (no file at the target component path AND `--revise` not passed), step 2.5 of [../workflows/generate-single-surface.md](../workflows/generate-single-surface.md) will have produced a per-surface composition reference HTML via the `frontend-design:frontend-design` plugin. Append the captured HTML here, framed as:
+
+```
+## Aesthetic reference (composition only)
+
+This is a fresh aesthetic exploration produced for this specific surface within
+the venture's locked design language. Use it as a composition reference —
+translate its layout, hierarchy, density, and visual rhythm into Astro using the
+venture's tokens. Do NOT copy raw colors, fonts, or spacing from this HTML —
+those are shimmed for standalone rendering only; the venture's DESIGN.md /
+@theme tokens are authoritative.
+
+<full HTML output from /tmp/pd-fdref-<surface>.html>
+```
+
+For existing surfaces and `--revise` invocations, this block is omitted entirely (no frontend-design call was made).
+
+See [frontend-design-handoff.md](frontend-design-handoff.md) for the seed prompt that produced the reference, the drift-check protocol, and the retry policy.
+
 ### 8. Prior version (only for `--revise`)
 
 If revising an existing file, include its current contents:

--- a/.agents/skills/product-design/workflows/generate-single-surface.md
+++ b/.agents/skills/product-design/workflows/generate-single-surface.md
@@ -37,6 +37,17 @@ Where `<area>` matches the surface class (e.g., `portal`, `admin`) and `<Compone
 
 If the component path already exists and `--revise` was not passed, confirm with the Captain before overwriting.
 
+### 2.5. Greenfield aesthetic reference (skip if file exists at target path or `--revise` was passed)
+
+If the target component path does not yet exist and this is not a `--revise` invocation, this is a greenfield surface. Produce a per-surface composition reference before assembling the main prompt:
+
+1. Invoke `Skill(frontend-design:frontend-design)` with the seed prompt described in [../references/frontend-design-handoff.md](../references/frontend-design-handoff.md). The seed paste-includes the venture's DESIGN.md tokens verbatim and explicitly tells frontend-design **not** to introduce new fonts, colors, or spacing — its job is distinctive **composition** within the venture's locked design language, not new identity exploration.
+2. Capture the HTML output to a temp file: `/tmp/pd-fdref-<surface>.html`. Frontend-design produces self-contained HTML, not Astro — that is by design (see calibration log in PR #556 follow-up). The HTML is a **reference only**; the in-loop generator translates layout/hierarchy/density into Astro using the venture's tokens.
+3. **Drift check.** Grep the captured HTML for new color families, font-family declarations not present in DESIGN.md, or spacing values outside the declared scale. If frontend-design contradicts DESIGN.md (e.g., introduces a different display font), regenerate once with the contradiction explicitly forbidden in the seed prompt. If the second attempt also drifts, drop the reference entirely and proceed to step 3 with normal blocks 1–8 only — never let frontend-design override the venture's identity.
+4. The captured HTML is appended to the prompt as block 7-bis in step 3.
+
+Existing surfaces and `--revise` invocations skip this step. No additional API spend on routine work.
+
 ### 3. Assemble the prompt
 
 See [../references/prompt-assembly.md](../references/prompt-assembly.md) for the exact block order. Briefly:
@@ -48,6 +59,7 @@ See [../references/prompt-assembly.md](../references/prompt-assembly.md) for the
 5. Design system tokens (from DESIGN.md or @theme extraction)
 6. UX brief excerpt (the brief section covering this surface)
 7. Existing component source (raw content of all `.astro`/`.tsx` files under `src/components/**`)
+   7-bis. For greenfield only: the frontend-design composition reference HTML from step 2.5, framed as: "This is a fresh aesthetic exploration produced for this specific surface within the venture's locked design language. Use it as a composition reference — translate its layout, hierarchy, density, and visual rhythm into Astro using the venture's tokens. Do NOT copy raw colors, fonts, or spacing from this HTML — those are shimmed for standalone rendering only; the venture's DESIGN.md / `@theme` tokens are authoritative."
 8. For `--revise`: the prior version of the file as context, plus the revision request
 
 ### 4. Generate

--- a/docs/instructions/tooling.md
+++ b/docs/instructions/tooling.md
@@ -8,7 +8,7 @@
 - **TypeScript LSP** — use for type-aware navigation and diagnostics before spinning up `tsc`.
 - **Vercel plugin** — use for deploy status, env inspection, and deploy logs on Vercel-hosted ventures (crane-console).
 - **Playwright** — use to codify repeatable browser flows (post-deploy smoke checks, E2E tests). Not a replacement for `claude-in-chrome` ad-hoc use.
-- **Frontend Design** — invoke for production-grade UI generation. Wire-in to `/product-design` is in-flight in a separate session.
+- **Frontend Design** — auto-invoked by `/product-design` on greenfield surfaces (no file at target component path) to produce a per-surface composition reference within the venture's locked design language; also available for direct invocation for net-new aesthetic exploration outside the pipeline.
 - **Semgrep** — CI-only gate in each venture's `security.yml`. Not a Claude Code plugin (retired 2026-04-22). Fix findings in the PR that surfaces them.
 <!-- SOD_SUMMARY_END -->
 
@@ -91,19 +91,20 @@ The five plugins below are installed enterprise-wide via `/plugin install` and b
 
 ### Frontend Design
 
-**What it does.** Anthropic skill for generating production-grade React/TSX components that avoid generic AI aesthetics. Invoked via the `frontend-design:frontend-design` skill.
+**What it does.** Anthropic skill for generating distinctive, production-grade UI. Invoked via the `frontend-design:frontend-design` skill. Calibrated against existing output (ss-console exploration-v2, 2026-04-19): produces self-contained HTML files with inline `<style>` blocks defining their own `:root` CSS variables — not Astro, not framework-bound components, not Tailwind classes. This shape is stable plugin behavior, not a configuration choice.
 
 **When to use.**
 
-- Building net-new UI surfaces that need distinctive polish
-- Inside `/product-design` once the wire-in lands (currently in-flight in a separate session)
+- Inside `/product-design` greenfield runs (no file at target component path). Auto-invoked by step 2.5 of `generate-single-surface.md` to produce a per-surface composition reference within the venture's locked design language; the reference appends to prompt-assembly as block 7-bis. See `.agents/skills/product-design/references/frontend-design-handoff.md` for the seed prompt and drift protocol.
+- Direct invocation for net-new aesthetic exploration outside the pipeline (e.g., spinning up a fresh identity direction before `/design-brief --extract-identity`).
 
 **When NOT to use.**
 
-- Copy-editing existing components — use direct edits
-- Wireframing or design-spec authoring — use `/ux-brief`, `/nav-spec`, `/design-brief`
+- Existing components or `--revise` runs — the wire-in skips this step deliberately to control cost and avoid identity drift across surfaces.
+- Copy-editing existing components — use direct edits.
+- Wireframing or design-spec authoring — use `/ux-brief`, `/nav-spec`, `/design-brief`.
 
-**Note.** If the output contradicts a venture's `.design/DESIGN.md` spec, the spec wins. Frontend Design is a generator, not a style arbiter.
+**Note.** If the output contradicts a venture's `.design/DESIGN.md` spec, the spec wins. Frontend Design is a generator, not a style arbiter. The greenfield wire-in narrows the plugin's "BOLD aesthetic direction" guidance toward composition (layout, hierarchy, density, motion) within the locked design language — not new identity exploration.
 
 ### Semgrep (CI gate, not a plugin)
 
@@ -134,7 +135,7 @@ The five plugins below are installed enterprise-wide via `/plugin install` and b
 | Cloudflare Workers deploy status    | `wrangler tail` / `wrangler deployments`                                      |
 | Codifying a smoke test              | Playwright                                                                    |
 | Ad-hoc browser check                | `claude-in-chrome` MCP                                                        |
-| Generating new UI components        | Frontend Design (direct; `/product-design` wire-in in-flight)                 |
+| Generating new UI components        | `/product-design` (auto-invokes Frontend Design on greenfield surfaces)       |
 | Pre-ship security scan              | Automatic via CI (`security.yml`); pair with `/security-review` for reasoning |
 | Internal enterprise docs            | `crane_doc('global', '<name>.md')`                                            |
 | Venture-scoped docs                 | `crane_doc('{venture}', '<name>.md')`                                         |


### PR DESCRIPTION
## Summary

- Closes the loose end flagged in PR #556: `frontend-design` plugin is now actually wired into `/product-design` (no more "in-flight in a separate session" caveats in `tooling.md`)
- Greenfield-only — auto-invokes on net-new surfaces; existing files and `--revise` runs pay zero additional API cost
- `frontend-design` output is treated as a **per-surface composition reference**, not a final component, because plugin output is HTML-only by design

## Calibration log

Examined existing frontend-design output on disk at `ss-console/.design/frontend-design-output/exploration-v2/` (3 HTML files, 410 lines each, generated 2026-04-19):

| Check | Result |
| --- | --- |
| `.astro` files produced | 0 |
| `.tsx` / `.jsx` files produced | 0 |
| `.html` files produced | 3 |
| Raw `#hexcode` values per file | ~9 (in inline `<style>` blocks) |
| Tailwind class uses (`bg-`, `text-`, `p-N`) | 0 |
| `--{venture}-*` token references | 0 |
| `@theme` blocks | 0 |
| `client:` directives | 0 |

Conclusion: structural leakage is intentional plugin behavior. Path A (output IS the component) and Path B (rewrite raw values) both fail — there is nothing structural to rewrite. Chose **Modified Path C**: per-surface composition reference within the venture's locked design language.

## What changed

| File | Change |
| --- | --- |
| `.agents/skills/product-design/SKILL.md` | Frontmatter version `1.0.1` → `1.1.0`; description updated; iteration-loop step 2 documents the greenfield branch; "Related skills" lists `frontend-design`. |
| `.agents/skills/product-design/workflows/generate-single-surface.md` | New step 2.5 (greenfield aesthetic reference); step 3 prompt-assembly enumerates block 7-bis. |
| `.agents/skills/product-design/references/prompt-assembly.md` | New block 7-bis section with framing instructions for the in-loop generator. |
| `.agents/skills/product-design/references/frontend-design-handoff.md` | **NEW.** Seed prompt, drift-check protocol, retry policy, calibration result, rationale. |
| `docs/instructions/tooling.md` | Three edits: SOD summary, "When to use" bullets, Invocation Reference table. All "in-flight" caveats removed. |

## Why composition-only, not identity

The venture's design language was already extracted from frontend-design output once via `/design-brief --extract-identity`. DESIGN.md is the codified identity. Running frontend-design again per-surface for *identity* exploration would re-open a closed decision and invite drift across surfaces. What's still useful per-surface is the plugin's training on **distinctive composition**: layouts, asymmetry, density, motion, surprise. The seed prompt narrows it to that.

## Drift protocol (briefly)

Captured frontend-design HTML is grep'd for new color families and font-family declarations not in the venture's DESIGN.md. If drift detected, regenerate once with the contradiction explicit. If second attempt also drifts, drop the reference entirely and proceed with normal blocks 1–8 — never let frontend-design override the venture's identity.

## Retry policy (greenfield, asymmetric by failure type)

| Failure | Retry against |
| --- | --- |
| Build check | In-loop generator (Astro/TypeScript out of frontend-design's domain) |
| Validator | In-loop generator (NAVIGATION-spec contracts ditto) |
| Drift check | Frontend-design (targeted fix) |
| Drift check twice | Drop reference, continue without it |

Total budget unchanged at 2.

## Mirrored skill propagation

Edits land in `crane-console` (canon). All venture repos (`.agents/skills/` gitignored mirrors) pick up the new behavior on next session launch via `.claude/launch.ts`.

## Test plan

- [x] `npm run verify` passes (typecheck, format, lint, test)
- [x] No stale "in-flight" mentions for Frontend Design in `docs/instructions/tooling.md`
- [x] SKILL.md frontmatter `version: 1.1.0`
- [x] New reference doc reachable from SKILL.md via the workflow
- [x] Calibration grounded in observed plugin output (ss-console exploration-v2)
- [ ] CI green
- [ ] First greenfield surface generation in a venture exercises the new step 2.5 (will validate next time `/product-design --surface <new-surface>` is invoked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)