### PR TITLE
feat(ss): wire client/engagement tier under SS venture

### DIFF
--- a/.claude/commands/new-client.md
+++ b/.claude/commands/new-client.md
@@ -1,0 +1,104 @@
+# /new-client - Set Up a New SS Client
+
+Adds a client entity under the SS venture. A client is the billing entity; engagements (the unit of work) live underneath.
+
+This is **wiring**, not process — no SOW, kickoff, lifecycle states, or templates. Just the registry and Infisical entries needed for `/new-engagement` to work for that client.
+
+## Prerequisites (one-time, manual)
+
+These must already be done before any client can be onboarded. See `docs/process/new-engagement-setup-checklist.md` for details:
+
+1. `smdservices-clients` GitHub org exists
+2. `smdservices-platform` GitHub App created and installed on the org
+3. `INFISICAL_MANAGEMENT_TOKEN` set as a secret on `crane-context` (staging + production), scoped to `/ss/clients/*`
+4. `smdservices-clients/engagement-template` repo exists with branch protection on `main` and CODEOWNERS pointing to Captain
+
+## Execution
+
+### Step 1: Gather information
+
+Ask the user for:
+
+- **Client slug** (kebab-case, regex `^[a-z][a-z0-9-]{1,31}$`, e.g., `acme`)
+- **Display name** (e.g., `Acme Co`)
+- **Client GitHub org** (optional override — leave blank unless the client wants their work in their own org)
+
+Confirm before proceeding.
+
+### Step 2: Verify uniqueness
+
+```bash
+jq -e ".ventures[] | select(.code == \"ss\") | .clients[]? | select(.slug == \"<slug>\")" config/ventures.json && echo "EXISTS"
+```
+
+If the client exists, abort.
+
+### Step 3: Append to ventures.json
+
+```bash
+cp config/ventures.json config/ventures.json.bak
+jq --arg slug "<slug>" --arg name "<displayName>" --arg org "<githubOrg-or-default>" '
+  (.ventures[] | select(.code == "ss") | .clients) += [{
+    "slug": $slug,
+    "displayName": $name,
+    "githubOrg": $org,
+    "infisicalPath": "/ss/clients/\($slug)",
+    "engagements": []
+  }]
+' config/ventures.json > config/ventures.json.tmp
+jq empty config/ventures.json.tmp || { mv config/ventures.json.bak config/ventures.json; exit 1; }
+mv config/ventures.json.tmp config/ventures.json
+rm -f config/ventures.json.bak
+```
+
+If the venture entry has no `clients` array yet, the jq above creates it via `+=` on null returning `null` — initialize first if needed:
+
+```bash
+jq '(.ventures[] | select(.code == "ss") | .clients) //= []' config/ventures.json > config/ventures.json.tmp && mv config/ventures.json.tmp config/ventures.json
+```
+
+### Step 4: Provision Infisical folder
+
+```bash
+curl -fsS -X POST "$CRANE_CONTEXT_URL/admin/provision-engagement" \
+  -H "X-Admin-Key: $CRANE_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"client_slug\":\"<slug>\"}"
+```
+
+Idempotent — existing folder returns success.
+
+### Step 5: Create local directory
+
+```bash
+mkdir -p ~/dev/ss/<slug>/
+```
+
+This is where engagements for this client will be cloned.
+
+### Step 6: Commit + redeploy
+
+```bash
+git add config/ventures.json
+git commit -m "chore(ss): add client <slug>"
+git push
+cd workers/crane-context && npm run deploy && npm run deploy:prod
+cd packages/crane-mcp && npm run build
+```
+
+The crane-context worker imports `ventures.json` at build time — redeploy is required for the new client to be visible to the worker. Rebuilding crane-mcp picks up the new client in the launcher's `INFISICAL_PATHS` map.
+
+### Step 7: Verify
+
+```bash
+crane --list  # Should show the new client (no engagements yet) under SS
+```
+
+The user can now run `/new-engagement <slug> <engagement-slug> "<name>"` to create the first engagement.
+
+## Reference Files
+
+- **ventures.json:** `config/ventures.json` (single source of truth)
+- **Provisioning endpoint:** `workers/crane-context/src/endpoints/admin-provision-engagement.ts`
+- **Engagement skill:** `.claude/commands/new-engagement.md`
+- **Setup checklist:** `docs/process/new-engagement-setup-checklist.md`

--- a/.claude/commands/new-engagement.md
+++ b/.claude/commands/new-engagement.md
@@ -1,0 +1,72 @@
+# /new-engagement - Set Up a New SS Engagement
+
+Creates a new engagement repo under an existing client and wires it into the launcher. An engagement is the unit of billable work for a client.
+
+This is **wiring**, not process — no SOW scaffolding, kickoff documents, status reporting cadence, or lifecycle states. The agent inside the engagement repo writes whatever the engagement actually needs.
+
+## Prerequisites
+
+The client must already exist. Run `/new-client <slug> "<name>"` first if needed.
+
+Manual one-time prereqs (`docs/process/new-engagement-setup-checklist.md`): `smdservices-clients` GitHub org exists, `smdservices-platform` GitHub App installed, `INFISICAL_MANAGEMENT_TOKEN` configured on `crane-context`, `engagement-template` repo exists with branch protection.
+
+## Execution
+
+### Step 1: Gather information
+
+Ask the user for:
+
+- **Client slug** (must already exist in `config/ventures.json` under SS clients)
+- **Engagement slug** (kebab-case, regex `^[a-z][a-z0-9-]{1,31}$`, unique within the client)
+- **Display name**
+
+Verify the client exists:
+
+```bash
+jq -e ".ventures[] | select(.code == \"ss\") | .clients[] | select(.slug == \"<client>\")" config/ventures.json
+```
+
+### Step 2: Run the setup script
+
+```bash
+./scripts/setup-new-engagement.sh <client-slug> <engagement-slug> "<display-name>"
+```
+
+**Dry run first** to preview what will happen:
+
+```bash
+DRY_RUN=true ./scripts/setup-new-engagement.sh <client-slug> <engagement-slug> "<display-name>"
+```
+
+The script handles, in order:
+
+1. Validation (args, client exists, slug uniqueness within client)
+2. **Infisical provisioning first** (folder creation via crane-context `/admin/provision-engagement`) — fails before any registry mutation if Infisical is down
+3. GitHub repo creation from `smdservices-clients/engagement-template` (or `<client.githubOrg>/engagement-template` for external-repo clients)
+4. ventures.json append (with backup + ERR trap rollback covering the rest of the script)
+5. Clone to `~/dev/ss/<client>/<engagement>/`
+6. Drop `.infisical.json` and `.claude/settings.json` (with `additionalDirectories` locked to the engagement path only)
+7. Commit + push initial scaffold
+8. Rebuild crane-mcp (so the launcher sees the new engagement)
+9. Redeploy crane-context (so the worker sees the new engagement)
+
+### Step 3: Verify
+
+```bash
+crane --list                              # Should show ss/<client>/<engagement>
+crane ss/<client>/<engagement> --debug    # Confirms launcher resolves and fetches secrets via crane-context proxy
+```
+
+If the agent doesn't launch, check:
+
+- `gh repo view smdservices-clients/<client>-<engagement>` — repo exists
+- `crane-context` deployed with the new ventures.json baked in
+- `INFISICAL_MANAGEMENT_TOKEN` set on the worker
+
+## Reference Files
+
+- **Setup script:** `scripts/setup-new-engagement.sh`
+- **Provisioning endpoints:** `workers/crane-context/src/endpoints/admin-provision-engagement.ts`
+- **Launcher dispatch:** `packages/crane-mcp/src/cli/launch-lib.ts` (search `parseEngagementArg`, `launchEngagement`)
+- **Setup checklist:** `docs/process/new-engagement-setup-checklist.md`
+- **Client skill:** `.claude/commands/new-client.md`

