### PR TITLE
fix(ci): use GraphQL ClosedEvent.closer for PR-driven close detection

### DIFF
--- a/.github/workflows/unmet-ac-on-close-reusable.yml
+++ b/.github/workflows/unmet-ac-on-close-reusable.yml
@@ -58,22 +58,48 @@ jobs:
 
             // Skip when the close was driven by a PR merge — the companion
             // workflow tick-acs-on-merge-reusable.yml owns that path.
-            // PR-driven closes have `commit_id` set on the most recent
-            // `closed` timeline event (the merge commit SHA). Manual closes
-            // do not.
+            // The REST API's `commit_id` on the close event is null for
+            // squash merges (verified empirically: crane-console#775
+            // closed by squash of PR #776 had commit_id=null). GraphQL's
+            // ClosedEvent.closer correctly resolves to the PR for any merge
+            // strategy, so we use that instead.
             try {
-              const events = await github.rest.issues.listEvents({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                per_page: 100,
-              });
-              const mostRecentClose = events.data
-                .filter(e => e.event === 'closed')
-                .pop();
-              if (mostRecentClose && mostRecentClose.commit_id != null) {
+              const result = await github.graphql(
+                `query($owner: String!, $repo: String!, $issue: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $issue) {
+                      timelineItems(itemTypes: CLOSED_EVENT, last: 1) {
+                        nodes {
+                          ... on ClosedEvent {
+                            closer {
+                              __typename
+                              ... on PullRequest { number }
+                              ... on Commit { oid }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue: issue.number,
+                }
+              );
+              const closer = result?.repository?.issue?.timelineItems
+                ?.nodes?.[0]?.closer;
+              if (closer && closer.__typename === 'PullRequest') {
                 core.info(
-                  `Issue #${issue.number}: PR-driven close (commit ${mostRecentClose.commit_id.slice(0, 8)}) — ` +
+                  `Issue #${issue.number}: PR-driven close (PR #${closer.number}) — ` +
+                  `companion workflow tick-acs-on-merge owns AC ticking. Skipping.`
+                );
+                return;
+              }
+              if (closer && closer.__typename === 'Commit') {
+                core.info(
+                  `Issue #${issue.number}: commit-driven close (${closer.oid.slice(0, 8)}) — ` +
                   `companion workflow tick-acs-on-merge owns AC ticking. Skipping.`
                 );
                 return;


### PR DESCRIPTION
## Summary

Smoke test of the host PR (#776) on its own merge revealed that `unmet-ac-on-close-reusable.yml` reopened crane-console#775 even though it was closed by the squash merge of #776. Root cause: GitHub's REST API does not set `commit_id` on the close event when the close is driven by a squash merge — the workflow's existing skip-PR-driven-close logic relied on that field and failed.

GraphQL's `ClosedEvent.closer` resolves to the PullRequest for any merge strategy (verified empirically against #775's timeline). Switching to that detection makes the skip path work for squash, merge-commit, and rebase strategies.

## Linked issue

Refs #775

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| Skip on PR-driven close (any merge strategy) | met | `.github/workflows/unmet-ac-on-close-reusable.yml` (this commit) — uses GraphQL `ClosedEvent.closer` |

## Empirical verification

`gh api graphql` query against `crane-console issue 775`:

```json
[{"closer":{"__typename":"PullRequest","number":776,"title":"feat(ci): host reusable AC-tick workflows + cascade-ready seed (#775)"},"createdAt":"2026-05-01T03:15:37Z"}]
```

Compare with the REST API's `commit_id` on the same event: `null`.

## Test plan

- [x] YAML parses (validated by GitHub on push)
- [x] Manual GraphQL query confirms `closer` resolves correctly for squash-merged PRs
- [ ] After merge: force-update `tick-acs-v1` tag to point to the merge commit so existing callers (7 ventures) pick up the fix without a tag bump
- [ ] Smoke: re-close #775 (now with all ACs ticked) — workflow should log "all items checked ✓" and not interfere

## Tag bump policy

The original `tick-acs-v1` tag is hours old, has only seen one production exercise (the buggy one on #776), and the fix is non-breaking. Per `docs/runbooks/ac-tick-workflow-rollout.md`:

> Non-breaking changes can update `tick-acs-v1` in place by force-pushing the tag, but prefer a new tag for clarity.

For this fix specifically, force-updating `tick-acs-v1` is the right call — bumping to `v2` would require 7 cascade PRs to point callers at the new tag, for a fix that's effectively zero-risk.

## Feature impact

**Feature impact:** None — bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
