### PR TITLE
chore(skills): strip dangling Companion scripts section from ui-drift-audit

### DIFF
--- a/.agents/skills/ui-drift-audit/SKILL.md
+++ b/.agents/skills/ui-drift-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-drift-audit
 description: Source-level audit of UI visual-design drift across Astro/React/Next surfaces; counts token / typography / spacing / heading / shared-primitive violations and emits a markdown matrix or JSON. Covers all 7 patterns.
-version: 2.2.0
+version: 2.2.1
 scope: enterprise
 owner: agent-team
 status: stable
@@ -136,12 +136,6 @@ Markdown document at `.design/audits/ui-drift-{YYYY-MM-DD}.md`:
 ### JSON (`--format json`)
 
 Stable schema documented in `audit.py` module docstring. Designed for CI threshold gating and tooling integration.
-
-## Companion scripts
-
-- **`normalize.py`** — Post-Stitch class-attribute normalizer. Rewrites raw Tailwind / Material-3 colors to semantic tokens.
-- **`strip.py`** — Post-Stitch DOM stripper. Removes hero imagery, marketing CTAs, decorative ornaments per UI CONTRACT.
-- **`evaluate-embellishments.py`** — Detects Stitch-invented features (stat cards, auto-pay banners, etc.) not in source.
 
 ## Relationship to other skills
 


### PR DESCRIPTION
## Summary

The three post-Stitch codemods (\`normalize.py\` / \`strip.py\` / \`evaluate-embellishments.py\`) were deleted in #753 as part of the Stitch retirement. This removes their now-broken references from \`.agents/skills/ui-drift-audit/SKILL.md\` and bumps to 2.2.1.

## Test plan

- [ ] CI green
- [ ] No remaining Stitch refs in tracked active surfaces (\`.agents/\`, \`.gemini/\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)