--- a/docs/process/new-engagement-setup-checklist.md
+++ b/docs/process/new-engagement-setup-checklist.md
@@ -1,0 +1,148 @@
+# SS Engagement Setup Checklist
+
+**Purpose:** One-time prerequisites for SS client/engagement wiring, plus the per-engagement runbook driven by `/new-engagement` and `scripts/setup-new-engagement.sh`.
+
+## One-Time Prerequisites (Captain action, manual)
+
+These must be in place before any `/new-client` or `/new-engagement` invocation will work end-to-end. Items 1-3 are GitHub side; 4 is Infisical; 5 is Cloudflare worker secrets.
+
+### 1. `smdservices-clients` GitHub organization
+
+- Create at https://github.com/organizations/new
+- Owner: smdurgan-llc personal account (matches the `venturecrane-github` App ownership pattern — keeps audit logs separate from `venturecrane/` portfolio repos)
+- All client engagement repos live here as `smdservices-clients/<client>-<engagement>` (private)
+
+### 2. `smdservices-platform` GitHub App
+
+A separate App from `venturecrane-github` (App ID 2619905). Rationale: privacy non-negotiable. A compromised PEM should not span venture infrastructure AND client code.
+
+- Create at https://github.com/settings/apps/new
+  - Owner: smdurgan-llc personal account
+  - Name: `smdservices-platform`
+  - Permissions (minimum):
+    - Contents: Read & write
+    - Metadata: Read
+    - Pull requests: Read & write
+    - Issues: Read & write
+  - Webhook: not required for v1
+- Install on `smdservices-clients` org only
+- Note the installation ID
+- Generate a PEM key, store in Infisical at `/ss/SMDSERVICES_PLATFORM_PEM`
+- Store the App ID in Infisical at `/ss/SMDSERVICES_PLATFORM_APP_ID`
+
+### 3. `smdservices-clients/engagement-template` repo
+
+This is the template `gh repo create --template` copies for every engagement.
+
+Create with:
+
+- Minimal contents:
+  - `.claude/` (empty directory committed via `.gitkeep`)
+  - `.infisical.json` (placeholder — overwritten by `setup-new-engagement.sh`)
+  - `.gitignore` (Node + macOS standards)
+  - `README.md` (one-line description)
+- Mark "Template repository" in repo settings
+- **Branch protection on `main`**:
+  - Require PR before merging
+  - Require linear history
+  - Restrict who can push (Captain only)
+- **CODEOWNERS** at `.github/CODEOWNERS`:
+  ```
+  *  @SMDurgan
+  ```
+
+> **Known limitation (out of scope for v1):** drift-sync to existing engagement repos is not implemented. Engagements created before a template change won't auto-pick-up new template content; they'd need a manual update PR. Acceptable given low template-churn expectation.
+
+### 4. Infisical management token
+
+The crane-context worker needs a token to create folders and proxy secret reads on behalf of the launcher. **Scope it tightly** — this is the highest-privilege token in the SS pipeline.
+
+- Generate at https://app.infisical.com/ → Project Settings → Access Control → Service Tokens
+- Project: SMDurgan ventures (workspace `2da2895e-aba2-4faf-a65a-b86e1a7aa2cb`)
+- Environment: `prod`
+- **Scope: `/ss/clients/*` only** — NOT project-wide. Child folders inherit access.
+- Permissions: Read + Write for secrets and folders within scope
+- **Rotation: quarterly.** Add a calendar reminder. Existing engagements continue working through rotation since the token is held server-side, not embedded in repos.
+
+Set it as a worker secret on `crane-context`:
+
+```bash
+cd workers/crane-context
+wrangler secret put INFISICAL_MANAGEMENT_TOKEN              # staging
+wrangler secret put INFISICAL_MANAGEMENT_TOKEN --env production
+```
+
+### 5. Verify the worker is wired
+
+```bash
+curl -fsS -X POST "https://crane-context-staging.automation-ab6.workers.dev/admin/provision-engagement" \
+  -H "X-Admin-Key: $CRANE_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"client_slug":"smoke-test"}'
+```
+
+Expected: `{"success":true,"infisical_path":"/ss/clients/smoke-test"}`. Re-run to confirm idempotency (existing folder → still 200). After confirming, delete the test folder via the Infisical UI.
+
+## Per-Engagement Runbook
+
+For each new engagement after prereqs are in place:
+
+### Adding a client (first time, or new client)
+
+```bash
+crane ss            # Launch SS agent
+/new-client acme "Acme Co"
+```
+
+The `/new-client` skill: validates the slug, appends a client entry to `config/ventures.json`, calls `/admin/provision-engagement` to create `/ss/clients/acme/`, creates `~/dev/ss/acme/`, commits + pushes ventures.json, redeploys crane-context.
+
+### Adding an engagement
+
+```bash
+crane ss            # Inside SS context (so CRANE_ADMIN_KEY is in env)
+/new-engagement acme website "Acme Co Website"
+```
+
+The `/new-engagement` skill runs `scripts/setup-new-engagement.sh` which: provisions Infisical first, creates the GitHub repo from `engagement-template`, mutates `ventures.json` (with rollback trap), clones to `~/dev/ss/acme/website/`, drops scaffold files including a scope-locked `.claude/settings.json`, rebuilds crane-mcp, redeploys crane-context.
+
+### Launching an engagement
+
+```bash
+crane ss/acme/website
+```
+
+The launcher parses the `/`-containing arg, resolves via `ENGAGEMENT_REGISTRY` (built from `config/ventures.json` at module init), 2-stage fetches secrets (SS-level for `CRANE_ADMIN_KEY` → engagement secrets via `/admin/engagement-secrets` proxy), asserts `additionalDirectories` scope, and spawns Claude Code with `CRANE_CLIENT_SLUG` + `CRANE_ENGAGEMENT_SLUG` env vars set.
+
+## Operational Notes
+
+### Rotation
+
+- **Quarterly:** rotate `INFISICAL_MANAGEMENT_TOKEN` (calendar reminder). Re-issue the worker secret with the new token; nothing else needs to change.
+- **As needed:** rotate the `smdservices-platform` GitHub App PEM if compromised. Re-store at Infisical `/ss/SMDSERVICES_PLATFORM_PEM`.
+
+### Cross-client isolation
+
+Filesystem layout `~/dev/ss/<client>/<engagement>/` plus `additionalDirectories` lock plus per-engagement Infisical path together prevent cross-client data leaks at the launcher tier. The launcher asserts `additionalDirectories` is exactly the engagement path (or an absolute-form equivalent) on every engagement launch — broader scope fails loudly rather than silently letting an agent read sibling engagements via `cat ../`.
+
+### Cross-client lessons
+
+Generalizable lessons learned during engagement work (e.g., "Astro+Clerk works for SMB marketing sites") belong in SS-venture-level memory at `~/.claude/projects/.../ss-console/memory/`, not in engagement memory. Memory governance and Captain review remain the controls — no special skill machinery for client-identifier scrubbing in v1.
+
+### Out of scope (v1)
+
+- Lifecycle states / archive flow (Captain explicit deferral)
+- D1 tables for clients/engagements (ventures.json is the registry)
+- SOW/kickoff/handoff/status-report scaffolding (process, not wiring)
+- Engagement-template drift-sync to existing repos
+- Excessive-provisioning-call alerting
+
+## Reference Files
+
+| File                                                                | Purpose                                          |
+| ------------------------------------------------------------------- | ------------------------------------------------ |
+| `config/ventures.json`                                              | Single source of truth (clients[].engagements[]) |
+| `packages/crane-mcp/src/cli/launch-lib.ts`                          | Launcher path parsing + ENGAGEMENT_REGISTRY      |
+| `workers/crane-context/src/endpoints/admin-provision-engagement.ts` | Infisical folder + secrets proxy                 |
+| `scripts/setup-new-engagement.sh`                                   | Engagement wiring script                         |
+| `.claude/commands/new-client.md`                                    | /new-client skill                                |
+| `.claude/commands/new-engagement.md`                                | /new-engagement skill                            |

