### PR TITLE
feat: fleet-branch-protection script + canonical-profile flip

### DIFF
--- a/config/github-ruleset-main-protection.json
+++ b/config/github-ruleset-main-protection.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Canonical main-branch protection profile applied by scripts/fleet-branch-protection.sh to every venture repo. strict_required_status_checks_policy is intentionally false: the up-to-date requirement was driving rebase+force-push churn whenever main moved under an open PR. Required CI checks still run; admin enforcement still applies. Tradeoff and backstop documented in docs/instructions/git-guardrails.md.",
   "name": "Main Branch Protection",
   "target": "branch",
   "enforcement": "active",
@@ -29,7 +30,7 @@
       "type": "required_status_checks",
       "parameters": {
         "required_status_checks": [{ "context": "Security Summary" }],
-        "strict_required_status_checks_policy": true
+        "strict_required_status_checks_policy": false
       }
     }
   ]

--- a/scripts/fleet-branch-protection.sh
+++ b/scripts/fleet-branch-protection.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# scripts/fleet-branch-protection.sh
+#
+# Apply or audit the canonical branch-protection profile across venture
+# repos. Reads venture list from config/ventures.json. Idempotent.
+#
+# THE FLIP: this script's primary job is setting `required_status_checks.strict`
+# to false on every venture main. The "branches must be up to date before
+# merging" requirement is what drove the rebase + force-push churn whenever
+# main moved under an open PR. Required CI checks still run; required reviews
+# still gate; admin enforcement still applies. Only `strict` changes.
+#
+# Per repo, the script checks BOTH layers:
+#   - Classic protection: gh api repos/{o}/{r}/branches/main/protection
+#       If strict=true → PATCH .../required_status_checks with strict=false
+#       (partial update via dedicated sub-endpoint; preserves contexts/checks).
+#   - Rulesets: gh api repos/{o}/{r}/rulesets
+#       For each ruleset that contains a required_status_checks rule with
+#       strict_required_status_checks_policy=true, fetch the full ruleset,
+#       flip that field, PUT the entire ruleset back. (No PATCH for rulesets.)
+#
+# Edge case: if a repo has neither classic protection nor any rulesets, the
+# script POSTs the canonical ruleset profile from
+# config/github-ruleset-main-protection.json. New ventures land here.
+#
+# Idempotency: a repo with all strict flags already false produces no actions
+# and no API writes. Safe to re-run.
+#
+# Output modes:
+#   --dry-run  (default) — print planned action per repo, do nothing
+#   --apply              — execute the plan
+#
+# Filters:
+#   --venture <code>     — limit to one venture (vc, ss, dc, ke, sc, dfg)
+#   --repo <full_name>   — limit to one repo (venturecrane/vc-web)
+#
+# Auth requirements:
+#   Local `gh auth status` must have admin scope on each org. The fleet
+#   audit PAT (GH_FLEET_AUDIT_TOKEN) is read-only and cannot apply changes.
+#   Use your normal gh login.
+#
+# Pre-flight:
+#   Probes venturecrane/crane-console branch protection. Aborts with a
+#   clear message if 403 (insufficient scope).
+#
+# Usage:
+#   bash scripts/fleet-branch-protection.sh
+#   bash scripts/fleet-branch-protection.sh --dry-run --venture vc
+#   bash scripts/fleet-branch-protection.sh --apply --repo venturecrane/vc-web
+#   bash scripts/fleet-branch-protection.sh --apply       # all 6 active ventures
+
+set -uo pipefail
+
+# ----- Args -----
+MODE="dry-run"
+VENTURE_FILTER=""
+REPO_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) MODE="dry-run"; shift ;;
+    --apply) MODE="apply"; shift ;;
+    --venture) VENTURE_FILTER="$2"; shift 2 ;;
+    --repo) REPO_FILTER="$2"; shift 2 ;;
+    --help|-h) sed -n '2,46p' "$0"; exit 0 ;;
+    *) echo "fleet-branch-protection: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ----- Paths -----
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENTURES_JSON="$REPO_ROOT/config/ventures.json"
+RULESET_PROFILE="$REPO_ROOT/config/github-ruleset-main-protection.json"
+
+# ----- Colors -----
+RED='\033[0;31m'; YELLOW='\033[0;33m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+# ----- Preflight -----
+command -v gh >/dev/null 2>&1 || { echo "fleet-branch-protection: gh CLI required" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "fleet-branch-protection: jq required" >&2; exit 2; }
+gh auth status >/dev/null 2>&1 || { echo "fleet-branch-protection: gh CLI not authenticated" >&2; exit 2; }
+[ -f "$VENTURES_JSON" ] || { echo "fleet-branch-protection: $VENTURES_JSON missing" >&2; exit 2; }
+[ -f "$RULESET_PROFILE" ] || { echo "fleet-branch-protection: $RULESET_PROFILE missing" >&2; exit 2; }
+
+# Probe admin scope on a known venture repo.
+PROBE_REPO="venturecrane/crane-console"
+probe_http_status=$(gh api "repos/$PROBE_REPO/branches/main/protection" \
+  --silent -i 2>/dev/null | head -n 1 | awk '{print $2}' || true)
+if [ -z "$probe_http_status" ]; then
+  # Older gh versions may not echo status with --silent; fall back to raw call.
+  if gh api "repos/$PROBE_REPO/branches/main/protection" >/dev/null 2>&1; then
+    probe_http_status="200"
+  else
+    probe_http_status="error"
+  fi
+fi
+case "$probe_http_status" in
+  200|404)
+    : # 200 = protection exists and we can read it; 404 = no protection (acceptable)
+    ;;
+  403)
+    cat >&2 <<EOF
+${RED}fleet-branch-protection: probe returned 403 on $PROBE_REPO${NC}
+
+Your gh CLI lacks admin scope. Apply branch-protection changes require:
+  gh auth login --scopes "repo,admin:org,workflow"
+
+Or set GH_TOKEN to a fine-grained PAT with
+  Repository permissions: Administration (Read and write)
+on every venture repo.
+EOF
+    exit 2
+    ;;
+  *)
+    echo "${RED}fleet-branch-protection: probe failed (status: $probe_http_status)${NC}" >&2
+    exit 2
+    ;;
+esac
+
+# ----- Build target repo list from ventures.json -----
+# Each entry: "<venture_code> <owner/repo>"
+TARGETS=()
+while IFS= read -r line; do
+  TARGETS+=("$line")
+done < <(
+  jq -r '
+    .ventures[]
+    | select(.repos | length > 0)
+    | . as $v
+    | $v.repos[] | "\($v.code) \($v.org)/\(.)"
+  ' "$VENTURES_JSON"
+)
+
+# Apply filters.
+FILTERED_TARGETS=()
+for t in "${TARGETS[@]}"; do
+  code="${t%% *}"
+  full="${t#* }"
+  if [ -n "$VENTURE_FILTER" ] && [ "$code" != "$VENTURE_FILTER" ]; then continue; fi
+  if [ -n "$REPO_FILTER" ] && [ "$full" != "$REPO_FILTER" ]; then continue; fi
+  FILTERED_TARGETS+=("$t")
+done
+
+if [ "${#FILTERED_TARGETS[@]}" -eq 0 ]; then
+  echo "fleet-branch-protection: no repos matched filters (venture=$VENTURE_FILTER, repo=$REPO_FILTER)" >&2
+  exit 1
+fi
+
+echo -e "${CYAN}fleet-branch-protection: mode=$MODE, ${#FILTERED_TARGETS[@]} repo(s)${NC}"
+echo ""
+
+# ----- Helpers -----
+
+# Returns 0 (and echoes "true"|"false") if a ruleset enforces strict; non-zero otherwise.
+ruleset_strict_value() {
+  local repo="$1" rs_id="$2"
+  gh api "repos/$repo/rulesets/$rs_id" \
+    --jq '.rules[]? | select(.type=="required_status_checks") | .parameters.strict_required_status_checks_policy // empty' \
+    2>/dev/null
+}
+
+# Flip strict_required_status_checks_policy=false on a ruleset via PUT (full replace).
+# Strips read-only fields the API rejects on PUT.
+ruleset_flip_strict() {
+  local repo="$1" rs_id="$2"
+  local tmp_in tmp_out
+  tmp_in="$(mktemp)"
+  tmp_out="$(mktemp)"
+  gh api "repos/$repo/rulesets/$rs_id" >"$tmp_in" 2>/dev/null || { rm -f "$tmp_in" "$tmp_out"; return 1; }
+  jq '
+    del(.id, .node_id, .source_type, .source, .created_at, .updated_at, ._links, .current_user_can_bypass)
+    | (.rules[]?
+       | select(.type == "required_status_checks")
+       | .parameters.strict_required_status_checks_policy) = false
+  ' "$tmp_in" >"$tmp_out" || { rm -f "$tmp_in" "$tmp_out"; return 1; }
+  if gh api "repos/$repo/rulesets/$rs_id" \
+       --method PUT \
+       --header "Accept: application/vnd.github+json" \
+       --input "$tmp_out" >/dev/null 2>&1; then
+    rm -f "$tmp_in" "$tmp_out"
+    return 0
+  fi
+  rm -f "$tmp_in" "$tmp_out"
+  return 1
+}
+
+# ----- Per-repo loop -----
+ACTIONS=()  # "<repo>|<action>|<message>"
+HAS_FAIL=0
+
+for t in "${FILTERED_TARGETS[@]}"; do
+  code="${t%% *}"
+  full="${t#* }"
+
+  printf "%-12s %s\n" "[$code]" "$full"
+
+  classic_json=$(gh api "repos/$full/branches/main/protection" 2>/dev/null || echo "")
+  rulesets_json=$(gh api "repos/$full/rulesets" 2>/dev/null || echo "[]")
+
+  any_action_taken_for_repo=0
+  any_strict_found=0
+
+  # ----- Classic protection check -----
+  if [ -n "$classic_json" ]; then
+    classic_strict=$(echo "$classic_json" | jq -r '.required_status_checks.strict // false')
+    if [ "$classic_strict" = "true" ]; then
+      any_strict_found=1
+      if [ "$MODE" = "dry-run" ]; then
+        echo -e "    classic protection: ${YELLOW}strict=true → would PATCH to false${NC}"
+        ACTIONS+=("$full|flip-classic|strict: true → false")
+      else
+        if gh api "repos/$full/branches/main/protection/required_status_checks" \
+             --method PATCH \
+             --header "Accept: application/vnd.github+json" \
+             -f strict=false >/dev/null 2>&1; then
+          verify=$(gh api "repos/$full/branches/main/protection" \
+            --jq '.required_status_checks.strict' 2>/dev/null || echo "?")
+          if [ "$verify" = "false" ]; then
+            echo -e "    classic protection: ${GREEN}FLIPPED strict=true → false${NC}"
+            ACTIONS+=("$full|flip-classic|verified strict=false")
+          else
+            echo -e "    classic protection: ${RED}verify mismatch: strict=$verify${NC}"
+            ACTIONS+=("$full|fail|classic verify mismatch")
+            HAS_FAIL=1
+          fi
+        else
+          echo -e "    classic protection: ${RED}PATCH failed${NC}"
+          ACTIONS+=("$full|fail|classic PATCH failed")
+          HAS_FAIL=1
+        fi
+      fi
+      any_action_taken_for_repo=1
+    fi
+  fi
+
+  # ----- Rulesets check -----
+  ruleset_count=$(echo "$rulesets_json" | jq 'length')
+  if [ "$ruleset_count" -gt 0 ]; then
+    while IFS= read -r rs_id; do
+      [ -z "$rs_id" ] && continue
+      rs_strict=$(ruleset_strict_value "$full" "$rs_id" || echo "")
+      if [ "$rs_strict" = "true" ]; then
+        any_strict_found=1
+        rs_name=$(echo "$rulesets_json" | jq -r ".[] | select(.id == $rs_id) | .name")
+        if [ "$MODE" = "dry-run" ]; then
+          echo -e "    ruleset \"$rs_name\" (id=$rs_id): ${YELLOW}strict=true → would PUT with strict=false${NC}"
+          ACTIONS+=("$full|flip-ruleset|ruleset id=$rs_id strict: true → false")
+        else
+          if ruleset_flip_strict "$full" "$rs_id"; then
+            verify=$(ruleset_strict_value "$full" "$rs_id" || echo "?")
+            if [ "$verify" = "false" ]; then
+              echo -e "    ruleset \"$rs_name\" (id=$rs_id): ${GREEN}FLIPPED strict=true → false${NC}"
+              ACTIONS+=("$full|flip-ruleset|id=$rs_id verified")
+            else
+              echo -e "    ruleset \"$rs_name\" (id=$rs_id): ${RED}verify mismatch: strict=$verify${NC}"
+              ACTIONS+=("$full|fail|ruleset verify mismatch")
+              HAS_FAIL=1
+            fi
+          else
+            echo -e "    ruleset \"$rs_name\" (id=$rs_id): ${RED}PUT failed${NC}"
+            ACTIONS+=("$full|fail|ruleset PUT failed")
+            HAS_FAIL=1
+          fi
+        fi
+        any_action_taken_for_repo=1
+      fi
+    done < <(echo "$rulesets_json" | jq -r '.[].id')
+  fi
+
+  # ----- No-protection-at-all case -----
+  if [ -z "$classic_json" ] && [ "$ruleset_count" -eq 0 ]; then
+    if [ "$MODE" = "dry-run" ]; then
+      echo -e "    ${YELLOW}NO PROTECTION → would apply canonical ruleset profile${NC}"
+      ACTIONS+=("$full|create-ruleset|none → canonical profile")
+    else
+      if gh api "repos/$full/rulesets" \
+           --method POST \
+           --header "Accept: application/vnd.github+json" \
+           --input "$RULESET_PROFILE" >/dev/null 2>&1; then
+        echo -e "    ${GREEN}APPLIED canonical ruleset profile${NC}"
+        ACTIONS+=("$full|create-ruleset|created from $RULESET_PROFILE")
+      else
+        echo -e "    ${RED}FAILED to apply ruleset profile${NC}"
+        ACTIONS+=("$full|fail|ruleset POST failed")
+        HAS_FAIL=1
+      fi
+    fi
+    any_action_taken_for_repo=1
+  fi
+
+  if [ "$any_action_taken_for_repo" -eq 0 ] && [ "$any_strict_found" -eq 0 ]; then
+    echo -e "    ${GREEN}already correct (strict=false everywhere)${NC}"
+    ACTIONS+=("$full|noop|all strict=false")
+  fi
+done
+
+# ----- Summary -----
+echo ""
+echo -e "${CYAN}Summary (mode=$MODE):${NC}"
+echo ""
+printf "  %-40s  %-15s  %s\n" "Repo" "Action" "Detail"
+printf "  %-40s  %-15s  %s\n" "----" "------" "------"
+for a in "${ACTIONS[@]}"; do
+  full="${a%%|*}"; rest="${a#*|}"
+  action="${rest%%|*}"; detail="${rest#*|}"
+  printf "  %-40s  %-15s  %s\n" "$full" "$action" "$detail"
+done
+echo ""
+
+if [ "$MODE" = "dry-run" ]; then
+  echo -e "${YELLOW}Dry-run only. Re-run with --apply to execute.${NC}"
+fi
+
+[ "$HAS_FAIL" -eq 0 ] || exit 1
+exit 0

