### PR TITLE
fix(sync-docs): use fetch-depth 0 so squash-merge change detection works

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2 # Fetch last 2 commits to detect changes
+          fetch-depth: 0 # Full history so HEAD^ resolves on squash merges
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` with `fetch-depth: 2` does not reliably include the parent commit on squash merges, so `HEAD^` cannot be resolved in the runner.
- This caused PR #748 (which added `docs/ventures/ss/design-spec.md`) to silently no-op the auto-triggered sync — the workflow concluded `success` while uploading nothing, and the Captain had to manually dispatch.
- Switch both sync workflows to `fetch-depth: 0` (full history) so `HEAD^` (and any other historical ref) always resolves.

## Root cause

When PR #748 squash-merged to main at `c6d81b3`, the auto-triggered run of `.github/workflows/sync-docs.yml` produced empty change-detection output. In the runner, `git diff --name-status HEAD^ HEAD` errored to stderr because `HEAD^` was unresolvable under `fetch-depth: 2` — squash merges don't reliably surface the parent on a shallow fetch. The empty stdout flowed through `grep -E ... || true`, which masked the failure. With no upserts and no deletions detected, both upload and delete steps were skipped via their `if:` guards, and the job concluded `success`. Net effect: the new doc never uploaded until the workflow was manually dispatched.

`.github/workflows/sync-docs-to-context-worker.yml` has the identical pattern and the identical risk.

## The fix

One line per file:

- `.github/workflows/sync-docs.yml` — `fetch-depth: 2` → `fetch-depth: 0`
- `.github/workflows/sync-docs-to-context-worker.yml` — same

Full history makes `HEAD^` always resolvable on this repo. Cost is negligible at our size.

## Test plan

- [ ] CI green on this PR
- [ ] Next commit landing under `docs/ventures/**/*.md` on main auto-syncs without manual dispatch
- [ ] Next commit landing under `docs/{process,adr,infra,design-system}/**/*.md` on main auto-syncs without manual dispatch