### PR TITLE
fix(schedule): accept display title or slug; surface canonical key on 404

### DIFF
--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -11,6 +11,121 @@ import { jsonResponse, errorResponse, validationErrorResponse, nowIso } from '..
 import { HTTP_STATUS } from '../constants'
 
 // ============================================================================
+// Resilient name resolution
+// ============================================================================
+//
+// The /sos briefing renders cadence items by display title (e.g. "Code Review
+// (ke)") while the API key is the slug ("code-review-ke"). Agents reading the
+// briefing reasonably guessed the display form and got 404s with no hint at
+// the canonical key, so completions were silently dropped. These helpers
+// accept either form and surface near-matches on a true miss.
+
+// The route splits `pathname.split('/')[2]` and passes it through unmodified,
+// so `Code Review (ke)` arrives URL-encoded as `Code%20Review%20(ke)`. We try
+// the raw form first (preserves behavior for slug callers) then the decoded
+// form (needed for callers that pass display titles with spaces or punctuation).
+function candidateNames(input: string): string[] {
+  const candidates = [input]
+  try {
+    const decoded = decodeURIComponent(input)
+    if (decoded !== input) candidates.push(decoded)
+  } catch {
+    // Malformed percent-encoding — fall back to raw input only.
+  }
+  return candidates
+}
+
+async function resolveScheduleItem<T = ScheduleItemRecord>(
+  env: Env,
+  input: string,
+  columns = '*'
+): Promise<{ canonicalName: string; record: T } | null> {
+  for (const candidate of candidateNames(input)) {
+    // Exact slug match first — the canonical case.
+    const bySlug = await env.DB.prepare(
+      `SELECT ${columns}, name AS __canonical_name FROM schedule_items WHERE name = ?1`
+    )
+      .bind(candidate)
+      .first<T & { __canonical_name: string }>()
+    if (bySlug) {
+      const { __canonical_name: canonicalName, ...rest } = bySlug
+      return { canonicalName, record: rest as unknown as T }
+    }
+
+    // Fall back to display title.
+    const byTitle = await env.DB.prepare(
+      `SELECT ${columns}, name AS __canonical_name FROM schedule_items WHERE title = ?1`
+    )
+      .bind(candidate)
+      .first<T & { __canonical_name: string }>()
+    if (byTitle) {
+      const { __canonical_name: canonicalName, ...rest } = byTitle
+      return { canonicalName, record: rest as unknown as T }
+    }
+  }
+
+  return null
+}
+
+async function suggestScheduleNames(env: Env, input: string, limit = 5): Promise<string[]> {
+  // Try the decoded form for substring matching when input is URL-encoded —
+  // otherwise "Code%20Review" never matches "Code Review (ke)".
+  let trimmed = input.trim()
+  try {
+    const decoded = decodeURIComponent(trimmed)
+    if (decoded !== trimmed) trimmed = decoded.trim()
+  } catch {
+    // Keep raw input.
+  }
+  if (!trimmed) return []
+
+  // Match either name or title that contains the input as a substring.
+  const pattern = `%${trimmed}%`
+  const matches = await env.DB.prepare(
+    `SELECT name, title FROM schedule_items
+     WHERE enabled = 1 AND (name LIKE ?1 OR title LIKE ?1)
+     ORDER BY priority ASC
+     LIMIT ?2`
+  )
+    .bind(pattern, limit)
+    .all<{ name: string; title: string }>()
+
+  if (matches.results && matches.results.length > 0) {
+    return matches.results.map((row) => row.name)
+  }
+
+  // No substring match — return the highest-priority items as a fallback so
+  // the caller at least sees what the registry contains.
+  const fallback = await env.DB.prepare(
+    `SELECT name FROM schedule_items
+     WHERE enabled = 1
+     ORDER BY priority ASC
+     LIMIT ?1`
+  )
+    .bind(limit)
+    .all<{ name: string }>()
+
+  return fallback.results?.map((row) => row.name) ?? []
+}
+
+function notFoundWithSuggestions(
+  input: string,
+  suggestions: string[],
+  correlationId: string
+): Response {
+  const suggestionText = suggestions.length > 0 ? `. Did you mean: ${suggestions.join(', ')}` : ''
+  return jsonResponse(
+    {
+      error: `Schedule item not found: ${input}${suggestionText}`,
+      correlation_id: correlationId,
+      available_names: suggestions,
+    },
+    HTTP_STATUS.NOT_FOUND,
+    correlationId
+  )
+}
+
+// ============================================================================
 // Request/Response Types
 // ============================================================================
 