--- a/scripts/setup-new-venture.sh
+++ b/scripts/setup-new-venture.sh
@@ -740,6 +740,41 @@ fi
 echo ""
 
 # ============================================================================
+# Step N: Apply canonical branch protection
+# ============================================================================
+#
+# Sets the canonical "Main Branch Protection" ruleset on the new repo's
+# default branch. Profile lives at config/github-ruleset-main-protection.json
+# (notably strict_required_status_checks_policy=false; see git-guardrails.md
+# for why).
+#
+# Precondition: main must exist on the remote. The push at the end of Step 2
+# is what creates it; if that step was skipped, this step skips with a
+# non-fatal warning rather than blocking new-venture flow.
+
+echo -e "${CYAN}### Step N: Apply branch protection${NC}"
+echo ""
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo -e "  ${YELLOW}[DRY RUN]${NC} Would apply canonical branch protection to $FULL_REPO"
+else
+  branch_check=$(gh api "repos/$FULL_REPO/branches/main" --jq '.name' 2>/dev/null || echo "")
+  if [ "$branch_check" != "main" ]; then
+    echo -e "  ${YELLOW}main branch not found on $FULL_REPO yet — skipping${NC}"
+    echo -e "  ${YELLOW}Re-run later: bash scripts/fleet-branch-protection.sh --apply --repo $FULL_REPO${NC}"
+  else
+    if bash "$REPO_ROOT/scripts/fleet-branch-protection.sh" --apply --repo "$FULL_REPO"; then
+      echo -e "  ${GREEN}Branch protection applied${NC}"
+    else
+      echo -e "  ${YELLOW}fleet-branch-protection.sh exited non-zero — review output above${NC}"
+      echo -e "  ${YELLOW}Re-run later: bash scripts/fleet-branch-protection.sh --apply --repo $FULL_REPO${NC}"
+    fi
+  fi
+fi
+
+echo ""
+
+# ============================================================================
 # Summary
 # ============================================================================
 
