### PR TITLE
docs(ss): add product-overview, roadmap, metrics

### DIFF
--- a/docs/ventures/ss/metrics.md
+++ b/docs/ventures/ss/metrics.md
@@ -11,58 +11,58 @@ sidebar:
 
 ## Phase 1A Exit Gate
 
-| Metric | Target |
-|---|---|
-| Monthly run-rate | $10k/mo sustained 2+ months |
-| Equivalent at launch rate ($175/hr) | ~57 billable hours/month |
-| Equivalent at next-tier ($200/hr) | ~75 billable hours/month |
+| Metric                              | Target                      |
+| ----------------------------------- | --------------------------- |
+| Monthly run-rate                    | $10k/mo sustained 2+ months |
+| Equivalent at launch rate ($175/hr) | ~57 billable hours/month    |
+| Equivalent at next-tier ($200/hr)   | ~75 billable hours/month    |
 
 Hitting the gate triggers Phase 1B: rate ladder advances, premium tooling stack unlocks, case study → outbound loop.
 
 ## Pipeline Funnel (instrumented, awaiting volume)
 
-| Stage | Metric | Source |
-|---|---|---|
-| Top of funnel | /scan submissions/week | `scan_requests` table |
-| | Outbound emails sent/week | `outreach_events` |
-| Engagement | /scan completion rate (submitted → report delivered) | `scan_requests.workflow_run_id` non-null + email delivered |
-| | Magic-link click-through rate | scan_requests verification join |
-| | Reply rate on cold outbound | reply parser (blocked) |
-| Conversion | Assessment-call booking rate | meetings DAL |
-| | Assessment → engagement signed | quotes/SOW pipeline |
-| | First-3-free vs paid assessment ratio | quotes payment status |
-| Delivery | Engagements active | engagements DAL |
-| | Avg engagement size ($) | quote totals |
-| | Avg engagement duration (signed → handoff) | engagement timestamps |
-| Retention | Retainer attach rate | post-delivery retainer signups |
-| | Retainer MRR | retainer billing |
+| Stage         | Metric                                               | Source                                                     |
+| ------------- | ---------------------------------------------------- | ---------------------------------------------------------- |
+| Top of funnel | /scan submissions/week                               | `scan_requests` table                                      |
+|               | Outbound emails sent/week                            | `outreach_events`                                          |
+| Engagement    | /scan completion rate (submitted → report delivered) | `scan_requests.workflow_run_id` non-null + email delivered |
+|               | Magic-link click-through rate                        | scan_requests verification join                            |
+|               | Reply rate on cold outbound                          | reply parser (blocked)                                     |
+| Conversion    | Assessment-call booking rate                         | meetings DAL                                               |
+|               | Assessment → engagement signed                       | quotes/SOW pipeline                                        |
+|               | First-3-free vs paid assessment ratio                | quotes payment status                                      |
+| Delivery      | Engagements active                                   | engagements DAL                                            |
+|               | Avg engagement size ($)                              | quote totals                                               |
+|               | Avg engagement duration (signed → handoff)           | engagement timestamps                                      |
+| Retention     | Retainer attach rate                                 | post-delivery retainer signups                             |
+|               | Retainer MRR                                         | retainer billing                                           |
 
 ## Engine 1 Diagnostic Health (instrumented)
 
-| Metric | Threshold |
-|---|---|
-| Cost per scan (median) | ≤ $0.14 |
-| Cost per scan (P95) | ≤ $0.27 |
-| Workflow success rate | ≥ 95% |
+| Metric                              | Threshold                         |
+| ----------------------------------- | --------------------------------- |
+| Cost per scan (median)              | ≤ $0.14                           |
+| Cost per scan (P95)                 | ≤ $0.27                           |
+| Workflow success rate               | ≥ 95%                             |
 | Render quality issues per 100 scans | 0 (anti-fabrication is hard rule) |
 
 ## Lead-Gen Conversion Reference
 
 From `docs/strategy/lead-gen-pipeline-math-2026-04-25.md`:
 