@@ -265,18 +380,12 @@ export async function handleLinkScheduleCalendar(
   try {
     const body = (await request.json()) as LinkCalendarBody
 
-    // Find the schedule item by name
-    const existing = await env.DB.prepare('SELECT id FROM schedule_items WHERE name = ?1')
-      .bind(name)
-      .first<{ id: string }>()
-
-    if (!existing) {
-      return errorResponse(
-        `Schedule item not found: ${name}`,
-        HTTP_STATUS.NOT_FOUND,
-        context.correlationId
-      )
+    const resolved = await resolveScheduleItem<{ id: string }>(env, name, 'id')
+    if (!resolved) {
+      const suggestions = await suggestScheduleNames(env, name)
+      return notFoundWithSuggestions(name, suggestions, context.correlationId)
     }
+    const canonicalName = resolved.canonicalName
 
     const now = nowIso()
 
@@ -286,12 +395,12 @@ export async function handleLinkScheduleCalendar(
            updated_at = ?2
        WHERE name = ?3`
     )
-      .bind(body.gcal_event_id, now, name)
+      .bind(body.gcal_event_id, now, canonicalName)
       .run()
 
     return jsonResponse(
       {
-        name,
+        name: canonicalName,
         gcal_event_id: body.gcal_event_id,
         updated_at: now,
         correlation_id: context.correlationId,
@@ -337,20 +446,18 @@ export async function handleCompleteScheduleItem(
       )
     }
 
-    // Find the schedule item by name
-    const existing = await env.DB.prepare(
-      'SELECT id, cadence_days, gcal_event_id FROM schedule_items WHERE name = ?1'
-    )
-      .bind(name)
-      .first<{ id: string; cadence_days: number; gcal_event_id: string | null }>()
+    const resolved = await resolveScheduleItem<{
+      id: string
+      cadence_days: number
+      gcal_event_id: string | null
+    }>(env, name, 'id, cadence_days, gcal_event_id')
 
-    if (!existing) {
-      return errorResponse(
-        `Schedule item not found: ${name}`,
-        HTTP_STATUS.NOT_FOUND,
-        context.correlationId
-      )
+    if (!resolved) {
+      const suggestions = await suggestScheduleNames(env, name)
+      return notFoundWithSuggestions(name, suggestions, context.correlationId)
     }
+    const canonicalName = resolved.canonicalName
+    const existing = resolved.record
 
     const now = nowIso()
 
@@ -369,7 +476,7 @@ export async function handleCompleteScheduleItem(
         body.result,
         body.summary || null,
         now,
-        name
+        canonicalName
       )
       .run()
 
@@ -380,7 +487,7 @@ export async function handleCompleteScheduleItem(
 
     return jsonResponse(
       {
-        name,
+        name: canonicalName,
         completed_at: now,
         result: body.result,
         gcal_event_id: existing.gcal_event_id,

--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -39,12 +39,12 @@ function candidateNames(input: string): string[] {
 // Tries each candidate (raw + URL-decoded) against `name` then `title`.
 async function resolveScheduleItem(env: Env, input: string): Promise<ScheduleItemRecord | null> {
   for (const candidate of candidateNames(input)) {
-    const bySlug = await env.DB.prepare('SELECT * FROM schedule_items WHERE name = ?1')
+    const bySlug = await env.DB.prepare('SELECT * FROM schedule_items WHERE name = ?')
       .bind(candidate)
       .first<ScheduleItemRecord>()
     if (bySlug) return bySlug
 
-    const byTitle = await env.DB.prepare('SELECT * FROM schedule_items WHERE title = ?1')
+    const byTitle = await env.DB.prepare('SELECT * FROM schedule_items WHERE title = ?')
       .bind(candidate)
       .first<ScheduleItemRecord>()
     if (byTitle) return byTitle
@@ -69,11 +69,11 @@ async function suggestScheduleNames(env: Env, input: string, limit = 5): Promise
   const pattern = `%${trimmed}%`
   const matches = await env.DB.prepare(
     `SELECT name, title FROM schedule_items
-     WHERE enabled = 1 AND (name LIKE ?1 OR title LIKE ?1)
+     WHERE enabled = 1 AND (name LIKE ? OR title LIKE ?)
      ORDER BY priority ASC
-     LIMIT ?2`
+     LIMIT ?`
   )
-    .bind(pattern, limit)
+    .bind(pattern, pattern, limit)
     .all<{ name: string; title: string }>()
 
   if (matches.results && matches.results.length > 0) {
@@ -86,7 +86,7 @@ async function suggestScheduleNames(env: Env, input: string, limit = 5): Promise
     `SELECT name FROM schedule_items
      WHERE enabled = 1
      ORDER BY priority ASC
-     LIMIT ?1`
+     LIMIT ?`
   )
     .bind(limit)
     .all<{ name: string }>()

--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -377,9 +377,9 @@ export async function handleLinkScheduleCalendar(
 
     await env.DB.prepare(
       `UPDATE schedule_items
-       SET gcal_event_id = ?1,
-           updated_at = ?2
-       WHERE name = ?3`
+       SET gcal_event_id = ?,
+           updated_at = ?
+       WHERE name = ?`
     )
       .bind(body.gcal_event_id, now, canonicalName)
       .run()
@@ -444,12 +444,12 @@ export async function handleCompleteScheduleItem(
 
     await env.DB.prepare(
       `UPDATE schedule_items
-       SET last_completed_at = ?1,
-           last_completed_by = ?2,
-           last_result = ?3,
-           last_result_summary = ?4,
-           updated_at = ?5
-       WHERE name = ?6`
+       SET last_completed_at = ?,
+           last_completed_by = ?,
+           last_result = ?,
+           last_result_summary = ?,
+           updated_at = ?
+       WHERE name = ?`
     )
       .bind(
         now,

--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -35,33 +35,22 @@ function candidateNames(input: string): string[] {
   return candidates
 }
 
-async function resolveScheduleItem<T = ScheduleItemRecord>(
+// Resolve a /schedule/:name path parameter to a canonical schedule_items row.
+// Tries each candidate (raw + URL-decoded) against `name` then `title`.
+async function resolveScheduleItem(
   env: Env,
-  input: string,
-  columns = '*'
-): Promise<{ canonicalName: string; record: T } | null> {
+  input: string
+): Promise<ScheduleItemRecord | null> {
   for (const candidate of candidateNames(input)) {
-    // Exact slug match first — the canonical case.
-    const bySlug = await env.DB.prepare(
-      `SELECT ${columns}, name AS __canonical_name FROM schedule_items WHERE name = ?1`
-    )
+    const bySlug = await env.DB.prepare('SELECT * FROM schedule_items WHERE name = ?1')
       .bind(candidate)
-      .first<T & { __canonical_name: string }>()
-    if (bySlug) {
-      const { __canonical_name: canonicalName, ...rest } = bySlug
-      return { canonicalName, record: rest as unknown as T }
-    }
+      .first<ScheduleItemRecord>()
+    if (bySlug) return bySlug
 
-    // Fall back to display title.
-    const byTitle = await env.DB.prepare(
-      `SELECT ${columns}, name AS __canonical_name FROM schedule_items WHERE title = ?1`
-    )
+    const byTitle = await env.DB.prepare('SELECT * FROM schedule_items WHERE title = ?1')
       .bind(candidate)
-      .first<T & { __canonical_name: string }>()
-    if (byTitle) {
-      const { __canonical_name: canonicalName, ...rest } = byTitle
-      return { canonicalName, record: rest as unknown as T }
-    }
+      .first<ScheduleItemRecord>()
+    if (byTitle) return byTitle
   }
 
   return null
@@ -380,12 +369,12 @@ export async function handleLinkScheduleCalendar(
   try {
     const body = (await request.json()) as LinkCalendarBody
 
-    const resolved = await resolveScheduleItem<{ id: string }>(env, name, 'id')
+    const resolved = await resolveScheduleItem(env, name)
     if (!resolved) {
       const suggestions = await suggestScheduleNames(env, name)
       return notFoundWithSuggestions(name, suggestions, context.correlationId)
     }
-    const canonicalName = resolved.canonicalName
+    const canonicalName = resolved.name
 
     const now = nowIso()
 
@@ -446,18 +435,13 @@ export async function handleCompleteScheduleItem(
       )
     }
 
-    const resolved = await resolveScheduleItem<{
-      id: string
-      cadence_days: number
-      gcal_event_id: string | null
-    }>(env, name, 'id, cadence_days, gcal_event_id')
-
+    const resolved = await resolveScheduleItem(env, name)
     if (!resolved) {
       const suggestions = await suggestScheduleNames(env, name)
       return notFoundWithSuggestions(name, suggestions, context.correlationId)
     }
-    const canonicalName = resolved.canonicalName
-    const existing = resolved.record
+    const canonicalName = resolved.name
+    const existing = resolved
 
     const now = nowIso()
 

--- a/workers/crane-context/src/endpoints/schedule.ts
+++ b/workers/crane-context/src/endpoints/schedule.ts
@@ -37,10 +37,7 @@ function candidateNames(input: string): string[] {
 
 // Resolve a /schedule/:name path parameter to a canonical schedule_items row.
 // Tries each candidate (raw + URL-decoded) against `name` then `title`.
-async function resolveScheduleItem(
-  env: Env,
-  input: string
-): Promise<ScheduleItemRecord | null> {
+async function resolveScheduleItem(env: Env, input: string): Promise<ScheduleItemRecord | null> {
   for (const candidate of candidateNames(input)) {
     const bySlug = await env.DB.prepare('SELECT * FROM schedule_items WHERE name = ?1')
       .bind(candidate)

--- a/workers/crane-context/test/harness/schedule.test.ts
+++ b/workers/crane-context/test/harness/schedule.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Harness Test: schedule completion accepts slug or display title
+ *
+ * #761 — the /sos briefing renders cadence items by display title (e.g.
+ * "Code Review (ke)") while the API key is the slug ("code-review-ke"). Agents
+ * reading the briefing reasonably guessed the display form and got 404s with
+ * no hint at the canonical key. Verify the endpoint now accepts either form
+ * and surfaces near-matches on a true miss.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  invoke,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import worker from '../../src/index'
+import type { Env } from '../../src/types'
+import type { D1Database } from '@cloudflare/workers-types'
+
+beforeAll(() => {
+  installWorkerdPolyfills()
+})
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, '..', '..', 'migrations')
+
+const headers = { 'X-Relay-Key': 'test-relay-key' }
+
+interface CompleteResponse {
+  name: string
+  result: string
+  completed_at: string
+  next_due_date: string
+  gcal_event_id: string | null
+  correlation_id: string
+}
+
+interface LinkCalendarResponse {
+  name: string
+  gcal_event_id: string | null
+  updated_at: string
+  correlation_id: string
+}
+
+interface NotFoundResponse {
+  error: string
+  available_names: string[]
+  correlation_id: string
+}
+
+describe('Schedule endpoints (via harness)', () => {
+  let db: D1Database
+  let env: Env
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    env = {
+      DB: db,
+      CONTEXT_RELAY_KEY: 'test-relay-key',
+      CONTEXT_ADMIN_KEY: 'test-admin-key',
+      CONTEXT_SESSION_STALE_MINUTES: '45',
+      IDEMPOTENCY_TTL_SECONDS: '3600',
+      HEARTBEAT_INTERVAL_SECONDS: '600',
+      HEARTBEAT_JITTER_SECONDS: '120',
+    }
+  })
+
+  describe('POST /schedule/:name/complete — name resolution', () => {
+    it('accepts the canonical slug', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: '/schedule/code-review-ke/complete',
+        headers,
+        body: { result: 'success', summary: 'test', completed_by: 'test-suite' },
+        env,
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as CompleteResponse
+      expect(body.name).toBe('code-review-ke')
+      expect(body.result).toBe('success')
+    })
+
+    it('accepts the display title and returns the canonical slug', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: `/schedule/${encodeURIComponent('Code Review (ke)')}/complete`,
+        headers,
+        body: { result: 'success', completed_by: 'test-suite' },
+        env,
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as CompleteResponse
+      // Caller passed the display form — response surfaces the canonical slug
+      // so they learn what to use next time.
+      expect(body.name).toBe('code-review-ke')
+    })
+
+    it('returns 404 with available_names suggestions on a true miss', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: '/schedule/code-review/complete',
+        headers,
+        body: { result: 'success', completed_by: 'test-suite' },
+        env,
+      })
+
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as NotFoundResponse
+      expect(body.error).toContain('Schedule item not found')
+      expect(body.error).toContain('Did you mean')
+      // The seed data has multiple code-review-* slugs; substring match should
+      // surface them.
+      expect(body.available_names).toEqual(
+        expect.arrayContaining(['code-review-vc', 'code-review-ke'])
+      )
+    })
+
+    it('returns 404 with a fallback list when nothing matches', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: '/schedule/totally-unknown-zzz/complete',
+        headers,
+        body: { result: 'success', completed_by: 'test-suite' },
+        env,
+      })
+
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as NotFoundResponse
+      // Nothing matches "totally-unknown-zzz"; suggester returns the
+      // highest-priority items so the caller at least sees the registry shape.
+      expect(body.available_names.length).toBeGreaterThan(0)
+    })
+
+    it('updates last_completed_at on the canonical row regardless of input form', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: `/schedule/${encodeURIComponent('Code Review (ke)')}/complete`,
+        headers,
+        body: { result: 'success', completed_by: 'display-test' },
+        env,
+      })
+      expect(res.status).toBe(200)
+
+      const row = await db
+        .prepare('SELECT name, last_completed_by, last_result FROM schedule_items WHERE name = ?1')
+        .bind('code-review-ke')
+        .first<{ name: string; last_completed_by: string; last_result: string }>()
+
+      expect(row?.name).toBe('code-review-ke')
+      expect(row?.last_completed_by).toBe('display-test')
+      expect(row?.last_result).toBe('success')
+    })
+  })
+
+  describe('POST /schedule/:name/link-calendar — name resolution', () => {
+    it('accepts the display title and updates the canonical row', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: `/schedule/${encodeURIComponent('Code Review (ke)')}/link-calendar`,
+        headers,
+        body: { gcal_event_id: 'event_test_123' },
+        env,
+      })
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as LinkCalendarResponse
+      expect(body.name).toBe('code-review-ke')
+      expect(body.gcal_event_id).toBe('event_test_123')
+    })
+
+    it('returns 404 with suggestions on miss', async () => {
+      const res = await invoke(worker, {
+        method: 'POST',
+        path: '/schedule/no-such-thing/link-calendar',
+        headers,
+        body: { gcal_event_id: null },
+        env,
+      })
+
+      expect(res.status).toBe(404)
+      const body = (await res.json()) as NotFoundResponse
+      expect(Array.isArray(body.available_names)).toBe(true)
+    })
+  })
+})

--- a/workers/crane-context/test/harness/schedule.test.ts
+++ b/workers/crane-context/test/harness/schedule.test.ts
@@ -150,7 +150,7 @@ describe('Schedule endpoints (via harness)', () => {
       expect(res.status).toBe(200)
 
       const row = await db
-        .prepare('SELECT name, last_completed_by, last_result FROM schedule_items WHERE name = ?1')
+        .prepare('SELECT name, last_completed_by, last_result FROM schedule_items WHERE name = ?')
         .bind('code-review-ke')
         .first<{ name: string; last_completed_by: string; last_result: string }>()
 


### PR DESCRIPTION
Closes #761.

## Summary

The `/sos` briefing renders cadence items by display title (e.g. \`Code Review (ke)\`) while `POST /schedule/:name/complete` only accepted the slug (\`code-review-ke\`). Agents reading the briefing reasonably guessed the display form and got 404s with no hint at the canonical key — completions were silently dropped. KE on 2026-04-27 hit exactly this: the review ran (handoff continuity confirmed it), but cadence stayed \`UNTRACKED\`.

## Approach

Make the lookup forgiving in both endpoints (`/complete` and `/link-calendar`):

- `resolveScheduleItem` tries raw input, then the URL-decoded form, against `name` first and `title` second. The response always returns the canonical slug so callers learn the right key for next time.
- On a true miss, `suggestScheduleNames` returns up to 5 substring matches, or the highest-priority items as a fallback when nothing matches the input. The 404 body includes them as `available_names` and a "Did you mean: …" hint in the error message — so a misnamed call self-corrects without round-tripping the user.
- The lookup decodes URL-encoded display titles (`Code%20Review%20(ke)` → `Code Review (ke)`) so the route handler doesn't need to change.

## Test coverage

7 new harness tests in `test/harness/schedule.test.ts`:

- canonical slug → 200, returns slug
- display title → 200, returns canonical slug
- partial substring miss → 404 with substring matches in `available_names`
- total miss → 404 with priority-ordered fallback list
- DB write lands on the canonical row regardless of input form
- `/link-calendar` parity for both display-title and miss paths

`npm run verify` → all 1127 tests pass.

## Test plan

- [ ] CI: `Typecheck, Lint, Format, Test` passes
- [ ] CI: `review` passes
- [ ] After merge, deploy `crane-context` worker so the production API picks up the new behavior
- [ ] Verify in a real session: `crane_schedule(action: "complete", name: "Code Review (ke)", ...)` returns 200 with `name: "code-review-ke"` in the response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)