### PR TITLE
fix(health-checks): scope notifications-truth-window query per venture

### DIFF
--- a/packages/crane-mcp/src/lib/health-checks.test.ts
+++ b/packages/crane-mcp/src/lib/health-checks.test.ts
@@ -33,7 +33,11 @@ function makeCountsResponse(
 }
 
 function makeContext(
-  overrides: { ciCountsTotal?: number; counts?: NotificationCountsResponse } = {}
+  overrides: {
+    ciCountsTotal?: number
+    counts?: NotificationCountsResponse
+    venture?: string
+  } = {}
 ): HealthCheckContext {
   const counts = overrides.counts ?? makeCountsResponse()
   const api = {
@@ -41,7 +45,7 @@ function makeContext(
   } as unknown as CraneApi
   return {
     api,
-    venture: 'vc',
+    venture: overrides.venture ?? 'vc',
     ciCountsTotal: overrides.ciCountsTotal,
   }
 }
@@ -85,6 +89,31 @@ describe('notifications-truth-window check', () => {
 
   it('has zero failure budget (any divergence escalates)', () => {
     expect(notificationsTruthWindowCheck.failureBudgetPerWeek).toBe(0)
+  })
+
+  it('queries fleet-wide on the captain seat (vc) — matches SoS rollup display', async () => {
+    const ctx = makeContext({
+      venture: 'vc',
+      ciCountsTotal: 35,
+      counts: makeCountsResponse({ total: 35 }),
+    })
+    const result = await notificationsTruthWindowCheck.run(ctx)
+    expect(result.status).toBe('pass')
+    expect(ctx.api.getNotificationCounts).toHaveBeenCalledWith({ status: 'new' })
+  })
+
+  it('scopes the query to ctx.venture for non-captain seats — matches SoS per-venture display (post-#771)', async () => {
+    const ctx = makeContext({
+      venture: 'ss',
+      ciCountsTotal: 0,
+      counts: makeCountsResponse({ total: 0 }),
+    })
+    const result = await notificationsTruthWindowCheck.run(ctx)
+    expect(result.status).toBe('pass')
+    expect(ctx.api.getNotificationCounts).toHaveBeenCalledWith({
+      status: 'new',
+      venture: 'ss',
+    })
   })
 })
 

--- a/packages/crane-mcp/src/lib/health-checks.ts
+++ b/packages/crane-mcp/src/lib/health-checks.ts
@@ -113,13 +113,15 @@ export const notificationsTruthWindowCheck: HealthCheck = {
       }
     }
 
-    // Fleet-wide count, matching the SOS-side query (see #564). The check
-    // is comparing the TRUE fleet count to the displayed value — passing
-    // venture here would make the check always false-fail for sessions
-    // where other ventures have open notifications.
-    const counts = await ctx.api.getNotificationCounts({
-      status: 'new',
-    })
+    // Mirror the SoS-side scoping (sos.ts, post-#771): the captain seat
+    // (vc) displays the fleet rollup, every other venture displays only
+    // its own count. The check has to query at the same scope or it
+    // compares apples to oranges and false-fails in any non-vc session
+    // whenever another venture has open notifications.
+    const isCaptainSeat = ctx.venture === 'vc'
+    const counts = await ctx.api.getNotificationCounts(
+      isCaptainSeat ? { status: 'new' } : { status: 'new', venture: ctx.venture }
+    )
 
     if (counts.total !== ctx.ciCountsTotal) {
       return {


### PR DESCRIPTION
## Summary

The `notifications-truth-window` health check has been firing P0 in every non-vc session since #771 ("scope CI/CD alerts per venture") landed. Surfaced today as an SS-session alert: `Displayed count 0 differs from server count 35 (delta: 35)`.

**Root cause.** Before #771, `sos.ts` rendered a fleet-wide notification count, and this check queried `getNotificationCounts({ status: 'new' })` (also fleet-wide). Same scope, valid comparison. #771 flipped `sos.ts` to scope the displayed count by venture for all non-captain seats but did not update the check, so the check has been comparing a venture-scoped displayed value to a fleet-wide server value ever since. They diverge whenever any other venture has open notifications — which is always.

**Fix.** Mirror the SoS-side scoping (`packages/crane-mcp/src/tools/sos.ts:453-455`):
- Captain seat (`vc`) → fleet-wide query (`{ status: 'new' }`), matches the rollup display.
- Every other venture → `{ status: 'new', venture: ctx.venture }`, matches the per-venture display.

The check's docblock comment was rewritten — its prior text ("passing venture here would make the check always false-fail…") was exactly backwards after #771.

## Files

- `packages/crane-mcp/src/lib/health-checks.ts` — 8-line behavioral fix + comment rewrite.
- `packages/crane-mcp/src/lib/health-checks.test.ts` — added two pinning tests so a future SoS-scoping flip can't silently regress this again. ${'`makeContext`'} now accepts a ${'`venture`'} override.

## Verification

- ${'`npm test -- health-checks`'} → 21/21 pass (was 19/19; +2 new).
- ${'`npm run typecheck`'} → clean.
- ${'`npm run format:check`'} → clean.
- ${'`npm run lint`'} → 0 errors (30 pre-existing warnings in unrelated files).

## Test plan

- [ ] Run ${'`/sos`'} from any non-vc venture (ss, ke, dfg) → System Health section reports `notifications-truth-window` as pass when that venture has no open notifications, even if other ventures do.
- [ ] Run ${'`/sos`'} from vc → check still queries fleet-wide and matches the rollup display.
- [ ] Confirm the ss-session alert delta=35 stops firing on the next session after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)