-| Channel | Conversion Multiplier vs Cold |
-|---|---|
-| Cold outbound | 1× (baseline) |
-| Warm referral (steady-state, with social proof) | ~54× |
+| Channel                                         | Conversion Multiplier vs Cold |
+| ----------------------------------------------- | ----------------------------- |
+| Cold outbound                                   | 1× (baseline)                 |
+| Warm referral (steady-state, with social proof) | ~54×                          |
 
 The warm multiplier is the strategic driver of Engine 3 (referral-partner cultivation) — the math says it's worth the slower ramp.
 
 ## Operating Cost Ceiling
 
-| Phase | Monthly Cap | Notes |
-|---|---|---|
-| Phase 1A | ~$20/mo | Resend free tier, Cloudflare Workers paid plan, D1, Anthropic API metered |
-| Phase 1B (post-gate) | ~$200/mo | Premium tooling unlocked once $10k/mo run-rate clears |
+| Phase                | Monthly Cap | Notes                                                                     |
+| -------------------- | ----------- | ------------------------------------------------------------------------- |
+| Phase 1A             | ~$20/mo     | Resend free tier, Cloudflare Workers paid plan, D1, Anthropic API metered |
+| Phase 1B (post-gate) | ~$200/mo    | Premium tooling unlocked once $10k/mo run-rate clears                     |
 
 ## Health Signals (qualitative, weekly review)
 

--- a/docs/ventures/ss/metrics.md
+++ b/docs/ventures/ss/metrics.md
@@ -1,0 +1,72 @@
+---
+sidebar:
+  order: 2
+---
+
+# SMD Services - Metrics
+
+## Stage
+
+**Pre-revenue, Phase 1A.** Lead-gen and Engine 1 just shipped. No clients signed. Metrics below are the instrumentation targets and operating thresholds — not historical performance.
+
+## Phase 1A Exit Gate
+
+| Metric | Target |
+|---|---|
+| Monthly run-rate | $10k/mo sustained 2+ months |
+| Equivalent at launch rate ($175/hr) | ~57 billable hours/month |
+| Equivalent at next-tier ($200/hr) | ~75 billable hours/month |
+
+Hitting the gate triggers Phase 1B: rate ladder advances, premium tooling stack unlocks, case study → outbound loop.
+
+## Pipeline Funnel (instrumented, awaiting volume)
+
+| Stage | Metric | Source |
+|---|---|---|
+| Top of funnel | /scan submissions/week | `scan_requests` table |
+| | Outbound emails sent/week | `outreach_events` |
+| Engagement | /scan completion rate (submitted → report delivered) | `scan_requests.workflow_run_id` non-null + email delivered |
+| | Magic-link click-through rate | scan_requests verification join |
+| | Reply rate on cold outbound | reply parser (blocked) |
+| Conversion | Assessment-call booking rate | meetings DAL |
+| | Assessment → engagement signed | quotes/SOW pipeline |
+| | First-3-free vs paid assessment ratio | quotes payment status |
+| Delivery | Engagements active | engagements DAL |
+| | Avg engagement size ($) | quote totals |
+| | Avg engagement duration (signed → handoff) | engagement timestamps |
+| Retention | Retainer attach rate | post-delivery retainer signups |
+| | Retainer MRR | retainer billing |
+
+## Engine 1 Diagnostic Health (instrumented)
+
+| Metric | Threshold |
+|---|---|
+| Cost per scan (median) | ≤ $0.14 |
+| Cost per scan (P95) | ≤ $0.27 |
+| Workflow success rate | ≥ 95% |
+| Render quality issues per 100 scans | 0 (anti-fabrication is hard rule) |
+
+## Lead-Gen Conversion Reference
+
+From `docs/strategy/lead-gen-pipeline-math-2026-04-25.md`:
+
+| Channel | Conversion Multiplier vs Cold |
+|---|---|
+| Cold outbound | 1× (baseline) |
+| Warm referral (steady-state, with social proof) | ~54× |
+
+The warm multiplier is the strategic driver of Engine 3 (referral-partner cultivation) — the math says it's worth the slower ramp.
+
+## Operating Cost Ceiling
+
+| Phase | Monthly Cap | Notes |
+|---|---|---|
+| Phase 1A | ~$20/mo | Resend free tier, Cloudflare Workers paid plan, D1, Anthropic API metered |
+| Phase 1B (post-gate) | ~$200/mo | Premium tooling unlocked once $10k/mo run-rate clears |
+
+## Health Signals (qualitative, weekly review)
+
+- Are inbound /scan submissions trending up week-over-week?
+- Is the assessment-booking rate from /scan above outbound-cold baseline?
+- Is at least one referral-partner conversation happening per week?
+- Are render quality issues at zero? (Hard pass/fail — any anti-fab violation is P0.)

