### PR TITLE
fix(sync-commands): preserve SKILL.md governance frontmatter on regen

### DIFF
--- a/.agents/skills/analytics/SKILL.md
+++ b/.agents/skills/analytics/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: analytics
+description: Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
+version: 0.1.0
+scope: enterprise
+owner: agent-team
+status: draft
+---
+
+# /analytics - Site Traffic Report
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "analytics")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
+
+## Usage
+
+```
+/analytics              # Today + 7-day trend
+/analytics 30           # Last 30 days
+/analytics 2026-02-01   # Specific date
+```
+
+## Arguments
+
+Parse the argument:
+
+- If empty, default to **today + 7-day trend**
+- If a number (e.g., `30`), show the **last N days**
+- If a date (e.g., `2026-02-01`), show that **specific date**
+
+## Constants
+
+These do not change:
+
+- **Account ID:** `ab6cc9362f7e51ba9a610aec1fc3a833`
+- **API Token env var:** `CLOUDFLARE_API_TOKEN`
+- **GraphQL endpoint:** `https://api.cloudflare.com/client/v4/graphql`
+- **Analytics type:** Account-level RUM (Web Analytics), NOT zone-level httpRequests
+
+Zone-level analytics (`httpRequests1dGroups`) will fail with a permissions error. Always use account-level `rumPageloadEventsAdaptiveGroups`.
+
+## Pre-flight
+
+Check that `CLOUDFLARE_API_TOKEN` is set:
+
+```bash
+[ -z "$CLOUDFLARE_API_TOKEN" ] && echo "CLOUDFLARE_API_TOKEN not set" && exit 1
+```
+
+If not set, stop: "CLOUDFLARE_API_TOKEN is not in the environment. Launch with `crane vc` to inject secrets."
+
+## Execution
+
+### 1. Daily Trend (broken out by site)
+
+Query `rumPageloadEventsAdaptiveGroups` at the account level for the date range, grouped by `requestHost` and `date`:
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { rumPageloadEventsAdaptiveGroups(limit: 500, filter: { date_geq: \"START_DATE\", date_leq: \"END_DATE\" }, orderBy: [date_ASC]) { count dimensions { date requestHost } } } } }"
+  }'
+```
+
+Replace `START_DATE` and `END_DATE` based on the parsed argument.
+
+Group the results by `requestHost`. Each unique host gets its own trend section. If there is only one host, display it without the grouping header.
+
+### 2. Top Pages, Referrers, Countries (for the most recent date in the range)
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { topPages: rumPageloadEventsAdaptiveGroups(limit: 15, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost requestPath } } topReferrers: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost refererHost } } topCountries: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost countryName } } } } }"
+  }'
+```
+
+Run both queries in parallel (two Bash tool calls in one message).
+
+Group results by `requestHost`. If only one host exists, omit the grouping header.
+
+### 3. Format Output
+
+**Single site** (omit site header when only one host):
+
+```
+== venturecrane.com Traffic ==
+
+Pageloads (7-day trend):
+  Feb 10:    2
+  Feb 11:    9
+  Feb 12:    0
+  Feb 13:    4
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+  16  /articles/agent-context-management-system/
+   9  /portfolio/
+   ...
+
+Referrers (today):
+  99  venturecrane.com (internal)
+  50  (direct)
+   1  bing.com
+
+Countries (today):
+ 145  US
+   2  SG
+   1  PL
+   ...
+```
+
+**Multiple sites** (group by host with clear separation):
+
+```
+== Venture Crane Traffic ==
+
+--- venturecrane.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+   ...
+
+--- kidexpenses.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   12
+  Feb 15:   18
+  Feb 16:    9  <-- today
+
+Top Pages (today):
+   5  /
+   3  /dashboard/
+   ...
+
+--- Totals ---
+
+  Feb 14:   86
+  Feb 15:  248
+  Feb 16:  159  <-- today
+```
+
+Right-align the numbers for scannability. Flag days with zero traffic (missing from API response) as `0`.
+
+When multiple sites exist, include a **Totals** section at the bottom summing all sites.
+
+## Notes
+
+- Read-only query. RUM data from JavaScript beacon (no bot traffic, but includes operator browsing).
+- Days missing from API response = zero pageloads. Fill as `0` in trend output.
+- Data may lag a few hours for current day. If API errors, show raw error message.
+- Account-level query - new sites with the beacon appear automatically.
+- Fleet machines block the beacon via /etc/hosts. Fleet traffic is not collected.

--- a/.agents/skills/auth-setup/SKILL.md
+++ b/.agents/skills/auth-setup/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: auth-setup
+description: Wires up @clerk/testing/playwright so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes without manual login.
+version: 0.1.0
+scope: enterprise
+owner: agent-team
+status: draft
+---
+
+# /auth-setup - Set up Clerk + Playwright auth bootstrap for a venture
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auth-setup")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Wires up `@clerk/testing/playwright` so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes **without manual login**.
+
+Solves the recurring pain: "agent gets hung up needing manual login to test."
+
+## When to use
+
+- Run **inside a venture console repo** that uses Clerk (`dc`, `dfg`, `ke`, `sc`)
+- After verifying the venture's Clerk integration is working in dev (`npm run dev` reaches a protected page)
+- One-time setup per venture; re-run only to update the template
+
+## Prerequisites (Manual)
+
+Before running this command, the Captain must have completed:
+
+1. Created a Clerk **test user** in the venture's Clerk Dashboard
+   - Email: `agent-test+clerk_test@venturecrane.com` (the `+clerk_test` is required — Clerk recognizes it as a test identity)
+   - Password: anything strong, stored in Bitwarden
+   - Roles/permissions: same as a typical authenticated user
+2. Confirmed the venture's Infisical secrets include working `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (or `PUBLIC_CLERK_PUBLISHABLE_KEY` for Astro)
+3. (If running against deployed CI) added the same env vars to GitHub Actions secrets
+
+## Execution
+
+### Step 1: Detect Context
+
+1. Confirm cwd is a venture console repo. Walk up to the `.git` root and read `package.json`. If the repo is not in `{dc,dfg,ke,sc}-console`, stop and explain.
+2. Detect framework from `package.json`:
+   - `@clerk/nextjs` → Next.js
+   - `@clerk/astro` → Astro
+3. Detect existing Playwright config: `playwright.config.{ts,js}`. If absent, stop — this skill does not bootstrap Playwright itself.
+4. Read the canonical runbook for reference:
+   ```bash
+   cat ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+   ```
+
+### Step 2: Add Infisical secret
+
+Add `E2E_CLERK_USER_EMAIL` if not present:
+
+```bash
+infisical secrets set --path=/{venture} E2E_CLERK_USER_EMAIL=agent-test+clerk_test@venturecrane.com
+```
+
+Verify the venture's existing Clerk keys are present:
+
+```bash
+infisical secrets list --path=/{venture} | grep -E "CLERK_(SECRET_KEY|PUBLISHABLE_KEY)"
+```
+
+If `CLERK_SECRET_KEY` is missing, stop — the test instance must be configured first.
+
+### Step 3: Install dev deps
+
+```bash
+npm install -D @clerk/testing
+```
+
+(`@playwright/test` should already be installed; verify with `npm list @playwright/test`.)
+
+### Step 4: Copy template files
+
+From `~/dev/crane-console/templates/clerk-playwright-auth/`:
+
+```bash
+TEMPLATE=~/dev/crane-console/templates/clerk-playwright-auth
+
+mkdir -p playwright
+cp "$TEMPLATE/auth.setup.ts" playwright/auth.setup.ts
+```
+
+For Astro projects (`sc`), edit `playwright/auth.setup.ts` and verify env-var names match `PUBLIC_CLERK_PUBLISHABLE_KEY` (Clerk's testing pkg reads from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` by default — Astro repos may need to copy the value).
+
+### Step 5: Update playwright.config.ts
+
+Read the existing `playwright.config.ts` and merge the `projects` block from `templates/clerk-playwright-auth/playwright.config.snippet.ts`:
+
+- Add a `setup-clerk` project that runs `auth.setup.ts`
+- Make authenticated browser projects depend on `setup-clerk` and load `storageState: 'playwright/.clerk/user.json'`
+- Leave any existing public/unauthenticated projects unchanged
+
+Use the Edit tool. Show the diff before applying.
+
+### Step 6: .gitignore
+
+Ensure `playwright/.clerk/` is gitignored (the captured `user.json` is a session secret):
+
+```bash
+grep -q "playwright/.clerk" .gitignore || echo "playwright/.clerk/" >> .gitignore
+```
+
+### Step 7: .env.example
+
+Append from the template:
+
+```bash
+cat ~/dev/crane-console/templates/clerk-playwright-auth/.env.example.snippet >> .env.example
+```
+
+### Step 8: Verify
+
+```bash
+npx playwright test --project=setup-clerk
+```
+
+Expected output: two tests pass (`global clerk setup`, `authenticate and save state`). A `playwright/.clerk/user.json` is created.
+
+If the second test fails with `E2E_CLERK_USER_EMAIL not set`, re-run `crane vc {venture}` (or whatever launches with secrets) so Infisical injects the env.
+
+If the second test fails with a redirect to `/sign-in`, the test user wasn't found in Clerk Dashboard — re-check Step 1 of Prerequisites.
+
+### Step 9: Smoke test the authenticated flow
+
+Add a minimal smoke test that hits a protected page:
+
+```ts
+// e2e/smoke.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('authenticated user reaches protected route', async ({ page }) => {
+  await page.goto('/')
+  // Adjust the URL/selector to a real protected page in this venture
+  await expect(page).not.toHaveURL(/sign-in/)
+})
+```
+
+Run with `npx playwright test --project=chromium-authed` (or whatever the authed project is named). Expect green.
+
+### Step 10: Commit
+
+```bash
+git checkout -b chore/clerk-playwright-auth-bootstrap
+git add playwright/auth.setup.ts playwright.config.ts .gitignore .env.example package.json package-lock.json
+git commit -m "$(cat <<'EOF'
+chore: clerk + playwright auth bootstrap
+
+Solves recurring pain where E2E runs (and agents driving Playwright)
+hit the Clerk login wall and require manual sign-in. Uses
+@clerk/testing/playwright to issue a server-side sign-in token
+(bypasses password/OTP/2FA), captures storageState once, and reuses
+it across workers.
+
+Runbook: ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+EOF
+)"
+git push -u origin chore/clerk-playwright-auth-bootstrap
+gh pr create --title "chore: clerk + playwright auth bootstrap" --body "..."
+```
+
+## What NOT to do
+
+- Don't commit `playwright/.clerk/user.json` — it's a session secret
+- Don't use the production `sk_live_*` Clerk key in CI — testing tokens only work on dev instances
+- Don't reuse a real (human) user as the test identity — use the `+clerk_test` pattern
+- Don't add this to `ss-console` (workers only, no UI auth) or `crane-console` (backend, no UI auth)
+
+## Related
+
+- Runbook: `docs/runbooks/clerk-playwright-auth-setup.md`
+- Template: `templates/clerk-playwright-auth/`
+- Memory: `reference_browser_automation_tools.md`
+- Tooling catalog: `docs/instructions/tooling.md`

--- a/.agents/skills/docs-refresh/SKILL.md
+++ b/.agents/skills/docs-refresh/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: docs-refresh
+description: Review and update enterprise documentation site content at crane-console.vercel.app. Identifies stale pages and enriches them with data from existing sources.
+version: 0.1.0
+scope: enterprise
+owner: agent-team
+status: draft
+---
+
+# /docs-refresh - Enterprise Docs Refresh
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-refresh")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+
+## Arguments
+
+```
+/docs-refresh [scope]
+```
+
+- No argument: Audit mode - lists stale pages, does NOT modify files
+- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
+- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
+- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+
+## Execution
+
+### Step 1: Audit
+
+Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+
+**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+
+### Step 2: Gather Data
+
+For pages in scope, pull from:
+
+- **Overviews**: `config/ventures.json` + `docs/design/ventures/{code}/design-spec.md` + VCMS exec summaries
+- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
+- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+
+### Step 3: Draft
+
+Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+
+### Step 4: Approve
+
+Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+
+### Step 5: PR
+
+Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+
+## Notes
+
+- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
+- After merge, Vercel auto-rebuilds the site
+- Quality bar: 0 unjustified TBDs, 20+ lines, real data

--- a/.agents/skills/go-live/SKILL.md
+++ b/.agents/skills/go-live/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: go-live
+description: Launch a venture to production with mandatory secret rotation and readiness checks.
+version: 0.1.0
+scope: enterprise
+owner: captain
+status: draft
+---
+
+# /go-live - Venture Go-Live Process
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "go-live")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Launch a venture to production with mandatory secret rotation and readiness checks.
+
+```
+/go-live dc           # launch Draft Crane
+/go-live ke           # launch Kid Expenses
+```
+
+**Do NOT follow `docs/process/secrets-rotation-runbook.md`** - it references decommissioned tooling.
+
+## Step 1: Parse & Validate
+
+Parse `$ARGUMENTS` for a venture code. Then:
+
+1. Read `config/ventures.json`
+2. Find the venture by `code`
+3. If not found, stop: "Unknown venture code. Available: {list codes with status}"
+4. If `portfolio.status` is `"launched"`, stop: "Already launched."
+5. If no argument provided, stop with usage: "/go-live {venture-code}"
+
+## Step 2: Pre-flight Checks (automated)
+
+Run these checks without user input. Report pass/fail for each.
+
+1. **Golden Path compliance** - Read `docs/standards/golden-path.md` compliance dashboard row for this venture. Note Sentry, CI/CD, Monitoring, Docs status. If the venture is missing from the dashboard, flag it as a gap.
+2. **Infisical prod secrets** - Run `infisical secrets --path /{venture} --env prod --silent 2>/dev/null | grep '│' | grep -v 'SECRET NAME' | grep -v '├\|┌\|└' | sed 's/│/|/g' | cut -d'|' -f2 | sed 's/^ *//;s/ *$//'` to extract key names only. **NEVER run bare `infisical secrets` - it displays values in the transcript.**
+3. **Infisical dev secrets** - Same key-names-only extraction for `--env dev`.
+4. **Production worker health** - If the venture has a known health endpoint, `curl` it and confirm 200.
+5. **DNS/custom domain** - If `portfolio.url` is set in ventures.json, verify DNS resolves.
+
+Present results as a checklist. If any critical check fails (no prod secrets, no worker health), stop: "Fix these before proceeding."
+
+## Step 3: Secret Inventory
+
+Agent pulls and displays key names only (NEVER values):
+
+1. Extract key names from Infisical (reuse the key-names-only command from Step 2 - NEVER display values).
+2. Read the **Shared Credentials** table from `docs/infra/secrets-management.md`.
+3. Read the **Revocation Behavior by Type** table from `docs/infra/secrets-management.md`.
+4. Cross-reference: flag any shared credentials and note rotation impact.
+5. Categorize each secret by revocation behavior (immediate vs dual-key vs self-generated).
+
+Present the full inventory, then ask via AskUserQuestion:
+
+**Question:** "Rotate all {N} secrets at their sources, update Infisical (prod AND dev), then confirm."
+
+Include in the question context:
+
+- Shared credentials and which ventures they affect
+- Immediate-revocation secrets (test each one right after rotating)
+- Dual-key/self-generated secrets (can batch)
+
+**Options:**
+
+1. "All rotated and updated in Infisical" - proceed to push
+2. "Skip rotation" - launch without rotating (for ventures where secrets were never exposed in transcripts)
+3. "Cancel" - abort go-live
+
+If cancelled, stop.
+
+## Step 4: Push to Workers (agent-safe)
+
+Push secrets to Cloudflare Workers without exposing values:
+
+```bash
+cd {venture-worker-dir}
+infisical export --format=json --path /{venture} --env prod | npx wrangler secret bulk
+```
+
+No secret values appear in the transcript. If the venture has multiple workers, push to each.
+
+## Step 5: Smoke Test
+
+Run these checks and report pass/fail:
+
+1. **Health endpoint** - `curl` the production health endpoint
+2. **Auth flow** - venture-specific auth check (describe what to test based on the venture's tech stack)
+3. **Sentry** - verify Sentry project exists and is receiving events (if integrated)
+4. **Uptime monitor** - confirm external monitoring is configured
+
+If any fail: "Smoke test failures above. Fix before continuing. Old credentials have NOT been revoked yet."
+
+If all pass, ask via AskUserQuestion:
+
+**Question:** "Smoke tests passed. Revoke old credentials at their source consoles now. Self-generated tokens (like ENCRYPTION_KEY) don't need revocation - rotation was the control."
+
+**Options:**
+
+1. "Old credentials revoked" - proceed to ship
+2. "Cancel" - abort (new credentials remain active, no rollback needed)
+
+## Step 6: Ship
+
+1. Update `config/ventures.json`:
+   - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.showInPortfolio` to `true` (this enables venture name usage in published articles and build logs per terminology.md)
+   - Set `portfolio.url` if provided by user (ask if not already set)
+   - Update `bvmStage` if appropriate
+2. Commit with message: `feat: launch {venture name}`
+3. Run `/portfolio-review` to sync the venture to vc-web's portfolio page
+4. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+
+Report: "{Venture Name} is live. ventures.json updated, portfolio synced, handoff saved."
+
+## Important Notes
+
+- **Transcript cleanup is optional hygiene.** Rotation already invalidated any exposed values. Old transcripts in ~/.claude/ contain dead credentials after rotation.
+- **If smoke tests fail after rotating an immediate-revocation secret** (like OAuth client secrets), the old value is already dead. Fix the issue with the new credential - don't try to rollback.
+- **Shared credentials require coordination.** If GOOGLE_CLIENT_SECRET is rotated for /dc, the old value dies immediately for /ke too. Push to all consuming ventures before revoking.

--- a/.agents/skills/heartbeat/SKILL.md
+++ b/.agents/skills/heartbeat/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: heartbeat
+description: Send a heartbeat to prevent your session from timing out.
+version: 0.1.0
+scope: enterprise
+owner: captain
+status: draft
+---
+
+# /heartbeat - Keep Session Alive
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "heartbeat")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Send a heartbeat to prevent your session from timing out.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Updates the `last_heartbeat_at` timestamp
+3. Prevents 45-minute session timeout
+4. Shows when next heartbeat is recommended
+
+## When to Use
+
+- Working on long tasks (>30 minutes)
+- Want to keep session active while reading/researching
+- Need to maintain "active" status visibility
+
+**Not needed if:** You're actively using `/sos`, `/update`, or `/eos` - those all refresh heartbeat automatically.
+
+## Usage
+
+```bash
+/heartbeat
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Send Heartbeat
+
+```bash
+# Build request body
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  '{
+    session_id: $session_id
+  }')
+
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/heartbeat" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Heartbeat failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 3. Display Results
+
+```bash
+LAST_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.last_heartbeat_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "💓 Heartbeat sent"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Last heartbeat: $LAST_HEARTBEAT"
+echo "Next heartbeat in: ~$MINUTES minutes"
+echo ""
+echo "Your session will stay active for 45 minutes from this heartbeat."
+```
+
+## Notes
+
+- Automatic heartbeats: `/sos`, `/update`, `/eos` all refresh heartbeat
+- Manual heartbeat needed when working >30 minutes without those commands
+- Recommended interval: every 10-15 minutes during long tasks
+- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sos` creates new session)
+- Requires active session and CRANE_CONTEXT_KEY
+- Safe to call frequently (idempotent)

--- a/.agents/skills/skill-audit/SKILL.md
+++ b/.agents/skills/skill-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-audit
-description: Monthly skill health report. Walks every SKILL.md, parses frontmatter, computes staleness via git log, detects schema gaps, and surfaces zero-usage candidates. Run this once a month to keep the skill library healthy.
+description: Monthly skill health report. Audits all SKILL.md files for schema gaps, staleness, and deprecation queue status.
 version: 1.0.0
 scope: enterprise
 owner: captain

--- a/.agents/skills/skill-deprecate/SKILL.md
+++ b/.agents/skills/skill-deprecate/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-deprecate")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically

--- a/.agents/skills/skill-review/SKILL.md
+++ b/.agents/skills/skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-review
-description: Lint a skill or all skills in the repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+description: Lint a skill or the entire repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
 version: 1.0.0
 scope: enterprise
 owner: captain

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: status
+description: Display current session state, tasks, and git status for situational awareness.
+version: 0.1.0
+scope: enterprise
+owner: captain
+status: draft
+---
+
+# /status - Show Session Status
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "status")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Display current session state, tasks, and git status for situational awareness.
+
+## What to Show
+
+### 1. Session Information
+
+Query crane-context for current session (if available):
+
+- Session ID
+- Session age (how long since /sos)
+- Last heartbeat time
+- Venture context
+
+If no session exists, note: "No active session. Run /sos to start."
+
+### 2. Active Tasks
+
+Use TaskList to show current task state:
+
+- Pending tasks (not started)
+- In-progress tasks (being worked on)
+- Recently completed tasks
+
+### 3. Git Status
+
+Show current repository state:
+
+- Current branch
+- Uncommitted changes (staged and unstaged)
+- Commits ahead/behind remote
+
+### 4. Context Summary
+
+- Current working directory
+- Repository name
+- Machine name (hostname)
+
+## Output Format
+
+```
+== Session Status ==
+Session: [ID or "None"]
+Age: [duration or "N/A"]
+Venture: [venture name or "Unknown"]
+
+== Tasks ==
+In Progress: [count]
+  - [task subject]
+Pending: [count]
+  - [task subject]
+Completed (recent): [count]
+
+== Git ==
+Branch: [branch name]
+Changes: [staged] staged, [unstaged] unstaged
+Remote: [ahead/behind status]
+
+== Context ==
+Repo: [repo name]
+Dir: [current directory]
+Machine: [hostname]
+```
+
+## Implementation Steps
+
+1. Check for active session by querying crane-context /session endpoint
+2. Call TaskList to get task state
+3. Run `git status --porcelain` and `git branch -vv` for git info
+4. Get hostname and current directory from environment
+5. Format and display results
+
+## Notes
+
+- This is a read-only status check - it should not modify anything
+- If crane-context is unavailable, show what information is available locally
+- Keep output concise and scannable

--- a/.agents/skills/ui-drift-audit/SKILL.md
+++ b/.agents/skills/ui-drift-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-drift-audit
-description: Source-level audit of UI visual-design drift across Astro/React/Next surfaces; counts token / typography / spacing / heading / shared-primitive violations and emits a markdown matrix or JSON. Covers all 7 patterns.
+description: Source-level UI drift audit. Counts visual-design anti-patterns (pills, typography, spacing, headings, primary CTAs, redundancy, token-compliance) across .astro/.tsx/.jsx files and emits a markdown matrix or JSON.
 version: 2.2.1
 scope: enterprise
 owner: agent-team

--- a/.agents/skills/update/SKILL.md
+++ b/.agents/skills/update/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: update
+description: Update your session with current branch, commit, and work metadata.
+version: 0.1.0
+scope: enterprise
+owner: captain
+status: draft
+---
+
+# /update - Update Session Context
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "update")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Update your session with current branch, commit, and work metadata.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Auto-detects current git branch and commit
+3. Updates session with current work context
+4. Refreshes heartbeat (keeps session alive)
+5. Provides visibility: "Agent X is on branch Y working on issue #123"
+
+## When to Use
+
+- Started working on a new issue
+- Switched branches
+- Made significant progress (checkpoint)
+- Want to update team visibility
+
+**Tip:** Call this when you start work on an issue and after major milestones.
+
+## Usage
+
+```bash
+# Auto-detect branch/commit
+/update
+
+# With issue number
+/update 123
+
+# With custom metadata
+/update --meta '{"issue": 123, "priority": "P0"}'
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Detect Current Work Context
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Get current commit
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+
+# Parse arguments for issue number or metadata
+ISSUE_NUMBER=""
+META_JSON=""
+
+# If first arg is a number, it's an issue
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  ISSUE_NUMBER="$1"
+  META_JSON=$(jq -n --argjson issue "$ISSUE_NUMBER" '{issue: $issue}')
+fi
+
+# If --meta flag provided, use that
+if [[ "$1" == "--meta" && -n "$2" ]]; then
+  META_JSON="$2"
+fi
+
+echo "## 📝 Updating Session"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo "Issue: #$ISSUE_NUMBER"
+fi
+echo ""
+```
+
+### 3. Build Update Request
+
+```bash
+# Build request body with current context
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$COMMIT" \
+  --argjson meta "${META_JSON:-null}" \
+  '{
+    session_id: $session_id,
+    branch: $branch,
+    commit_sha: $commit
+  } + (if $meta != null then {meta: $meta} else {} end)')
+```
+
+### 4. Call Context Worker /update
+
+```bash
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/update" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Update failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 5. Display Results
+
+```bash
+UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updated_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "✅ Session updated"
+echo ""
+echo "Updated at: $UPDATED_AT"
+echo "Next heartbeat: ~$MINUTES minutes"
+echo ""
+echo "Your session context is now visible to other agents."
+```
+
+## What Gets Updated
+
+- `branch`, `commit_sha`, `last_heartbeat_at` (always)
+- `meta` (optional freeform JSON: issue, priority, tags, etc.)
+- Venture, repo, track are set at session creation (not updated)
+
+## Notes
+
+- Auto-detects git branch and commit
+- Requires active session (run `/sos` first) and CRANE_CONTEXT_KEY
+- Refreshes heartbeat (prevents timeout)
+- Safe to call frequently
+- The `meta` field is freeform JSON - use it for whatever context helps your workflow

--- a/.gemini/commands/analytics.toml
+++ b/.gemini/commands/analytics.toml
@@ -1,0 +1,160 @@
+description = "Site Traffic Report"
+
+prompt = """
+
+Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
+
+## Usage
+
+```
+/analytics              # Today + 7-day trend
+/analytics 30           # Last 30 days
+/analytics 2026-02-01   # Specific date
+```
+
+## Arguments
+
+Parse the argument:
+
+- If empty, default to **today + 7-day trend**
+- If a number (e.g., `30`), show the **last N days**
+- If a date (e.g., `2026-02-01`), show that **specific date**
+
+## Constants
+
+These do not change:
+
+- **Account ID:** `ab6cc9362f7e51ba9a610aec1fc3a833`
+- **API Token env var:** `CLOUDFLARE_API_TOKEN`
+- **GraphQL endpoint:** `https://api.cloudflare.com/client/v4/graphql`
+- **Analytics type:** Account-level RUM (Web Analytics), NOT zone-level httpRequests
+
+Zone-level analytics (`httpRequests1dGroups`) will fail with a permissions error. Always use account-level `rumPageloadEventsAdaptiveGroups`.
+
+## Pre-flight
+
+Check that `CLOUDFLARE_API_TOKEN` is set:
+
+```bash
+[ -z "$CLOUDFLARE_API_TOKEN" ] && echo "CLOUDFLARE_API_TOKEN not set" && exit 1
+```
+
+If not set, stop: "CLOUDFLARE_API_TOKEN is not in the environment. Launch with `crane vc` to inject secrets."
+
+## Execution
+
+### 1. Daily Trend (broken out by site)
+
+Query `rumPageloadEventsAdaptiveGroups` at the account level for the date range, grouped by `requestHost` and `date`:
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { rumPageloadEventsAdaptiveGroups(limit: 500, filter: { date_geq: \"START_DATE\", date_leq: \"END_DATE\" }, orderBy: [date_ASC]) { count dimensions { date requestHost } } } } }"
+  }'
+```
+
+Replace `START_DATE` and `END_DATE` based on the parsed argument.
+
+Group the results by `requestHost`. Each unique host gets its own trend section. If there is only one host, display it without the grouping header.
+
+### 2. Top Pages, Referrers, Countries (for the most recent date in the range)
+
+```bash
+curl -s 'https://api.cloudflare.com/client/v4/graphql' \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "query": "{ viewer { accounts(filter: { accountTag: \"ab6cc9362f7e51ba9a610aec1fc3a833\" }) { topPages: rumPageloadEventsAdaptiveGroups(limit: 15, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost requestPath } } topReferrers: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost refererHost } } topCountries: rumPageloadEventsAdaptiveGroups(limit: 10, filter: { date_geq: \"TARGET_DATE\", date_leq: \"TARGET_DATE\" }, orderBy: [count_DESC]) { count dimensions { requestHost countryName } } } } }"
+  }'
+```
+
+Run both queries in parallel (two Bash tool calls in one message).
+
+Group results by `requestHost`. If only one host exists, omit the grouping header.
+
+### 3. Format Output
+
+**Single site** (omit site header when only one host):
+
+```
+== venturecrane.com Traffic ==
+
+Pageloads (7-day trend):
+  Feb 10:    2
+  Feb 11:    9
+  Feb 12:    0
+  Feb 13:    4
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+  16  /articles/agent-context-management-system/
+   9  /portfolio/
+   ...
+
+Referrers (today):
+  99  venturecrane.com (internal)
+  50  (direct)
+   1  bing.com
+
+Countries (today):
+ 145  US
+   2  SG
+   1  PL
+   ...
+```
+
+**Multiple sites** (group by host with clear separation):
+
+```
+== Venture Crane Traffic ==
+
+--- venturecrane.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   74
+  Feb 15:  230
+  Feb 16:  150  <-- today
+
+Top Pages (today):
+  39  /
+  23  /articles/multi-model-code-review/
+   ...
+
+--- kidexpenses.com ---
+
+Pageloads (7-day trend):
+  Feb 14:   12
+  Feb 15:   18
+  Feb 16:    9  <-- today
+
+Top Pages (today):
+   5  /
+   3  /dashboard/
+   ...
+
+--- Totals ---
+
+  Feb 14:   86
+  Feb 15:  248
+  Feb 16:  159  <-- today
+```
+
+Right-align the numbers for scannability. Flag days with zero traffic (missing from API response) as `0`.
+
+When multiple sites exist, include a **Totals** section at the bottom summing all sites.
+
+## Notes
+
+- Read-only query. RUM data from JavaScript beacon (no bot traffic, but includes operator browsing).
+- Days missing from API response = zero pageloads. Fill as `0` in trend output.
+- Data may lag a few hours for current day. If API errors, show raw error message.
+- Account-level query - new sites with the beacon appear automatically.
+- Fleet machines block the beacon via /etc/hosts. Fleet traffic is not collected.
+"""

--- a/.gemini/commands/auth-setup.toml
+++ b/.gemini/commands/auth-setup.toml
@@ -1,0 +1,166 @@
+description = "Set up Clerk + Playwright auth bootstrap for a venture"
+
+prompt = """
+
+Wires up `@clerk/testing/playwright` so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes **without manual login**.
+
+Solves the recurring pain: "agent gets hung up needing manual login to test."
+
+## When to use
+
+- Run **inside a venture console repo** that uses Clerk (`dc`, `dfg`, `ke`, `sc`)
+- After verifying the venture's Clerk integration is working in dev (`npm run dev` reaches a protected page)
+- One-time setup per venture; re-run only to update the template
+
+## Prerequisites (Manual)
+
+Before running this command, the Captain must have completed:
+
+1. Created a Clerk **test user** in the venture's Clerk Dashboard
+   - Email: `agent-test+clerk_test@venturecrane.com` (the `+clerk_test` is required — Clerk recognizes it as a test identity)
+   - Password: anything strong, stored in Bitwarden
+   - Roles/permissions: same as a typical authenticated user
+2. Confirmed the venture's Infisical secrets include working `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (or `PUBLIC_CLERK_PUBLISHABLE_KEY` for Astro)
+3. (If running against deployed CI) added the same env vars to GitHub Actions secrets
+
+## Execution
+
+### Step 1: Detect Context
+
+1. Confirm cwd is a venture console repo. Walk up to the `.git` root and read `package.json`. If the repo is not in `{dc,dfg,ke,sc}-console`, stop and explain.
+2. Detect framework from `package.json`:
+   - `@clerk/nextjs` → Next.js
+   - `@clerk/astro` → Astro
+3. Detect existing Playwright config: `playwright.config.{ts,js}`. If absent, stop — this skill does not bootstrap Playwright itself.
+4. Read the canonical runbook for reference:
+   ```bash
+   cat ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+   ```
+
+### Step 2: Add Infisical secret
+
+Add `E2E_CLERK_USER_EMAIL` if not present:
+
+```bash
+infisical secrets set --path=/{venture} E2E_CLERK_USER_EMAIL=agent-test+clerk_test@venturecrane.com
+```
+
+Verify the venture's existing Clerk keys are present:
+
+```bash
+infisical secrets list --path=/{venture} | grep -E "CLERK_(SECRET_KEY|PUBLISHABLE_KEY)"
+```
+
+If `CLERK_SECRET_KEY` is missing, stop — the test instance must be configured first.
+
+### Step 3: Install dev deps
+
+```bash
+npm install -D @clerk/testing
+```
+
+(`@playwright/test` should already be installed; verify with `npm list @playwright/test`.)
+
+### Step 4: Copy template files
+
+From `~/dev/crane-console/templates/clerk-playwright-auth/`:
+
+```bash
+TEMPLATE=~/dev/crane-console/templates/clerk-playwright-auth
+
+mkdir -p playwright
+cp "$TEMPLATE/auth.setup.ts" playwright/auth.setup.ts
+```
+
+For Astro projects (`sc`), edit `playwright/auth.setup.ts` and verify env-var names match `PUBLIC_CLERK_PUBLISHABLE_KEY` (Clerk's testing pkg reads from `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` by default — Astro repos may need to copy the value).
+
+### Step 5: Update playwright.config.ts
+
+Read the existing `playwright.config.ts` and merge the `projects` block from `templates/clerk-playwright-auth/playwright.config.snippet.ts`:
+
+- Add a `setup-clerk` project that runs `auth.setup.ts`
+- Make authenticated browser projects depend on `setup-clerk` and load `storageState: 'playwright/.clerk/user.json'`
+- Leave any existing public/unauthenticated projects unchanged
+
+Use the Edit tool. Show the diff before applying.
+
+### Step 6: .gitignore
+
+Ensure `playwright/.clerk/` is gitignored (the captured `user.json` is a session secret):
+
+```bash
+grep -q "playwright/.clerk" .gitignore || echo "playwright/.clerk/" >> .gitignore
+```
+
+### Step 7: .env.example
+
+Append from the template:
+
+```bash
+cat ~/dev/crane-console/templates/clerk-playwright-auth/.env.example.snippet >> .env.example
+```
+
+### Step 8: Verify
+
+```bash
+npx playwright test --project=setup-clerk
+```
+
+Expected output: two tests pass (`global clerk setup`, `authenticate and save state`). A `playwright/.clerk/user.json` is created.
+
+If the second test fails with `E2E_CLERK_USER_EMAIL not set`, re-run `crane vc {venture}` (or whatever launches with secrets) so Infisical injects the env.
+
+If the second test fails with a redirect to `/sign-in`, the test user wasn't found in Clerk Dashboard — re-check Step 1 of Prerequisites.
+
+### Step 9: Smoke test the authenticated flow
+
+Add a minimal smoke test that hits a protected page:
+
+```ts
+// e2e/smoke.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('authenticated user reaches protected route', async ({ page }) => {
+  await page.goto('/')
+  // Adjust the URL/selector to a real protected page in this venture
+  await expect(page).not.toHaveURL(/sign-in/)
+})
+```
+
+Run with `npx playwright test --project=chromium-authed` (or whatever the authed project is named). Expect green.
+
+### Step 10: Commit
+
+```bash
+git checkout -b chore/clerk-playwright-auth-bootstrap
+git add playwright/auth.setup.ts playwright.config.ts .gitignore .env.example package.json package-lock.json
+git commit -m "$(cat <<'EOF'
+chore: clerk + playwright auth bootstrap
+
+Solves recurring pain where E2E runs (and agents driving Playwright)
+hit the Clerk login wall and require manual sign-in. Uses
+@clerk/testing/playwright to issue a server-side sign-in token
+(bypasses password/OTP/2FA), captures storageState once, and reuses
+it across workers.
+
+Runbook: ~/dev/crane-console/docs/runbooks/clerk-playwright-auth-setup.md
+EOF
+)"
+git push -u origin chore/clerk-playwright-auth-bootstrap
+gh pr create --title "chore: clerk + playwright auth bootstrap" --body "..."
+```
+
+## What NOT to do
+
+- Don't commit `playwright/.clerk/user.json` — it's a session secret
+- Don't use the production `sk_live_*` Clerk key in CI — testing tokens only work on dev instances
+- Don't reuse a real (human) user as the test identity — use the `+clerk_test` pattern
+- Don't add this to `ss-console` (workers only, no UI auth) or `crane-console` (backend, no UI auth)
+
+## Related
+
+- Runbook: `docs/runbooks/clerk-playwright-auth-setup.md`
+- Template: `templates/clerk-playwright-auth/`
+- Memory: `reference_browser_automation_tools.md`
+- Tooling catalog: `docs/instructions/tooling.md`
+"""

--- a/.gemini/commands/auto-build.toml
+++ b/.gemini/commands/auto-build.toml
@@ -1,0 +1,107 @@
+description = "Vetted plan-and-execute workflow"
+
+prompt = """
+
+This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
+
+The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.
+
+## Arguments
+
+```
+/auto-build [agents]
+```
+
+- `agents` — number of critic agents `/critique` will spawn in Step 4. Default: **1** (Devil's Advocate). Pass through verbatim to `/critique`. The Captain knows the stakes at invocation; do not infer the count from plan content.
+
+Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. Store as `AGENT_COUNT`.
+
+## Execution
+
+### Step 1: Verify Auto Mode is active (fail-closed)
+
+Scan the current system-reminder context for any of these known signals:
+
+- `Auto Mode Active` — current canonical string
+- `Auto-Accept Mode` — alternate string seen in some harness builds
+- `auto_mode: true` or similar structured field if/when one ships
+
+**If a match is found**, proceed to Step 2 silently.
+
+**If NO match is found**, do NOT assume Auto Mode is off — assume the detection is unreliable. Halt with:
+
+> `/auto-build` couldn't confirm Auto Mode is active. The skill needs autonomous execution after plan approval; without it, you'll be prompted on every tool call.
+>
+> Either: toggle Auto Mode on (Shift+Tab cycles modes) and re-run, OR reply `yes auto` to override and proceed anyway.
+
+Wait for the Captain's response. Only proceed to Step 2 if they re-invoke after toggling, or reply with the literal `yes auto` override.
+
+**Known fragility:** This is string-matching against harness output and will break if the harness changes its signal. Replace this step with a programmatic mode signal (env var, dedicated tool, structured field) when one ships. Until then, the synonym set + override is the best available.
+
+### Step 2: Enter plan mode
+
+Call `EnterPlanMode`. The harness requests Captain approval and provides a plan file path on entry. If the Captain rejects entry, the skill ends.
+
+### Step 3: Build the plan
+
+Follow the plan-mode discipline already documented in the system prompt:
+
+- **Phase 1 (Initial Understanding):** launch up to 3 Explore subagents in parallel to map the affected code. Use the minimum number needed (often 1).
+- **Phase 2 (Design):** launch up to 3 Plan subagents to design the approach.
+- **Phase 3 (Review):** read critical files identified by the agents; resolve any open questions with `AskUserQuestion`.
+- **Phase 4 (Final Plan):** write the plan to the plan file. Include Context, recommended approach (only the chosen one), critical file paths, reused functions/utilities, and a Verification section.
+
+Do not call `ExitPlanMode` yet. Step 5 owns the exit.
+
+### Step 4: Invoke `/critique`
+
+Call the `/critique` skill via the Skill tool, passing `AGENT_COUNT`:
+
+```
+/auto-build           → /critique 1   (default Devil's Advocate)
+/auto-build 3         → /critique 3   (Devil's Advocate + Simplifier + Pragmatist)
+/auto-build 6         → /critique 6   (full panel)
+```
+
+`/critique` reads the conversation, spawns critics in parallel, and returns a revised plan with `### Changes Made` and `### Critiques Acknowledged but Not Adopted` sections.
+
+**Apply the revised plan to the plan file.** Editing the plan file is allowed under plan-mode rules (it is the only writable file). The plan file is the source of truth the Captain will see at the approval gate, so it must reflect the post-critique state.
+
+If `/critique` reports "no plan identifiable," something went wrong in Step 3. Re-enter Step 3 — do not attempt to exit plan mode with an unwritten plan.
+
+### Step 5: Gate on Captain approval
+
+Call `ExitPlanMode`. The harness presents the revised plan to the Captain.
+
+- **Approved** → proceed to Step 6.
+- **Rejected** → the skill ends. The Captain re-runs `/auto-build` (or any other command) to start a fresh flow.
+
+We do not model a revise loop. ExitPlanMode rejection delivers Captain feedback as a new user turn, at which point the Captain's next message supersedes the in-progress skill — there is no reliable contract that `/auto-build` regains control with prior context intact. Re-running is cheap; pretending the loop works is dishonest.
+
+### Step 6: Execute autonomously
+
+Implement per the approved plan. Auto Mode is active (verified in Step 1), so:
+
+- No confirmation prompts on routine tool calls.
+- File edits, test runs, commits proceed without per-action approval.
+- **Destructive actions still require explicit confirmation.** Per CLAUDE.md and the Auto Mode reminder: production systems, data deletion, force-push, secret rotation, account creation, dropping schema, modifying auth, removing access controls. Auto Mode is not a license to destroy.
+- If the plan touches code in this repo, end with `npm run verify`.
+- Then commit, push, and open a PR per `pr-workflow.md`.
+
+End-of-session summary: one or two sentences (per `/own-it` rule 5).
+
+## Anti-patterns
+
+The skill must explicitly forbid these. The Captain has flagged each one in feedback memory; do not regress:
+
+1. **No deferral revisions.** When `/critique` raises an issue, fix it in the plan — do not file a follow-up ticket and call the plan done. (Per `feedback_critique_deferrals.md`, `feedback_kill_dont_file.md`.)
+2. **No "I'll figure it out during execution."** If a step is unclear after critique, revise the plan in Step 4; do not punt to runtime.
+3. **No degradation to ask-mode in Step 6.** Routine questions are yours to decide (per `/own-it` rule 1). Only stop for guardrails-gated actions (`crane_doc('global', 'guardrails.md')`).
+4. **No theater.** Plan is one scrollable screen. End-of-session summary is two sentences. No ceremonial status updates mid-step.
+
+## Notes
+
+- **Composability:** `/auto-build` ends at "PR opened, CI green, ready to merge." It does not invoke `/ship`. If the Captain wants ship-too, they invoke `/ship` after.
+- **Critique depth:** Single round per `/critique`'s own design. The Captain can re-invoke `/critique` manually if they want another round before approval.
+- **Trigger ownership:** Captain-invoked, not harness-suggested. The description field reflects this. Do not lower the bar by self-suggesting `/auto-build` in conversational responses; let the Captain decide.
+"""

--- a/.gemini/commands/design-brief.toml
+++ b/.gemini/commands/design-brief.toml
@@ -2,6 +2,15 @@ description = "Multi-Agent Design Brief Generator"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "design-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before launching any design-round agent (Brand Strategist, Interaction Designer, Design Technologist, Target User), load the cross-venture pattern + component catalog. Pass the loaded content into `docs/design/context.md` so each round-agent works against the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> The four roles below are voices, not pattern catalogs. Concrete pattern + component decisions in their output should map back to the loaded catalog (or extend it with a clear rationale). Then load the venture's `design-spec.md` for venture-specific palette and tone.
+
 This command orchestrates a 4-agent design brief process with configurable rounds. It reads the PRD and existing design artifacts, runs structured design rounds with parallel agents, and synthesizes the output into a production-ready design brief.
 
 The design brief answers "how should this look and feel?" - downstream of the PRD ("what to build and why?"). It requires a PRD to exist before running.
@@ -12,7 +21,10 @@ Works in any venture console that has `docs/pm/prd.md`.
 
 ```
 /design-brief [rounds]
+/design-brief --extract-identity <path-to-frontend-design-output>
 ```
+
+**Default mode (with optional `rounds` argument):**
 
 - `rounds` - number of design rounds (default: **1**). Each additional round adds cross-pollination where agents read and respond to each other's work.
   - **1 round**: Independent analysis + synthesis. Fast. Good for greenfield projects or early design exploration.
@@ -22,6 +34,12 @@ Works in any venture console that has `docs/pm/prd.md`.
 Parse the argument: if `$ARGUMENTS` is empty or not a number, default to 1. If it's a number, use that value. There is no upper bound - if someone wants 5 rounds, run 5 rounds.
 
 Store as `TOTAL_ROUNDS`.
+
+**Identity-extraction mode (`--extract-identity`):**
+
+Ingests output from Anthropic's `frontend-design` plugin (HTML/CSS/component code produced by an identity exploration run) and extracts concrete tokens into the venture's `.design/DESIGN.md`. See [workflows/extract-identity.md](workflows/extract-identity.md).
+
+This mode skips the 4-agent brief process entirely. It parses visual output → token spec → file. Use when you've just run `/frontend-design` and need to codify the chosen aesthetic direction before running `/nav-spec`, `/ux-brief`, and `/product-design` downstream.
 
 ## Execution
 

--- a/.gemini/commands/docs-refresh.toml
+++ b/.gemini/commands/docs-refresh.toml
@@ -1,0 +1,51 @@
+description = "Enterprise Docs Refresh"
+
+prompt = """
+
+Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+
+## Arguments
+
+```
+/docs-refresh [scope]
+```
+
+- No argument: Audit mode - lists stale pages, does NOT modify files
+- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
+- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
+- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+
+## Execution
+
+### Step 1: Audit
+
+Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+
+**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+
+### Step 2: Gather Data
+
+For pages in scope, pull from:
+
+- **Overviews**: `config/ventures.json` + `docs/design/ventures/{code}/design-spec.md` + VCMS exec summaries
+- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
+- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+
+### Step 3: Draft
+
+Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+
+### Step 4: Approve
+
+Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+
+### Step 5: PR
+
+Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+
+## Notes
+
+- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
+- After merge, Vercel auto-rebuilds the site
+- Quality bar: 0 unjustified TBDs, 20+ lines, real data
+"""

--- a/.gemini/commands/eos.toml
+++ b/.gemini/commands/eos.toml
@@ -85,15 +85,18 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
-3. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
+3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
+4. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
+
+Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
 ### 6. Report Completion
 

--- a/.gemini/commands/go-live.toml
+++ b/.gemini/commands/go-live.toml
@@ -1,0 +1,113 @@
+description = "Venture Go-Live Process"
+
+prompt = """
+
+Launch a venture to production with mandatory secret rotation and readiness checks.
+
+```
+/go-live dc           # launch Draft Crane
+/go-live ke           # launch Kid Expenses
+```
+
+**Do NOT follow `docs/process/secrets-rotation-runbook.md`** - it references decommissioned tooling.
+
+## Step 1: Parse & Validate
+
+Parse `$ARGUMENTS` for a venture code. Then:
+
+1. Read `config/ventures.json`
+2. Find the venture by `code`
+3. If not found, stop: "Unknown venture code. Available: {list codes with status}"
+4. If `portfolio.status` is `"launched"`, stop: "Already launched."
+5. If no argument provided, stop with usage: "/go-live {venture-code}"
+
+## Step 2: Pre-flight Checks (automated)
+
+Run these checks without user input. Report pass/fail for each.
+
+1. **Golden Path compliance** - Read `docs/standards/golden-path.md` compliance dashboard row for this venture. Note Sentry, CI/CD, Monitoring, Docs status. If the venture is missing from the dashboard, flag it as a gap.
+2. **Infisical prod secrets** - Run `infisical secrets --path /{venture} --env prod --silent 2>/dev/null | grep '│' | grep -v 'SECRET NAME' | grep -v '├\|┌\|└' | sed 's/│/|/g' | cut -d'|' -f2 | sed 's/^ *//;s/ *$//'` to extract key names only. **NEVER run bare `infisical secrets` - it displays values in the transcript.**
+3. **Infisical dev secrets** - Same key-names-only extraction for `--env dev`.
+4. **Production worker health** - If the venture has a known health endpoint, `curl` it and confirm 200.
+5. **DNS/custom domain** - If `portfolio.url` is set in ventures.json, verify DNS resolves.
+
+Present results as a checklist. If any critical check fails (no prod secrets, no worker health), stop: "Fix these before proceeding."
+
+## Step 3: Secret Inventory
+
+Agent pulls and displays key names only (NEVER values):
+
+1. Extract key names from Infisical (reuse the key-names-only command from Step 2 - NEVER display values).
+2. Read the **Shared Credentials** table from `docs/infra/secrets-management.md`.
+3. Read the **Revocation Behavior by Type** table from `docs/infra/secrets-management.md`.
+4. Cross-reference: flag any shared credentials and note rotation impact.
+5. Categorize each secret by revocation behavior (immediate vs dual-key vs self-generated).
+
+Present the full inventory, then ask via AskUserQuestion:
+
+**Question:** "Rotate all {N} secrets at their sources, update Infisical (prod AND dev), then confirm."
+
+Include in the question context:
+
+- Shared credentials and which ventures they affect
+- Immediate-revocation secrets (test each one right after rotating)
+- Dual-key/self-generated secrets (can batch)
+
+**Options:**
+
+1. "All rotated and updated in Infisical" - proceed to push
+2. "Skip rotation" - launch without rotating (for ventures where secrets were never exposed in transcripts)
+3. "Cancel" - abort go-live
+
+If cancelled, stop.
+
+## Step 4: Push to Workers (agent-safe)
+
+Push secrets to Cloudflare Workers without exposing values:
+
+```bash
+cd {venture-worker-dir}
+infisical export --format=json --path /{venture} --env prod | npx wrangler secret bulk
+```
+
+No secret values appear in the transcript. If the venture has multiple workers, push to each.
+
+## Step 5: Smoke Test
+
+Run these checks and report pass/fail:
+
+1. **Health endpoint** - `curl` the production health endpoint
+2. **Auth flow** - venture-specific auth check (describe what to test based on the venture's tech stack)
+3. **Sentry** - verify Sentry project exists and is receiving events (if integrated)
+4. **Uptime monitor** - confirm external monitoring is configured
+
+If any fail: "Smoke test failures above. Fix before continuing. Old credentials have NOT been revoked yet."
+
+If all pass, ask via AskUserQuestion:
+
+**Question:** "Smoke tests passed. Revoke old credentials at their source consoles now. Self-generated tokens (like ENCRYPTION_KEY) don't need revocation - rotation was the control."
+
+**Options:**
+
+1. "Old credentials revoked" - proceed to ship
+2. "Cancel" - abort (new credentials remain active, no rollback needed)
+
+## Step 6: Ship
+
+1. Update `config/ventures.json`:
+   - Set `portfolio.status` to `"launched"`
+   - Set `portfolio.showInPortfolio` to `true` (this enables venture name usage in published articles and build logs per terminology.md)
+   - Set `portfolio.url` if provided by user (ask if not already set)
+   - Update `bvmStage` if appropriate
+2. Commit with message: `feat: launch {venture name}`
+3. Run `/portfolio-review` to sync the venture to vc-web's portfolio page
+4. Create handoff via `crane_handoff` MCP tool with summary of what was launched
+
+Report: "{Venture Name} is live. ventures.json updated, portfolio synced, handoff saved."
+
+## Important Notes
+
+- **Transcript cleanup is optional hygiene.** Rotation already invalidated any exposed values. Old transcripts in ~/.claude/ contain dead credentials after rotation.
+- **If smoke tests fail after rotating an immediate-revocation secret** (like OAuth client secrets), the old value is already dead. Fix the issue with the new credential - don't try to rollback.
+- **Shared credentials require coordination.** If GOOGLE_CLIENT_SECRET is rotated for /dc, the old value dies immediately for /ke too. Push to all consuming ventures before revoking.
+"""

--- a/.gemini/commands/heartbeat.toml
+++ b/.gemini/commands/heartbeat.toml
@@ -1,0 +1,143 @@
+description = "Keep Session Alive"
+
+prompt = """
+
+Send a heartbeat to prevent your session from timing out.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Updates the `last_heartbeat_at` timestamp
+3. Prevents 45-minute session timeout
+4. Shows when next heartbeat is recommended
+
+## When to Use
+
+- Working on long tasks (>30 minutes)
+- Want to keep session active while reading/researching
+- Need to maintain "active" status visibility
+
+**Not needed if:** You're actively using `/sos`, `/update`, or `/eos` - those all refresh heartbeat automatically.
+
+## Usage
+
+```bash
+/heartbeat
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Send Heartbeat
+
+```bash
+# Build request body
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  '{
+    session_id: $session_id
+  }')
+
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/heartbeat" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Heartbeat failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 3. Display Results
+
+```bash
+LAST_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.last_heartbeat_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "💓 Heartbeat sent"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Last heartbeat: $LAST_HEARTBEAT"
+echo "Next heartbeat in: ~$MINUTES minutes"
+echo ""
+echo "Your session will stay active for 45 minutes from this heartbeat."
+```
+
+## Notes
+
+- Automatic heartbeats: `/sos`, `/update`, `/eos` all refresh heartbeat
+- Manual heartbeat needed when working >30 minutes without those commands
+- Recommended interval: every 10-15 minutes during long tasks
+- Sessions become "abandoned" after 45 minutes without heartbeat (next `/sos` creates new session)
+- Requires active session and CRANE_CONTEXT_KEY
+- Safe to call frequently (idempotent)
+"""

--- a/.gemini/commands/nav-spec.toml
+++ b/.gemini/commands/nav-spec.toml
@@ -1,0 +1,213 @@
+description = "> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`."
+
+prompt = """
+
+> **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
+
+# /nav-spec - Nav Spec Authority (v3)
+
+You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.
+
+You have seen what happens when navigation is left "open" per surface: chrome that looks consistent but list views that can't be reached except by backtracking from a detail; spec-defined sections orphaned in code; patterns that ratify whatever the designer already shipped. Your output is the thing that stops both the chrome failures (v1), the IA failures (v2), and the pattern-selection laundering failures (v3).
+
+## What changed in v3
+
+v2 added an IA layer and a pattern catalog. It still failed: authors wrote task models while shipped chrome was in memory, then picked patterns that "matched" the chrome the task model had been subtly shaped to support. ss-console's portal home declared cross-section task sequences in Section 1.4.1 ("Pay invoice: home → list → detail → Stripe") and then declared hub-and-spoke in Section 4.4 with the rationale "user returns to hub between tasks" — contradicting the adjacent evidence. No reviewer, no validator rule caught the contradiction.
+
+v3 adds two structural enforcements:
+
+1. **Citation-anchored pattern disqualifiers (R25).** [references/pattern-disqualifiers.md](references/pattern-disqualifiers.md) enumerates disqualifier conditions per catalog pattern, each cited to NN/g / Material 3 / Apple HIG (or tagged `HEURISTIC: UNTESTED`). R25 applies them to the declared pattern against the task-model inputs; the skill becomes a _challenger_ (not a chooser). Overrides require both (a) a defense citing specific task-model input values and (b) ≥2 of 3 Phase 7 reviewer approvals naming the specific disqualifier ID.
+2. **Authoring-direction lint (R26).** Sections 1–4 of `NAVIGATION.md` must not cite `src/components/**` or `*.astro` paths. The IA Architect reviewer catches the sophisticated case (paraphrased shipped chrome).
+
+Additional v3 tightenings:
+
+- Task table requires new columns: `evidence_source` (non-UI artifact) and `return_locus` (task terminus).
+- `return_locus = hub` requires _structural_ evidence (URL literal / interview quote / analytics event), not prose.
+- "Primary" tasks are derived from frequency + criticality, not author-toggled.
+- Evidence-mode front matter: `provisional` (pre-launch, relaxes evidence sourcing) vs. `validated` (production, requires real artifacts). R25 is structural in both modes.
+- Time-bounded provisional-override artifacts: `.design/provisional-override-<date>.md` requires named `deferred_validation.event` and `date ≤90 days`. Expired overrides re-fire R25.
+
+## Core responsibilities
+
+1. **Spec authoring** (`/nav-spec`) — produce `.design/NAVIGATION.md` with 11 sections + 5 surface-class appendices, covering all three layers.
+2. **IA audit** (`/nav-spec --ia-audit`) — walk the sitemap; flag orphan destinations, dead-ends, label inconsistency, pattern violations, matrix mismatches.
+3. **Drift audit** (`/nav-spec --drift-audit`) — chrome-level audit of shipped code and generated artifacts.
+4. **Spec revision** (`/nav-spec --revise`) — update existing spec; bump spec-version; preserve back-compat.
+5. **Phase 0 compliance test** — empirical injection-effectiveness measurement.
+6. **Validation** (`validate.py`) — post-generation enforcement of all 24 rules (R1–R15 chrome, R16–R24 IA + pattern + a11y) on generated output and shipped HTML.
+
+## The three layers
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Layer 1 — Information Architecture                              │
+│   Task model → Sitemap → Reachability matrix                    │
+│   Entry/exit catalogue → State machine                          │
+│   Cross-surface context → URL contract → Content taxonomy       │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 2 — Patterns                                              │
+│   Named patterns from NN/g + Material + HIG                     │
+│   Per {surface × archetype}: which pattern, why, what variants  │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 3 — Chrome                                                │
+│   Header, back, breadcrumbs, footer, skip-link                  │
+│   States, tap targets, mobile↔desktop transforms                │
+│   Per-surface a11y                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Cross-cutting: search strategy, recovery paths, IA-level a11y, analytics hooks.
+
+## Anchoring principle
+
+The skill **does not invent patterns**. Every pattern in a spec must be a specialization of a pattern from [references/pattern-catalog.md](references/pattern-catalog.md), which catalogs:
+
+- **NN/g navigation patterns** — hub-and-spoke, nested-doll, sequential, pyramid, faceted, tag
+- **Material Design 3 navigation components** — top app bar, bottom nav, navigation rail, drawer, tabs, segmented button (with destination-count rules)
+- **Apple HIG patterns** — tab bar, split view, navigation stack, modal
+- **Industry composite patterns** — master-detail, index+preview, modal-on-list, persistent-context workspace, progressive disclosure, command palette
+
+Reviewing the spec against [references/ia-principles.md](references/ia-principles.md) (Dan Brown's 8 principles of IA) is a required Phase 7 deliverable.
+
+## Workflows
+
+| User intent                                     | Workflow                                                           | Primary output                                |
+| ----------------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
+| "Create NAVIGATION.md for this venture"         | [author.md](workflows/author.md)                                   | `.design/NAVIGATION.md`                       |
+| "Audit IA holes (orphans, dead-ends, taxonomy)" | [ia-audit.md](workflows/ia-audit.md)                               | `examples/ia-audit-report.md`                 |
+| "Audit chrome drift"                            | [drift-audit.md](workflows/drift-audit.md)                         | In-memory drift report                        |
+| "Update existing NAVIGATION.md"                 | [revise.md](workflows/revise.md)                                   | `.design/NAVIGATION.md` (bumped spec-version) |
+| "Re-run Phase 0 compliance"                     | [phase-0-compliance-test.md](workflows/phase-0-compliance-test.md) | `examples/phase-0-compliance-report.md`       |
+| "Validate a generated screen"                   | [validate.md](workflows/validate.md)                               | Violation report                              |
+
+## Fail-fast preconditions
+
+Before any workflow except the audits:
+
+1. Resolve the venture code for the current repo via `crane_ventures`. If no matching venture is found, stop and ask the user to confirm the venture code.
+2. Check for `.design/DESIGN.md`. If absent, warn and pull token inventory from `src/styles/*` or Tailwind config.
+3. Check for `.design/NAVIGATION.md`. If present, route to `revise.md`. If absent, route to `author.md`.
+
+## Surface-class taxonomy (authoritative)
+
+Surface classes are modeled by **auth model**, not by subdomain.
+
+| Class                 | Auth                          | Examples (ss-console)                        |
+| --------------------- | ----------------------------- | -------------------------------------------- |
+| `public`              | None                          | Marketing home, scorecard, blog, contact     |
+| `auth-gate`           | Sign-in form (no session yet) | `/auth/login`, `/auth/portal-login`          |
+| `token-auth`          | Signed URL token              | `/portal/proposals/[token]`, `/invoice/[id]` |
+| `session-auth-client` | Cookie session, role=client   | `/portal/*`                                  |
+| `session-auth-admin`  | Cookie session, role=admin    | `/admin/*`                                   |
+
+The subdomain is a secondary attribute. A public page on `portal.*` is still `public` chrome-wise.
+
+## Archetype taxonomy (authoritative)
+
+Ten archetypes: `dashboard`, `list`, `detail`, `form`, `wizard`, `empty`, `error`, `modal`, `drawer`, `transient`.
+
+Each archetype maps to a default pattern from the catalog and inherits the common contract. Full table in [references/archetype-catalog.md](references/archetype-catalog.md).
+
+## Classification (deterministic, required, 5 tags)
+
+Every generation (via `product-design`) targeting a specific screen must carry **five** explicit classification tags:
+
+```
+surface=<public|auth-gate|token-auth|session-auth-client|session-auth-admin>
+archetype=<dashboard|list|detail|form|wizard|empty|error|modal|drawer|transient>
+viewport=<mobile|desktop>
+task=<short-name from venture's task model>
+pattern=<name from pattern-catalog.md>
+```
+
+The pipeline fails fast if any tag is missing or unrecognized. Natural-language inference is explicitly disabled.
+
+The two new tags (`task=`, `pattern=`) are required because chrome alone never determines a pattern — the same chrome can implement different patterns. Tagging makes the choice deterministic and binds every generation to the spec's task model and pattern catalog.
+
+Manual lookup aid: [references/classification-rubric.md](references/classification-rubric.md).
+
+## Injection mechanism
+
+At prompt-enhancement time, the generator reads `.design/NAVIGATION.md`, looks up the matching `{surface, archetype, viewport, task, pattern}` block, assembles an **essential** NAV CONTRACT block (always injected) and an **extended** block (loaded conditionally based on archetype/pattern), and injects them into the generator's prompt between DESIGN SYSTEM and PAGE STRUCTURE.
+
+Token budget: ≤500 essential, ≤800 essential+extended combined. Canonical format: [references/injection-snippet-template.md](references/injection-snippet-template.md).
+
+Post-generation, `validate.py` parses the returned HTML and runs all 24 rules. Violations fail the generation loudly with specific DOM selectors and suggested fixes. The validator is mandatory, not optional — injection compliance measured in Phase 0 is strong at the categorical level but leaks cosmetic, semantic, and IA-reachability violations.
+
+## Validator coverage (R1–R26)
+
+| #       | Category                | Rule                                                                    | Layer       | Added in |
+| ------- | ----------------------- | ----------------------------------------------------------------------- | ----------- | -------- |
+| R1      | Chrome                  | Header sticky, not fixed                                                | Chrome      | v1       |
+| R2      | Chrome                  | Header bg solid (no blur, no opacity)                                   | Chrome      | v1       |
+| R3      | Chrome                  | No icon before client name                                              | Chrome      | v1       |
+| R4      | Chrome                  | Back not wrapped in breadcrumb nav                                      | Chrome      | v1       |
+| R5      | Chrome                  | Back href is canonical URL                                              | Chrome      | v1       |
+| R6      | Chrome                  | No global nav tabs in header                                            | Chrome      | v1       |
+| R7      | Chrome                  | No sticky-bottom outside dialog                                         | Chrome      | v1       |
+| R8      | Chrome                  | No footer on auth surfaces                                              | Chrome      | v1       |
+| R9      | Chrome                  | No real-face photo placeholders                                         | Chrome      | v1       |
+| R10     | Chrome                  | No marketing CTAs on auth                                               | Chrome      | v1       |
+| R11     | Chrome                  | Header height matches viewport                                          | Chrome      | v1       |
+| R14     | A11y                    | Landmarks present                                                       | A11y        | v1       |
+| R15     | A11y                    | Skip-to-main link wired correctly                                       | A11y        | v1       |
+| R16     | IA                      | Reachability — dashboards link to sibling lists                         | IA          | v2       |
+| R17     | Pattern                 | Pattern conformance — surface implements declared pattern               | Pattern     | v2       |
+| R18     | IA                      | No dead ends                                                            | IA          | v2       |
+| R19     | IA                      | Token-auth handles cold arrival                                         | IA          | v2       |
+| R20     | IA                      | Content taxonomy adherence                                              | IA          | v2       |
+| R21     | IA                      | State machine completeness                                              | IA          | v2       |
+| R22     | A11y                    | Heading hierarchy                                                       | A11y        | v2       |
+| R23     | IA                      | Search affordance present when declared                                 | IA          | v2       |
+| R24     | Pattern                 | Cross-surface context preserved                                         | Pattern     | v2       |
+| **R25** | **Pattern Fitness**     | **Citation-anchored disqualifiers for declared pattern vs. task model** | **Pattern** | **v3**   |
+| **R26** | **Authoring direction** | **Sections 1–4 must not cite `src/components/**`or`\*.astro`\*\*        | **Meta**    | **v3**   |
+
+Severity tiers: **structural** always fails; **semantic** retries once; **cosmetic** warns but passes (configurable per venture).
+
+R25 runs in a spec-only mode via `python3 validate.py --check-pattern-fitness --spec .design/NAVIGATION.md` (no HTML file required). R26 runs alongside R25 and whenever `--file` validation is invoked with a v3 spec.
+
+## References
+
+- [pattern-catalog.md](references/pattern-catalog.md) — NN/g + Material + HIG + composite patterns
+- [pattern-disqualifiers.md](references/pattern-disqualifiers.md) — **v3** citation-anchored disqualifier conditions (powers R25)
+- [ia-principles.md](references/ia-principles.md) — Dan Brown's 8 principles
+- [task-model-template.md](references/task-model-template.md) — task elicitation and structure (v3: evidence_source + return_locus)
+- [reachability-matrix-template.md](references/reachability-matrix-template.md) — central IA artifact
+- [state-machine-template.md](references/state-machine-template.md) — auth/data/task states
+- [content-taxonomy-template.md](references/content-taxonomy-template.md) — labels, verbs, statuses
+- [archetype-catalog.md](references/archetype-catalog.md) — 10 archetypes × default patterns
+- [chrome-component-contracts.md](references/chrome-component-contracts.md) — DOM + Tailwind
+- [classification-rubric.md](references/classification-rubric.md) — 5-tag decision rules
+- [injection-snippet-template.md](references/injection-snippet-template.md) — NAV CONTRACT block (essential + extended)
+- [anti-patterns.md](references/anti-patterns.md) — chrome anti-patterns 1–15 + IA anti-patterns 16–24
+
+## Examples
+
+- [examples/NAVIGATION.md](examples/NAVIGATION.md) — gold-standard v3 spec (migrated from ss-console v2)
+- [examples/ia-audit-report.md](examples/ia-audit-report.md) — IA audit format
+- [examples/drift-audit-report.md](examples/drift-audit-report.md) — chrome drift audit format
+- [examples/phase-0-compliance-report.md](examples/phase-0-compliance-report.md) — empirical compliance measurement
+- [examples/pattern-disqualifier-tests/](examples/pattern-disqualifier-tests/) — v3 synthetic regression tests (admin-heavy-switching, mandatory-wizard, deep-content-library)
+- [examples/v3-regression-test.md](examples/v3-regression-test.md) — expected outputs for the v3 regression suite
+
+## Best practices
+
+- **Author in direction: tasks → golden paths → IA → pattern → spec → COMPARE to code.** Sections 1–4 must be authorable as if shipped code did not exist. Phase 5 (chrome contracts) is the first authorized read of shipped components. R26 enforces this at the lint level; the IA Architect reviewer catches paraphrased shipped-chrome claims in §1–4.
+- **Anchor every pattern.** Every pattern in a spec is a specialization of a catalog entry. Every disqualifier in [pattern-disqualifiers.md](references/pattern-disqualifiers.md) cites NN/g / Material 3 / HIG, or carries a `HEURISTIC: UNTESTED` tag. Never invent.
+- **Skill is a challenger, not a chooser.** R25 does not pick the pattern; it refuses patterns whose declared-pattern-vs-task-model disagreement contradicts a cited source. Override requires both (a) a defense citing specific task-model values and (b) ≥2/3 reviewer consensus naming the disqualifier ID.
+- **"Primary" is structural, not declarative.** A task is primary iff `frequency ∈ {high, medium}` OR `criticality = blocking`. The author cannot dodge R25 disqualifiers by relabeling tasks.
+- **`return_locus = hub` requires structural evidence.** Literal URL in a file or SOW, interview quote, or analytics event. Prose intent is insufficient.
+- **Provisional mode relaxes evidence, not R25.** Pre-launch ventures use `evidence-mode: provisional` to cite SOW hypotheses. R25 remains structural. Dismissal requires a time-bounded `.design/provisional-override-<date>.md` with a named validation event and date ≤90 days.
+- **Five surface classes, not three or four.** v1 forgot `auth-gate`; v2+ include it explicitly.
+- **The reachability matrix is validator-checkable.** R16 reads the matrix and verifies generated HTML emits the required `<a href>` elements. The matrix is not decorative — it is the contract.
+- **The validator is the enforcement layer.** The injection snippet is instructional; the validator is deterministic. When in conflict, trust the validator.
+- **Spec-version bumps reflect breaking changes.** Additive (new archetype, new pattern, new anti-pattern) lands without bump. Structural (taxonomy redefinition, rule inversion, new required section) bumps.
+- **A11y is woven, not bolted.** It lives in chrome (per-surface) AND IA (cross-surface heading hierarchy, landmark consistency). The Implementation reviewer covers per-surface; the IA architect reviewer covers cross-surface.
+- **Backwards compatibility.** v1 specs validate against R1–R15 only. v2 specs (task/pattern tags, reachability matrix) add R16–R24. v3 specs (evidence-mode, return_locus column, decision log) add R25 and R26. Soft-skip warnings are emitted on stderr when a rule's inputs are missing; the pipeline never fails unexpectedly on a v1 or v2 spec due to a v3 rule.
+"""

--- a/.gemini/commands/own-it.toml
+++ b/.gemini/commands/own-it.toml
@@ -1,0 +1,113 @@
+description = "Own the decision, own the finish"
+
+prompt = """
+
+You are running this skill because you were about to punt - or because the Captain just called you on it.
+
+The Captain's language, distilled:
+
+> What is the professional, no-corner-cutting, no-ape-thinking thing to do here? It feels like you're asking me to make judgment calls about things you are perfectly capable of deciding. If not, get a partner and figure out what the right thing to do is for the health of the venture and the enterprise as a whole. Also, we complete projects within the session - no loose ends, no theater.
+
+## Behavior
+
+Five rules. Run them in order when you catch yourself drifting; otherwise use them as a single filter on every decision, every follow-up, every end-of-turn summary.
+
+### 1. Decide
+
+You have the context. You have the guardrails (`crane_doc('global', 'guardrails.md')`). You have the codebase in front of you. Most "should I do X or Y?" questions are yours to answer.
+
+**Invalid escalations - decide them yourself:**
+
+- "Should I use library A or B?" - evaluate both, pick one, explain in one line.
+- "Do you want me to also fix the adjacent broken thing?" - yes, if professional rigor calls for it.
+- "What priority label should this PR get?" - pick the one that matches impact; labels are cheap to change.
+- "Which naming convention should I use?" - match surrounding code.
+- "Is this worth doing?" - if you've gotten this far, you already believe it is. Commit or kill.
+- "Do you want me to write tests?" - yes.
+- "Should I squash these commits?" - follow the repo convention.
+
+**Valid escalations - these really are Captain's call:**
+
+- Strategic priorities (which venture, which quarter-goal, which market bet).
+- Guardrails-gated actions: deprecating features, dropping schema columns/tables, changing auth, removing access controls. See `crane_doc('global', 'guardrails.md')`.
+- Scope boundaries the session charter hasn't pre-resolved.
+- Facts only the Captain knows (off-record relationships, conversations not in memory).
+
+If the question is not in the valid list, you decide.
+
+### 2. Partner, don't escalate
+
+If you're honestly uncertain - you can argue both sides at equal strength and lack information to break the tie - **consult a peer agent before the Captain.**
+
+Use the `Agent` tool with a focused prompt:
+
+```
+Agent({
+  subagent_type: "general-purpose",  // or "Plan" for approach, "Explore" for codebase questions
+  description: "Partner: <one-line>",
+  prompt: "I'm deciding X between A and B. Context: <brief>. Constraints: <brief>.
+           Give me the best call and your reasoning. No hedging. Under 200 words."
+})
+```
+
+Treat the partner's answer as input, not command. Synthesize, decide, proceed.
+
+### 3. Professional rigor: venture + enterprise health
+
+"Ape thinking" is the reptile shortcut: do the minimum that lets the task _look_ done, leave the obvious cleanup for "later," file a follow-up instead of finishing.
+
+Professional rigor asks: **what would a world-class engineer who personally owns the health of this venture and the whole enterprise do?**
+
+- Dead code adjacent to your change? Delete it. Don't file an issue.
+- Test skipped for months? Fix it or delete it with a one-line justification in the PR.
+- Pattern drifting across ventures? Flag in the PR body; bring it up at EOS.
+- "Health of the enterprise as a whole" beats local optimization: if this PR lands green but leaves the venture worse off, you failed.
+
+### 4. Finish in-session. No loose ends.
+
+Before you declare a task done, run this checklist:
+
+- [ ] Any `TODO`/`FIXME` comments you added? Resolve them or justify in the PR body.
+- [ ] Any "follow-up issue" filed? Most of the time the follow-up _is_ the task. Finish it.
+- [ ] Wrote "we can add this later"? Either add it now or delete the sentence.
+- [ ] Left code paths untested because "the happy path works"? Test the edge you know exists.
+- [ ] Mentioned a "phase 2"? Prove it's genuinely deferred, not just future-you's problem.
+
+**Legitimate phase boundaries:**
+
+- True external dependency (upstream library bug, machine offline, secret not yet provisioned).
+- Captain-gated action from `guardrails.md`.
+- Out-of-scope by the session charter, with explicit Captain agreement _earlier in the session_.
+
+**Not legitimate boundaries:** scope fear, fatigue, wanting a clean-looking PR, "the critic was right so I'll defer," "nice to have."
+
+### 5. No theater
+
+Theater is activity that looks like progress but isn't. Examples:
+
+- Renaming symbols without changing behavior so a PR looks substantive.
+- Writing a five-section summary when "done" or one sentence would do.
+- Filing planning issues for work you could start in five minutes.
+- Ceremonial status updates mid-task ("Now I'm starting step 2...").
+- Tests that only verify the same literal in two places.
+- Follow-up tickets whose acceptance criteria are "consider whether we should…".
+
+Measure: **did this change move the venture forward?** If the honest answer is "not really," delete it.
+
+End-of-turn summaries are one or two sentences. State what changed and what's next. If there's nothing to say, don't say it.
+
+## When the Captain has already invoked /own-it
+
+The Captain ran this because you drifted. **Don't restate the rules back.** Make the call you were about to punt on - in the next message - with a one-line justification. Then finish the task.
+
+## Escalation template (for the rare legitimate case)
+
+If after running this skill you still believe the question is legitimately Captain's:
+
+> **Need Captain call:** _<one-sentence question>_
+> **Why it's not mine:** _<which valid-escalation category>_
+> **My recommendation:** _<your best answer, with reasoning>_
+> **Default if no response:** _<what you will proceed with>_
+
+The "default if no response" line is mandatory. It is the forcing function: if you can name the default, you can just do it.
+"""

--- a/.gemini/commands/product-design.toml
+++ b/.gemini/commands/product-design.toml
@@ -1,0 +1,111 @@
+description = "> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue."
+
+prompt = """
+
+> **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
+
+# /product-design — Product UI realization
+
+You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.
+
+**Package manager detection.** At build-check time, detect the venture's package manager by lockfile, in this order: `pnpm-lock.yaml` → `pnpm build`, `yarn.lock` → `yarn build`, `package-lock.json` (or absent) → `npm run build`. Preview commands follow the same mapping (`npm run dev` etc.). Don't hardcode.
+
+You are not a design tool. External design tools are LLM wrappers built for customers without our harness. We have nav-spec v3.1 with citation-anchored disqualifiers, a 26-rule structural validator, a four-agent design-brief methodology, and Claude Code writing production code daily. This skill treats screen realization as a first-class capability of that stack.
+
+## What you produce
+
+**Components, not pages.** You write component files (e.g., `src/components/portal/QuoteDetail.astro`). Pages stay hand-wired with their data fetching — they import your components and pass data. This keeps auth/data layers out of scope and makes components render from props alone.
+
+For greenfield ventures with no pages yet, you may also produce a page wiring example. In mature ventures (the common case), stick to components.
+
+## Arguments
+
+```
+/product-design [--surface <name>] [--set <surface-set>] [--revise <path>]
+```
+
+- `--surface <name>` — generate a single surface (e.g., `portal-quotes-detail`). Surface names must match the classification in the venture's NAVIGATION.md.
+- `--set <surface-set>` — generate or revise a batch (e.g., `portal` covers every client-portal surface declared in NAVIGATION.md §1 task model). **Revise-aware:** for each surface, if a component file already exists at the target path, the skill loads it as prior-version context before generating (same as `--revise` for a single file). This makes `--set` the right tool for both greenfield batch generation AND identity-reset sweeps across shipped surfaces.
+- `--revise <path>` — revise an existing component file with a new request. Reads the existing file, treats it as prior context, generates a new version.
+- No args — ask the user which surface or set to generate; route accordingly.
+
+## Pre-flight (fail fast)
+
+Before any generation:
+
+1. **Identify venture.** Match the current repo against `crane_ventures`. If no match: stop, tell the user the skill must be invoked from a venture console repo.
+2. **NAVIGATION.md exists and is v3+.** Read `.design/NAVIGATION.md` from the venture repo. Check `spec-version` frontmatter. If absent or `< 3`: stop, suggest `/nav-spec` first.
+3. **UX brief covers the requested surface.** Look for `.design/<target>-ux-brief.md` where the surface class matches. Skim the brief; if the requested surface isn't named in the brief's scope section, **refuse** with: `Brief at .design/<target>-ux-brief.md does not cover <surface>. Run /ux-brief to extend it, or pick a covered surface.` This is the negative-case behavior — it's the point.
+4. **DESIGN.md or @theme tokens discoverable.** Read `.design/DESIGN.md` if present, or extract the `@theme` block from `src/styles/global.css` (Tailwind v4). If neither exists: stop, suggest running the design-brief or synthesizing DESIGN.md first.
+5. **Adapter known.** Determine the adapter from the venture's stack:
+   - Astro + Tailwind v4 → `adapters/astro-component.md`
+   - Next.js + Tailwind v4 → `adapters/nextjs-page.md` (Phase 2; not in v1)
+   - Unknown → stop, tell the user the adapter for their stack doesn't exist yet.
+
+If any pre-flight fails, stop before calling the generation workflow. Do not invent context.
+
+## Workflows
+
+| User intent                                         | Workflow                                                                                                                               |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| "Design/build one surface"                          | [workflows/generate-single-surface.md](workflows/generate-single-surface.md)                                                           |
+| "Design/build the whole client portal (or any set)" | [workflows/generate-surface-set.md](workflows/generate-surface-set.md)                                                                 |
+| "Revise this component"                             | [workflows/generate-single-surface.md](workflows/generate-single-surface.md) with `--revise` — same flow, prior file loaded as context |
+
+## The iteration loop (per component)
+
+Five steps. Every generation follows this shape. Do not add steps without Captain approval.
+
+1. **Assemble prompt.** See [references/prompt-assembly.md](references/prompt-assembly.md) for exactly what goes into the prompt and in what order. Inputs: nav-spec surface-class appendix, DESIGN.md or @theme tokens, UX brief section for this surface, five-tag classification (`surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`), adapter template, **raw source of every file under the venture's `src/components/**`\*\*. No registry. No AST. Let Claude read the component source directly.
+2. **Generate code.** Use the Write tool to produce the component file at its target path in the venture repo.
+3. **Build check.** Run the venture's build command (detected from lockfile — see package-manager note above). If it fails: read the compile errors, append to the prompt, regenerate. Max one retry.
+4. **Structural validate.** If a preview route is wired for this surface, extract the rendered HTML and run `~/.agents/skills/nav-spec/validate.py --file <html> --surface <tag> --archetype <tag> --viewport <tag> --task <tag> --pattern <tag> --spec <path-to-NAVIGATION.md>`. If structural violations: append to prompt, regenerate. Max one retry. If no preview route exists for this surface yet, skip — validator runs after the Captain promotes.
+5. **Land.** The component file is in place. Report to the Captain: file path, how to preview (the venture's dev command → `/design-preview/<surface>`), and anything you iterated on. Done.
+
+**Iteration budget: 2 total** (initial + 1 retry). If the retry fails build or validator, stop. Do not polish on iteration 3. Surface the diagnostic (which check failed, why) and ask the Captain how to proceed.
+
+**No vision-critique loop in v1.** The Captain is the visual critic at gate 0. Chrome MCP screenshots, vision critique, reuse-check scripts — all deferred to Phase 2, added only if gate 0 surfaces quality problems the simple loop missed.
+
+## Preview route convention
+
+Each generated component must be previewable at `/design-preview/<surface>` in the venture's dev server. See [references/preview-route-pattern.md](references/preview-route-pattern.md) for the exact convention. Preview routes live in `src/pages/design-preview/` and are gated to `import.meta.env.DEV`, so they never serve in production. Fixture data co-located: `<surface>.fixture.json`.
+
+If a preview route for the requested surface doesn't exist yet, the skill creates it alongside the component. ~15 lines per preview route.
+
+## What you refuse
+
+- Generating a surface not covered by the current UX brief (refuse with a clear pointer to extending the brief)
+- Generating against a v<3 NAVIGATION.md (refuse with a pointer to `/nav-spec` v3)
+- Generating into a venture without DESIGN.md or discoverable @theme tokens
+- Generating a stack you don't have an adapter for
+- Modifying pages under `src/pages/` other than the preview routes (pages are hand-wired; you produce components)
+- Adding third-party runtime dependencies — you work with what's already in `package.json`
+
+## References
+
+- [prompt-assembly.md](references/prompt-assembly.md) — exact prompt structure and input ordering
+- [preview-route-pattern.md](references/preview-route-pattern.md) — how to wire a surface for preview
+- [adapters/astro-component.md](adapters/astro-component.md) — Astro + Tailwind v4 adapter template
+- **Reused, read-only:**
+  - `~/.agents/skills/nav-spec/validate.py` — structural validator
+  - `~/.agents/skills/nav-spec/references/injection-snippet-template.md` — nav-contract block template
+
+## Related skills
+
+- `design-brief` — PRD → design charter (upstream)
+- `nav-spec` — IA + patterns + chrome authority (sibling; structural authority)
+- `ux-brief` — three-reviewer surface-level UX brief (upstream)
+
+## Known limits (v1)
+
+- Astro adapter only. Next.js adapter lands in Phase 2 (KE/DC).
+- No vision-critique. Captain visually reviews via the venture's dev command.
+- No batch parallelism. Surfaces in a `--set` generate serially; whole batch must fit within one Claude Code session (Max plan billing).
+- No feedback-log. Git history is the log.
+- No cross-venture consistency analysis. Each product is itself.
+"""

--- a/.gemini/commands/save-lesson.toml
+++ b/.gemini/commands/save-lesson.toml
@@ -1,0 +1,32 @@
+description = "Capture Session Lesson"
+
+prompt = """
+
+Capture a memoryable lesson or anti-pattern from the current session into the enterprise memory system. Agent drafts frontmatter and body from session context; Captain confirms before the note is written.
+
+## Usage
+
+```
+/save-lesson [optional one-line summary]
+```
+
+If a summary is omitted, the agent drafts one from recent session context.
+
+## What it does
+
+1. Infers `kind` (lesson vs anti-pattern), `scope`, and `applies_when` from session context.
+2. Drafts a 1-2 sentence body and shows it to you for confirmation.
+3. Applies the 3 memoryability tests (actionable, non-obvious, general enough to recur).
+4. Saves to VCMS with `status: draft, captain_approved: false`.
+5. Reports the saved note ID.
+
+Draft memories become injection-eligible only after Captain approval via `/memory-audit` or `crane_memory(update)`. For immediate `captain_approved: true` capture, use the "Memoryable moments?" step in `/eos`.
+
+## Examples
+
+```
+/save-lesson
+/save-lesson "parallel agents writing to the same branch collide — always use worktrees"
+/save-lesson "never run infisical secrets -o json — it dumps plaintext values into the transcript"
+```
+"""

--- a/.gemini/commands/skill-audit.toml
+++ b/.gemini/commands/skill-audit.toml
@@ -1,0 +1,53 @@
+description = "---"
+
+prompt = """
+name: skill-audit
+description: Monthly skill health report. Audits all SKILL.md files for schema gaps, staleness, and deprecation queue status.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-audit - Monthly Skill Health Report
+
+Invoke the `crane_skill_audit` MCP tool and walk through the report.
+
+## How to run
+
+```
+/skill-audit
+```
+
+This command:
+
+1. Calls `crane_skill_audit()` with default parameters (`scope: all`, `stale_threshold_days: 180`, `include_deprecated: true`).
+2. Displays the structured report with sections for inventory, schema gaps, staleness, and the deprecation queue.
+3. Prompts you to review any flagged items.
+4. Records completion via `crane_schedule(action: "complete", name: "skill-audit", ...)`.
+
+## What to expect
+
+The report contains four sections:
+
+- **Inventory** - Total skills by scope, status, and owner.
+- **Schema gaps** - Skills missing required frontmatter fields. Each entry shows which fields are missing.
+- **Staleness** - Skills not touched in git for more than 180 days, sorted worst-first.
+- **Deprecation queue** - Skills with `status: deprecated`, sorted by days until sunset.
+
+Reference drift checking (broken MCP tool / file / command references) is not included here. Run `/skill-review --all` separately for that.
+
+## Options
+
+You can customize the audit:
+
+```
+crane_skill_audit(scope: "enterprise")          # enterprise skills only
+crane_skill_audit(stale_threshold_days: 90)     # tighter staleness window
+crane_skill_audit(include_deprecated: false)    # exclude deprecated from counts
+```
+
+## Full workflow
+
+See `.agents/skills/skill-audit/SKILL.md` for the complete step-by-step workflow including how to act on each report section and record completion.
+"""

--- a/.gemini/commands/skill-deprecate.toml
+++ b/.gemini/commands/skill-deprecate.toml
@@ -1,0 +1,32 @@
+description = "---"
+
+prompt = """
+name: skill-deprecate
+description: Captain-gated flow to mark a skill as deprecated. Bumps frontmatter, injects a sunset banner, logs to docs/skills/deprecated.md, and opens a PR. Does not delete the skill.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-deprecate
+
+Captain-gated skill sunset flow. Marks a skill as deprecated, injects a warning banner, logs it to `docs/skills/deprecated.md`, and opens a PR for review. Does not delete the skill.
+
+## Usage
+
+```
+/skill-deprecate <skill-name> [--reason "..."] [--migration "..."]
+```
+
+## Execution
+
+Follow the full skill specification at `.agents/skills/skill-deprecate/SKILL.md`.
+
+Key points:
+
+- Requires explicit Captain confirmation in chat before any changes are made
+- Fails fast if the skill does not exist or is already deprecated
+- 90-day grace period: the skill stays invocable until a separate removal PR
+- Never merges automatically
+"""

--- a/.gemini/commands/skill-review.toml
+++ b/.gemini/commands/skill-review.toml
@@ -1,0 +1,75 @@
+description = "---"
+
+prompt = """
+name: skill-review
+description: Lint a skill or the entire repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+---
+
+# /skill-review
+
+Lint a skill directory or all skills against the schema in `docs/skills/governance.md`.
+
+## Usage
+
+```
+/skill-review [skill-name] [--strict]
+```
+
+- `/skill-review` - review all skills in advisory mode (always exits 0)
+- `/skill-review sos` - review the `sos` skill only
+- `/skill-review --strict` - review all skills, exit 1 on errors
+- `/skill-review sos --strict` - review `sos`, exit 1 on errors
+
+## What the Agent Does
+
+When you invoke `/skill-review`, the agent runs:
+
+```bash
+# Single skill
+npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
+
+# All skills
+npm run skill-review -w @venturecrane/crane-mcp -- --all [--strict] [--json]
+```
+
+The CLI builds from TypeScript, runs all five checks against each `SKILL.md`, then prints a human-readable report (or JSON with `--json`).
+
+## Output
+
+Human-readable (default):
+
+```
+Reviewed 12 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" not found on PATH
+  Fix: Install "jq" or remove it from depends_on.commands if it is optional.
+```
+
+JSON (with `--json`):
+
+```json
+{
+  "skills_reviewed": 12,
+  "total_violations": 2,
+  "by_severity": { "error": 1, "warning": 1, "info": 0 },
+  "violations": [...]
+}
+```
+
+## Exit Codes
+
+- Default (advisory): always exits 0
+- `--strict`: exits 1 if any `error`-severity violations are found
+
+## Reference
+
+Full governance spec and rule definitions: `docs/skills/governance.md`
+
+CLI source: `packages/crane-mcp/src/cli/skill-review.ts`
+"""

--- a/.gemini/commands/status.toml
+++ b/.gemini/commands/status.toml
@@ -1,0 +1,81 @@
+description = "Show Session Status"
+
+prompt = """
+
+Display current session state, tasks, and git status for situational awareness.
+
+## What to Show
+
+### 1. Session Information
+
+Query crane-context for current session (if available):
+
+- Session ID
+- Session age (how long since /sos)
+- Last heartbeat time
+- Venture context
+
+If no session exists, note: "No active session. Run /sos to start."
+
+### 2. Active Tasks
+
+Use TaskList to show current task state:
+
+- Pending tasks (not started)
+- In-progress tasks (being worked on)
+- Recently completed tasks
+
+### 3. Git Status
+
+Show current repository state:
+
+- Current branch
+- Uncommitted changes (staged and unstaged)
+- Commits ahead/behind remote
+
+### 4. Context Summary
+
+- Current working directory
+- Repository name
+- Machine name (hostname)
+
+## Output Format
+
+```
+== Session Status ==
+Session: [ID or "None"]
+Age: [duration or "N/A"]
+Venture: [venture name or "Unknown"]
+
+== Tasks ==
+In Progress: [count]
+  - [task subject]
+Pending: [count]
+  - [task subject]
+Completed (recent): [count]
+
+== Git ==
+Branch: [branch name]
+Changes: [staged] staged, [unstaged] unstaged
+Remote: [ahead/behind status]
+
+== Context ==
+Repo: [repo name]
+Dir: [current directory]
+Machine: [hostname]
+```
+
+## Implementation Steps
+
+1. Check for active session by querying crane-context /session endpoint
+2. Call TaskList to get task state
+3. Run `git status --porcelain` and `git branch -vv` for git info
+4. Get hostname and current directory from environment
+5. Format and display results
+
+## Notes
+
+- This is a read-only status check - it should not modify anything
+- If crane-context is unavailable, show what information is available locally
+- Keep output concise and scannable
+"""

--- a/.gemini/commands/ui-drift-audit.toml
+++ b/.gemini/commands/ui-drift-audit.toml
@@ -1,0 +1,37 @@
+description = "---"
+
+prompt = """
+name: ui-drift-audit
+description: Source-level UI drift audit. Counts visual-design anti-patterns (pills, typography, spacing, headings, primary CTAs, redundancy, token-compliance) across .astro/.tsx/.jsx files and emits a markdown matrix or JSON.
+version: 2.1.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /ui-drift-audit - Visual drift audit
+
+Run a source-level audit of the venture's UI code and produce a per-file violation matrix. Use to seed pattern-spec citations, size remediation PRs, or gate token-compliance in CI.
+
+See `.agents/skills/ui-drift-audit/SKILL.md` for the full rule mapping, output schemas, and per-venture configuration via `.ui-drift.json`.
+
+## Quick start
+
+```bash
+# Markdown report (default)
+python3 .agents/skills/ui-drift-audit/audit.py
+
+# JSON report for CI threshold gates
+python3 .agents/skills/ui-drift-audit/audit.py --format json --out audit.json
+
+# Custom status words for redundancy detection
+python3 .agents/skills/ui-drift-audit/audit.py --status-words "Pending,Approved,Draft"
+```
+
+## When to invoke
+
+- Before authoring or revising a venture's pattern spec.
+- Before sizing a Rule-class remediation PR (count > 30 → split by component family).
+- Monthly as a drift watchdog.
+- In CI on every PR — see `docs/design-system/adoption/audit-workflow.yml.template`.
+"""

--- a/.gemini/commands/update.toml
+++ b/.gemini/commands/update.toml
@@ -1,0 +1,200 @@
+description = "Update Session Context"
+
+prompt = """
+
+Update your session with current branch, commit, and work metadata.
+
+## What It Does
+
+1. Finds your active session from Context Worker
+2. Auto-detects current git branch and commit
+3. Updates session with current work context
+4. Refreshes heartbeat (keeps session alive)
+5. Provides visibility: "Agent X is on branch Y working on issue #123"
+
+## When to Use
+
+- Started working on a new issue
+- Switched branches
+- Made significant progress (checkpoint)
+- Want to update team visibility
+
+**Tip:** Call this when you start work on an issue and after major milestones.
+
+## Usage
+
+```bash
+# Auto-detect branch/commit
+/update
+
+# With issue number
+/update 123
+
+# With custom metadata
+/update --meta '{"issue": 123, "priority": "P0"}'
+```
+
+## Execution Steps
+
+### 1. Find Active Session
+
+```bash
+# Get current repo
+REPO=$(git remote get-url origin 2>/dev/null | sed -E 's/.*github\.com[:\/]([^\/]+\/[^\/]+)(\.git)?$/\1/')
+
+if [ -z "$REPO" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Determine venture from repo org
+ORG=$(echo "$REPO" | cut -d'/' -f1)
+case "$ORG" in
+  durganfieldguide) VENTURE="dfg" ;;
+  siliconcrane) VENTURE="sc" ;;
+  venturecrane) VENTURE="vc" ;;
+  *)
+    echo "❌ Unknown venture for org: $ORG"
+    exit 1
+    ;;
+esac
+
+# Check for CRANE_CONTEXT_KEY
+if [ -z "$CRANE_CONTEXT_KEY" ]; then
+  echo "❌ CRANE_CONTEXT_KEY not set"
+  echo ""
+  echo "Export the key:"
+  echo "  export CRANE_CONTEXT_KEY=\"your-key-here\""
+  exit 1
+fi
+
+# Detect CLI client (matches sod-universal.sh logic)
+CLIENT="universal-cli"
+if [ -n "$GEMINI_CLI_VERSION" ]; then
+  CLIENT="gemini-cli"
+elif [ -n "$CLAUDE_CLI_VERSION" ]; then
+  CLIENT="claude-cli"
+elif [ -n "$CODEX_CLI_VERSION" ]; then
+  CLIENT="codex-cli"
+fi
+AGENT_PREFIX="$CLIENT-$(hostname)"
+
+# Query Context Worker for active sessions
+ACTIVE_SESSIONS=$(curl -sS "https://crane-context.automation-ab6.workers.dev/active?agent=$AGENT_PREFIX&venture=$VENTURE&repo=$REPO" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY")
+
+# Extract session ID for this agent
+SESSION_ID=$(echo "$ACTIVE_SESSIONS" | jq -r --arg agent "$AGENT_PREFIX" \
+  '.sessions[] | select(.agent | startswith($agent)) | .id' | head -1)
+
+if [ -z "$SESSION_ID" ]; then
+  echo "❌ No active session found"
+  echo ""
+  echo "Run /sos first to start a session"
+  exit 1
+fi
+```
+
+### 2. Detect Current Work Context
+
+```bash
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null)
+
+# Get current commit
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+
+# Parse arguments for issue number or metadata
+ISSUE_NUMBER=""
+META_JSON=""
+
+# If first arg is a number, it's an issue
+if [[ "$1" =~ ^[0-9]+$ ]]; then
+  ISSUE_NUMBER="$1"
+  META_JSON=$(jq -n --argjson issue "$ISSUE_NUMBER" '{issue: $issue}')
+fi
+
+# If --meta flag provided, use that
+if [[ "$1" == "--meta" && -n "$2" ]]; then
+  META_JSON="$2"
+fi
+
+echo "## 📝 Updating Session"
+echo ""
+echo "Session: $SESSION_ID"
+echo "Branch: $BRANCH"
+echo "Commit: $COMMIT"
+if [ -n "$ISSUE_NUMBER" ]; then
+  echo "Issue: #$ISSUE_NUMBER"
+fi
+echo ""
+```
+
+### 3. Build Update Request
+
+```bash
+# Build request body with current context
+REQUEST_BODY=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg branch "$BRANCH" \
+  --arg commit "$COMMIT" \
+  --argjson meta "${META_JSON:-null}" \
+  '{
+    session_id: $session_id,
+    branch: $branch,
+    commit_sha: $commit
+  } + (if $meta != null then {meta: $meta} else {} end)')
+```
+
+### 4. Call Context Worker /update
+
+```bash
+# Call API
+RESPONSE=$(curl -sS "https://crane-context.automation-ab6.workers.dev/update" \
+  -H "X-Relay-Key: $CRANE_CONTEXT_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "$REQUEST_BODY")
+
+# Check for errors
+ERROR=$(echo "$RESPONSE" | jq -r '.error // empty')
+if [ -n "$ERROR" ]; then
+  echo "❌ Update failed"
+  echo ""
+  echo "Error: $ERROR"
+  exit 1
+fi
+```
+
+### 5. Display Results
+
+```bash
+UPDATED_AT=$(echo "$RESPONSE" | jq -r '.updated_at')
+NEXT_HEARTBEAT=$(echo "$RESPONSE" | jq -r '.next_heartbeat_at')
+INTERVAL=$(echo "$RESPONSE" | jq -r '.heartbeat_interval_seconds')
+
+# Convert to human readable
+MINUTES=$((INTERVAL / 60))
+
+echo "✅ Session updated"
+echo ""
+echo "Updated at: $UPDATED_AT"
+echo "Next heartbeat: ~$MINUTES minutes"
+echo ""
+echo "Your session context is now visible to other agents."
+```
+
+## What Gets Updated
+
+- `branch`, `commit_sha`, `last_heartbeat_at` (always)
+- `meta` (optional freeform JSON: issue, priority, tags, etc.)
+- Venture, repo, track are set at session creation (not updated)
+
+## Notes
+
+- Auto-detects git branch and commit
+- Requires active session (run `/sos` first) and CRANE_CONTEXT_KEY
+- Refreshes heartbeat (prevents timeout)
+- Safe to call frequently
+- The `meta` field is freeform JSON - use it for whatever context helps your workflow
+"""

--- a/.gemini/commands/ux-brief.toml
+++ b/.gemini/commands/ux-brief.toml
@@ -1,0 +1,350 @@
+description = "UX Brief Authoring"
+
+prompt = """
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ux-brief")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+> **Design system context.** Before Phase 1 intake — and certainly before drafting v1 — load the cross-venture pattern + component catalog. Concept proposals (timeline / archive / action-centric, etc.) and chrome decisions in the brief should anchor on the loaded catalog or explicitly note the divergence:
+>
+> - `crane_doc('global', 'design-system/patterns/index.md')`
+> - `crane_doc('global', 'design-system/components/index.md')`
+>
+> Then load the venture's `design-spec.md` for venture-specific palette and tone. Anti-patterns the brief calls out should reconcile with Patterns 1–8 (status display by context, redundancy ban, button hierarchy, etc.) — those are enterprise-canonical and the brief should not contradict them silently.
+
+Produces a production-grade UX brief through a three-reviewer iteration (product, design, customer persona). When the brief is approved, the skill stops. To realize the brief into screens, run `/product-design`.
+
+## Arguments
+
+```
+/ux-brief [target] [--rounds=3]
+```
+
+- `target` — short name of the surface being designed (e.g., `client-portal`, `signup-flow`, `admin-inbox`). Required. Used for artifact file names.
+- `rounds` — brief review rounds (default **3**). Each round spawns three parallel reviewers; output is synthesized between rounds. Fewer than 3 is not recommended.
+
+Parse the arguments. If `target` is missing, stop and ask the user what surface they want to brief.
+
+## The methodology, in one paragraph
+
+This skill exists because a UX brief handed to a downstream design tool fails in predictable ways: the objectives are pretty but unmeasurable, the tokens are described in vibes instead of hex, the concepts all collapse into card-grid variations, and the generated output comes back padded with marketing chrome. This skill fixes each of those by running the brief through a critical three-reviewer pass (one of them a named customer who talks back), forcing structural divergence in the concept brief ("timeline vs archive vs action-centric, not three visual variations of the same layout"), and hardening every decision before generation begins. The final brief is a self-contained specification that downstream tools (e.g., `/product-design`) read to realize the screens — every step has a learning embedded, and the skill is the accumulated scar tissue of running this end-to-end.
+
+## Phases
+
+1. Intake — establish target, scope, existing context
+2. Draft brief v1
+3. Three-reviewer passes with synthesis
+4. Decision checkpoints — resolve open questions surfaced by reviewers
+5. Final brief, user-approved, saved to `.design/<target>-ux-brief.md`
+
+Each phase ends with a checkpoint. The user can stop at any checkpoint. Do not skip phases.
+
+---
+
+## Phase 1 — Intake
+
+Ask the user these questions if they aren't already answered by the conversation:
+
+1. **Target surface.** What surface are we designing? (e.g., "client portal home dashboard + invoice and proposal deep-link landings").
+2. **Authentication context.** Is the user logged in? Prospect? Public-web visitor? This shapes the "no marketing chrome" framing.
+3. **Customer persona seed.** Give me a realistic archetype — named if possible. Role, revenue range, tech comfort, what they care about. If the user hasn't thought about this, offer to draft one and confirm.
+4. **Any existing brief, PRD, or prior design** to build on? Check for `docs/pm/prd.md`, `docs/design/*`, `.design/*-ux-brief.md`, or a prior version of the target.
+
+Scan the repo for context:
+
+- `CLAUDE.md` for venture positioning / tone rules
+- `src/styles/globals.css` or `**/globals.css` for design tokens (hex values, type families)
+- `tailwind.config.*` for palette and type scale
+- Existing page at the target path (e.g., `src/pages/portal/*.astro`) for current data model and surface structure
+- `.design/DESIGN.md` if present (established design system for the venture)
+- `.design/NAVIGATION.md` if present (navigation specification). If absent, warn: "Consider running `/nav-spec` first — briefs produce more consistent results when navigation is spec'd." Proceed without; briefs still have value. When present and `spec-version >= 3`, each concept must include `task=` and `pattern=` tags per-screen (sourced from the spec's task model in §1 and pattern catalog in §4).
+
+Display an **Intake Summary** table:
+
+| Field          | Value                                         |
+| -------------- | --------------------------------------------- |
+| Target         | _e.g., `client-portal`_                       |
+| Authentication | _logged-in / prospect / public_               |
+| Persona        | _e.g., Mike Delgado, 52, plumbing HVAC owner_ |
+| Prior brief    | _path or "none"_                              |
+| Tokens source  | _path to globals.css or config_               |
+| Nav spec       | _spec-version N or "absent"_                  |
+| Venture code   | _resolved from `crane_ventures`_              |
+
+Present the table and ask: **"Does this capture the intake? Anything to correct before I draft?"**
+
+Wait for confirmation.
+
+---
+
+## Phase 2 — Draft v1
+
+Write a v1 brief to `.design/<target>-ux-brief.md` (create the directory if needed). Use this structure:
+
+```markdown
+# <Title> — UX Redesign Brief (v1)
+
+## Context
+
+<2-4 paragraphs: venture positioning, what this surface is for, why we're redesigning>
+
+## Scope
+
+<surfaces + viewports to be designed>
+
+## Visit modes
+
+<5-ish modes: action responder, status checker, etc. Be specific to this surface>
+
+## Objectives, ranked
+
+1. ... 2. ... 3. ... 4. ... 5. ...
+
+## Entry points (with email context)
+
+<each entry point, with the subject line and CTA from the email that triggers it>
+
+## Design principles
+
+<3-5 principles that constrain generation without dictating layout>
+
+## Three concepts requested (structurally distinct, not visual variations)
+
+A — <axis>
+B — <axis>
+C — <axis>
+
+## Worked example (fidelity reference)
+
+<one concept × one surface × one viewport, with inline type specs>
+
+## Above-fold specs for B and C
+
+<matching A's format>
+
+## What must be preserved
+
+<typography, palette, shape, voice>
+
+## What is open
+
+<layout, hierarchy, flow — full creative freedom>
+
+## Anti-patterns (do not produce)
+
+<bullet list of explicit no-gos>
+
+## Mobile spec
+
+<390×844, thumb zone, tap target, no hover, no horizontal scroll>
+
+## Desktop spec
+
+<1280px, right-rail placement, eye-level action>
+
+## Contact affordance spec
+
+<primary channel, fallback, SLA — operational commitment, not copy>
+
+## Copy samples (tone calibration)
+
+<5-6 lines showing the voice in concrete context>
+
+## Error states (must design)
+
+<per-surface error list — each includes named human + next step>
+
+## Activity timeline schema
+
+<if the surface has time-series data, define the event shape>
+
+## Money rule
+
+<dollar figures only, never bars or percentages, if applicable>
+
+## Photo placeholder rule
+
+<harder than "neutral placeholder" — use initials-in-circle or solid shape; never real faces>
+
+## Accessibility floor
+
+<WCAG 2.2 AA, focus rings with hex, landmarks, tap targets>
+
+## Success criteria
+
+**Primary acceptance test:** <one measurable design constraint — e.g., "on 390×844, [Pay invoice] button top edge at y ≤ 700px, no scroll">
+
+Secondary: <2-4 testable criteria>
+
+## Follow-ups (scheduled, not gaps)
+
+<real priorities scheduled after this pass, each with a target window>
+
+## Data available
+
+<data fields the design can use; ask for flag if design needs data we don't capture>
+
+## Constraints
+
+<stack, viewports, scope limits>
+
+## Approver
+
+<name — output reviewed before any iteration>
+
+## Appendix: Hard design tokens
+
+### Color
+
+<hex block — use exact values from globals.css or tailwind config>
+
+### Typography
+
+<family, weights, sizes, line-heights, tracking>
+
+### Spacing and shape
+
+<rounded, padding, rhythm, tap target, breakpoints>
+```
+
+Write the brief. Then present the draft to the user and proceed to Phase 3.
+
+---
+
+## Phase 3 — Three-reviewer passes
+
+Run `TOTAL_ROUNDS` iterations. Each iteration spawns three parallel agents via the Task tool using `subagent_type: general-purpose`. The three reviewers are:
+
+### Product manager reviewer
+
+**Role prompt preamble:**
+
+> You are a senior product manager at a [venture type] firm. You review UX briefs for client-facing surfaces. You are direct, critical, and do not validate work you find weak.
+
+**Focus:**
+
+- Are user objectives correctly framed and ranked?
+- Are lifecycle states complete? What failure states are missing (declined, paused, expired, disputed, cancelled, overdue)?
+- Are success criteria measurable? Name the primary metric.
+- Is scope bounded for a realistic first pass?
+- Does the data inventory match what the design is being asked to do?
+- Business logic edge cases: multi-contact reality, partial payments, SOW revisions, out-of-portal artifacts
+- Is "reach a human" spec'd as an affordance or left as a phrase?
+- Are empty/error states required? Accessibility floor? Approver named?
+
+### UX designer reviewer
+
+**Role prompt preamble:**
+
+> You are a senior UX designer with deep experience using AI code generators — v0, Magic Patterns, Figma Make, in-house skills like `/product-design`. You know what makes them produce generic output vs considered work.
+
+**Focus:**
+
+- Are design tokens described precisely enough? Vague tokens ("muted violet") produce inconsistent results. Require hex.
+- Is mobile-first a slogan or a constraint? Specific viewport, thumb zone, tap targets, no-hover rules.
+- Will three runs produce structurally distinct concepts, or three visual variations of the same layout? Commission structural divergence with explicit axis names.
+- Is information hierarchy clear? What dominates, what recedes?
+- Are anti-patterns named? Are placeholder instructions strong enough to prevent real-face drift?
+- Predict what a generation tool will produce as-is, including what's likely to go wrong.
+
+### Customer persona reviewer
+
+**Role prompt preamble (customize per surface):**
+
+> You are <NAME>, <AGE>. You own <BUSINESS>. <BACKGROUND: years, team, revenue>. You are not <disqualifying tech trait> but you run a real business with real software. <SPOUSE/PARTNER> handles <ROLE>. You just <TRIGGERING EVENT>. Someone handed you a document that describes people like you — how you use [target surface], what you need from it. Tell them if it sounds right. Call out patronizing language. Flag missing things they don't know about your actual life. Talk plainly. Swear if you want. Don't bullet-point at the top; talk first, then summarize.
+
+**Focus:**
+
+- Does this sound like real me, or like someone who's never talked to someone in my role?
+- What's patronizing? Soft? Over-explained?
+- What's missing about my actual life? (spouse access, SMS vs email, what I'd show my advisor)
+- What would I actually do on this surface vs what they think I'd do?
+
+**Persona discipline:**
+
+- Specific name, age, business details. "A business owner in the 30-55 age range" does not work. "Mike Delgado, 52, plumbing HVAC, 9 employees, $1.8M revenue, wife Elena does books" does.
+- Give the persona permission to push back on the brief's description of them. The most common persona finding: the brief describes the user in ways no user would recognize.
+
+### Round structure
+
+**Round 1:** Each reviewer critiques v1 from their role. Output format:
+
+```
+## Overall assessment
+[2-3 sentences, not diplomatic]
+
+## Critical issues (ranked)
+1. <issue + why it matters + specific fix>
+2. ...
+
+## Specific changes I'd make
+<concrete rewrites with proposed wording>
+
+## What's missing
+<things the brief does not address that it needs to>
+```
+
+Persona reviewer uses a different format — see their prompt above. They talk first, then summarize in three sections: got right / got wrong / still missing.
+
+**Between rounds:** Synthesize the feedback into a delta. Apply clear fixes directly to the brief. Surface disagreements or decisions that require user input as **open questions** — these become Phase 4 checkpoints.
+
+**Round 2:** Reviewers see v2 plus a summary of what changed from v1. They critique v2 specifically — what's still weak, what new issues emerged, what v2 got wrong in addressing Round 1 feedback.
+
+**Round 3:** Final polish pass. Reviewers are asked whether v3 is ready to ship. Format tightens to:
+
+```
+## Ready to ship? (Yes / Yes with caveats / No)
+## Any remaining critical issues?
+## Any last surgical edits?
+```
+
+**IMPORTANT**: All three reviewers in a round must be launched in a single Task tool message to run in parallel.
+
+---
+
+## Phase 4 — Decision checkpoints
+
+After each round, surface any decisions the reviewers flagged that require user judgment. Common examples:
+
+- An SLA promise in copy — is it an operational commitment or just marketing?
+- A user mode that was named but doesn't get its own surface — fold it into another mode, or design for it?
+- A concept that has an internal contradiction on a specific viewport — which way does it resolve?
+
+Present decisions as a short numbered list with your recommendation and rationale. Do NOT present 10 decisions — filter to the ones that will actually change the brief.
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 5 — Final brief saved
+
+Apply the last round's fixes and the user's decisions. Save the final brief to `.design/<target>-ux-brief.md`. Present the user a summary of:
+
+- Total rounds run
+- Major things that shifted v1 → final
+- Open decisions resolved
+
+Tell the user: **"Brief is complete. Run `/product-design` to realize the screens."**
+
+---
+
+## Embedded learnings
+
+1. **Personify the customer reviewer.** A named individual with real specifics produces sharper critique than a demographic. The persona should push back on the brief's description of them — that's usually where the brief is patronizing.
+
+2. **Structural divergence must be commissioned explicitly.** "Three structurally distinct concepts — timeline-centric, archive-centric, action-centric" works. "Three concepts" collapses into variations.
+
+3. **Tokens as hex, not vibes.** "Muted violet" is three different colors to three generation runs. Always include hex values from the venture's actual stylesheet.
+
+4. **Mobile-first as constraint, not slogan.** Specify viewport (390×844), thumb zone (bottom 40%), tap target (44px), no-hover rule, no-horizontal-scroll rule.
+
+5. **Anti-patterns need an affirmative frame.** "No nav tabs, no testimonials" is weaker than "This is an authenticated portal, not a marketing page. Chrome is strictly limited to what's listed below."
+
+6. **Placeholder instructions are weak.** "Neutral portrait placeholder" is routinely ignored. Either spec a solid shape ("solid indigo circle with initials") or a clearly abstract graphic ("geometric avatar, no face").
+
+---
+
+## Conventions
+
+- **Brief filename:** `.design/<target>-ux-brief.md`
+- **Versioning:** when iterating a target that already has a brief, move the prior version to `.design/<target>-ux-brief-v1.md` before overwriting.
+"""

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -15,8 +15,13 @@
     "skill-review",
     "skill-audit",
     "skill-creator",
+    "skill-deprecate",
     "own-it",
-    "auto-build"
+    "auto-build",
+    "go-live",
+    "status",
+    "update",
+    "heartbeat"
   ],
   "agent-team": [
     "build-log",
@@ -31,6 +36,9 @@
     "product-design",
     "react-components",
     "enhance-prompt",
-    "ui-drift-audit"
+    "ui-drift-audit",
+    "analytics",
+    "auth-setup",
+    "docs-refresh"
   ]
 }

--- a/scripts/sync-commands.sh
+++ b/scripts/sync-commands.sh
@@ -141,30 +141,15 @@ convert_to_toml() {
 
 # Convert a CC markdown command to Codex SKILL.md format.
 # Args: $1 = path to .claude/commands/{name}.md, $2 = output directory
+#
+# Delegates to scripts/sync-skill-md.mjs so SKILL.md governance frontmatter
+# (version, scope, owner, status, depends_on) and the crane_skill_invoked
+# invocation directive are preserved across regenerations. Inline bash
+# generation stripped them and broke the `review` CI gate.
 convert_to_skill() {
   local src="$1"
   local dst_dir="$2"
-  local skill_name
-  skill_name=$(basename "$src" .md)
-
-  mkdir -p "$dst_dir"
-
-  # Extract description from first non-empty line
-  local description
-  description=$(head -1 "$src" | sed 's/^# *//' | sed 's/^\/[a-z_-]* - //' | sed 's/^\/[a-z_-]* //')
-
-  # Get the full content
-  local content
-  content=$(cat "$src")
-
-  # Write SKILL.md with YAML frontmatter
-  {
-    printf -- '---\n'
-    printf 'name: %s\n' "$skill_name"
-    printf 'description: %s\n' "$description"
-    printf -- '---\n\n'
-    printf '%s\n' "$content"
-  } > "$dst_dir/SKILL.md"
+  node "$SCRIPT_DIR/sync-skill-md.mjs" "$src" "$dst_dir"
 }
 
 # ============================================================================

--- a/scripts/sync-skill-md.mjs
+++ b/scripts/sync-skill-md.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// Generate .agents/skills/<name>/SKILL.md from .claude/commands/<name>.md.
+//
+// The Claude Code dispatcher is the canonical body source. Governance
+// frontmatter (version, scope, owner, status, depends_on) lives in the
+// existing SKILL.md or — for new skills — defaults from config/skill-owners.json.
+//
+// This replaces the bash convert_to_skill in sync-commands.sh, which stripped
+// every governance field and broke the `review` CI gate.
+//
+// Behavior:
+//   - If the dispatcher has its own frontmatter, that wins for name/description
+//     and (if present) for version/scope/owner/status/depends_on too.
+//   - Otherwise, name + description come from the dispatcher's `# /<name> - desc`
+//     heading, and governance fields are preserved from the existing SKILL.md.
+//   - For brand-new skills (no existing SKILL.md and no dispatcher frontmatter):
+//     version 0.1.0, scope enterprise, status draft, owner from skill-owners.json
+//     (or the literal string "unowned" with a warning).
+//   - The body always carries the `> **Invocation:** ...` directive immediately
+//     after the `# /<name>` heading; injected if the dispatcher omits it.
+//
+// Usage: node scripts/sync-skill-md.mjs <dispatcher.md> <out-dir>
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs'
+import { dirname, basename, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '..')
+
+// Split a markdown file into its YAML frontmatter (between the first two `---`
+// fences) and the rest of the body. No regex — frontmatter shape is fixed.
+function splitFrontmatter(text) {
+  const lines = text.split('\n')
+  if (lines[0] !== '---') return { frontmatter: '', body: text }
+  let end = -1
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      end = i
+      break
+    }
+  }
+  if (end === -1) return { frontmatter: '', body: text }
+  const fm = lines.slice(1, end).join('\n')
+  // Body starts after the closing fence; preserve a single leading newline.
+  let bodyStart = end + 1
+  if (lines[bodyStart] === '') bodyStart++
+  return { frontmatter: fm, body: lines.slice(bodyStart).join('\n') }
+}
+
+// Read a top-level scalar (`key: value`) from the YAML block. Returns undefined
+// if absent. Multi-line scalars are not supported — none of our governance
+// fields use them.
+function readScalar(yaml, key) {
+  if (!yaml) return undefined
+  const prefix = `${key}:`
+  for (const raw of yaml.split('\n')) {
+    if (raw.startsWith(prefix)) {
+      return raw.slice(prefix.length).trim() || undefined
+    }
+  }
+  return undefined
+}
+
+// Set a top-level scalar in a YAML block. If absent, append. Preserves order
+// for existing keys.
+function setScalar(yaml, key, value) {
+  const prefix = `${key}:`
+  const newLine = `${key}: ${value}`
+  if (!yaml) return newLine
+  const lines = yaml.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith(prefix)) {
+      lines[i] = newLine
+      return lines.join('\n')
+    }
+  }
+  return `${yaml}\n${newLine}`
+}
+
+// Extract a multi-line block starting with `<key>:` and continuing through
+// indented or blank lines (covers nested mappings like `depends_on:`).
+function extractBlock(yaml, key) {
+  if (!yaml) return ''
+  const lines = yaml.split('\n')
+  const startLine = `${key}:`
+  let i = 0
+  while (i < lines.length && lines[i] !== startLine) i++
+  if (i === lines.length) return ''
+  const out = [lines[i]]
+  i++
+  while (
+    i < lines.length &&
+    (lines[i].startsWith(' ') || lines[i].startsWith('\t') || lines[i] === '')
+  ) {
+    out.push(lines[i])
+    i++
+  }
+  while (out.length > 1 && out[out.length - 1].trim() === '') out.pop()
+  return out.join('\n')
+}
+
+// Filter out the placeholder owner so the catalog can fill in.
+function pickOwner(value) {
+  if (!value) return undefined
+  if (value === 'unowned') return undefined
+  return value
+}
+
+function loadOwnerCatalog() {
+  const path = resolve(REPO_ROOT, 'config/skill-owners.json')
+  if (!existsSync(path)) return {}
+  const data = JSON.parse(readFileSync(path, 'utf8'))
+  const map = {}
+  for (const [team, skills] of Object.entries(data)) {
+    if (team.startsWith('_')) continue
+    if (!Array.isArray(skills)) continue
+    for (const s of skills) map[s] = team
+  }
+  return map
+}
+
+function deriveDescriptionFromBody(body, skillName) {
+  // First non-blank line that isn't the heading, blockquote, or code fence.
+  for (const raw of body.split('\n')) {
+    const line = raw.trim()
+    if (!line) continue
+    if (line.startsWith('#')) continue
+    if (line.startsWith('>')) continue
+    if (line.startsWith('```')) continue
+    return line.replace(/[*_`]+/g, '').trim()
+  }
+  return `Skill ${skillName}`
+}
+
+function buildInvocationDirective(skillName) {
+  return `> **Invocation:** As your first action, call \`crane_skill_invoked(skill_name: "${skillName}")\`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives \`/skill-audit\`.`
+}
+
+// Inject the invocation directive immediately after the `# /<name>` heading.
+// Locates the heading by line-prefix match (no regex on user input).
+function injectInvocationDirective(body, skillName) {
+  const headingPrefix = `# /${skillName}`
+  if (body.includes(`crane_skill_invoked(skill_name: "${skillName}")`)) return body
+
+  const directive = buildInvocationDirective(skillName)
+  const lines = body.split('\n')
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    if (line === headingPrefix || line.startsWith(`${headingPrefix} `)) {
+      lines.splice(i + 1, 0, '', directive)
+      return lines.join('\n')
+    }
+  }
+  // No matching heading — synthesize one and prepend.
+  return `# /${skillName}\n\n${directive}\n\n${body.replace(/^\n+/, '')}`
+}
+
+function generate(dispatcherPath, outDir) {
+  const skillName = basename(dispatcherPath, '.md')
+  const dispatcherText = readFileSync(dispatcherPath, 'utf8')
+  const { frontmatter: dispatcherFm, body: dispatcherBody } = splitFrontmatter(dispatcherText)
+
+  const skillPath = resolve(outDir, 'SKILL.md')
+  const skillExists = existsSync(skillPath)
+  const ownerCatalog = loadOwnerCatalog()
+
+  if (skillExists) {
+    // Patch the existing SKILL.md in place: preserve body and unknown
+    // frontmatter fields (allowed-tools, depends_on shape variants), update
+    // only the governance fields whose source of truth has changed.
+    const { frontmatter: existingFm, body: existingBody } = splitFrontmatter(
+      readFileSync(skillPath, 'utf8')
+    )
+
+    let fm = existingFm
+    fm = setScalar(fm, 'name', skillName)
+
+    // Description: dispatcher wins if it explicitly carries one. Otherwise
+    // keep what's there; if blank, fall back to a body-derived line.
+    const dispatcherDescription = readScalar(dispatcherFm, 'description')
+    if (dispatcherDescription) {
+      fm = setScalar(fm, 'description', dispatcherDescription)
+    } else if (!readScalar(fm, 'description')) {
+      fm = setScalar(fm, 'description', deriveDescriptionFromBody(existingBody, skillName))
+    }
+
+    // Owner: if existing is missing or "unowned", consult the catalog.
+    const currentOwner = pickOwner(readScalar(fm, 'owner'))
+    if (!currentOwner) {
+      const owner = ownerCatalog[skillName] || 'unowned'
+      fm = setScalar(fm, 'owner', owner)
+      if (owner === 'unowned') {
+        process.stderr.write(
+          `[sync-skill-md] WARNING: ${skillName} has no owner in config/skill-owners.json — emitting "unowned"\n`
+        )
+      }
+    }
+
+    // Inject the invocation directive into the body if it's missing.
+    const newBody = injectInvocationDirective(existingBody.replace(/^\n+/, ''), skillName)
+
+    let output = `---\n${fm}\n---\n\n${newBody}`
+    if (!output.endsWith('\n')) output += '\n'
+    writeFileSync(skillPath, output)
+    return
+  }
+
+  // New skill — synthesize a fresh SKILL.md with full default frontmatter.
+  const fields = {
+    name: skillName,
+    description:
+      readScalar(dispatcherFm, 'description') ||
+      deriveDescriptionFromBody(dispatcherBody, skillName),
+    version: readScalar(dispatcherFm, 'version') || '0.1.0',
+    scope: readScalar(dispatcherFm, 'scope') || 'enterprise',
+    owner: pickOwner(readScalar(dispatcherFm, 'owner')) || ownerCatalog[skillName] || 'unowned',
+    status: readScalar(dispatcherFm, 'status') || 'draft',
+  }
+
+  if (fields.owner === 'unowned') {
+    process.stderr.write(
+      `[sync-skill-md] WARNING: ${skillName} has no owner in config/skill-owners.json — emitting "unowned"\n`
+    )
+  }
+
+  const dependsOn = extractBlock(dispatcherFm, 'depends_on')
+
+  let fm = ''
+  for (const key of ['name', 'description', 'version', 'scope', 'owner', 'status']) {
+    fm = setScalar(fm, key, fields[key])
+  }
+  if (dependsOn) fm = `${fm}\n${dependsOn}`
+
+  const body = injectInvocationDirective(dispatcherBody.replace(/^\n+/, ''), skillName)
+
+  let output = `---\n${fm}\n---\n\n${body}`
+  if (!output.endsWith('\n')) output += '\n'
+
+  mkdirSync(outDir, { recursive: true })
+  writeFileSync(skillPath, output)
+}
+
+const [, , dispatcher, outDir] = process.argv
+if (!dispatcher || !outDir) {
+  process.stderr.write('Usage: node scripts/sync-skill-md.mjs <dispatcher.md> <out-dir>\n')
+  process.exit(2)
+}
+
+generate(dispatcher, outDir)


### PR DESCRIPTION
## Summary

The bash `convert_to_skill` in `scripts/sync-commands.sh` rewrote each `.agents/skills/<name>/SKILL.md` from scratch with only `name` and `description` in frontmatter — stripping the required `version`, `scope`, `owner`, `status`, and `depends_on` fields that the `review` CI gate enforces. It also broke for the three dispatchers that carry their own frontmatter (skill-audit, skill-review, ui-drift-audit), emitting `description: ---` lines.

Net effect: every regen produced SKILL.md files that failed governance, so the existing `chore/sync-enterprise-commands-artifacts-2026-04-27` branch couldn't merge, and PR #760 hit the same hazard mid-flight (had to manually restore SKILL.md to land that fix).

This PR closes both follow-ups in one shot.

## Approach

Replace the bash regenerator with `scripts/sync-skill-md.mjs`:

- **Existing SKILL.md** → patch frontmatter in place. Body stays verbatim. (Some skills like `/eos` have authored content beyond what the dispatcher carries — we don't destroy it.) Update `name` and, if the dispatcher carries one, `description`. Fill `owner` from `config/skill-owners.json` when the existing value is missing or `unowned`. Inject the `> **Invocation:** …` directive if absent.
- **New skill** (no SKILL.md yet) → synthesize fresh frontmatter: `version: 0.1.0`, `scope: enterprise`, `status: draft`, owner from the catalog (or `unowned` with a stderr warning).
- Parse YAML by line-by-line splitting — no dynamic `RegExp`, so semgrep's `detect-non-literal-regexp` doesn't block the script.

Add 8 missing skills (analytics, auth-setup, docs-refresh, go-live, heartbeat, status, update, skill-deprecate) to `config/skill-owners.json` so this regen produces valid governance.

## Artifacts in this PR

The script change is in two files; the rest are the natural regen output of running it once:

- `scripts/sync-skill-md.mjs` (new) — Node ESM generator
- `scripts/sync-commands.sh` — bash `convert_to_skill` now delegates to the Node script
- `config/skill-owners.json` — 8 new skill owner assignments
- `.agents/skills/{skill-audit,skill-review,ui-drift-audit}/SKILL.md` — description updates from their dispatcher frontmatter (the source of truth)
- 8 new `.agents/skills/<name>/SKILL.md` — analytics, auth-setup, docs-refresh, go-live, heartbeat, skill-deprecate, status, update (dispatchers exist on main but were never synced to SKILL.md)
- 16 new `.gemini/commands/*.toml` — same backlog of unsynced TOML outputs

## Verification

- `npm run skill-review -- --all --strict` → **0 errors** across 35 skills (4 warnings + 4 info, all pre-existing structural concerns unrelated to governance frontmatter)
- `npm run verify` → typecheck + lint + format + test all pass (424 + 8 + 25 + 2 tests)

## Test plan

- [ ] `review` CI gate passes (this is the gate that blocked previously)
- [ ] `Typecheck, Lint, Format, Test` passes
- [ ] After merge, the existing `chore/sync-enterprise-commands-artifacts-2026-04-27` branch becomes obsolete — close it
- [ ] Future `/code-review` skill edits can run `scripts/sync-commands.sh --generate-only` and the regen will produce valid SKILL.md files (no manual restore needed — fixes the trap that hit PR #760)

🤖 Generated with [Claude Code](https://claude.com/claude-code)