### PR TITLE
feat: session reflex primer v2 (always-on, corpus-driven)

### DIFF
--- a/docs/instructions/session-reflexes.md
+++ b/docs/instructions/session-reflexes.md
@@ -27,9 +27,13 @@ When the Captain lands an imprecise redirect, decode it before acting. The signa
 
 ## The Hook
 
-`scripts/redirect-reflex-hook.sh`, wired up via `.claude/settings.json`, fires on every user prompt that matches the redirect patterns above. It prepends a one-line reminder to the agent's context for that turn, pointing back at this doc. The hook is the forcing function — without it, "real-time" is just retrospective work in present-tense costume.
+`scripts/redirect-reflex-hook.sh`, wired up via `.claude/settings.json`, fires on **every** user prompt and prepends a one-line primer to the agent's context for that turn:
 
-If the hook fires and you didn't actually need it (false positive), note that in the next `/eos` so the patterns can be tuned.
+> `[reflex] Verify before opining; decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing. See docs/instructions/session-reflexes.md.`
+
+The primer maps to the four reflexes in clause order. It's the forcing function — without it, "real-time" is just retrospective work in present-tense costume.
+
+The primer is **always-on** by design. v1 of this hook tried to detect "imprecise redirects" via regex patterns drawn from one session's verbatim language. Corpus mining (5 recent JSONL transcripts, 906 user turns, 18 verbatim Captain redirects) showed those patterns matched **0 of 18 redirects**. Captain redirect language is too varied — and dominated by negation openers ("i don't", "what", "no") that are too noisy to match safely. The reflexes are universal; firing the primer universally is the only honest mechanism. v2 rationale below.
 
 ## Cross-References
 
@@ -42,3 +46,40 @@ If the hook fires and you didn't actually need it (false positive), note that in
 The originating session: agent (me) drifted multiple times, Captain redirected with imprecise shorthand ("step up"), agent internalized as "ask less" instead of "verify more," and the misalignment compounded. The retrospective made the patterns nameable. This doc + the hook makes them fire in real-time so future sessions don't need the same retrospective.
 
 The ethos ("Mission first. Execute. If unclear, ask.") is the gestalt; the reflexes are the procedure for catching the moment when the gestalt would otherwise produce surface-confident drift.