--- a/docs/ventures/ss/product-overview.md
+++ b/docs/ventures/ss/product-overview.md
@@ -1,0 +1,66 @@
+---
+sidebar:
+  order: 0
+---
+
+# SMD Services
+
+**Tagline:** Operations consulting for growing businesses, delivered at AI-native speed.
+
+## What It Is
+
+SMD Services is a solutions consulting venture under SMDurgan, LLC. We work alongside business owners to understand where they're trying to go, figure out what's slowing them down, and build the right solution together. Engagement length and pricing are scoped per project. This is a services business, not a SaaS product.
+
+## The Problem It Solves
+
+Owners of $750k-$5M revenue businesses are too big for one person and too small for a COO. They know their operations are broken but can't articulate the fix. Traditional consultancies start at $15-50k+ engagements with months-long timelines. Fractional CTOs/COOs commit them to ongoing cost without a bounded deliverable. EOS implementers force a single framework. Managed IT providers stop at the wire. Nobody else delivers assessment + implementation + handoff as bounded, scope-priced engagements.
+
+## Solution Categories
+
+Six categories cover the full delivery surface:
+
+1. Process design
+2. Custom internal tools
+3. Systems integration
+4. Operational visibility
+5. Vendor/platform selection
+6. AI & automation
+
+A separate five-category observation taxonomy (`process_design`, `tool_systems`, `data_visibility`, `customer_pipeline`, `team_operations`) drives lead-gen signal extraction. The two layers are deliberately distinct — see [ADR 0001](https://github.com/venturecrane/ss-console/blob/main/docs/adr/0001-taxonomy-two-layer-model.md).
+
+## Target Market
+
+- **Geography:** Phoenix metro, in-person default for Phase 1 (first 5 clients). Remote-capable after.
+- **Revenue band:** $750k-$5M, expanding to $10M.
+- **Buyer:** the owner. Sometimes the office manager fields the call, but the owner writes the check.
+
+## Positioning
+
+The client is the hero, we are the guide. Collaborative, objectives-first. Enterprise operational discipline applied to businesses that have never had access to it, delivered at speed and pricing that works for their stage. AI & automation is a named capability, not a brand veneer — we do AI work when AI is the right answer and say so plainly.
+
+## Pricing Model
+
+- **Internal rate ladder:** $175/hr at launch → $200/hr after first case study → $250/hr → $300/hr with volume.
+- **Engagement range:** scoped per project. Smallest engagements (targeted automation scripts, AI pilots) start around $2,500. Largest engagements have no fixed ceiling.
+- **Paid Assessment:** $250, applied toward engagement if they proceed. First 3 free.
+- **Retainer (post-delivery):** $200-500/mo for ongoing support and optimization.
+- **No dollar amounts published externally.**
+
+## Tech Stack
+
+- **Site/app:** Astro SSR on Cloudflare Workers + Static Assets (single Worker `ss-web`, three subdomains: apex marketing, `admin.smd.services` admin console, `portal.smd.services` client portal).
+- **Workflow Worker:** `ss-scan-workflow` — durable orchestration for the /scan diagnostic via Cloudflare Workflows.
+- **Data layer:** D1.
+- **Email:** Resend (transactional + outbound + inbound).
+- **Auth:** session cookies per-host (admin/portal isolation).
+- **Domain:** smd.services.
+
+## Status
+
+Pre-launch. Engine 1 (free AI diagnostic at /scan) shipped 2026-04-27, production-deployed but unverified happy-path pending Worker secret provisioning. No clients signed yet. First 5 in-person Phoenix engagements are the immediate goal.
+
+## Links
+
+- **Repo:** [venturecrane/ss-console](https://github.com/venturecrane/ss-console)
+- **Site:** [smd.services](https://smd.services)
+- **Decision Stack:** `docs/adr/decision-stack.md` (29 locked decisions across 6 layers)

--- a/docs/ventures/ss/roadmap.md
+++ b/docs/ventures/ss/roadmap.md
@@ -11,15 +11,16 @@ sidebar:
 
 ## Active Engines
 
-| Engine | Status | Notes |
-|---|---|---|
-| 1 — Free AI diagnostic at smd.services/scan | **Production-deployed, unverified** | `ss-scan-workflow` Worker live. Awaiting secret provisioning + first real-prospect smoke test. |
-| 2 — Cold volume on free stack (~$20/mo) | Building | Resend outbound wired; reply parser blocked on Resend Inbound DNS. |
-| 3 — Phoenix referral-partner cultivation | Manual | Vistage, EO Arizona, fractional CFOs, BNI/chamber, accountants/bookkeepers, commercial insurance, SBA/SCORE. Captain TODO. |
+| Engine                                      | Status                              | Notes                                                                                                                      |
+| ------------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| 1 — Free AI diagnostic at smd.services/scan | **Production-deployed, unverified** | `ss-scan-workflow` Worker live. Awaiting secret provisioning + first real-prospect smoke test.                             |
+| 2 — Cold volume on free stack (~$20/mo)     | Building                            | Resend outbound wired; reply parser blocked on Resend Inbound DNS.                                                         |
+| 3 — Phoenix referral-partner cultivation    | Manual                              | Vistage, EO Arizona, fractional CFOs, BNI/chamber, accountants/bookkeepers, commercial insurance, SBA/SCORE. Captain TODO. |
 
 ## Planned Work
 
 **Phase 1A engineering punch list (in flight):**
+
 - Send-booking-link admin action (P0 — fixes "Book Assessment" lie)
 - Outbound send queue
 - Reply parser (blocked on Resend Inbound DNS)
@@ -27,18 +28,21 @@ sidebar:
 - Partner-nurture cadence decision
 
 **Phase 1A go-to-market:**
+
 - Domain warm-up clock running (~14d from 2026-04-27)
 - Partner cultivation conversations
 - Pipeline math sustaining profitability at chosen volume
 - First 5 in-person Phoenix clients
 
 **Phase 1A delivery readiness:**
+
 - Tool and solution matrix across all 6 solution categories
 - SOP templates (reusable frameworks, filled per client)
 - Client onboarding checklist
 - Quality checklist templates
 
 **Phase 1B (post-$10k/mo gate):**
+
 - Premium tooling stack provisioned
 - First case study published (unblocks rate advance to $200/hr)
 - Outbound social proof loop

--- a/docs/ventures/ss/roadmap.md
+++ b/docs/ventures/ss/roadmap.md
@@ -1,0 +1,60 @@
+---
+sidebar:
+  order: 1
+---
+
+# SMD Services - Roadmap
+
+## Current Milestone
+
+**Phase 1A: launch the venture and reach $10k/mo run-rate sustained 2+ months.** That gate triggers Phase 1B: rate ladder advances to $200/hr, premium tooling stack unlocks (~$200/mo), and the first case study turns into outbound social proof.
+
+## Active Engines
+
+| Engine | Status | Notes |
+|---|---|---|
+| 1 — Free AI diagnostic at smd.services/scan | **Production-deployed, unverified** | `ss-scan-workflow` Worker live. Awaiting secret provisioning + first real-prospect smoke test. |
+| 2 — Cold volume on free stack (~$20/mo) | Building | Resend outbound wired; reply parser blocked on Resend Inbound DNS. |
+| 3 — Phoenix referral-partner cultivation | Manual | Vistage, EO Arizona, fractional CFOs, BNI/chamber, accountants/bookkeepers, commercial insurance, SBA/SCORE. Captain TODO. |
+
+## Planned Work
+
+**Phase 1A engineering punch list (in flight):**
+- Send-booking-link admin action (P0 — fixes "Book Assessment" lie)
+- Outbound send queue
+- Reply parser (blocked on Resend Inbound DNS)
+- Programmatic SEO for AI search
+- Partner-nurture cadence decision
+
+**Phase 1A go-to-market:**
+- Domain warm-up clock running (~14d from 2026-04-27)
+- Partner cultivation conversations
+- Pipeline math sustaining profitability at chosen volume
+- First 5 in-person Phoenix clients
+
+**Phase 1A delivery readiness:**
+- Tool and solution matrix across all 6 solution categories
+- SOP templates (reusable frameworks, filled per client)
+- Client onboarding checklist
+- Quality checklist templates
+
+**Phase 1B (post-$10k/mo gate):**
+- Premium tooling stack provisioned
+- First case study published (unblocks rate advance to $200/hr)
+- Outbound social proof loop
+- Recurring retainer model details ($200-500/mo)
+
+## Recent Completions
+
+- **2026-04-27** Engine 1 shipped: durable Workflow orchestration via separate `ss-scan-workflow` Worker, magic-link diagnostic, strict Places domain-match guard, render quality fixes
+- **2026-04-27** ADR 0001 — taxonomy two-layer model locked (5-cat observation + 6-cat delivery)
+- **2026-04-27** Lead-gen strategy authored: 5 docs in `docs/strategy/`, 8 strategic decisions locked, 16 issues closed in single session
+- **2026-04-25** Three-subdomain architecture live: `smd.services` (marketing), `admin.smd.services`, `portal.smd.services`
+- **Earlier** Cloudflare Workers + Static Assets migration (off Pages); Decision Stack 29 locked decisions; SignWell SOW pipeline; quote/portal flow
+
+## Constraints
+
+- **Anti-fabrication is P0.** No invented client-facing content, ever. Pattern A (committed template sentences implying uncontracted commitments) and Pattern B (runtime fabrication from non-authoritative fields) are merge-gated.
+- **No fixed timeframes in external marketing content.** Internal estimates fine; signed SOWs fine; marketing copy never.
+- **No dollar amounts published externally.**
+- **Phase 1A budget cap: ~$20/mo.** Premium tooling deferred until Phase 1B gate clears.


### PR DESCRIPTION
## Summary

- Adds the last three required venture docs for SS (`product-overview.md`, `roadmap.md`, `metrics.md`).
- Authored from ss-console `CLAUDE.md`, `docs/adr/decision-stack.md`, and the 2026-04-27 lead-gen strategy package — **not** derivative of the stale `smd` peer doc which lists "5-50 employee businesses" / "Cloudflare Pages" (both wrong for SS).
- On merge, `sync-docs.yml` picks them up → uploads to scope `ss` → `crane_doc_audit(venture: "ss")` goes from 6 present + 3 missing to **9 present + 0 missing**.

## Companion fix

Pairs with #757 (merged earlier today) which dedupe'd the prod `doc_requirements` table from 1,152 rows to 9 — the audit was so noisy with 384 dupe-printed missing-doc lines that the actual gap (these three real docs) was hidden. With #757 in, the audit honestly shows 3 missing; this PR closes them.

## Test plan
- [x] `npm run verify` passes (pre-push hook)
- [x] File shape matches sibling design-spec.md / sibling venture metrics/overview/roadmap conventions
- [ ] CI green
- [ ] After merge: confirm `sync-docs.yml` runs and uploads to scope `ss`
- [ ] After sync: `crane_doc_audit(venture: "ss")` returns 9 present + 0 missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)