### PR TITLE
fix(/eos): support multi-venture handoffs via keep_session_open flag

### DIFF
--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -83,15 +83,18 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
-3. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
+3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
+4. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
+
+Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
 ### 6. Report Completion
 

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -173,6 +173,9 @@ export interface HandoffRequest {
   issue_number?: number
   payload?: Record<string, unknown>
   last_activity_at?: string
+  // When true, create the handoff record but keep the session active. Used by
+  // multi-venture flows that emit one handoff per venture before terminating.
+  keep_session_open?: boolean
 }
 
 export interface HandoffRecord {
@@ -1044,6 +1047,7 @@ export class CraneApi {
         issue_number: handoff.issue_number,
         last_activity_at: handoff.last_activity_at,
         payload: handoff.payload ?? {},
+        keep_session_open: handoff.keep_session_open,
       }),
     })
 

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -108,6 +108,76 @@ describe('handoff tool', () => {
     expect(body.payload).toEqual({})
   })
 
+  it('omits keep_session_open by default (single-handoff flow ends session)', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_abc',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    await executeHandoff({ summary: 'Test', status: 'done' })
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body)
+    // Default behavior: keep_session_open is undefined (or false) → API ends session
+    expect(body.keep_session_open).toBeFalsy()
+  })
+
+  it('passes keep_session_open=true when final: false (multi-venture middle call)', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_abc',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    await executeHandoff({ summary: 'Test', status: 'done', final: false })
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body)
+    expect(body.keep_session_open).toBe(true)
+  })
+
+  it('passes keep_session_open=false when final: true (explicit final call ends session)', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_abc',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    await executeHandoff({ summary: 'Test', status: 'done', final: true })
+
+    const body = JSON.parse(mockFetch.mock.calls[1][1].body)
+    expect(body.keep_session_open).toBe(false)
+  })
+
   it('includes last_activity_at when session log is available', async () => {
     const { executeHandoff } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -44,6 +44,12 @@ export const handoffInputSchema = z.object({
     .describe(
       'Venture code override for cross-venture sessions. When set, writes the handoff for this venture instead of auto-detecting from the current repo.'
     ),
+  final: z
+    .boolean()
+    .optional()
+    .describe(
+      'When false, create the handoff but keep the session active so additional per-venture handoffs can be saved. Pass false for ventures 1..N-1 in a multi-venture /eos flow, then true (or omit) on the final call. Defaults to true (current single-handoff behavior — ends the session).'
+    ),
 })
 
 export type HandoffInput = z.infer<typeof handoffInputSchema>
@@ -187,6 +193,12 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
       // Non-fatal: fall back to current behavior (ended_at = now)
     }
 
+    // Default: end the session on this call (single-handoff flow).
+    // Multi-venture flows pass `final: false` for ventures 1..N-1 to keep
+    // the session active so subsequent handoffs don't 409 with
+    // "Session is not active".
+    const keepSessionOpen = input.final === false
+
     await api.createHandoff({
       venture: venture.code,
       repo: handoffRepo,
@@ -196,6 +208,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
       session_id: session.sessionId,
       issue_number: input.issue_number,
       last_activity_at: lastActivityAt,
+      keep_session_open: keepSessionOpen,
     })
 
     return {
@@ -204,7 +217,7 @@ export async function executeHandoff(input: HandoffInput): Promise<HandoffResult
         `Handoff created.\n\n` +
         `Venture: ${venture.name}\n` +
         `Status: ${input.status}\n` +
-        `Session: ${session.sessionId}\n` +
+        `Session: ${session.sessionId}${keepSessionOpen ? ' (still active for additional per-venture handoffs)' : ''}\n` +
         (input.issue_number ? `Issue: #${input.issue_number}\n` : '') +
         `\nSummary:\n${input.summary}`,
     }

--- a/workers/crane-context/src/endpoints/sessions.ts
+++ b/workers/crane-context/src/endpoints/sessions.ts
@@ -70,6 +70,11 @@ interface EndOfSessionBody {
   end_reason?: string
   last_activity_at?: string
   update_id?: string
+  // When true, create the handoff record but do NOT mark the session ended.
+  // Used by multi-venture handoff flows where /eos is called once per venture
+  // in the same session; only the final call should end the session.
+  // Defaults to false (current behavior).
+  keep_session_open?: boolean
 }
 
 interface UpdateBody {
@@ -421,7 +426,10 @@ export async function handleStartOfSession(request: Request, env: Env): Promise<
  *   status_label?: string,
  *   summary: string,
  *   payload: object,
- *   end_reason?: string
+ *   end_reason?: string,
+ *   keep_session_open?: boolean   // When true, create handoff but don't end session.
+ *                                  // For multi-venture flows that emit one handoff
+ *                                  // per venture before terminating. Default false.
  * }
  *
  * Response:
@@ -429,7 +437,7 @@ export async function handleStartOfSession(request: Request, env: Env): Promise<
  *   session_id: string,
  *   handoff_id: string,
  *   handoff: HandoffRecord,
- *   ended_at: string
+ *   ended_at: string | null   // null when keep_session_open=true
  * }
  */
 export async function handleEndOfSession(request: Request, env: Env): Promise<Response> {
@@ -538,13 +546,15 @@ export async function handleEndOfSession(request: Request, env: Env): Promise<Re
         creation_correlation_id: context.correlationId,
       })
 