--- a/packages/crane-mcp/src/cli/launch-lib.engagements.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.engagements.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for SS client/engagement launcher extensions:
+ *   - parseEngagementArg
+ *   - ENGAGEMENT_REGISTRY derivation from ventures.json
+ *   - listClientEngagements
+ *   - assertEngagementScope (additionalDirectories isolation guard)
+ *
+ * Uses a local fs mock that injects nested clients[].engagements[] under SS,
+ * including a slug collision (`redesign` exists under both `acme` and `foo`)
+ * so we can verify the FK resolution doesn't ambiguously match.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ on: vi.fn().mockReturnThis(), kill: vi.fn() })),
+  spawnSync: vi.fn(),
+  execSync: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  copyFileSync: vi.fn(),
+  readFileSync: vi.fn((filePath: string) => {
+    if (String(filePath).includes('ventures.json')) {
+      return JSON.stringify({
+        ventures: [
+          { code: 'vc' },
+          { code: 'ke' },
+          {
+            code: 'ss',
+            clients: [
+              {
+                slug: 'acme',
+                displayName: 'Acme Co',
+                githubOrg: 'smdservices-clients',
+                infisicalPath: '/ss/clients/acme',
+                engagements: [
+                  {
+                    slug: 'website',
+                    displayName: 'Acme Website',
+                    repo: 'smdservices-clients/acme-website',
+                    infisicalPath: '/ss/clients/acme/website',
+                  },
+                  {
+                    slug: 'redesign',
+                    displayName: 'Acme Redesign',
+                    repo: 'smdservices-clients/acme-redesign',
+                    infisicalPath: '/ss/clients/acme/redesign',
+                  },
+                ],
+              },
+              {
+                slug: 'foo',
+                displayName: 'Foo Corp',
+                infisicalPath: '/ss/clients/foo',
+                engagements: [
+                  {
+                    slug: 'redesign',
+                    displayName: 'Foo Redesign',
+                    repo: 'smdservices-clients/foo-redesign',
+                    infisicalPath: '/ss/clients/foo/redesign',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    }
+    // Default: empty additionalDirectories settings.json (per-test override below)
+    return '{}'
+  }),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(() => []),
+  statSync: vi.fn(() => ({ mtimeMs: 0 })),
+}))
+
+vi.mock('../lib/repo-scanner.js', () => ({ scanLocalRepos: vi.fn(() => []) }))
+vi.mock('./ssh-auth.js', () => ({ prepareSSHAuth: vi.fn(() => ({ env: {} })) }))
+
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+import {
+  parseEngagementArg,
+  ENGAGEMENT_REGISTRY,
+  INFISICAL_PATHS,
+  listClientEngagements,
+  assertEngagementScope,
+  type EngagementContext,
+} from './launch-lib.js'
+
+describe('parseEngagementArg', () => {
+  it('returns venture for bare codes', () => {
+    expect(parseEngagementArg('ss')).toEqual({ kind: 'venture', code: 'ss' })
+    expect(parseEngagementArg('vc')).toEqual({ kind: 'venture', code: 'vc' })
+  })
+
+  it('lowercases the input', () => {
+    expect(parseEngagementArg('SS/ACME/Website')).toEqual({
+      kind: 'engagement',
+      code: 'ss',
+      clientSlug: 'acme',
+      engagementSlug: 'website',
+    })
+  })
+
+  it('returns missing-engagement for two-segment paths', () => {
+    expect(parseEngagementArg('ss/acme')).toEqual({
+      kind: 'missing-engagement',
+      code: 'ss',
+      clientSlug: 'acme',
+    })
+  })
+
+  it('returns engagement for three-segment paths', () => {
+    expect(parseEngagementArg('ss/acme/website')).toEqual({
+      kind: 'engagement',
+      code: 'ss',
+      clientSlug: 'acme',
+      engagementSlug: 'website',
+    })
+  })
+
+  it('returns invalid for four-segment paths', () => {
+    expect(parseEngagementArg('ss/acme/website/extra')).toEqual({
+      kind: 'invalid',
+      raw: 'ss/acme/website/extra',
+    })
+  })
+
+  it('returns invalid for paths with empty segments', () => {
+    expect(parseEngagementArg('ss//website')).toEqual({
+      kind: 'invalid',
+      raw: 'ss//website',
+    })
+    expect(parseEngagementArg('ss/acme/')).toEqual({
+      kind: 'invalid',
+      raw: 'ss/acme/',
+    })
+  })
+})
+
+describe('ENGAGEMENT_REGISTRY', () => {
+  it('populates from nested clients[].engagements[] in ventures.json', () => {
+    expect(ENGAGEMENT_REGISTRY['ss/acme/website']).toMatchObject({
+      code: 'ss',
+      clientSlug: 'acme',
+      engagementSlug: 'website',
+      repo: 'smdservices-clients/acme-website',
+      infisicalPath: '/ss/clients/acme/website',
+      githubOrg: 'smdservices-clients',
+    })
+  })
+
+  it('resolves slug collisions across clients to distinct entries', () => {
+    const acmeRedesign = ENGAGEMENT_REGISTRY['ss/acme/redesign']
+    const fooRedesign = ENGAGEMENT_REGISTRY['ss/foo/redesign']
+
+    expect(acmeRedesign).toBeDefined()
+    expect(fooRedesign).toBeDefined()
+    expect(acmeRedesign.repo).toBe('smdservices-clients/acme-redesign')
+    expect(fooRedesign.repo).toBe('smdservices-clients/foo-redesign')
+    expect(acmeRedesign.infisicalPath).not.toBe(fooRedesign.infisicalPath)
+  })
+
+  it('defaults githubOrg to smdservices-clients when client omits it', () => {
+    // foo client in the mock has no githubOrg
+    expect(ENGAGEMENT_REGISTRY['ss/foo/redesign'].githubOrg).toBe('smdservices-clients')
+  })
+
+  it('extends INFISICAL_PATHS with engagement keys', () => {
+    expect(INFISICAL_PATHS['ss']).toBe('/ss')
+    expect(INFISICAL_PATHS['ss/acme/website']).toBe('/ss/clients/acme/website')
+    expect(INFISICAL_PATHS['ss/foo/redesign']).toBe('/ss/clients/foo/redesign')
+  })
+
+  it('does not pollute non-SS ventures with engagement entries', () => {
+    expect(INFISICAL_PATHS['vc']).toBe('/vc')
+    expect(INFISICAL_PATHS['ke']).toBe('/ke')
+    // Only SS engagements should be in the registry
+    for (const e of Object.values(ENGAGEMENT_REGISTRY)) {
+      expect(e.code).toBe('ss')
+    }
+  })
+})
+
+describe('listClientEngagements', () => {
+  it('returns engagements for a known client', () => {
+    const acme = listClientEngagements('ss', 'acme')
+    const slugs = acme.map((e) => e.engagementSlug).sort()
+    expect(slugs).toEqual(['redesign', 'website'])
+  })
+
+  it('returns empty array for unknown client', () => {
+    expect(listClientEngagements('ss', 'unknown')).toEqual([])
+  })
+
+  it('returns empty array for non-SS venture', () => {
+    expect(listClientEngagements('vc', 'anything')).toEqual([])
+  })
+})
+
+describe('assertEngagementScope', () => {
+  const ctx: EngagementContext = {
+    code: 'ss',
+    clientSlug: 'acme',
+    engagementSlug: 'website',
+    repo: 'smdservices-clients/acme-website',
+    infisicalPath: '/ss/clients/acme/website',
+    githubOrg: 'smdservices-clients',
+  }
+
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(true)
+  })
+
+  it('returns null when settings.json is absent', () => {
+    vi.mocked(existsSync).mockReturnValueOnce(true) // localPath check
+    vi.mocked(existsSync).mockReturnValueOnce(false) // settings.json check
+    expect(assertEngagementScope('/tmp/anywhere', ctx)).toBeNull()
+  })
+
+  it('returns null when additionalDirectories matches engagement path (tilde form)', () => {
+    vi.mocked(readFileSync).mockReturnValueOnce(
+      JSON.stringify({ additionalDirectories: ['~/dev/ss/acme/website'] })
+    )
+    expect(assertEngagementScope('/tmp/anywhere', ctx)).toBeNull()
+  })
+
+  it('returns null when additionalDirectories matches engagement path (absolute form)', () => {
+    const home = homedir()
+    vi.mocked(readFileSync).mockReturnValueOnce(
+      JSON.stringify({ additionalDirectories: [`${home}/dev/ss/acme/website`] })
+    )
+    expect(assertEngagementScope('/tmp/anywhere', ctx)).toBeNull()
+  })
+
+  it('returns error when additionalDirectories includes the client dir (broader scope)', () => {
+    vi.mocked(readFileSync).mockReturnValueOnce(
+      JSON.stringify({ additionalDirectories: ['~/dev/ss/acme'] })
+    )
+    const err = assertEngagementScope('/tmp/anywhere', ctx)
+    expect(err).toBeTruthy()
+    expect(err).toContain('outside the engagement scope')
+  })
+
+  it('returns error when additionalDirectories includes a sibling engagement', () => {
+    vi.mocked(readFileSync).mockReturnValueOnce(
+      JSON.stringify({
+        additionalDirectories: ['~/dev/ss/acme/website', '~/dev/ss/foo/redesign'],
+      })
+    )
+    const err = assertEngagementScope('/tmp/anywhere', ctx)
+    expect(err).toBeTruthy()
+    expect(err).toContain('outside the engagement scope')
+  })
+
+  it('returns null when additionalDirectories is empty', () => {
+    vi.mocked(readFileSync).mockReturnValueOnce(JSON.stringify({ additionalDirectories: [] }))
+    expect(assertEngagementScope('/tmp/anywhere', ctx)).toBeNull()
+  })
+})

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -22,7 +22,12 @@ import { join, dirname, basename } from 'path'
 import { homedir } from 'os'
 import { fileURLToPath } from 'url'
 import { Venture } from '../lib/crane-api.js'
-import { API_BASE_PRODUCTION, getCraneEnv, getStagingInfisicalPath } from '../lib/config.js'
+import {
+  API_BASE_PRODUCTION,
+  getApiBase,
+  getCraneEnv,
+  getStagingInfisicalPath,
+} from '../lib/config.js'
 import { scanLocalRepos, LocalRepo } from '../lib/repo-scanner.js'
 import { prepareSSHAuth } from './ssh-auth.js'
 
@@ -60,6 +65,102 @@ const venturesConfig = JSON.parse(
 export const INFISICAL_PATHS: Record<string, string> = Object.fromEntries(
   venturesConfig.ventures.map((v: { code: string }) => [v.code, `/${v.code}`])
 )
+
+// SS engagement registry — flat lookup keyed by `<code>/<client>/<engagement>`.
+// Populated from optional clients[].engagements[] in ventures.json. Only SS
+// uses this today; other ventures have no nested clients.
+//
+// Disk-only by design: the /ventures HTTP API doesn't expose this nested
+// structure, which keeps the API contract stable when fleet machines run
+// different launcher builds. ventures.json is the source of truth.
+export interface EngagementContext {
+  code: string
+  clientSlug: string
+  engagementSlug: string
+  repo: string
+  infisicalPath: string
+  githubOrg: string
+}
+
+export const ENGAGEMENT_REGISTRY: Record<string, EngagementContext> = {}
+
+interface VenturesClientEntry {
+  slug: string
+  displayName?: string
+  githubOrg?: string
+  infisicalPath?: string
+  engagements?: Array<{
+    slug: string
+    displayName?: string
+    repo: string
+    infisicalPath: string
+  }>
+}
+
+for (const v of venturesConfig.ventures as Array<{
+  code: string
+  clients?: VenturesClientEntry[]
+}>) {
+  if (!Array.isArray(v.clients)) continue
+  for (const c of v.clients) {
+    if (!Array.isArray(c.engagements)) continue
+    for (const e of c.engagements) {
+      const key = `${v.code}/${c.slug}/${e.slug}`
+      ENGAGEMENT_REGISTRY[key] = {
+        code: v.code,
+        clientSlug: c.slug,
+        engagementSlug: e.slug,
+        repo: e.repo,
+        infisicalPath: e.infisicalPath,
+        githubOrg: c.githubOrg ?? 'smdservices-clients',
+      }
+      INFISICAL_PATHS[key] = e.infisicalPath
+    }
+  }
+}
+
+/**
+ * List all engagements registered for a given client under a venture.
+ * Used to print helpful hints when the user types `crane ss/<client>` without
+ * an engagement slug.
+ */
+export function listClientEngagements(code: string, clientSlug: string): EngagementContext[] {
+  return Object.values(ENGAGEMENT_REGISTRY).filter(
+    (e) => e.code === code && e.clientSlug === clientSlug
+  )
+}
+
+/**
+ * Parse a launcher argument and determine if it refers to an engagement.
+ * Returns null for non-engagement args (bare venture codes).
+ *
+ * Engagement shape: `<code>/<client>/<engagement>` — exactly 3 segments.
+ * Other slash-containing shapes return a partial result so the caller can
+ * emit a precise error.
+ */
+export function parseEngagementArg(
+  arg: string
+):
+  | { kind: 'venture'; code: string }
+  | { kind: 'engagement'; code: string; clientSlug: string; engagementSlug: string }
+  | { kind: 'missing-engagement'; code: string; clientSlug: string }
+  | { kind: 'invalid'; raw: string } {
+  const lower = arg.toLowerCase()
+  if (!lower.includes('/')) return { kind: 'venture', code: lower }
+  const parts = lower.split('/')
+  if (parts.length === 2) {
+    return { kind: 'missing-engagement', code: parts[0], clientSlug: parts[1] }
+  }
+  if (parts.length === 3 && parts.every((p) => p.length > 0)) {
+    return {
+      kind: 'engagement',
+      code: parts[0],
+      clientSlug: parts[1],
+      engagementSlug: parts[2],
+    }
+  }
+  return { kind: 'invalid', raw: arg }
+}
 
 export interface VentureWithRepo extends Venture {
   localPath: string | null
@@ -313,6 +414,20 @@ export async function cloneVenture(venture: VentureWithRepo): Promise<string | n
   }
 }
 
+/**
+ * Group engagements by client for display under their parent venture.
+ */
+function engagementsByClient(code: string): Map<string, EngagementContext[]> {
+  const grouped = new Map<string, EngagementContext[]>()
+  for (const e of Object.values(ENGAGEMENT_REGISTRY)) {
+    if (e.code !== code) continue
+    const existing = grouped.get(e.clientSlug) ?? []
+    existing.push(e)
+    grouped.set(e.clientSlug, existing)
+  }
+  return grouped
+}
+
 export function printVentureList(ventures: VentureWithRepo[]): void {
   console.log('\nCrane Ventures')
   console.log('==============\n')
@@ -325,6 +440,15 @@ export function printVentureList(ventures: VentureWithRepo[]): void {
     const code = `[${v.code}]`.padEnd(6)
     const path = v.localPath ? v.localPath.replace(home, '~') : '(not cloned)'
     console.log(`  ${num} ${name} ${code} ${path}`)
+
+    // Nest engagements under their parent venture (SS only today).
+    const grouped = engagementsByClient(v.code)
+    for (const [clientSlug, engagements] of grouped) {
+      console.log(`        ${clientSlug}:`)
+      for (const e of engagements) {
+        console.log(`          ${v.code}/${clientSlug}/${e.engagementSlug}  ${e.repo}`)
+      }
+    }
   }
   console.log()
 }
@@ -1667,6 +1791,201 @@ export function launchAgent(
 }
 
 // ============================================================================
+// Engagement launcher - 2-stage fetch (SS bootstrap → secrets proxy)
+// ============================================================================
+
+/**
+ * Verify .claude/settings.json in the engagement repo doesn't grant access
+ * to a broader filesystem scope than the engagement directory itself.
+ * Per-engagement isolation collapses if `additionalDirectories` includes
+ * the client dir (`~/dev/ss/<client>/`) — agents could read sibling
+ * engagements via `cat ../<other>/`.
+ *
+ * Returns null on success, error message string on failure.
+ */
+export function assertEngagementScope(localPath: string, ctx: EngagementContext): string | null {
+  const settingsPath = join(localPath, '.claude', 'settings.json')
+  if (!existsSync(settingsPath)) return null
+
+  let settings: { additionalDirectories?: unknown }
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+  } catch (e) {
+    return `Cannot parse ${settingsPath}: ${(e as Error).message}`
+  }
+
+  const dirs = settings.additionalDirectories
+  if (!Array.isArray(dirs) || dirs.length === 0) return null
+
+  const home = homedir()
+  const expectedTilde = `~/dev/ss/${ctx.clientSlug}/${ctx.engagementSlug}`
+  const expectedAbs = `${home}/dev/ss/${ctx.clientSlug}/${ctx.engagementSlug}`
+
+  for (const d of dirs) {
+    if (typeof d !== 'string') {
+      return `additionalDirectories contains non-string entry: ${JSON.stringify(d)}`
+    }
+    if (d !== expectedTilde && d !== expectedAbs) {
+      return (
+        `Engagement settings.json has additionalDirectories outside the engagement scope.\n` +
+        `  Expected: ["${expectedTilde}"]\n` +
+        `  Found:    ${JSON.stringify(dirs)}\n` +
+        `Fix: edit ${settingsPath} so additionalDirectories contains only the engagement path.`
+      )
+    }
+  }
+
+  return null
+}
+
+export async function launchEngagement(
+  ctx: EngagementContext,
+  agent: string,
+  debug: boolean = false,
+  extraArgs: string[] = []
+): Promise<void> {
+  const localPath = join(homedir(), 'dev', 'ss', ctx.clientSlug, ctx.engagementSlug)
+
+  if (!existsSync(localPath)) {
+    console.error(`Engagement repo not cloned: ${localPath}`)
+    console.error(`Clone: gh repo clone ${ctx.repo} "${localPath}"`)
+    process.exit(1)
+  }
+
+  // Filesystem isolation guard — fail fast if settings.json grants broader scope
+  const scopeError = assertEngagementScope(localPath, ctx)
+  if (scopeError) {
+    console.error(`\n${scopeError}`)
+    process.exit(1)
+  }
+
+  validateAgentBinary(agent)
+  checkMcpSetup(localPath, agent)
+
+  // Stage 1: fetch SS-level secrets (for CRANE_ADMIN_KEY needed by the proxy call)
+  const sshAuth = prepareSSHAuth(debug)
+  if (sshAuth.abort) {
+    console.error(`\n${sshAuth.abort}`)
+    process.exit(1)
+  }
+
+  const ssResult = fetchSecrets(localPath, '/ss', sshAuth.env)
+  if ('error' in ssResult) {
+    console.error(`\nSS-level secret fetch failed:\n${ssResult.error}`)
+    process.exit(1)
+  }
+
+  const adminKey = ssResult.secrets.CRANE_ADMIN_KEY
+  if (!adminKey) {
+    console.error(`CRANE_ADMIN_KEY missing from /ss secrets.`)
+    console.error(`Run: cd ~/dev/crane-console && bash scripts/sync-shared-secrets.sh --fix`)
+    process.exit(1)
+  }
+
+  // Stage 2: fetch engagement secrets via crane-context proxy
+  const apiBase = getApiBase()
+  let proxyRes: Response
+  try {
+    proxyRes = await fetch(`${apiBase}/admin/engagement-secrets`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Admin-Key': adminKey,
+      },
+      body: JSON.stringify({
+        client_slug: ctx.clientSlug,
+        engagement_slug: ctx.engagementSlug,
+      }),
+    })
+  } catch (err) {
+    console.error(`\nFailed to reach crane-context: ${(err as Error).message}`)
+    process.exit(1)
+  }
+
+  if (!proxyRes.ok) {
+    const body = await proxyRes.text()
+    console.error(
+      `\nEngagement secrets fetch failed (${proxyRes.status}) for ${ctx.clientSlug}/${ctx.engagementSlug}:\n${body}`
+    )
+    process.exit(1)
+  }
+
+  const proxyData = (await proxyRes.json()) as {
+    secrets: Array<{ key: string; value: string }>
+  }
+
+  const engagementSecrets: Record<string, string> = {}
+  for (const s of proxyData.secrets) {
+    if (s.key && typeof s.value === 'string') {
+      engagementSecrets[s.key] = s.value
+    }
+  }
+
+  console.log(`\n-> Switching to ${ctx.clientSlug}/${ctx.engagementSlug}...`)
+  console.log(`-> Launching ${agent} with ${ctx.infisicalPath} secrets (via crane-context)...\n`)
+
+  process.chdir(localPath)
+  syncVentureRepo(localPath)
+
+  const binary = KNOWN_AGENTS[agent]
+
+  if (process.stdout.isTTY) {
+    process.stdout.write(
+      `\x1b]2;[${ctx.code.toUpperCase()}/${ctx.clientSlug}/${ctx.engagementSlug}]\x07`
+    )
+  }
+
+  // Build child env: SS-level (CRANE_*, GH_TOKEN, etc.) + engagement-specific overrides + ssh auth
+  const childEnv: Record<string, string | undefined> = {
+    ...process.env,
+    ...ssResult.secrets,
+    ...engagementSecrets,
+    ...sshAuth.env,
+    CRANE_ENV: getCraneEnv(),
+    CRANE_VENTURE_CODE: ctx.code,
+    CRANE_VENTURE_NAME: 'SMD Services',
+    CRANE_REPO: basename(localPath),
+    CRANE_CLIENT_SLUG: ctx.clientSlug,
+    CRANE_ENGAGEMENT_SLUG: ctx.engagementSlug,
+    MCP_TIMEOUT: process.env.MCP_TIMEOUT ?? '30000',
+    ENABLE_TOOL_SEARCH: 'false',
+  }
+
+  const startupPrompt = getStartupPrompt(agent, extraArgs)
+  if (startupPrompt !== null) {
+    extraArgs.push(startupPrompt)
+  }
+
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process — `binary` is closed-set from KNOWN_AGENTS; argv-array form, no shell interpolation
+  const child = spawn(binary, extraArgs, {
+    stdio: 'inherit',
+    cwd: localPath,
+    env: childEnv,
+  })
+
+  for (const sig of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(sig, () => child.kill(sig))
+  }
+
+  child.on('error', (err) => {
+    console.error(`Failed to launch ${binary}: ${err.message}`)
+    process.exit(1)
+  })
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      const signalCodes: Record<string, number> = {
+        SIGTERM: 143,
+        SIGINT: 130,
+        SIGKILL: 137,
+      }
+      process.exit(signalCodes[signal] || 128)
+    }
+    process.exit(code || 0)
+  })
+}
+
+// ============================================================================
 // main() - CLI entry point logic
 // ============================================================================
 
