### PR TITLE
feat: real-time session reflexes (UserPromptSubmit hook + agent-facing doc)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "permissions": {
     "deny": ["mcp__claude_ai_crane_context__*"]
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/redirect-reflex-hook.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/instructions/operating-ethos.md
+++ b/docs/instructions/operating-ethos.md
@@ -103,6 +103,7 @@ These skills and memory patterns are expressions of this same core ethos:
 - **Kill don't file** - no follow-up tickets for speculative work.
 - **Critique deferrals aren't the answer** - when Captain says "soup to nuts in one session," find a better design, don't punt.
 - **No human-ergonomics arguments** - agents run the code. Valid justifications are determinism, cost, CI throughput. "It's easier for a human to read" is not.
+- **`session-reflexes.md`** - real-time pause patterns that catch drift before it ships. The ethos is the gestalt; the reflexes are the procedure for the moment.
 
 When the ethos feels in tension with operational directives in
 `guardrails.md` or `team-workflow.md`, the operational directives win on

--- a/docs/instructions/session-reflexes.md
+++ b/docs/instructions/session-reflexes.md
@@ -1,0 +1,44 @@
+# Session Reflexes
+
+Real-time pause patterns the agent runs _before_ producing substantive output.
+
+This doc is agent-facing. Read it on receipt of an imprecise redirect, or on any of the four signals below. The Captain doesn't read this — they use natural language. The agent decodes.
+
+## The Four Reflexes
+
+| Signal                                                                          | Reflex                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **You just received a redirect** ("recalibrate", "step up", "no, X not Y")      | Pause. Name the precise correction. Verify against code/memory before next action. Do NOT just shift the surface of your last answer and keep going.                                                                                                                                                                                                                                                                                                            |
+| **You're about to opine on system behavior, architecture, or feasibility**      | Pause. Did you read the code? If no, read first. Theorizing about a system you haven't read is the most common drift.                                                                                                                                                                                                                                                                                                                                           |
+| **You're about to ask a clarifying question**                                   | Classify it: **(a)** factual / in-codebase → read first; **(b)** judgment-call within guardrails → decide (see `/own-it`); **(c)** Captain-only (strategy, off-record context, guardrails-gated) → ask plainly. The trichotomy matters: collapsing (b) and (c) into "find it yourself" is the lossy "ask less" interpretation this doc exists to fix. Asking the Captain for genuine Captain-only judgment is correct; asking for a fact you could grep is not. |
+| **The user explicitly framed the mode** ("research", "think", "design", "ship") | Note the mode. Check current behavior against it before producing output. Research mode is not "research while sliding toward design." Ship mode is not "let me write a plan first."                                                                                                                                                                                                                                                                            |
+
+## Decoder for Imprecise Redirects
+
+When the Captain lands an imprecise redirect, decode it before acting. The signal is fast and shorthand on purpose. Your job is to translate.
+
+| Imprecise signal received              | Decode to                                                                           | Action                                                                                             |
+| -------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| "step up"                              | "verify against the code, then act"                                                 | Bias toward verification, not assumption. Don't bias toward "ask less" — that's the lossy reading. |
+| "stop asking questions you can answer" | "before asking, check if (a) factual — files/memory; ask only for (c) Captain-only" | Apply reflex #3 trichotomy. Captain-only questions are still valid.                                |
+| "this is wrong"                        | "wrong because — what specifically did I miss?"                                     | Identify the precise miss before responding. Don't apologize and try again on vibes.               |
+| "we're out of sync"                    | "we drifted at some point — locate it, then re-anchor"                              | Re-anchor on framing, not surface. Find the moment of divergence.                                  |
+| "recalibrate"                          | "re-read the most-relevant doc and re-evaluate; or, what mode are we in?"           | Verification or mode reset. Often both.                                                            |
+
+## The Hook
+
+`scripts/redirect-reflex-hook.sh`, wired up via `.claude/settings.json`, fires on every user prompt that matches the redirect patterns above. It prepends a one-line reminder to the agent's context for that turn, pointing back at this doc. The hook is the forcing function — without it, "real-time" is just retrospective work in present-tense costume.
+
+If the hook fires and you didn't actually need it (false positive), note that in the next `/eos` so the patterns can be tuned.
+
+## Cross-References
+
+- **`docs/instructions/operating-ethos.md`** — the standing order. Reflexes are how the ethos lands in the moment.
+- **`/own-it`** — decision ownership. Reflex #3(b) defers to /own-it's "decide instead of escalating." Don't double-prescribe.
+- **`feedback_*.md` auto-memory** — patterns the agent has saved from prior corrections. Read on session start; the reflexes complement, not replace.
+
+## Why This Exists
+
+The originating session: agent (me) drifted multiple times, Captain redirected with imprecise shorthand ("step up"), agent internalized as "ask less" instead of "verify more," and the misalignment compounded. The retrospective made the patterns nameable. This doc + the hook makes them fire in real-time so future sessions don't need the same retrospective.
+
+The ethos ("Mission first. Execute. If unclear, ask.") is the gestalt; the reflexes are the procedure for catching the moment when the gestalt would otherwise produce surface-confident drift.

--- a/scripts/redirect-reflex-hook.sh
+++ b/scripts/redirect-reflex-hook.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Redirect Reflex Hook (UserPromptSubmit)
+#
+# Pattern-matches imprecise redirect language in the Captain's prompt and
+# prepends a one-line reflex reminder so the next assistant turn fires the
+# verify-then-act loop documented in docs/instructions/session-reflexes.md.
+#
+# Reads Claude Code hook input on stdin (JSON with .prompt). On match: prints
+# a single reminder line to stdout (becomes additional context for the next
+# turn). On no match: silent, exit 0 — zero overhead.
+#
+# Patterns are conservative on purpose: the cost of a false positive is
+# annoying the Captain; the cost of a false negative is the originating
+# session this work was built to prevent.
+
+set -e
+
+# Read prompt from stdin JSON. If jq unavailable or input malformed, exit 0
+# silently — never block the Captain on a hook plumbing failure.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+PROMPT=$(jq -r '.prompt // empty' 2>/dev/null) || exit 0
+[ -z "$PROMPT" ] && exit 0
+
+# Patterns — case-insensitive, word-boundary anchored where it matters.
+PATTERNS=(
+  '\brecalibrat(e|ing|ion)\b'
+  '\bstep up\b'
+  '\bstop asking\b'
+  '\bout of sync\b'
+  '\byou keep [a-zA-Z]+ing\b'
+  '\bquestions? you can answer\b'
+)
+
+for pat in "${PATTERNS[@]}"; do
+  if echo "$PROMPT" | grep -qiE "$pat"; then
+    echo "[reflex] Imprecise redirect detected. Pause; decode the signal (see docs/instructions/session-reflexes.md); verify against code/memory before acting."
+    exit 0
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Agents drift in real time when imprecise Captain redirects ("step up", "recalibrate") land lossy and bias toward "ask less" instead of "verify more." The retrospective from a recent bumpy session made the patterns nameable; the moment-of-action signals were almost always present. This PR wires a forcing function so the patterns fire without depending on voluntary self-invocation.

**What ships:**

- `scripts/redirect-reflex-hook.sh` — bash script reads the user prompt from stdin (Claude Code UserPromptSubmit hook input), regex-matches a conservative set of redirect markers (`recalibrate`, `step up`, `stop asking`, `out of sync`, `you keep <verb>ing`, `questions you can answer`), prepends a one-line reflex reminder to the agent's context. Silent on miss, zero overhead.
- `.claude/settings.json` — wires the hook via `UserPromptSubmit`.
- `docs/instructions/session-reflexes.md` — agent-facing doc. Four reflexes (reflex #3 written as a trichotomy: factual / judgment-call / Captain-only — NOT collapsed into "find it yourself" which would reproduce the lossy reading this work exists to fix). Decoder section for common imprecise redirects.
- `docs/instructions/operating-ethos.md` — one cross-reference line. No `SOD_SUMMARY` edit, no `sos.ts` mirror update. Motivation doc stays motivation; reflexes referenced, not bolted on.

## Plan revisions adopted from `/critique`

- Dropped `/check` skill (voluntary self-invocation isn't a forcing function — the agent that needs it most won't recognize the need).
- Dropped a separate `captain-redirects.md` (inverts who reads what — Captain doesn't consult a rubric mid-redirect; the agent decodes).
- Kept the hook (was deferred in the original plan — exactly backwards; the hook is the only piece that makes any of this real-time).
- Reflex #3 reframed as the trichotomy noted above (the original binary was the lossy interpretation itself).

## Test plan

- [x] All six positive patterns fire correctly
- [x] Negatives stay silent — `make a sandwich`, `step into the room` (no false positive on partial "step up")
- [x] `npm run verify` passes
- [x] `jq empty .claude/settings.json` validates
- [ ] After merge: `./scripts/upload-doc-to-context-worker.sh docs/instructions/session-reflexes.md` and `./scripts/upload-doc-to-context-worker.sh docs/instructions/operating-ethos.md`
- [ ] After 5 sessions: review hook fire rate vs behavior change (per success metric in plan); tune patterns or remove if false positives exceed true positives

## Known limitations

- Project-level hook in crane-console only — `.claude/settings.json` is not propagated to venture repos by `syncClaudeAssets` (which only syncs `.claude/commands/` and `.claude/agents/`). User-level move or per-venture propagation is a follow-up once the mechanism proves out.
- Read-before-Edit and opining-verb hook detection deferred — second-order patterns harder to match cleanly than user-prompt language. Obvious next wave if redirect-detection proves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)