@@ -761,6 +796,7 @@ echo "  - upload-doc-to-context-worker.sh updated"
 echo "  - Repo cloned to dev machines"
 echo "  - .infisical.json copied to local repo"
 echo "  - Infisical folder created + shared secrets synced"
+echo "  - Branch protection applied (canonical ruleset)"
 echo ""
 echo "  - Design spec template created in new repo"
 echo "  - Venture design directory created in crane-console"


### PR DESCRIPTION
## Summary

Layer 1 of the durable git-friction fix. New `scripts/fleet-branch-protection.sh` rolls out the canonical branch-protection profile across venture repos and audits drift. Investigation against live state surfaced the actual culprit: 6 of 7 venture repos enforce `strict_required_status_checks_policy = true` via a **ruleset** (not classic protection), so the script handles both the classic-protection PATCH path and the rulesets PUT path. Apply against the 6 production repos is a separate Captain-confirmed run.

## Linked issue

None — durable enterprise fix authored from `/auto-build` plan. Layer 2 ships in #781.

## Acceptance criteria status

| AC (verbatim from issue)                                                              | Status | Evidence                                                                                                                                  |
| ------------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
| New `scripts/fleet-branch-protection.sh` (read-only by default; `--apply` opt-in)     | met    | New file; `--dry-run` is default; `--apply`, `--venture <code>`, `--repo <full_name>` all supported                                       |
| Auth pre-flight (admin scope on probe repo) + clear error if 403                      | met    | Probe runs `gh api repos/venturecrane/crane-console/branches/main/protection`; 403 path prints actionable instructions and aborts         |
| Read-modify-write that preserves all other protection fields                          | met    | Classic: PATCH `.../required_status_checks` (sub-endpoint preserves contexts/checks). Rulesets: PUT after `del()`-stripping read-only fields |
| Canonical profile JSON updated to set `strict_required_status_checks_policy: false`   | met    | `config/github-ruleset-main-protection.json` flipped + `_comment` field documents the tradeoff                                            |
| Wire-in to `setup-new-venture.sh` so new ventures inherit the profile                 | met    | New "Step N: Apply branch protection" added between secrets sync and final summary; precondition guard checks main exists; non-fatal skip |

