### PR TITLE
feat(fleet-health): drift detection for required-up-to-date

### DIFF
--- a/scripts/fleet-ops-health.sh
+++ b/scripts/fleet-ops-health.sh
@@ -136,6 +136,82 @@ for i in $(seq 0 $((REPO_COUNT - 1))); do
       "Latest workflow run on $default_branch is cancelled"
   fi
 
+  # ---- Branch protection: required-up-to-date drift ----
+  # The plan flips required_status_checks.strict to false fleet-wide via
+  # scripts/fleet-branch-protection.sh. This audit catches drift back to
+  # strict=true (which re-introduces the rebase + force-push churn that
+  # tripped Claude's pause logic). Both classic protection AND rulesets
+  # enforce this independently; check both.
+  #
+  # Status-code dispatch:
+  #   200 + strict=true   → branch-protection-strict (ERROR)
+  #   200 + strict=false  → no finding
+  #   4xx/5xx             → protection-check-failed (WARN) — distinguishes
+  #                          "no drift" from "couldn't tell" (silent 403 was
+  #                          identified as a Layer 3 risk during planning)
+  protection_strict_found=0
+  protection_check_failed=0
+  protection_check_status=""
+
+  classic_resp=$(gh api -i "repos/$full_name/branches/main/protection" 2>/dev/null || echo "")
+  classic_status=$(echo "$classic_resp" | head -n 1 | awk '{print $2}')
+  classic_body=$(echo "$classic_resp" | awk 'BEGIN{p=0} /^\r?$/{p=1; next} p{print}')
+  case "$classic_status" in
+    200)
+      classic_strict=$(echo "$classic_body" | jq -r '.required_status_checks.strict // false' 2>/dev/null || echo "false")
+      if [ "$classic_strict" = "true" ]; then protection_strict_found=1; fi
+      ;;
+    404)
+      : # No classic protection; fine.
+      ;;
+    "")
+      : # gh-api returned nothing; treat as a soft probe failure but don't escalate yet
+      ;;
+    *)
+      protection_check_failed=1
+      protection_check_status="classic=$classic_status"
+      ;;
+  esac
+
+  rulesets_resp=$(gh api -i "repos/$full_name/rulesets" 2>/dev/null || echo "")
+  rulesets_status=$(echo "$rulesets_resp" | head -n 1 | awk '{print $2}')
+  rulesets_body=$(echo "$rulesets_resp" | awk 'BEGIN{p=0} /^\r?$/{p=1; next} p{print}')
+  case "$rulesets_status" in
+    200)
+      # Iterate ruleset ids; for each, fetch detail and check strict flag.
+      ruleset_ids=$(echo "$rulesets_body" | jq -r '.[].id' 2>/dev/null || echo "")
+      for rs_id in $ruleset_ids; do
+        rs_detail_status=$(gh api -i "repos/$full_name/rulesets/$rs_id" 2>/dev/null | head -n 1 | awk '{print $2}')
+        if [ "$rs_detail_status" = "200" ]; then
+          rs_strict=$(gh api "repos/$full_name/rulesets/$rs_id" \
+            --jq '.rules[]? | select(.type=="required_status_checks") | .parameters.strict_required_status_checks_policy // empty' \
+            2>/dev/null)
+          if [ "$rs_strict" = "true" ]; then
+            protection_strict_found=1
+          fi
+        else
+          protection_check_failed=1
+          protection_check_status="ruleset/$rs_id=$rs_detail_status"
+        fi
+      done
+      ;;
+    "")
+      :
+      ;;
+    *)
+      protection_check_failed=1
+      protection_check_status="${protection_check_status:+$protection_check_status,}rulesets=$rulesets_status"
+      ;;
+  esac
+
+  if [ "$protection_strict_found" -eq 1 ]; then
+    record "$full_name" "branch-protection-strict" "error" \
+      "main has required_status_checks.strict=true (re-introduces up-to-date rebase requirement; flip via scripts/fleet-branch-protection.sh)"
+  elif [ "$protection_check_failed" -eq 1 ]; then
+    record "$full_name" "protection-check-failed" "warning" \
+      "Could not read protection state ($protection_check_status); audit token may lack Administration:read scope"
+  fi
+
   # ---- Dependabot backlog ----
   # Count open dependabot PRs.
   dep_count=$(gh api \

--- a/workers/crane-context/src/fleet-health.ts
+++ b/workers/crane-context/src/fleet-health.ts
@@ -55,6 +55,8 @@ export const KNOWN_FINDING_TYPES = [
   'dependabot-stale',
   'secret-missing',
   'security-workflow-failed',
+  'branch-protection-strict',
+  'protection-check-failed',
   // Machine-source (Hermes-on-mini, #657)
   'os-security-patches',
   'os-feature-updates',


### PR DESCRIPTION
## Summary

Layer 3 of the durable git-friction fix. Extends the weekly fleet-ops-health audit to detect when `required_status_checks.strict` returns to `true` on any venture main — whether via classic protection or rulesets. Adds two finding types: `branch-protection-strict` (ERROR) for actual drift, and `protection-check-failed` (WARN) for non-200 responses, so a silent 403 from a token-scope gap shows up as a visible warning rather than as false-green.

## Linked issue

None — Layer 3 of the `/auto-build` plan. Layers 2 (#781) and 1 (#782) are already up.

## Acceptance criteria status

| AC (verbatim from issue)                                                                | Status | Evidence                                                                                                                                  |
| --------------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
| Add `branch-protection-strict` (ERROR) to KNOWN_FINDING_TYPES                           | met    | `workers/crane-context/src/fleet-health.ts` enum updated                                                                                  |
| Add `protection-check-failed` (WARN) to KNOWN_FINDING_TYPES (silent 403 → visible WARN) | met    | Same enum, same file                                                                                                                      |
| Audit script queries BOTH classic protection and rulesets                               | met    | `scripts/fleet-ops-health.sh` calls `branches/main/protection` AND `rulesets` (then per-ruleset detail) per repo                          |
| Status-code dispatch: 200+strict→ERROR, 200+!strict→noop, 4xx/5xx→WARN                  | met    | Case-statement on HTTP status; status string interpolated into the WARN message for triage                                                |
| Auto-resolution and SOS surfacing inherit from existing pipeline                        | met    | New finding types ride the same `record()` helper → JSON ingest → snapshot-diff auto-resolve → existing SOS Fleet Health renderer         |

## Test plan

- [x] `npm run verify` passes
- [x] **Live audit run** correctly emits `branch-protection-strict` ERROR for the 7 org repos that currently have ruleset strict=true (the 6 venture mains + `smd-console`, which exists in the org but is not in `ventures.json`). vc-web (no ruleset, classic strict already false) correctly emits no finding.
- [ ] **Failure-path verification** (token without Administration:read → emits `protection-check-failed`): logic is well-isolated but not exercised against a real 403 because the Captain's local gh has admin scope. If the CI-bound token has narrower scope, this WARN will surface on first scheduled run and we'll know.
- [ ] **End-to-end roundtrip:** post-Layer-1-apply, a re-run of fleet-ops-health.sh should report zero `branch-protection-strict` findings on the 6 venture mains; existing rows auto-resolve via snapshot-diff.

### Live audit excerpt (current state, pre-Layer-1-apply)

```
[ERROR] venturecrane/crane-console (branch-protection-strict): main has required_status_checks.strict=true ...
[ERROR] venturecrane/sc-console (branch-protection-strict): ...
[ERROR] venturecrane/dfg-console (branch-protection-strict): ...
[ERROR] venturecrane/ke-console (branch-protection-strict): ...
[ERROR] venturecrane/ss-console (branch-protection-strict): ...
[ERROR] venturecrane/dc-console (branch-protection-strict): ...
[ERROR] venturecrane/smd-console (branch-protection-strict): ...
```

(`smd-console` exists in the org but is not in `config/ventures.json` — out-of-scope drift signal that this PR correctly surfaces.)

## Security Checklist

- [x] No secrets in code or comments
- [x] No PII exposed in frontend responses
- [x] Input validation on new endpoints — N/A
- [x] Parameterized queries for any SQL — N/A
- [x] Auth required on new endpoints — N/A
- [x] No internal IDs that enable enumeration

## Feature Impact

**Feature impact:** None. Pure additive observability. Existing finding types and severity levels unchanged. SOS Fleet Health rendering is generic on finding type, so the new types appear without code changes there.

## Deployment Notes

- The CI-bound `GH_FLEET_AUDIT_TOKEN` needs `Administration: read` (or repo admin via classic scopes) on each venture repo to read `branches/main/protection` and `rulesets`. If the current scope is narrower, the next scheduled audit run will surface `protection-check-failed` WARN findings — that's the intended visibility.
- **Sequencing with Layer 1:** if this PR merges before Layer 1's Captain-confirmed `--apply` run, fleet-health will start surfacing 6+ `branch-protection-strict` ERROR findings immediately. Either:
  1. Apply Layer 1 first (preferred), then merge this PR;
  2. Merge this PR first, accept the temporary noise, then apply Layer 1 to clear it.
- Worker (`crane-context`) needs to be redeployed to pick up the new finding-type strings in the enum. The enum is forward-compat (storage stores unknowns), so this is cosmetic — but the deploy keeps the type-safety promise.

## Out of Scope

- Backfilling drift detection for repos not in `ventures.json` (e.g., `smd-console`). The audit happily reports them; whether to act is a separate registry-cleanup question.
- "PR behind main by N commits" warning (deferred per plan; reconsider after Layer 1 has run for a week).

🤖 Generated with [Claude Code](https://claude.com/claude-code)