@@ -1694,6 +2013,7 @@ crane - Venture launcher
 Usage:
   crane              Interactive menu - pick a venture
   crane <code>       Direct launch - e.g., crane vc, crane ke
+  crane ss/<client>/<engagement>  Launch into an SS engagement
   crane <code> [agent args...]  Pass args through to agent binary
   crane --claude     Launch with Claude (default)
   crane --gemini     Launch with Gemini
@@ -1756,10 +2076,52 @@ Examples:
   // Extract passthrough args for agent binary (e.g., -p "prompt" for headless mode)
   const passthrough = extractPassthroughArgs(args)
 
-  // Direct launch by code
+  // Direct launch by code (or engagement path `<code>/<client>/<engagement>`)
   const nonFlagArgs = cleanArgs.filter((a) => !a.startsWith('-'))
   if (nonFlagArgs.length > 0) {
-    const code = nonFlagArgs[0].toLowerCase()
+    const parsed = parseEngagementArg(nonFlagArgs[0])
+
+    if (parsed.kind === 'invalid') {
+      console.error(`Invalid launcher arg: ${parsed.raw}`)
+      console.error(`Expected: <code>  or  <code>/<client>/<engagement>`)
+      process.exit(1)
+    }
+
+    if (parsed.kind === 'missing-engagement') {
+      const engagements = listClientEngagements(parsed.code, parsed.clientSlug)
+      console.error(
+        `Missing engagement slug. ${parsed.code}/${parsed.clientSlug}/<engagement> requires three segments.`
+      )
+      if (engagements.length > 0) {
+        console.error(`Available engagements for ${parsed.code}/${parsed.clientSlug}:`)
+        for (const e of engagements) {
+          console.error(`  crane ${parsed.code}/${parsed.clientSlug}/${e.engagementSlug}`)
+        }
+      } else {
+        console.error(`(No engagements registered for ${parsed.code}/${parsed.clientSlug}.)`)
+      }
+      process.exit(1)
+    }
+
+    if (parsed.kind === 'engagement') {
+      const key = `${parsed.code}/${parsed.clientSlug}/${parsed.engagementSlug}`
+      const ctx = ENGAGEMENT_REGISTRY[key]
+      if (!ctx) {
+        console.error(`Unknown engagement: ${key}`)
+        const siblings = listClientEngagements(parsed.code, parsed.clientSlug)
+        if (siblings.length > 0) {
+          console.error(`Engagements registered for ${parsed.code}/${parsed.clientSlug}:`)
+          for (const e of siblings) {
+            console.error(`  ${e.engagementSlug}`)
+          }
+        }
+        process.exit(1)
+      }
+      await launchEngagement(ctx, agent, debug, passthrough)
+      return
+    }
+
+    const code = parsed.code
     const venture = withRepos.find((v) => v.code === code)
 
     if (!venture) {

--- a/scripts/setup-new-engagement.sh
+++ b/scripts/setup-new-engagement.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+#
+# Setup a New SS Engagement with Crane Infrastructure
+#
+# Wires a new engagement under an existing SS client into the launcher and
+# Infisical. Mirrors scripts/setup-new-venture.sh in shape but operates one
+# tier down (engagement, not venture).
+#
+# Usage: ./scripts/setup-new-engagement.sh <client-slug> <engagement-slug> "<display-name>"
+# Example: ./scripts/setup-new-engagement.sh acme website "Acme Co Website"
+#
+# Prerequisites (one-time, manual — see docs/process/new-engagement-setup-checklist.md):
+# - smdservices-clients GitHub org exists
+# - smdservices-platform GitHub App installed on the org
+# - INFISICAL_MANAGEMENT_TOKEN set as a secret on crane-context (staging + prod)
+# - smdservices-clients/engagement-template repo exists (branch-protected, CODEOWNERS)
+# - The client must already exist (run /new-client first)
+#
+# Provision-first ordering: Infisical folder is created BEFORE ventures.json is
+# mutated, so a transient Infisical failure can't leave the registry ahead of
+# reality. After ventures.json is mutated, an ERR trap restores the backup.
+
+set -e
+set -o pipefail
+
+# ============================================================================
+# Colors
+# ============================================================================
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# ============================================================================
+# Setup
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CLIENT_SLUG="${1:-}"
+ENGAGEMENT_SLUG="${2:-}"
+DISPLAY_NAME="${3:-}"
+DRY_RUN="${DRY_RUN:-false}"
+
+VENTURES_JSON="$REPO_ROOT/config/ventures.json"
+SLUG_REGEX='^[a-z][a-z0-9-]{1,31}$'
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+if [ -z "$CLIENT_SLUG" ] || [ -z "$ENGAGEMENT_SLUG" ] || [ -z "$DISPLAY_NAME" ]; then
+  echo -e "${RED}Error: missing required arguments${NC}"
+  echo "  Usage: $0 <client-slug> <engagement-slug> \"<display-name>\""
+  exit 1
+fi
+
+if ! [[ "$CLIENT_SLUG" =~ $SLUG_REGEX ]]; then
+  echo -e "${RED}Error: client-slug must match $SLUG_REGEX${NC}"
+  exit 1
+fi
+
+if ! [[ "$ENGAGEMENT_SLUG" =~ $SLUG_REGEX ]]; then
+  echo -e "${RED}Error: engagement-slug must match $SLUG_REGEX${NC}"
+  exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+  echo -e "${RED}Error: jq is required${NC}"
+  echo "  Install: brew install jq"
+  exit 1
+fi
+
+if ! command -v gh &> /dev/null; then
+  echo -e "${RED}Error: gh CLI is required${NC}"
+  exit 1
+fi
+
+if ! gh auth status &> /dev/null 2>&1; then
+  echo -e "${RED}Error: gh CLI not authenticated${NC}"
+  exit 1
+fi
+
+if [ ! -f "$VENTURES_JSON" ]; then
+  echo -e "${RED}Error: $VENTURES_JSON not found${NC}"
+  exit 1
+fi
+
+# Verify client exists in ventures.json
+if ! jq -e ".ventures[] | select(.code == \"ss\") | .clients[]? | select(.slug == \"$CLIENT_SLUG\")" \
+    "$VENTURES_JSON" > /dev/null; then
+  echo -e "${RED}Error: client '$CLIENT_SLUG' not found in ventures.json${NC}"
+  echo "  Run /new-client first."
+  exit 1
+fi
+
+# Verify engagement slug is unique within the client
+if jq -e ".ventures[] | select(.code == \"ss\") | .clients[] | select(.slug == \"$CLIENT_SLUG\") | .engagements[]? | select(.slug == \"$ENGAGEMENT_SLUG\")" \
+    "$VENTURES_JSON" > /dev/null; then
+  echo -e "${RED}Error: engagement '$ENGAGEMENT_SLUG' already exists for client '$CLIENT_SLUG'${NC}"
+  exit 1
+fi
+
+# Resolve client's githubOrg (defaults to smdservices-clients)
+CLIENT_GITHUB_ORG=$(jq -r ".ventures[] | select(.code == \"ss\") | .clients[] | select(.slug == \"$CLIENT_SLUG\") | .githubOrg // \"smdservices-clients\"" "$VENTURES_JSON")
+REPO_NAME="${CLIENT_SLUG}-${ENGAGEMENT_SLUG}"
+FULL_REPO="${CLIENT_GITHUB_ORG}/${REPO_NAME}"
+INFISICAL_PATH="/ss/clients/${CLIENT_SLUG}/${ENGAGEMENT_SLUG}"
+LOCAL_PATH="$HOME/dev/ss/${CLIENT_SLUG}/${ENGAGEMENT_SLUG}"
+
+# Resolve crane-context URL + admin key from launcher env (must be in env)
+CONTEXT_URL="${CRANE_CONTEXT_URL:-https://crane-context.automation-ab6.workers.dev}"
+if [ -z "${CRANE_ADMIN_KEY:-}" ]; then
+  echo -e "${RED}Error: CRANE_ADMIN_KEY not in env${NC}"
+  echo "  Run inside an SS launcher session (crane ss) so secrets are injected."
+  exit 1
+fi
+
+echo -e "${CYAN}==========================================${NC}"
+echo -e "${CYAN}  New SS Engagement${NC}"
+echo -e "${CYAN}==========================================${NC}"
+echo ""
+echo -e "${BLUE}Client:${NC}           $CLIENT_SLUG"
+echo -e "${BLUE}Engagement:${NC}       $ENGAGEMENT_SLUG"
+echo -e "${BLUE}Display Name:${NC}     $DISPLAY_NAME"
+echo -e "${BLUE}Repo:${NC}             $FULL_REPO"
+echo -e "${BLUE}Infisical Path:${NC}   $INFISICAL_PATH"
+echo -e "${BLUE}Local Path:${NC}       $LOCAL_PATH"
+echo -e "${BLUE}Dry Run:${NC}          $DRY_RUN"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "${YELLOW}DRY RUN MODE - No changes will be made${NC}"
+  echo ""
+fi
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+run_cmd() {
+  local desc="$1"
+  shift
+
+  echo -e "${BLUE}$desc${NC}"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo -e "  ${YELLOW}[DRY RUN]${NC} $*"
+    return 0
+  fi
+
+  if "$@"; then
+    echo -e "  ${GREEN}Done${NC}"
+    return 0
+  else
+    echo -e "  ${RED}Failed${NC}"
+    return 1
+  fi
+}
+
+# ============================================================================
+# Step 1: Provision Infisical (BEFORE registry mutation, so a failure here
+# leaves nothing behind)
+# ============================================================================
+
+echo -e "${CYAN}### Step 1: Provision Infisical Folder${NC}"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} POST $CONTEXT_URL/admin/provision-engagement"
+  echo -e "  ${YELLOW}[DRY RUN]${NC} body: {client_slug: $CLIENT_SLUG, engagement_slug: $ENGAGEMENT_SLUG}"
+else
+  HTTP_CODE=$(curl -sS -o /tmp/provision-engagement.out -w "%{http_code}" -X POST \
+    "$CONTEXT_URL/admin/provision-engagement" \
+    -H "X-Admin-Key: $CRANE_ADMIN_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"client_slug\":\"$CLIENT_SLUG\",\"engagement_slug\":\"$ENGAGEMENT_SLUG\"}")
+  if [ "$HTTP_CODE" != "200" ]; then
+    echo -e "  ${RED}Failed (HTTP $HTTP_CODE):${NC}"
+    cat /tmp/provision-engagement.out
+    exit 1
+  fi
+  echo -e "  ${GREEN}Provisioned $INFISICAL_PATH${NC}"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 2: Create GitHub Repository (idempotent: existing repo treated as success)
+# ============================================================================
+
+echo -e "${CYAN}### Step 2: Create GitHub Repository${NC}"
+echo ""
+
+if gh repo view "$FULL_REPO" &> /dev/null 2>&1; then
+  echo -e "${YELLOW}Repository $FULL_REPO already exists - skipping creation${NC}"
+else
+  TEMPLATE_REPO="${CLIENT_GITHUB_ORG}/engagement-template"
+  run_cmd "Creating repository $FULL_REPO from $TEMPLATE_REPO..." \
+    gh repo create "$FULL_REPO" --template "$TEMPLATE_REPO" --private \
+      --description "$DISPLAY_NAME"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 3: Mutate ventures.json (with backup + ERR trap rollback)
+# ============================================================================
+
+echo -e "${CYAN}### Step 3: Update ventures.json${NC}"
+echo ""
+
+VENTURES_BAK="${VENTURES_JSON}.bak"
+
+restore_ventures_json() {
+  if [ -f "$VENTURES_BAK" ]; then
+    echo -e "${YELLOW}Restoring ventures.json from backup...${NC}"
+    mv "$VENTURES_BAK" "$VENTURES_JSON"
+  fi
+}
+trap restore_ventures_json ERR
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} jq append engagement to ventures.json"
+else
+  cp "$VENTURES_JSON" "$VENTURES_BAK"
+
+  # Ensure clients[] exists, then ensure target client's engagements[] exists,
+  # then append the new engagement object.
+  jq --arg client "$CLIENT_SLUG" \
+     --arg slug "$ENGAGEMENT_SLUG" \
+     --arg name "$DISPLAY_NAME" \
+     --arg repo "$FULL_REPO" \
+     --arg path "$INFISICAL_PATH" '
+    (.ventures[] | select(.code == "ss") | .clients) //= [] |
+    (.ventures[] | select(.code == "ss") | .clients[] | select(.slug == $client) | .engagements) //= [] |
+    (.ventures[] | select(.code == "ss") | .clients[] | select(.slug == $client) | .engagements) += [{
+      "slug": $slug,
+      "displayName": $name,
+      "repo": $repo,
+      "infisicalPath": $path
+    }]
+  ' "$VENTURES_JSON" > "${VENTURES_JSON}.tmp"
+
+  if ! jq empty "${VENTURES_JSON}.tmp" > /dev/null 2>&1; then
+    rm -f "${VENTURES_JSON}.tmp"
+    echo -e "  ${RED}jq produced invalid JSON - aborting${NC}"
+    exit 1
+  fi
+
+  mv "${VENTURES_JSON}.tmp" "$VENTURES_JSON"
+  echo -e "  ${GREEN}Appended engagement to ventures.json${NC}"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 4: Clone engagement repo to ~/dev/ss/<client>/<engagement>/
+# ============================================================================
+
+echo -e "${CYAN}### Step 4: Clone Repository${NC}"
+echo ""
+
+if [ -d "$LOCAL_PATH/.git" ]; then
+  echo -e "${YELLOW}Already cloned at $LOCAL_PATH - skipping${NC}"
+else
+  if [ "$DRY_RUN" = "true" ]; then
+    echo -e "  ${YELLOW}[DRY RUN]${NC} mkdir -p $(dirname "$LOCAL_PATH"); gh repo clone $FULL_REPO $LOCAL_PATH"
+  else
+    mkdir -p "$(dirname "$LOCAL_PATH")"
+    gh repo clone "$FULL_REPO" "$LOCAL_PATH"
+    echo -e "  ${GREEN}Cloned to $LOCAL_PATH${NC}"
+  fi
+fi
+
+echo ""
+
+# ============================================================================
+# Step 5: Drop scaffold files (.infisical.json, .claude/settings.json)
+# ============================================================================
+
+echo -e "${CYAN}### Step 5: Drop Engagement Scaffold${NC}"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} write .infisical.json + .claude/settings.json"
+else
+  if [ -d "$LOCAL_PATH" ]; then
+    # .infisical.json - copy from crane-console root
+    if [ ! -f "$LOCAL_PATH/.infisical.json" ] && [ -f "$REPO_ROOT/.infisical.json" ]; then
+      cp "$REPO_ROOT/.infisical.json" "$LOCAL_PATH/.infisical.json"
+      echo -e "  ${GREEN}Copied .infisical.json${NC}"
+    fi
+
+    # .claude/settings.json - additionalDirectories locked to engagement path ONLY
+    mkdir -p "$LOCAL_PATH/.claude"
+    if [ ! -f "$LOCAL_PATH/.claude/settings.json" ]; then
+      cat > "$LOCAL_PATH/.claude/settings.json" <<EOF
+{
+  "additionalDirectories": ["~/dev/ss/${CLIENT_SLUG}/${ENGAGEMENT_SLUG}"]
+}
+EOF
+      echo -e "  ${GREEN}Wrote .claude/settings.json (engagement-scoped)${NC}"
+    fi
+
+    # Commit + push if scaffold added new files
+    cd "$LOCAL_PATH"
+    if [ -n "$(git status --porcelain)" ]; then
+      git add .infisical.json .claude/settings.json 2>/dev/null || true
+      git commit -m "chore: initialize engagement scaffold" || true
+      git push origin HEAD || true
+    fi
+    cd "$REPO_ROOT"
+  fi
+fi
+
+echo ""
+
+# ============================================================================
+# Step 6: Rebuild crane-mcp (so launcher INFISICAL_PATHS picks up new path)
+# ============================================================================
+
+echo -e "${CYAN}### Step 6: Rebuild crane-mcp${NC}"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} cd packages/crane-mcp && npm run build"
+else
+  (
+    cd "$REPO_ROOT/packages/crane-mcp"
+    npm run build > /tmp/crane-mcp-build.log 2>&1
+  ) || {
+    echo -e "  ${YELLOW}crane-mcp build failed - see /tmp/crane-mcp-build.log${NC}"
+  }
+  echo -e "  ${GREEN}Rebuilt crane-mcp${NC}"
+fi
+
+echo ""
+
+# ============================================================================
+# Step 7: Redeploy crane-context (so the worker sees new ventures.json)
+# ============================================================================
+
+echo -e "${CYAN}### Step 7: Redeploy crane-context${NC}"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} cd workers/crane-context && npm run deploy"
+  echo -e "  ${YELLOW}[DRY RUN]${NC} cd workers/crane-context && npm run deploy:prod"
+else
+  (
+    cd "$REPO_ROOT/workers/crane-context"
+    npm run deploy > /tmp/crane-context-staging.log 2>&1
+  ) && echo -e "  ${GREEN}Deployed crane-context (staging)${NC}" \
+    || echo -e "  ${YELLOW}staging deploy failed - see /tmp/crane-context-staging.log${NC}"
+
+  (
+    cd "$REPO_ROOT/workers/crane-context"
+    npm run deploy:prod > /tmp/crane-context-prod.log 2>&1
+  ) && echo -e "  ${GREEN}Deployed crane-context (production)${NC}" \
+    || echo -e "  ${YELLOW}prod deploy failed - see /tmp/crane-context-prod.log${NC}"
+fi
+
+echo ""
+
+# Clean up backup once everything past the registry mutation succeeded
+if [ -f "$VENTURES_BAK" ]; then
+  rm -f "$VENTURES_BAK"
+fi
+trap - ERR
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo -e "${CYAN}==========================================${NC}"
+echo -e "${GREEN}  Engagement setup complete${NC}"
+echo -e "${CYAN}==========================================${NC}"
+echo ""
+echo -e "Launch with: ${CYAN}crane ss/${CLIENT_SLUG}/${ENGAGEMENT_SLUG}${NC}"
+echo ""
+echo -e "${BLUE}Next:${NC}"
+echo "  1. cd $REPO_ROOT && git add config/ventures.json && git commit -m 'chore(ss): add engagement $CLIENT_SLUG/$ENGAGEMENT_SLUG' && git push"
+echo "  2. crane ss/${CLIENT_SLUG}/${ENGAGEMENT_SLUG} --debug  # verify launcher resolves"
+echo ""

