### PR TITLE
chore(cadence): retire Stitch refs in design-system-review item

### DIFF
--- a/workers/crane-context/migrations/0041_update_design_review_cadence.sql
+++ b/workers/crane-context/migrations/0041_update_design_review_cadence.sql
@@ -1,0 +1,12 @@
+-- Migration 0041: Update design-system-review cadence description
+--
+-- Stitch was retired in favor of /product-design + Claude Design (claude.ai/design).
+-- The cadence item seeded in 0019 still pointed at .stitch/DESIGN.md and "Stitch
+-- cloud design systems" — both gone. Refocus the description on the canonical
+-- per-venture design-spec.md and the current generation tools.
+
+UPDATE schedule_items
+SET
+  description = 'Cross-venture design sync: verify each Tier 1 venture''s `crane_doc(''{code}'', ''design-spec.md'')` matches the live tokens in the venture repo (globals.css, @theme), then refresh the corresponding Claude Design system at claude.ai/design. Run `/product-design` for any venture whose generated screens are stale.',
+  updated_at = datetime('now')
+WHERE name = 'design-system-review';


### PR DESCRIPTION
## Summary

Migration 0041 updates the \`schedule_items\` row for \`design-system-review\` to remove references to retired Stitch tooling (\`.stitch/DESIGN.md\`, "Stitch cloud design systems") and point at the canonical per-venture \`design-spec.md\` plus Claude Design (claude.ai/design).

## Why

The cadence item was seeded by 0019 and still fires every 90 days; agents picking it up would chase ghosts. This is the production-side companion to the broader Stitch retirement (ke-console#209, dc-console#526, dc-console#527, crane-console#753).

## Test plan

- [ ] CI green
- [ ] Apply to prod after merge: \`cd workers/crane-context && npm run db:migrate:prod\`
- [ ] Verify: \`curl -sS \$URL/schedule/briefing -H "X-Relay-Key: ..." | jq '.items[] | select(.name == "design-system-review")'\` — description should not mention "Stitch" or ".stitch/"

🤖 Generated with [Claude Code](https://claude.com/claude-code)