+
+## v2 Rationale (2026-04-30) — From Regex to Always-On
+
+v1 shipped (PR #778) with a six-pattern regex matcher derived from one session. The Captain pushed back: "are they just from the last session? will we continue to learn as new patterns emerge?" Both fair.
+
+We did the corpus work that should have happened the first time:
+
+- Mined 5 recent crane-console JSONL transcripts → 906 user turns, **18 verbatim Captain redirects**.
+- The original 6 regex patterns matched **0 of 18 (0%)**. They were artifacts of one session's syntax, not a generalizable signal.
+- Mined the 20 `feedback_*.md` memory files → drift clusters into 5 stable families (Verification/Evidence Skipping, Reference Blindness, False Thoroughness, Outsourcing/Delegation, Context Misalignment). The original 6 patterns covered family 3 weakly; missed families 1, 2, and 5 — the largest.
+
+**Why not tune the regex.** Captain's natural redirect language is dominated by pure-negation openers ("i don't", "what", "no, please") — matching on those would fire on most prompts (terrible signal:noise). Higher-signal phrases ("do the research", "look back", "think hard") catch ~30% of redirects but miss the rest. A tuned regex would still need always-on as a floor, making the regex layer redundant.
+
+**Why not LLM-classify.** A Haiku call per prompt adds 1-3s synchronous latency to every turn. That latency tax directly contradicts the operating ethos. v3 path only if always-on underperforms.
+
+**The honest conclusion.** Pattern-matching against natural-language redirects is the wrong abstraction. The reflexes are universal procedures — the agent should run them every turn, not only when a corpus-snapshot phrase fires.
+
+### What the hook can and can't do
+
+The UserPromptSubmit hook sees the user's prompt before the agent generates its turn. That means the primer can prime reflexes #1 (decode redirects) and #4 (respect mode framing) directly — both are user-prompt-side signals.
+
+Reflexes #2 (about to opine on system behavior) and #3 (about to ask a clarifying question) fire on **agent state**, not prompt content. The primer can remind the agent to consider them, but the hook cannot detect when the agent is about to violate them. If reflexes #2/#3 remain the dominant drift mode after the 30-day review, the next layer is a `PreToolUse` hook on Edit (read-before-edit forcing function). Out of scope for v2.
+
+### 30-day review window
+
+Captain reviews on or around 2026-05-30:
+
+- (a) New `feedback_*.md` files created in the 30-day window vs the prior 30 days.
+- (b) Agent self-corrections that cite the primer (search post-v2 JSONL for `[reflex]` mentions in agent turns or for verify-first patterns).
+- (c) Captain redirects that should have been prevented but weren't — mine the JSONL the same way the v2 corpus was mined.
+
+If (a) is flat or rising and (c) is high → escalate (LLM-classifier or richer telemetry). If (a) declines and (c) is rare → keep as-is.
+
+### Known limitations
+
+- **Habituation.** The same primer every turn may lose attention weight over a long session. Mitigation: keep it short. If the 30-day review shows the primer being ignored, rotation or per-turn salience signals become a v3 question.
+- **Crane-console only.** The hook is wired in this repo's `.claude/settings.json`, which the launcher's `syncClaudeAssets` does not propagate to venture repos. Ventures don't get the primer today. Captain works mostly here, but increasingly in ventures (SS work). Propagation is a deferred follow-up — not promised, contingent on v2 earning its keep.

--- a/scripts/redirect-reflex-hook.sh
+++ b/scripts/redirect-reflex-hook.sh
@@ -1,23 +1,35 @@
 #!/bin/bash
 #
-# Redirect Reflex Hook (UserPromptSubmit)
+# Session Reflex Primer Hook (UserPromptSubmit) — v2 (always-on)
 #
-# Pattern-matches imprecise redirect language in the Captain's prompt and
-# prepends a one-line reflex reminder so the next assistant turn fires the
-# verify-then-act loop documented in docs/instructions/session-reflexes.md.
+# Prepends a one-line reflex primer to the agent's context on every user
+# prompt. The agent reads it before generating its next turn, biasing toward
+# verify-before-opining and the four reflexes documented in
+# docs/instructions/session-reflexes.md.
 #
-# Reads Claude Code hook input on stdin (JSON with .prompt). On match: prints
-# a single reminder line to stdout (becomes additional context for the next
-# turn). On no match: silent, exit 0 — zero overhead.
+# Why always-on:
+#   v1 of this hook used six regex patterns derived from a single session's
+#   redirect language. Mining 5 recent JSONL transcripts (906 user turns,
+#   18 verbatim Captain redirects) showed those patterns matched 0 of 18.
+#   Pattern-matching against natural redirect language is too brittle to
+#   build a forcing function on. The reflexes are universal; the primer
+#   should fire universally too.
 #
-# Patterns are conservative on purpose: the cost of a false positive is
-# annoying the Captain; the cost of a false negative is the originating
-# session this work was built to prevent.
+# Wire protocol:
+#   stdin:  JSON with .prompt field (Claude Code hook contract)
+#   stdout: single line — becomes additional context for the next turn
+#   exit 0 always; never block the Captain on a hook plumbing failure
+#
+# If jq is unavailable or stdin is malformed, the hook exits silently. The
+# cost of a missed primer is one turn without the reminder; the cost of a
+# blocked prompt is the agent appearing broken to the Captain.
 
 set -e
 
-# Read prompt from stdin JSON. If jq unavailable or input malformed, exit 0
-# silently — never block the Captain on a hook plumbing failure.
+# Read prompt from stdin JSON. Even though the primer fires unconditionally,
+# we keep the input read to (a) preserve the Claude Code contract,
+# (b) leave room for future telemetry that needs the prompt, and
+# (c) fail silently on malformed input rather than emit a bare line.
 if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
@@ -25,21 +37,6 @@ fi
 PROMPT=$(jq -r '.prompt // empty' 2>/dev/null) || exit 0
 [ -z "$PROMPT" ] && exit 0
 
-# Patterns — case-insensitive, word-boundary anchored where it matters.
-PATTERNS=(
-  '\brecalibrat(e|ing|ion)\b'
-  '\bstep up\b'
-  '\bstop asking\b'
-  '\bout of sync\b'
-  '\byou keep [a-zA-Z]+ing\b'
-  '\bquestions? you can answer\b'
-)
-
-for pat in "${PATTERNS[@]}"; do
-  if echo "$PROMPT" | grep -qiE "$pat"; then
-    echo "[reflex] Imprecise redirect detected. Pause; decode the signal (see docs/instructions/session-reflexes.md); verify against code/memory before acting."
-    exit 0
-  fi
-done
+echo "[reflex] Verify before opining; decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing. See docs/instructions/session-reflexes.md."
 
 exit 0


### PR DESCRIPTION
## Summary

V1 (PR #778) used six regex patterns derived from a single session. Captain's challenge — *did we research these? will we learn as new patterns emerge?* — sent us to the data.

**Corpus findings:**

- 5 recent crane-console JSONL transcripts → 906 user turns → **18 verbatim Captain redirects**
- The original 6 regex patterns matched **0 of 18 (0%)** — artifacts of one session's syntax, not a generalizable signal
- 100% of redirects open with negation ("i don't", "what", "no, please"); matching on those would fire on most prompts
- 20 \`feedback_*.md\` memories cluster into 5 stable drift families; original patterns weakly cover 1, miss the largest (Verification Skipping, Reference Blindness, Context Misalignment)

**v2:** Replace the pattern matcher with an unconditional ~50-token primer that maps to the four reflexes from \`session-reflexes.md\`:

> \`[reflex] Verify before opining; decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing. See docs/instructions/session-reflexes.md.\`

Universal coverage. No false positives, no false negatives in detection (because we're not detecting). Tradeoff: ~50 tokens per turn permanent context cost vs the v1 0%-recall regex.

**Why not the alternatives:**

- **Tune regex** — corpus-validated patterns catch ~30% with bad signal:noise; still need always-on as floor
- **LLM-classifier** — 1-3s sync latency per prompt contradicts the ethos
- **Hybrid** — added complexity for marginal gain; v3 path only if v2 underperforms

**Learning loop:** No new telemetry. The existing \`feedback_*.md\` pattern is the corpus mechanism. 30-day review on 2026-05-30 compares new feedback rate to prior 30 days, decides keep/escalate/retire.

**Known limits documented in the doc:**

- Hook can only address reflexes #1 (decode redirects) and #4 (mode framing) directly. Reflexes #2 (about to opine) and #3 (about to ask) fire on agent state, not prompt content
- Crane-console only — \`.claude/settings.json\` not propagated by \`syncClaudeAssets\`. Ventures don't get the primer today
- Habituation risk: same primer every turn may lose attention weight; v3 question if 30-day review shows it

## Test plan

- [x] \`npm run verify\` passes (0 errors, 30 pre-existing warnings)
- [x] Hook fires on every prompt (\`echo '{"prompt":"x"}' | bash scripts/redirect-reflex-hook.sh\` → primer)
- [x] Hook handles malformed input silently (\`echo 'not json' | ...\` → exit 0, no output)
- [ ] Live agent test: post-merge, run a fresh session and observe whether the primer shapes verify-first behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)