--- a/workers/crane-context/src/endpoints/admin-provision-engagement.ts
+++ b/workers/crane-context/src/endpoints/admin-provision-engagement.ts
@@ -1,0 +1,327 @@
+/**
+ * Admin Endpoints - SS Engagement Provisioning
+ *
+ * Two endpoints supporting the SS client/engagement wiring (see
+ * docs/process/new-engagement-setup-checklist.md):
+ *
+ *   POST /admin/provision-engagement
+ *     Creates an Infisical folder for a client (engagement_slug omitted)
+ *     or an engagement (engagement_slug provided). Idempotent: existing
+ *     folders treated as success.
+ *
+ *   POST /admin/engagement-secrets
+ *     Returns the secret env at /ss/clients/<client>/<engagement>/ to an
+ *     authenticated launcher. Used by the crane CLI when it launches into
+ *     an engagement context (avoids persisting per-engagement Infisical
+ *     tokens anywhere — the worker proxies the read with its management
+ *     token).
+ *
+ * Both require X-Admin-Key auth and INFISICAL_MANAGEMENT_TOKEN scoped to
+ * /ss/clients/* (rotated quarterly).
+ */
+
+import venturesJson from '../../../../config/ventures.json'
+import type { Env } from '../types'
+import { HTTP_STATUS } from '../constants'
+import { errorResponse, successResponse, generateCorrelationId } from '../utils'
+import { verifyAdminKey } from './admin-shared'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const INFISICAL_API_BASE = 'https://app.infisical.com/api'
+const INFISICAL_WORKSPACE_ID = '2da2895e-aba2-4faf-a65a-b86e1a7aa2cb'
+const INFISICAL_ENVIRONMENT = 'prod'
+const SLUG_REGEX = /^[a-z][a-z0-9-]{1,31}$/
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ProvisionEngagementRequest {
+  client_slug: string
+  engagement_slug?: string
+}
+
+interface EngagementSecretsRequest {
+  client_slug: string
+  engagement_slug: string
+}
+
+interface VenturesClient {
+  slug: string
+  engagements?: Array<{ slug: string }>
+}
+
+interface VenturesVenture {
+  code: string
+  clients?: VenturesClient[]
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function buildInfisicalPath(client: string, engagement?: string): string {
+  return engagement ? `/ss/clients/${client}/${engagement}` : `/ss/clients/${client}`
+}
+
+function findClient(clientSlug: string): VenturesClient | null {
+  const ss = (venturesJson.ventures as VenturesVenture[]).find((v) => v.code === 'ss')
+  if (!ss?.clients) return null
+  return ss.clients.find((c) => c.slug === clientSlug) ?? null
+}
+
+function clientHasEngagement(client: VenturesClient, engagementSlug: string): boolean {
+  return (client.engagements ?? []).some((e) => e.slug === engagementSlug)
+}
+
+/**
+ * Create an Infisical folder. Idempotent: existing folders return success.
+ *
+ * Infisical's folder API treats path as the parent and name as the leaf.
+ * We split the requested path accordingly: /ss/clients/acme/website ->
+ * parent=/ss/clients/acme, name=website.
+ */
+async function createInfisicalFolder(
+  fullPath: string,
+  token: string,
+  correlationId: string
+): Promise<{ ok: true } | { ok: false; status: number; body: string }> {
+  const segments = fullPath.split('/').filter((s) => s.length > 0)
+  const name = segments[segments.length - 1]
+  const parent = '/' + segments.slice(0, -1).join('/')
+
+  const response = await fetch(`${INFISICAL_API_BASE}/v1/folders`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      workspaceId: INFISICAL_WORKSPACE_ID,
+      environment: INFISICAL_ENVIRONMENT,
+      path: parent,
+      name,
+    }),
+  })
+
+  if (response.ok) return { ok: true }
+
+  const body = await response.text()
+
+  // Infisical returns 400/409 with a "folder already exists" message for
+  // duplicate folder creation. Treat both as idempotent success.
+  if (
+    response.status === HTTP_STATUS.CONFLICT ||
+    (response.status === HTTP_STATUS.BAD_REQUEST && /already exists/i.test(body))
+  ) {
+    console.log('[infisical-folders] Folder already exists, treating as success', {
+      correlationId,
+      path: fullPath,
+    })
+    return { ok: true }
+  }
+
+  return { ok: false, status: response.status, body }
+}
+
+/**
+ * Fetch raw secrets at an Infisical path using the management token.
+ */
+async function fetchInfisicalSecrets(
+  path: string,
+  token: string
+): Promise<
+  | { ok: true; secrets: Array<{ key: string; value: string }> }
+  | {
+      ok: false
+      status: number
+      body: string
+    }
+> {
+  const url = new URL(`${INFISICAL_API_BASE}/v3/secrets/raw`)
+  url.searchParams.set('workspaceId', INFISICAL_WORKSPACE_ID)
+  url.searchParams.set('environment', INFISICAL_ENVIRONMENT)
+  url.searchParams.set('secretPath', path)
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, body: await response.text() }
+  }
+
+  const data = (await response.json()) as {
+    secrets: Array<{ secretKey: string; secretValue: string }>
+  }
+  return {
+    ok: true,
+    secrets: data.secrets.map((s) => ({ key: s.secretKey, value: s.secretValue })),
+  }
+}
+
+// ============================================================================
+// POST /admin/provision-engagement
+// ============================================================================
+
+export async function handleProvisionEngagement(request: Request, env: Env): Promise<Response> {
+  const correlationId = generateCorrelationId()
+
+  if (!(await verifyAdminKey(request, env))) {
+    return errorResponse(
+      'Unauthorized - Invalid admin key',
+      HTTP_STATUS.UNAUTHORIZED,
+      correlationId
+    )
+  }
+
+  if (!env.INFISICAL_MANAGEMENT_TOKEN) {
+    return errorResponse('INFISICAL_MANAGEMENT_TOKEN not configured', 503, correlationId)
+  }
+
+  let body: ProvisionEngagementRequest
+  try {
+    body = await request.json()
+  } catch {
+    return errorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST, correlationId)
+  }
+
+  if (!body.client_slug || !SLUG_REGEX.test(body.client_slug)) {
+    return errorResponse(
+      'Invalid client_slug (must match ^[a-z][a-z0-9-]{1,31}$)',
+      HTTP_STATUS.BAD_REQUEST,
+      correlationId
+    )
+  }
+
+  if (body.engagement_slug !== undefined && !SLUG_REGEX.test(body.engagement_slug)) {
+    return errorResponse(
+      'Invalid engagement_slug (must match ^[a-z][a-z0-9-]{1,31}$)',
+      HTTP_STATUS.BAD_REQUEST,
+      correlationId
+    )
+  }
+
+  const path = buildInfisicalPath(body.client_slug, body.engagement_slug)
+
+  // If creating an engagement folder, the parent client folder must exist
+  // first. Create it idempotently before the engagement.
+  if (body.engagement_slug) {
+    const parentResult = await createInfisicalFolder(
+      buildInfisicalPath(body.client_slug),
+      env.INFISICAL_MANAGEMENT_TOKEN,
+      correlationId
+    )
+    if (!parentResult.ok) {
+      console.error('[POST /admin/provision-engagement] parent folder failed', {
+        correlationId,
+        status: parentResult.status,
+        body: parentResult.body,
+      })
+      return errorResponse(
+        `Failed to create parent folder: ${parentResult.status}`,
+        HTTP_STATUS.INTERNAL_ERROR,
+        correlationId,
+        { upstream_body: parentResult.body }
+      )
+    }
+  }
+
+  const result = await createInfisicalFolder(path, env.INFISICAL_MANAGEMENT_TOKEN, correlationId)
+
+  if (!result.ok) {
+    console.error('[POST /admin/provision-engagement] folder create failed', {
+      correlationId,
+      status: result.status,
+      body: result.body,
+    })
+    return errorResponse(
+      `Failed to create folder: ${result.status}`,
+      HTTP_STATUS.INTERNAL_ERROR,
+      correlationId,
+      { upstream_body: result.body }
+    )
+  }
+
+  return successResponse({ success: true, infisical_path: path }, HTTP_STATUS.OK, correlationId)
+}
+
+// ============================================================================
+// POST /admin/engagement-secrets
+// ============================================================================
+
+export async function handleEngagementSecrets(request: Request, env: Env): Promise<Response> {
+  const correlationId = generateCorrelationId()
+
+  if (!(await verifyAdminKey(request, env))) {
+    return errorResponse(
+      'Unauthorized - Invalid admin key',
+      HTTP_STATUS.UNAUTHORIZED,
+      correlationId
+    )
+  }
+
+  if (!env.INFISICAL_MANAGEMENT_TOKEN) {
+    return errorResponse('INFISICAL_MANAGEMENT_TOKEN not configured', 503, correlationId)
+  }
+
+  let body: EngagementSecretsRequest
+  try {
+    body = await request.json()
+  } catch {
+    return errorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST, correlationId)
+  }
+
+  if (!body.client_slug || !SLUG_REGEX.test(body.client_slug)) {
+    return errorResponse('Invalid client_slug', HTTP_STATUS.BAD_REQUEST, correlationId)
+  }
+
+  if (!body.engagement_slug || !SLUG_REGEX.test(body.engagement_slug)) {
+    return errorResponse('Invalid engagement_slug', HTTP_STATUS.BAD_REQUEST, correlationId)
+  }
+
+  // Validate against ventures.json — unknown client/engagement → 404.
+  // This prevents the secrets-proxy from being used as a free path-probe
+  // against arbitrary Infisical paths.
+  const client = findClient(body.client_slug)
+  if (!client) {
+    return errorResponse(
+      `Unknown client: ${body.client_slug}`,
+      HTTP_STATUS.NOT_FOUND,
+      correlationId
+    )
+  }
+  if (!clientHasEngagement(client, body.engagement_slug)) {
+    return errorResponse(
+      `Unknown engagement: ${body.client_slug}/${body.engagement_slug}`,
+      HTTP_STATUS.NOT_FOUND,
+      correlationId
+    )
+  }
+
+  const path = buildInfisicalPath(body.client_slug, body.engagement_slug)
+  const result = await fetchInfisicalSecrets(path, env.INFISICAL_MANAGEMENT_TOKEN)
+
+  if (!result.ok) {
+    console.error('[POST /admin/engagement-secrets] fetch failed', {
+      correlationId,
+      status: result.status,
+      body: result.body,
+    })
+    return errorResponse(
+      `Failed to fetch secrets: ${result.status}`,
+      HTTP_STATUS.INTERNAL_ERROR,
+      correlationId
+    )
+  }
+
+  return successResponse(
+    { success: true, infisical_path: path, secrets: result.secrets },
+    HTTP_STATUS.OK,
+    correlationId
+  )
+}

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -112,6 +112,10 @@ import { handleGetVersion } from './endpoints/version'
 import { handleVerifySchema } from './endpoints/admin-verify'
 import { handleSecretHash } from './endpoints/admin-secret-hash'
 import {
+  handleProvisionEngagement,
+  handleEngagementSecrets,
+} from './endpoints/admin-provision-engagement'
+import {
   handleSmokeTestPurge,
   handleSmokeTestIngest,
   handleSmokeTestList,
@@ -363,6 +367,18 @@ export default {
           return await handleDeleteScript(request, env, scope, scriptName)
         }
         return errorResponse('Invalid DELETE path', HTTP_STATUS.BAD_REQUEST)
+      }
+
+      // ========================================================================
+      // Admin Endpoints (SS engagement provisioning + secrets proxy)
+      // ========================================================================
+
+      if (pathname === '/admin/provision-engagement' && method === 'POST') {
+        return await handleProvisionEngagement(request, env)
+      }
+
+      if (pathname === '/admin/engagement-secrets' && method === 'POST') {
+        return await handleEngagementSecrets(request, env)
       }
 
       // ========================================================================