-      // 6. End session
-      const endedAt = await endSession(
-        env.DB,
-        body.session_id,
-        body.end_reason || 'manual',
-        body.last_activity_at
-      )
+      // 6. End session (unless caller asked to keep it open for additional handoffs)
+      const endedAt = body.keep_session_open
+        ? null
+        : await endSession(
+            env.DB,
+            body.session_id,
+            body.end_reason || 'manual',
+            body.last_activity_at
+          )
 
       // 7. Build response
       const responseData = {


### PR DESCRIPTION
## Summary

- Resolves #751: `/eos` ended the session on the first call, blocking subsequent per-venture handoffs in cross-venture sessions with `HTTP 409: Session is not active`.
- Adds `keep_session_open` to the API and `final: boolean` to the MCP tool. When `final: false`, the API creates the handoff record but does NOT end the session, so subsequent calls succeed.
- Default behavior unchanged: a single `crane_handoff` call still ends the session as before.

## What changed

| Layer | File | Change |
|---|---|---|
| API | `workers/crane-context/src/endpoints/sessions.ts` | `EndOfSessionBody.keep_session_open?`; skip `endSession()` when true; response `ended_at` is null in held-open mode |
| MCP client | `packages/crane-mcp/src/lib/crane-api.ts` | `HandoffRequest.keep_session_open?`; forwarded in /eos request body |
| MCP tool | `packages/crane-mcp/src/tools/handoff.ts` | `handoffInputSchema.final?`; `final: false` → `keep_session_open: true` |
| Skill | `.claude/commands/eos.md` | Cross-venture section instructs callers to pass `final: false` for ventures 1..N-1, and final call omits (or sets `true`) to end |
| Tests | `packages/crane-mcp/src/tools/handoff.test.ts` | 3 new cases: default, `final:false`, `final:true` |

## Test plan

- [x] `npm run verify` green (typecheck + format + lint + 18 handoff tests + full suite)
- [ ] After merge + worker deploy: re-run a multi-venture `/eos` flow and confirm all handoffs persist to D1
- [ ] Manual smoke: single-handoff flow still terminates session (regression guard for default path)

## Backward compatibility

- API: `keep_session_open` is optional; when omitted, behavior matches pre-fix /eos exactly
- MCP tool: `final` is optional; when omitted, behavior matches pre-fix `crane_handoff` exactly

## Notes

The skill rewrite is the lever that operationally fixes this — without it, even the API change won't matter because nothing was passing `keep_session_open: true`. Both layers needed updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)