## Test plan

- [x] `npm run verify` passes
- [x] Dry-run against all 7 venture repos: vc-web shows `noop` (no rulesets, classic strict already false); the other 6 show `flip-ruleset` with the exact ruleset id and name. Output reproduced below.
- [ ] Apply against all 6 production repos: **deferred to a separate Captain-confirmed run** — modifying shared infrastructure on 6 production repos is not auto-mode work
- [ ] Post-apply verification: re-running dry-run shows all 7 as `noop` (idempotent)
- [ ] Functional test: open a feature PR in vc-web, let main move (merge an unrelated PR), squash-merge the original — succeeds without rebase

### Dry-run output (live, against current org state)

```
fleet-branch-protection: mode=dry-run, 7 repo(s)

[vc]         venturecrane/crane-console
    ruleset "Main Branch Protection" (id=15383940): strict=true → would PUT with strict=false
[vc]         venturecrane/vc-web
    already correct (strict=false everywhere)
[sc]         venturecrane/sc-console
    ruleset "Main Branch Protection" (id=15555250): strict=true → would PUT with strict=false
[dfg]        venturecrane/dfg-console
    ruleset "Main Branch Protection" (id=15555212): strict=true → would PUT with strict=false
[ke]         venturecrane/ke-console
    ruleset "Main Branch Protection" (id=15555140): strict=true → would PUT with strict=false
[ss]         venturecrane/ss-console
    ruleset "Main Branch Protection" (id=15555219): strict=true → would PUT with strict=false
[dc]         venturecrane/dc-console
    ruleset "Main Branch Protection" (id=15555287): strict=true → would PUT with strict=false
```

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints — N/A, no new endpoints
- [x] Parameterized queries for any SQL — N/A
- [x] Auth required on new endpoints — N/A
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None today. The PR adds tooling and updates the canonical profile JSON; live branch-protection rules on the 6 venture mains do **NOT** change as a result of this PR merging. The behavioral change happens when `bash scripts/fleet-branch-protection.sh --apply` is run separately by the Captain, after which main can be merged into without the up-to-date rebase dance.

**Risk accepted at apply time:** with `strict=false`, two PRs that each pass CI on their own snapshots can both merge and break main if combined. Backstop: `fleet-ops-health.sh`'s existing `ci-failed` finding catches a red main within ≤24h; revert PR is the fix. Velocity profile (Dependabot-dominated, low parallel concurrency) makes the failure mode rare enough to accept. See `docs/instructions/git-guardrails.md` (Layer 2 #781) for fuller discussion.

## Deployment Notes

No automated deploy. After merge, the Captain runs:

```
bash scripts/fleet-branch-protection.sh --dry-run        # final review
bash scripts/fleet-branch-protection.sh --apply          # flip strict on 6 repos
bash scripts/fleet-branch-protection.sh --dry-run        # confirm idempotent (all noop)
```

## Follow-up

Layer 3 (drift detection in fleet-health: `branch-protection-strict` finding type + pre-merge PAT verification) ships next. It should land **after** the Captain's `--apply` run, otherwise the new finding will fire on all 6 repos immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)