--- a/workers/crane-context/src/types.ts
+++ b/workers/crane-context/src/types.ts
@@ -62,6 +62,13 @@ export interface Env {
   // cron (src/deploy-heartbeats-reconcile.ts) to query workflow runs.
   // If unset, the reconciliation no-ops with a warning log.
   GH_TOKEN?: string
+
+  // Infisical management token used by /admin/provision-engagement and
+  // /admin/engagement-secrets to create folders and proxy secret reads
+  // for SS engagements. Scope this token to the /ss/clients/* subtree
+  // only; rotate quarterly. See docs/process/new-engagement-setup-checklist.md.
+  // If unset, the provisioning/secrets-proxy endpoints return 503.
+  INFISICAL_MANAGEMENT_TOKEN?: string
 }
 
 // ============================================================================

--- a/workers/crane-context/test/admin-provision-engagement.test.ts
+++ b/workers/crane-context/test/admin-provision-engagement.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit Tests: SS Engagement Provisioning + Secrets Proxy
+ *
+ * Tests the auth, slug validation, ventures.json lookup, and Infisical
+ * 409-as-success idempotency pathways. Does NOT exercise the real
+ * Infisical API — global.fetch is mocked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  handleProvisionEngagement,
+  handleEngagementSecrets,
+} from '../src/endpoints/admin-provision-engagement'
+import type { Env } from '../src/types'
+
+const ADMIN_KEY = 'test-admin-key'
+const MGMT_TOKEN = 'test-mgmt-token'
+
+function makeEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    DB: {} as D1Database,
+    CONTEXT_SESSION_STALE_MINUTES: '45',
+    IDEMPOTENCY_TTL_SECONDS: '3600',
+    HEARTBEAT_INTERVAL_SECONDS: '600',
+    HEARTBEAT_JITTER_SECONDS: '120',
+    CONTEXT_RELAY_KEY: 'relay',
+    CONTEXT_ADMIN_KEY: ADMIN_KEY,
+    INFISICAL_MANAGEMENT_TOKEN: MGMT_TOKEN,
+    ...overrides,
+  }
+}
+
+function makeRequest(path: string, body: unknown, key = ADMIN_KEY): Request {
+  return new Request(`https://example.com${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(key ? { 'X-Admin-Key': key } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('admin-provision-engagement', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Cloudflare Workers extends `crypto.subtle` with `timingSafeEqual`.
+    // Node's WebCrypto doesn't have it — polyfill for unit tests so
+    // verifyAdminKey() (src/utils.ts:125) doesn't crash.
+    if (!(globalThis.crypto?.subtle as unknown as { timingSafeEqual?: unknown })?.timingSafeEqual) {
+      ;(
+        globalThis.crypto.subtle as unknown as {
+          timingSafeEqual: (a: ArrayBuffer | Uint8Array, b: ArrayBuffer | Uint8Array) => boolean
+        }
+      ).timingSafeEqual = (a, b) => {
+        const aArr = a instanceof ArrayBuffer ? new Uint8Array(a) : a
+        const bArr = b instanceof ArrayBuffer ? new Uint8Array(b) : b
+        if (aArr.byteLength !== bArr.byteLength) return false
+        let diff = 0
+        for (let i = 0; i < aArr.byteLength; i++) diff |= aArr[i] ^ bArr[i]
+        return diff === 0
+      }
+    }
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('POST /admin/provision-engagement', () => {
+    it('returns 401 when admin key missing', async () => {
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' }, '')
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 503 when INFISICAL_MANAGEMENT_TOKEN unset', async () => {
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' })
+      const env = makeEnv({ INFISICAL_MANAGEMENT_TOKEN: undefined })
+      const res = await handleProvisionEngagement(req, env)
+      expect(res.status).toBe(503)
+    })
+
+    it('returns 400 on invalid client_slug', async () => {
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'BAD SLUG' })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 on invalid engagement_slug', async () => {
+      const req = makeRequest('/admin/provision-engagement', {
+        client_slug: 'acme',
+        engagement_slug: '!bad',
+      })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(400)
+    })
+
+    it('creates client folder (engagement_slug omitted)', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { infisical_path: string }
+      expect(body.infisical_path).toBe('/ss/clients/acme')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('creates parent client folder then engagement folder when both supplied', async () => {
+      fetchMock.mockResolvedValue(new Response(null, { status: 200 }))
+      const req = makeRequest('/admin/provision-engagement', {
+        client_slug: 'acme',
+        engagement_slug: 'website',
+      })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as { infisical_path: string }
+      expect(body.infisical_path).toBe('/ss/clients/acme/website')
+      // Parent folder + engagement folder = 2 calls
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('treats Infisical 409 (folder exists) as success', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('already exists', { status: 409 }))
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(200)
+    })
+
+    it('treats Infisical 400 with "already exists" body as success', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response('Folder already exists at this path', { status: 400 })
+      )
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(200)
+    })
+
+    it('returns 500 on Infisical 500 error', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500 }))
+      const req = makeRequest('/admin/provision-engagement', { client_slug: 'acme' })
+      const res = await handleProvisionEngagement(req, makeEnv())
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('POST /admin/engagement-secrets', () => {
+    it('returns 401 when admin key missing', async () => {
+      const req = makeRequest(
+        '/admin/engagement-secrets',
+        { client_slug: 'acme', engagement_slug: 'website' },
+        ''
+      )
+      const res = await handleEngagementSecrets(req, makeEnv())
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 404 when client not in ventures.json', async () => {
+      const req = makeRequest('/admin/engagement-secrets', {
+        client_slug: 'nonexistent',
+        engagement_slug: 'website',
+      })
+      const res = await handleEngagementSecrets(req, makeEnv())
+      expect(res.status).toBe(404)
+      // Must NOT have called Infisical — unknown client should short-circuit
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 on invalid slug shape', async () => {
+      const req = makeRequest('/admin/engagement-secrets', {
+        client_slug: 'BadCase',
+        engagement_slug: 'website',
+      })
+      const res = await handleEngagementSecrets(req, makeEnv())
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects missing engagement_slug (no defaulting)', async () => {
+      const req = makeRequest('/admin/engagement-secrets', { client_slug: 'acme' })
+      const res = await handleEngagementSecrets(req, makeEnv())
+      expect(res.status).toBe(400)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds the launcher path `crane ss/<client>/<engagement>` and `/new-client` + `/new-engagement` skills to wire SS clients and engagements into existing crane systems. **Wiring, not process** — mirrors `/new-venture` one tier down (registry entry, repo, Infisical path, worker redeploy). No lifecycle states, archive flow, SOW scaffolding, or process machinery.

- `ventures.json`: optional `clients[].engagements[]` under SS (other ventures untouched)
- Launcher: nested path resolution, INFISICAL_PATHS extension, 2-stage secret fetch (SS bootstrap → `/admin/engagement-secrets` proxy), filesystem-isolation guard via `additionalDirectories` scope assertion
- `crane-context`: two new admin endpoints — `/admin/provision-engagement` (folder creation, idempotent) and `/admin/engagement-secrets` (proxy fetch with management token)
- `/new-client` skill (light, no script), `/new-engagement` skill (delegates to `scripts/setup-new-engagement.sh`)
- `setup-new-engagement.sh`: provision-first ordering with `trap ERR` rollback on `ventures.json` mutation
- Docs: `docs/process/new-engagement-setup-checklist.md` covering manual prereqs

## Approved plan

`/auto-build with option b` — plan reviewed by Devil's Advocate critic, 8 fixes applied (source-of-truth resolution, token-storage privacy collapse eliminated, registry-before-provisioning reordered, scope assertion specified, etc.). Plan file: `~/.claude/plans/twinkling-toasting-kernighan.md`.

## Manual prerequisites (Captain action, separate from this PR)

This PR is wiring code only. Before `/new-engagement` will work end-to-end:

1. Create `smdservices-clients` GitHub org
2. Create `smdservices-platform` GitHub App, install on the org, store PEM at Infisical `/ss/SMDSERVICES_PLATFORM_PEM`
3. Generate Infisical management token scoped to `/ss/clients/*`, set as `INFISICAL_MANAGEMENT_TOKEN` worker secret on `crane-context` (staging + prod)
4. Create `smdservices-clients/engagement-template` repo with branch protection + CODEOWNERS

Full runbook in `docs/process/new-engagement-setup-checklist.md`.

## Test plan

- [x] `npm run verify` passes locally (typecheck + format + lint + 1158 tests + builds)
- [x] 20 new launcher tests cover: bare venture, engagement resolution, slug collision across clients, missing-engagement hard error, `additionalDirectories` scope assertion (positive + multiple negative cases)
- [x] 13 new endpoint tests cover: auth, slug validation, idempotent 409 handling, ventures.json 404 short-circuit, parent-then-child folder creation
- [ ] After merge: deploy staging crane-context, hit `POST /admin/provision-engagement` with test slugs against sandbox Infisical path, confirm folder created and re-run is idempotent
- [ ] After Captain provisions manual prereqs: end-to-end smoke test of `/new-client` + `/new-engagement` + `crane ss/<client>/<engagement>` against a real engagement

## Out of scope (consciously)

D1 tables for clients/engagements, status/lifecycle/archive fields, SOW/kickoff/handoff/status-report scaffolding, save-lesson scrubbing, billing fields, engagement-template drift-sync to existing repos, excessive-provisioning-call alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)