### PR TITLE
Parallel-session worktree isolation hooks (#788)

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,2 +1,9 @@
 # Local Claude Code settings (user-specific overrides)
 settings.local.json
+
+# Per-session worktrees (parallel-isolation feature, #788)
+worktrees/
+
+# Per-session isolation markers and logs (parallel-isolation feature, #788)
+parallel-isolation-required-*
+parallel-isolation-log/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,10 @@ if command -v gitleaks &> /dev/null; then
   gitleaks protect --staged --no-banner
 fi
 
+# Parallel-isolation branch check (#788)
+# When committing from a per-session worktree, branch name must include
+# session id. Skip outside worktrees. See scripts/parallel-session-branch-check.sh
+"$(git rev-parse --show-toplevel)"/scripts/parallel-session-branch-check.sh
+
 # Formatting + linting (lint-staged)
 npx lint-staged

--- a/packages/crane-mcp/src/cli/launch-lib.test.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.test.ts
@@ -61,6 +61,7 @@ import {
   setupClaudeMcp,
   ensureClaudeProjectTrust,
   ensureClaudeUserDenyRules,
+  ensureParallelIsolationHooks,
   syncClaudeAssets,
   syncGlobalSkills,
   syncVentureSkills,
@@ -386,9 +387,17 @@ describe('setupClaudeMcp', () => {
   // ~/.claude.json appear "already trusted" — that path becomes a no-op write
   // and won't pollute writeFileSync assertions.
   const CLAUDE_CONFIG_PATH = join(homedir(), '.claude.json')
+  const USER_SETTINGS_PATH = join(homedir(), '.claude', 'settings.json')
   const TRUSTED_CLAUDE_CONFIG = JSON.stringify({
     projects: { '/fake/repo': { hasTrustDialogAccepted: true } },
   })
+
+  // Filter helper: setupClaudeMcp also calls ensureParallelIsolationHooks,
+  // which writes to ~/.claude/settings.json. Tests in this block care about
+  // .mcp.json + ~/.claude.json behavior, so filter the side-channel write out.
+  function relevantWrites() {
+    return vi.mocked(writeFileSync).mock.calls.filter((c) => String(c[0]) !== USER_SETTINGS_PATH)
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -410,8 +419,13 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source unchanged (no API key to inject), target copied
-    expect(copyFileSync).toHaveBeenCalledTimes(1)
+    // Source unchanged (no API key to inject), target copied. Filter out
+    // any parallel-isolation script copies (those go to ~/.claude/parallel-
+    // isolation/scripts/, not /fake/repo/.mcp.json).
+    const mcpCopies = vi
+      .mocked(copyFileSync)
+      .mock.calls.filter((c) => String(c[1]).endsWith('.mcp.json'))
+    expect(mcpCopies).toHaveLength(1)
   })
 
   it('syncs missing servers from source into target', () => {
@@ -435,8 +449,10 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source matches target — no write expected
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source matches target — no .mcp.json/.claude.json write expected
+    // (the parallel-isolation hooks may write to ~/.claude/settings.json,
+    // filtered out by relevantWrites()).
+    expect(relevantWrites()).toHaveLength(0)
   })
 
   it('skips write when source and target already match', () => {
@@ -453,8 +469,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source and target already match — no writes
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source and target already match — no .mcp.json/.claude.json writes
+    expect(relevantWrites()).toHaveLength(0)
   })
 
   it('overwrites malformed target JSON', () => {
@@ -497,8 +513,8 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    // Source and target match on crane, custom preserved. No writes needed.
-    expect(writeFileSync).not.toHaveBeenCalled()
+    // Source and target match on crane, custom preserved. No .mcp.json/.claude.json writes.
+    expect(relevantWrites()).toHaveLength(0)
   })
 
   it('marks the project trusted via ensureClaudeProjectTrust', () => {
@@ -517,8 +533,9 @@ describe('setupClaudeMcp', () => {
 
     setupClaudeMcp('/fake/repo')
 
-    expect(writeFileSync).toHaveBeenCalledTimes(1)
-    const [path, body] = vi.mocked(writeFileSync).mock.calls[0]
+    const trustWrites = relevantWrites()
+    expect(trustWrites).toHaveLength(1)
+    const [path, body] = trustWrites[0]
     expect(path).toBe(CLAUDE_CONFIG_PATH)
     const written = JSON.parse(body as string)
     expect(written.projects['/fake/repo'].hasTrustDialogAccepted).toBe(true)
@@ -1412,5 +1429,204 @@ describe('extractPassthroughArgs', () => {
     // "vc" is venture code, "extra-arg" should pass through
     const result = extractPassthroughArgs(['vc', 'extra-arg'])
     expect(result).toEqual(['extra-arg'])
+  })
+})
+
+describe('ensureParallelIsolationHooks', () => {
+  const SETTINGS_PATH = join(homedir(), '.claude', 'settings.json')
+  const INSTALL_DIR = join(homedir(), '.claude', 'parallel-isolation', 'scripts')
+
+  // Mock fs reads with controllable settings.json content. Source scripts
+  // are always considered to exist; mtimeMs is 0 (so dest with mtimeMs > 0
+  // skips copy unless explicitly told otherwise).
+  function mockReads(opts: {
+    settings?: object | string
+    sourceMtime?: number
+    destMtime?: number
+    destExists?: boolean
+  }): void {
+    vi.mocked(readFileSync).mockImplementation((filePath: unknown) => {
+      const p = String(filePath)
+      if (p.includes('ventures.json')) {
+        return JSON.stringify({
+          ventures: [
+            { code: 'vc' },
+            { code: 'ke' },
+            { code: 'sc' },
+            { code: 'dfg' },
+            { code: 'ss' },
+            { code: 'dc' },
+          ],
+        })
+      }
+      if (p.includes('.claude/settings.json')) {
+        if (typeof opts.settings === 'string') return opts.settings
+        return JSON.stringify(opts.settings ?? {})
+      }
+      return '{}'
+    })
+    vi.mocked(existsSync).mockImplementation((p: unknown) => {
+      const s = String(p)
+      // Source scripts in crane-console always exist.
+      if (s.includes('/scripts/parallel-session-')) return true
+      if (s.includes('.claude/settings.json')) {
+        return opts.settings !== undefined
+      }
+      if (s.includes('/parallel-isolation/scripts/')) {
+        return opts.destExists ?? false
+      }
+      return false
+    })
+    vi.mocked(statSync).mockImplementation((p: unknown) => {
+      const s = String(p)
+      if (s.includes('/parallel-isolation/scripts/')) {
+        return { mtimeMs: opts.destMtime ?? 0 } as ReturnType<typeof statSync>
+      }
+      return { mtimeMs: opts.sourceMtime ?? 1 } as ReturnType<typeof statSync>
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('creates settings.json hooks block when missing', () => {
+    mockReads({})
+    ensureParallelIsolationHooks()
+
+    // Should have written settings.json with hook entries.
+    const settingsWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter((c) => String(c[0]) === SETTINGS_PATH)
+    expect(settingsWrites.length).toBe(1)
+    const written = JSON.parse(settingsWrites[0][1] as string)
+    expect(written.hooks.SessionStart).toBeDefined()
+    expect(written.hooks.PreToolUse).toBeDefined()
+    expect(written.hooks.PostToolUse).toBeDefined()
+    expect(written.hooks.PreToolUse[0].matcher).toBe('*')
+    expect(written.hooks.PostToolUse[0].matcher).toBe('EnterWorktree')
+    expect(written.hooks.SessionStart[0].hooks[0]._managedBy).toBe('crane-parallel-isolation')
+  })
+
+  it('preserves existing user-added hooks alongside managed entries', () => {
+    const existing = {
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [{ type: 'command', command: '/usr/local/bin/my-custom-hook.sh' }],
+          },
+        ],
+      },
+    }
+    mockReads({ settings: existing })
+    ensureParallelIsolationHooks()
+
+    const settingsWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter((c) => String(c[0]) === SETTINGS_PATH)
+    expect(settingsWrites.length).toBe(1)
+    const written = JSON.parse(settingsWrites[0][1] as string)
+    expect(written.hooks.UserPromptSubmit[0].hooks[0].command).toBe(
+      '/usr/local/bin/my-custom-hook.sh'
+    )
+    expect(written.hooks.SessionStart[0].hooks[0]._managedBy).toBe('crane-parallel-isolation')
+  })
+
+  it('replaces a stale managed entry rather than duplicating it', () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: 'command',
+                command: '/old/path/parallel-session-detect.sh',
+                _managedBy: 'crane-parallel-isolation',
+              },
+            ],
+          },
+        ],
+      },
+    }
+    mockReads({ settings })
+    ensureParallelIsolationHooks()
+
+    const settingsWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter((c) => String(c[0]) === SETTINGS_PATH)
+    expect(settingsWrites.length).toBe(1)
+    const written = JSON.parse(settingsWrites[0][1] as string)
+    // Only one SessionStart entry, and it points at the new install dir.
+    expect(written.hooks.SessionStart.length).toBe(1)
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain(INSTALL_DIR)
+    expect(written.hooks.SessionStart[0].hooks[0].command).not.toContain('/old/path/')
+  })
+
+  it('skips write when hooks already match desired state', () => {
+    // Pre-populate settings with the exact entries the function would add.
+    const detectCmd = join(INSTALL_DIR, 'parallel-session-detect.sh')
+    const gateCmd = join(INSTALL_DIR, 'parallel-session-gate.sh')
+    const provisionCmd = join(INSTALL_DIR, 'parallel-session-provision.sh')
+    const settings = {
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              { type: 'command', command: detectCmd, _managedBy: 'crane-parallel-isolation' },
+            ],
+          },
+        ],
+        PreToolUse: [
+          {
+            matcher: '*',
+            hooks: [{ type: 'command', command: gateCmd, _managedBy: 'crane-parallel-isolation' }],
+          },
+        ],
+        PostToolUse: [
+          {
+            matcher: 'EnterWorktree',
+            hooks: [
+              { type: 'command', command: provisionCmd, _managedBy: 'crane-parallel-isolation' },
+            ],
+          },
+        ],
+      },
+    }
+    mockReads({ settings })
+    ensureParallelIsolationHooks()
+
+    const settingsWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter((c) => String(c[0]) === SETTINGS_PATH)
+    expect(settingsWrites.length).toBe(0)
+  })
+
+  it('skips with warning when settings.json is malformed', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockReads({ settings: '{not json' })
+    ensureParallelIsolationHooks()
+
+    const settingsWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter((c) => String(c[0]) === SETTINGS_PATH)
+    expect(settingsWrites.length).toBe(0)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('malformed'))
+  })
+
+  it('copies scripts when source is newer than destination', () => {
+    mockReads({ destExists: true, sourceMtime: 100, destMtime: 50 })
+    ensureParallelIsolationHooks()
+
+    // copyFileSync invoked once per script (3 scripts).
+    expect(vi.mocked(copyFileSync)).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips script copy when destination is up to date', () => {
+    mockReads({ destExists: true, sourceMtime: 50, destMtime: 100 })
+    ensureParallelIsolationHooks()
+
+    expect(vi.mocked(copyFileSync)).not.toHaveBeenCalled()
   })
 })

--- a/packages/crane-mcp/src/cli/launch-lib.ts
+++ b/packages/crane-mcp/src/cli/launch-lib.ts
@@ -963,6 +963,152 @@ export function ensureClaudeUserDenyRules(): void {
   console.log('-> Added crane-context deny rule to ~/.claude/settings.json')
 }
 
+/**
+ * Parallel-isolation hooks (#788).
+ *
+ * Detects sibling claude processes attached to the same repo at SessionStart;
+ * if a peer is present, the model is forced through EnterWorktree before any
+ * tool call. PreToolUse gate enforces the wait. PostToolUse on EnterWorktree
+ * provisions node_modules into the worktree via APFS clonefile (or npm ci
+ * fallback) and clears the gate.
+ *
+ * Why user-scope, not per-repo: same reason as ensureClaudeUserDenyRules —
+ * writing the hook entries into each venture's tracked .claude/settings.json
+ * dirties working trees. User-scope ~/.claude/settings.json applies machine-
+ * wide. Non-venture sessions are no-ops because the detector exits silently
+ * when no peer is found.
+ *
+ * Scripts are copied from crane-console/scripts/ into ~/.claude/parallel-
+ * isolation/scripts/ so the hook commands resolve regardless of which
+ * directory claude was launched from.
+ *
+ * Idempotent: copies scripts only when the source is newer; merges hooks
+ * only when missing or pointing at a different command.
+ */
+const PARALLEL_ISOLATION_SCRIPTS = [
+  'parallel-session-detect.sh',
+  'parallel-session-gate.sh',
+  'parallel-session-provision.sh',
+] as const
+
+export function ensureParallelIsolationHooks(): void {
+  const claudeDir = join(homedir(), '.claude')
+  const installDir = join(claudeDir, 'parallel-isolation', 'scripts')
+  const sourceDir = join(CRANE_CONSOLE_ROOT, 'scripts')
+
+  // 1. Install scripts. Copy when source mtime > destination mtime, or when
+  // destination is missing.
+  let scriptsDirty = false
+  mkdirSync(installDir, { recursive: true })
+  for (const script of PARALLEL_ISOLATION_SCRIPTS) {
+    const src = join(sourceDir, script)
+    const dst = join(installDir, script)
+    if (!existsSync(src)) {
+      console.warn(
+        `-> Warning: ${script} missing in crane-console; skipping parallel-isolation install`
+      )
+      return
+    }
+    let needsCopy = false
+    if (!existsSync(dst)) {
+      needsCopy = true
+    } else {
+      try {
+        const srcMtime = statSync(src).mtimeMs
+        const dstMtime = statSync(dst).mtimeMs
+        if (srcMtime > dstMtime) needsCopy = true
+      } catch {
+        needsCopy = true
+      }
+    }
+    if (needsCopy) {
+      copyFileSync(src, dst)
+      // chmod +x — copyFileSync preserves source mode on macOS, but be
+      // explicit so we don't silently break if source bit was lost in transit.
+      try {
+        execSync(`chmod +x "${dst}"`, { stdio: 'ignore' })
+      } catch {
+        /* ignore */
+      }
+      scriptsDirty = true
+    }
+  }
+  if (scriptsDirty) {
+    console.log(
+      `-> Synced parallel-isolation hook scripts to ~/.claude/parallel-isolation/scripts/`
+    )
+  }
+
+  // 2. Merge hook entries into ~/.claude/settings.json. Only ours; preserve
+  // anything else the user has configured.
+  const settingsPath = join(claudeDir, 'settings.json')
+  let settings: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    } catch {
+      console.warn(
+        '-> Warning: ~/.claude/settings.json is malformed; skipping parallel-isolation hooks'
+      )
+      return
+    }
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== 'object') {
+    settings.hooks = {}
+  }
+  const hooks = settings.hooks as Record<string, unknown>
+
+  // Hook commands (absolute paths so they work in any cwd).
+  const detectCmd = join(installDir, 'parallel-session-detect.sh')
+  const gateCmd = join(installDir, 'parallel-session-gate.sh')
+  const provisionCmd = join(installDir, 'parallel-session-provision.sh')
+
+  // Desired entries. Marker field "_managedBy" lets us identify and replace
+  // launcher-managed entries on update without clobbering user-added hooks.
+  type HookEntry = {
+    matcher?: string
+    hooks: Array<{ type: string; command: string; _managedBy?: string }>
+  }
+  const desired: Record<string, HookEntry> = {
+    SessionStart: {
+      hooks: [{ type: 'command', command: detectCmd, _managedBy: 'crane-parallel-isolation' }],
+    },
+    PreToolUse: {
+      matcher: '*',
+      hooks: [{ type: 'command', command: gateCmd, _managedBy: 'crane-parallel-isolation' }],
+    },
+    PostToolUse: {
+      matcher: 'EnterWorktree',
+      hooks: [{ type: 'command', command: provisionCmd, _managedBy: 'crane-parallel-isolation' }],
+    },
+  }
+
+  // Snapshot before mutation for cheap dirty-detection at the end.
+  const before = JSON.stringify(hooks)
+
+  for (const [event, entry] of Object.entries(desired)) {
+    if (!Array.isArray(hooks[event])) {
+      hooks[event] = []
+    }
+    const arr = hooks[event] as HookEntry[]
+    // Drop any prior managed entry, then add the current desired entry.
+    const filtered = arr.filter(
+      (e) => !(e.hooks && e.hooks.some((h) => h._managedBy === 'crane-parallel-isolation'))
+    )
+    filtered.push(entry)
+    hooks[event] = filtered
+  }
+
+  if (JSON.stringify(hooks) === before) return
+
+  mkdirSync(claudeDir, { recursive: true })
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n')
+  console.log(
+    '-> Synced parallel-isolation hooks (SessionStart, PreToolUse, PostToolUse) to ~/.claude/settings.json'
+  )
+}
+
 export function setupClaudeMcp(repoPath: string): void {
   // Pre-accept the project trust dialog so Claude Code loads .mcp.json on first run.
   // Without this, project-scope MCP servers stay dormant until the user clicks
@@ -974,6 +1120,10 @@ export function setupClaudeMcp(repoPath: string): void {
   // MCP proxy tools (currently just crane-context, which duplicates our local
   // mcp__crane__* surface). Writes ~/.claude/settings.json idempotently.
   ensureClaudeUserDenyRules()
+
+  // Install parallel-isolation hooks (#788) into user-scope settings so they
+  // apply across every venture session without dirtying tracked working trees.
+  ensureParallelIsolationHooks()
 
   const mcpJson = join(repoPath, '.mcp.json')
   const source = join(CRANE_CONSOLE_ROOT, '.mcp.json')

--- a/scripts/parallel-isolation-metrics.sh
+++ b/scripts/parallel-isolation-metrics.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+#
+# Parallel Isolation Weekly Metrics (#788)
+#
+# Reads ~/.claude/projects/<encoded>/*.jsonl and the per-repo
+# .claude/parallel-isolation-log/provision.log to compute:
+#
+#   - Sessions per venture (last N days)
+#   - Active-tool-call overlap pairs per venture (sharper than session-range
+#     overlap: only counts overlap during actual tool-use windows, ignoring
+#     idle time)
+#   - Days with at least one overlap
+#   - Clone-fallback rate (cp_clonefile vs npm_ci vs failure)
+#
+# Usage:
+#   scripts/parallel-isolation-metrics.sh [days] [--json|--markdown]
+#
+# Default: last 7 days, markdown output.
+
+set -e
+
+DAYS=${1:-7}
+FORMAT=${2:-markdown}
+
+# Validate args.
+case "$FORMAT" in
+  --json|json)     FORMAT=json ;;
+  --markdown|md|*) FORMAT=markdown ;;
+esac
+
+PROJECTS_DIR="$HOME/.claude/projects"
+SINCE_EPOCH=$(date -v "-${DAYS}d" +%s 2>/dev/null) || SINCE_EPOCH=$(date -d "-${DAYS} days" +%s)
+
+if [ ! -d "$PROJECTS_DIR" ]; then
+  echo "no projects directory at $PROJECTS_DIR" >&2
+  exit 1
+fi
+
+# tmp file holds rows: encoded_path|session_id|first_tool_ts|last_tool_ts
+TMP=$(mktemp -t parallel-iso-metrics)
+trap 'rm -f "$TMP"' EXIT
+
+# Iterate venture project dirs.
+for venture_dir in "$PROJECTS_DIR"/-Users-scottdurgan-dev-*; do
+  [ -d "$venture_dir" ] || continue
+  encoded=$(basename "$venture_dir")
+  for jsonl in "$venture_dir"/*.jsonl; do
+    [ -f "$jsonl" ] || continue
+    # Extract first/last timestamps where type == assistant and tool_use is present.
+    # If a session never produced a tool_use, skip — nothing to compare.
+    # Single jq pass; awk picks min/max in one pass to avoid SIGPIPE on
+    # head/tail closing the sort pipe early. `|| true` because read returns
+    # non-zero on empty input and set -e would abort the loop.
+    range_pair=$(jq -r 'select(.type == "assistant") | select((.message.content // []) | any(.type == "tool_use")) | .timestamp' "$jsonl" 2>/dev/null | awk 'NR==1{f=$0; l=$0} {if($0<f)f=$0; if($0>l)l=$0} END{if(f)print f, l}') || true
+    [ -z "$range_pair" ] && continue
+    first=${range_pair% *}
+    last=${range_pair#* }
+    [ -z "$first" ] || [ -z "$last" ] && continue
+    # Filter by recency: drop files whose last tool-use is older than SINCE.
+    last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${last%.*}" +%s 2>/dev/null) || \
+                last_epoch=$(date -d "$last" +%s 2>/dev/null) || continue
+    [ "$last_epoch" -lt "$SINCE_EPOCH" ] && continue
+    session_id=$(basename "$jsonl" .jsonl)
+    echo "$encoded|$session_id|$first|$last" >> "$TMP"
+  done
+done
+
+# Decode pretty venture name from encoded path.
+decode_venture() {
+  echo "$1" | sed 's|^-Users-scottdurgan-dev-||' | sed 's|--claude-worktrees-.*$| (worktree)|'
+}
+
+# Compute overlap pairs per venture using awk on the sorted-by-venture rows.
+# Overlap: pair (a,b) overlaps if a.first < b.last AND b.first < a.last.
+compute_overlaps() {
+  awk -F'|' '
+    {
+      v=$1; s=$2; f=$3; l=$4
+      n[v]++
+      i = n[v]
+      first[v,i] = f
+      last[v,i] = l
+      session[v,i] = s
+    }
+    END {
+      for (v in n) {
+        cnt = n[v]
+        pairs = 0
+        delete days_set
+        for (i = 1; i <= cnt; i++) {
+          for (j = i + 1; j <= cnt; j++) {
+            if (first[v,i] < last[v,j] && first[v,j] < last[v,i]) {
+              pairs++
+              # day-with-overlap (UTC date of the overlap start)
+              start = (first[v,i] > first[v,j]) ? first[v,i] : first[v,j]
+              day = substr(start, 1, 10)
+              days_set[day] = 1
+            }
+          }
+        }
+        days = 0
+        for (d in days_set) days++
+        printf "%s|%d|%d|%d\n", v, cnt, pairs, days
+      }
+    }
+  ' "$TMP" | sort
+}
+
+OVERLAPS=$(compute_overlaps)
+
+# Provision log scan: walks every venture repo's parallel-isolation-log
+# (best-effort; venture repos must exist locally to count).
+DEV_DIR="$HOME/dev"
+total_clones=0
+total_npm_ci=0
+total_failed=0
+total_skip=0
+PROV_DETAIL=""
+if [ -d "$DEV_DIR" ]; then
+  for repo in "$DEV_DIR"/*-console "$DEV_DIR"/dc-marketing "$DEV_DIR"/vc-web; do
+    [ -d "$repo" ] || continue
+    log="$repo/.claude/parallel-isolation-log/provision.log"
+    [ -f "$log" ] || continue
+    # Filter by SINCE_EPOCH on the leading ISO timestamp.
+    while IFS= read -r line; do
+      ts=$(echo "$line" | awk '{print $1}')
+      [ -z "$ts" ] && continue
+      ts_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${ts%Z}" +%s 2>/dev/null) || continue
+      [ "$ts_epoch" -lt "$SINCE_EPOCH" ] && continue
+      method=$(echo "$line" | grep -oE 'method=[^ ]+' | cut -d= -f2)
+      result=$(echo "$line" | grep -oE 'result=[^ ]+' | cut -d= -f2)
+      case "$method" in
+        cp_clonefile)
+          [ "$result" = "ok" ] && total_clones=$((total_clones + 1)) || total_failed=$((total_failed + 1)) ;;
+        npm_ci|npm_ci_after_clone_fail)
+          [ "$result" = "ok" ] && total_npm_ci=$((total_npm_ci + 1)) || total_failed=$((total_failed + 1)) ;;
+        skip)
+          total_skip=$((total_skip + 1)) ;;
+      esac
+    done < "$log"
+  done
+fi
+
+# Output.
+if [ "$FORMAT" = "json" ]; then
+  jq -n \
+    --argjson days "$DAYS" \
+    --arg overlaps "$OVERLAPS" \
+    --argjson clones "$total_clones" \
+    --argjson npm_ci "$total_npm_ci" \
+    --argjson failed "$total_failed" \
+    --argjson skip "$total_skip" \
+    '{
+      window_days: $days,
+      overlaps_by_venture: ($overlaps | split("\n") | map(select(length > 0) | split("|") | {venture: .[0], sessions: (.[1]|tonumber), overlap_pairs: (.[2]|tonumber), days_with_overlap: (.[3]|tonumber)})),
+      provisioning: {
+        cp_clonefile_ok: $clones,
+        npm_ci_ok: $npm_ci,
+        skipped: $skip,
+        failed: $failed,
+        clone_fallback_rate: (if ($clones + $npm_ci) > 0 then ($npm_ci / ($clones + $npm_ci)) else 0 end)
+      }
+    }'
+else
+  echo "## Parallel-Isolation Metrics (last $DAYS days)"
+  echo ""
+  echo "### Overlap by venture"
+  echo ""
+  echo "| Venture | Sessions | Active-tool-call overlap pairs | Days w/ overlap |"
+  echo "|---|---|---|---|"
+  if [ -z "$OVERLAPS" ]; then
+    echo "| _(no sessions in window)_ | - | - | - |"
+  else
+    while IFS='|' read -r v cnt pairs days; do
+      [ -z "$v" ] && continue
+      pretty=$(decode_venture "$v")
+      echo "| $pretty | $cnt | $pairs | $days |"
+    done <<< "$OVERLAPS"
+  fi
+  echo ""
+  echo "### Provisioning"
+  echo ""
+  total_provisions=$((total_clones + total_npm_ci))
+  if [ "$total_provisions" -gt 0 ]; then
+    fallback_rate=$(awk -v n="$total_npm_ci" -v t="$total_provisions" 'BEGIN{ printf "%.1f", (n*100)/t }')
+  else
+    fallback_rate="n/a"
+  fi
+  echo "| Method | Count |"
+  echo "|---|---|"
+  echo "| cp_clonefile (APFS) | $total_clones |"
+  echo "| npm_ci fallback | $total_npm_ci |"
+  echo "| skipped | $total_skip |"
+  echo "| failed | $total_failed |"
+  echo ""
+  echo "**Clone-fallback rate**: ${fallback_rate}% of successful provisions used npm_ci instead of cp_clonefile."
+  echo ""
+  echo "_Window: last $DAYS days. Active tool-call overlap: pair counts only when both sessions have actual tool-use timestamps within each other's range, ignoring idle time. Sharper signal than raw session-range overlap._"
+fi

--- a/scripts/parallel-session-branch-check.sh
+++ b/scripts/parallel-session-branch-check.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Parallel Session Branch Check (pre-commit tripwire)
+#
+# When committing from inside a per-session worktree
+# (.claude/worktrees/<session-id>/), the current branch name MUST contain
+# <session-id>. This prevents two worktrees from independently creating
+# branches with the same name and racing on push.
+#
+# Canonical-checkout commits (anywhere outside .claude/worktrees/) are not
+# checked — branch naming for human PRs follows the existing convention.
+#
+# Exits non-zero on violation; zero otherwise. Called from .husky/pre-commit.
+
+set -e
+
+# Escape hatch for unusual cases. Use sparingly.
+[ "$PARALLEL_ISOLATION_BRANCH_CHECK" = "skip" ] && exit 0
+
+CWD=$(pwd -P)
+TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Are we inside a per-session worktree? Match the path pattern.
+WORKTREE_REL="${CWD#$TOPLEVEL/}"
+case "$CWD" in
+  */.claude/worktrees/*)
+    # Extract session id segment after .claude/worktrees/.
+    SESSION_ID=$(echo "$CWD" | sed -E 's|.*/\.claude/worktrees/([^/]+).*|\1|')
+    ;;
+  *)
+    # Not in a worktree; canonical commit. Skip.
+    exit 0
+    ;;
+esac
+
+[ -z "$SESSION_ID" ] && exit 0
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+
+# Empty / detached HEAD: skip.
+[ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ] && exit 0
+
+case "$BRANCH" in
+  *"$SESSION_ID"*)
+    # Branch contains session id; allowed.
+    exit 0
+    ;;
+esac
+
+cat >&2 <<EOF
+[parallel-isolation] pre-commit blocked: branch name does not include session id.
+
+  worktree:    $CWD
+  session id:  $SESSION_ID
+  branch:      $BRANCH
+
+When committing from inside a per-session worktree, the current branch must
+contain the session id so it cannot collide with branches from other
+concurrent sessions. Rename the branch to include "$SESSION_ID" (typically
+as a prefix), then retry the commit:
+
+  git branch -m <new-name-including-$SESSION_ID>
+
+If you really need to commit a non-prefixed branch from this worktree,
+escape with:
+
+  PARALLEL_ISOLATION_BRANCH_CHECK=skip git commit ...
+
+(Use sparingly — the check exists to prevent push-time collisions.)
+EOF
+exit 1

--- a/scripts/parallel-session-detect.sh
+++ b/scripts/parallel-session-detect.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Parallel Session Detector (SessionStart hook)
+#
+# Detects whether another claude process is already attached to this repo.
+# If yes, drops a marker file and injects strong context instructing the model
+# to call EnterWorktree before any other tool. The PreToolUse gate
+# (parallel-session-gate.sh) enforces the wait. The PostToolUse hook
+# (parallel-session-provision.sh) then clones node_modules into the worktree.
+#
+# Detection mechanism (kernel-reliable, ~3-6 syscalls):
+#   pgrep -x claude                              # enumerate claude pids by exact name
+#   lsof -p <pid> -a -d cwd -Fn                  # cwd of each pid (per-pid; not +D)
+#   git -C <cwd> rev-parse --show-toplevel       # normalize to repo toplevel
+#   compare against this session's toplevel
+#
+# Why pgrep -x not -f:
+#   -f matches argv strings; tab titles, prompts, or env vars containing
+#   "claude" produce false positives. -x matches the binary name only.
+#
+# Why lsof -p <pid> -a -d cwd not lsof +D:
+#   Per-pid fd query is one stat per process. +D recursively walks the path,
+#   which can take seconds on a large repo. Unsuitable for a hook.
+#
+# Wire protocol (Claude Code SessionStart):
+#   stdin:  JSON with .session_id, .cwd, .transcript_path
+#   stdout: JSON {"hookSpecificOutput": {"hookEventName": "SessionStart",
+#                                        "additionalContext": "..."}}
+#   exit 0 always; never block session start on hook plumbing
+#
+# Marker file:
+#   $REPO/.claude/parallel-isolation-required-$SESSION_ID
+#   Created when peer detected. Contains JSON with peer pid + repo toplevel.
+#   PreToolUse gate reads it. PostToolUse on EnterWorktree removes it.
+
+set -e
+
+# Required tools. If anything is missing, exit silently — the cost of a
+# missed detection is a possible collision; the cost of a blocked session
+# start is a broken Captain.
+for tool in jq pgrep lsof git; do
+  command -v "$tool" >/dev/null 2>&1 || exit 0
+done
+
+# Read hook input. CWD comes from Claude Code; SESSION_ID identifies this
+# session for the marker file name.
+INPUT=$(cat)
+CWD=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null) || exit 0
+SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null) || exit 0
+[ -z "$CWD" ] && exit 0
+[ -z "$SESSION_ID" ] && exit 0
+
+# Resolve canonical repo toplevel. If we're not in a git repo, no isolation
+# work to do — just exit silently.
+THIS_TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# This session's own pid is in $PPID? No — claude is the parent of the hook
+# script, so $PPID should be the claude process. We exclude it from peer
+# detection so we don't detect ourselves.
+SELF_PID=$PPID
+
+# Enumerate peer claude processes.
+PEER_PIDS=()
+while IFS= read -r pid; do
+  [ -z "$pid" ] && continue
+  [ "$pid" = "$SELF_PID" ] && continue
+  # Get cwd of this pid. lsof -Fn prints the cwd as a line starting with 'n'.
+  PEER_CWD=$(lsof -p "$pid" -a -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2); exit}')
+  [ -z "$PEER_CWD" ] && continue
+  # Normalize to repo toplevel. If pid isn't in a git repo, skip.
+  PEER_TOPLEVEL=$(git -C "$PEER_CWD" rev-parse --show-toplevel 2>/dev/null) || continue
+  # Same repo? Same toplevel string after normalization.
+  if [ "$PEER_TOPLEVEL" = "$THIS_TOPLEVEL" ]; then
+    PEER_PIDS+=("$pid")
+  fi
+done < <(pgrep -x claude 2>/dev/null)
+
+MARKER_DIR="$THIS_TOPLEVEL/.claude"
+MARKER_FILE="$MARKER_DIR/parallel-isolation-required-$SESSION_ID"
+LOG_DIR="$MARKER_DIR/parallel-isolation-log"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+if [ ${#PEER_PIDS[@]} -eq 0 ]; then
+  # No peer detected. Log for the weekly metric (no-peer = solo session,
+  # primary checkout). No additional context needed.
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) session=$SESSION_ID peer=none toplevel=$THIS_TOPLEVEL" \
+    >> "$LOG_DIR/sessions.log" 2>/dev/null || true
+  exit 0
+fi
+
+# Peer detected. Drop marker, log, inject context.
+PEER_LIST=$(IFS=,; echo "${PEER_PIDS[*]}")
+mkdir -p "$MARKER_DIR" 2>/dev/null || true
+cat > "$MARKER_FILE" <<EOF
+{
+  "session_id": "$SESSION_ID",
+  "toplevel": "$THIS_TOPLEVEL",
+  "peer_pids": [$PEER_LIST],
+  "created_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) session=$SESSION_ID peer=$PEER_LIST toplevel=$THIS_TOPLEVEL" \
+  >> "$LOG_DIR/sessions.log" 2>/dev/null || true
+
+# Inject context. The instruction is intentionally strong; it's the only
+# control surface we have over the model's first action. The PreToolUse
+# gate is the actual enforcement.
+ADDITIONAL_CONTEXT="[parallel-isolation] Peer claude process(es) detected on this repo (pid: $PEER_LIST). To prevent working-tree contamination across concurrent sessions, you MUST call EnterWorktree as your FIRST action this session. Do not call any other tool first. After EnterWorktree completes, the post-tool hook will provision node_modules automatically; you can proceed normally from there. This isolation is enforced by a PreToolUse gate — non-EnterWorktree tool calls will be blocked until you are inside a worktree under .claude/worktrees/."
+
+# Emit the SessionStart additionalContext payload.
+jq -n --arg ctx "$ADDITIONAL_CONTEXT" '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: $ctx
+  }
+}'
+
+exit 0

--- a/scripts/parallel-session-gate.sh
+++ b/scripts/parallel-session-gate.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Parallel Session Gate (PreToolUse hook)
+#
+# Enforces the worktree-first contract when SessionStart detected a peer.
+# This is the cwd-verify gate that closes the existing P0 anti-pattern
+# (verify-worktree-cwd-isolation-does-not-silently-fail): we don't trust
+# EnterWorktree to have actually moved cwd — we observe it.
+#
+# Decision flow:
+#   - No marker file present? Allow (no peer, primary-checkout mode).
+#   - Tool is EnterWorktree? Allow (this is the path out).
+#   - Cwd is inside .claude/worktrees/? Allow + cleanup stale marker.
+#   - Otherwise? Deny with systemMessage instructing EnterWorktree.
+#
+# Wire protocol (Claude Code PreToolUse):
+#   stdin:  JSON with .session_id, .cwd, .tool_name, .tool_input, .hook_event_name
+#   stdout: JSON {"hookSpecificOutput": {"permissionDecision": "allow|deny",
+#                                        "hookEventName": "PreToolUse"},
+#                 "systemMessage": "..."}
+#   exit 0
+
+set -e
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null)
+CWD=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null)
+TOOL=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null)
+
+[ -z "$SESSION_ID" ] || [ -z "$CWD" ] && exit 0
+
+# Find the repo toplevel from cwd. If not in a git repo, allow.
+TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+MARKER_FILE="$TOPLEVEL/.claude/parallel-isolation-required-$SESSION_ID"
+
+# No marker = no peer detected at SessionStart. Allow.
+if [ ! -f "$MARKER_FILE" ]; then
+  exit 0
+fi
+
+# Marker present. Enforcement logic.
+
+# Path 1: EnterWorktree call. This is the way out — let it through.
+if [ "$TOOL" = "EnterWorktree" ]; then
+  exit 0
+fi
+
+# Path 2: Already in a worktree. Cwd-verify gate says: trust observed state,
+# not the tool's claim. Cwd must be inside .claude/worktrees/<id>/ for the
+# session to be considered isolated.
+case "$CWD" in
+  "$TOPLEVEL/.claude/worktrees/"*)
+    # Isolation observed. Marker can be retired (PostToolUse normally does
+    # this, but if we got here it means the marker survived — clean it.)
+    rm -f "$MARKER_FILE" 2>/dev/null || true
+    exit 0
+    ;;
+esac
+
+# Path 3: Marker present, not EnterWorktree, not in a worktree. Deny.
+SYSTEM_MSG="[parallel-isolation] This session has a peer claude attached to the same repo. Working in the canonical checkout would contaminate the peer's working tree. Call EnterWorktree first; subsequent tools will be allowed once cwd is inside .claude/worktrees/. (Marker: $MARKER_FILE)"
+
+jq -n --arg msg "$SYSTEM_MSG" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny"
+  },
+  systemMessage: $msg
+}'
+
+exit 0

--- a/scripts/parallel-session-provision.sh
+++ b/scripts/parallel-session-provision.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Parallel Session Provisioner (PostToolUse hook on EnterWorktree)
+#
+# Runs after EnterWorktree creates a per-session worktree. Provisions
+# node_modules into the new worktree using APFS clonefile when available,
+# falling back to npm ci. Removes the parallel-isolation marker so the
+# PreToolUse gate stops blocking subsequent tool calls.
+#
+# Provisioning strategy:
+#   1. Detect APFS via diskutil. If APFS volume + node_modules exists in
+#      canonical -> cp -c -R (clonefile, ~5s for 484M).
+#   2. Else -> npm ci in the worktree (~30s, baseline).
+#   3. Failure of either -> log + exit 0 (don't block; the worktree exists,
+#      the model can resolve it manually if needed).
+#
+# CRITICAL: cp -c falls back silently to a regular copy on non-APFS volumes.
+# We pre-check with diskutil to avoid the silent slowdown. The clone-fallback
+# rate is logged for the weekly metric.
+#
+# Wire protocol (Claude Code PostToolUse):
+#   stdin:  JSON with .session_id, .cwd (POST-EnterWorktree, the new worktree path),
+#           .tool_name (will be "EnterWorktree"), .tool_input
+#   stdout: ignored unless we want to inject systemMessage
+#   exit 0
+
+set -e
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat)
+TOOL=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null)
+WORKTREE_CWD=$(jq -r '.cwd // empty' <<<"$INPUT" 2>/dev/null)
+SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null)
+
+# Only act on EnterWorktree calls.
+[ "$TOOL" != "EnterWorktree" ] && exit 0
+[ -z "$WORKTREE_CWD" ] && exit 0
+
+# Resolve canonical (the parent worktree). git worktree list shows all,
+# but the simplest path: the worktree's `.git` file points back to the
+# main .git via gitdir. We use `git rev-parse --git-common-dir` from inside
+# the worktree to get the shared .git, then derive canonical.
+COMMON_DIR=$(git -C "$WORKTREE_CWD" rev-parse --git-common-dir 2>/dev/null) || exit 0
+# common-dir is canonical/.git ; canonical toplevel is its parent.
+CANONICAL=$(cd "$COMMON_DIR" && cd .. && pwd)
+
+# Sanity: are we actually in a worktree? If WORKTREE_CWD == CANONICAL, the
+# tool didn't isolate (the silent-failure mode). Don't provision; let the
+# PreToolUse gate keep blocking.
+if [ "$WORKTREE_CWD" = "$CANONICAL" ]; then
+  exit 0
+fi
+
+# Logging dir.
+LOG_DIR="$CANONICAL/.claude/parallel-isolation-log"
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+LOG_FILE="$LOG_DIR/provision.log"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# If canonical has no node_modules, nothing to provision. Skip cleanly.
+if [ ! -d "$CANONICAL/node_modules" ]; then
+  echo "$TIMESTAMP session=$SESSION_ID method=skip reason=no-canonical-node_modules" \
+    >> "$LOG_FILE" 2>/dev/null || true
+  rm -f "$CANONICAL/.claude/parallel-isolation-required-$SESSION_ID" 2>/dev/null || true
+  exit 0
+fi
+
+# If worktree already has node_modules (manual provision, retry, etc.), skip.
+if [ -d "$WORKTREE_CWD/node_modules" ]; then
+  echo "$TIMESTAMP session=$SESSION_ID method=skip reason=already-provisioned" \
+    >> "$LOG_FILE" 2>/dev/null || true
+  rm -f "$CANONICAL/.claude/parallel-isolation-required-$SESSION_ID" 2>/dev/null || true
+  exit 0
+fi
+
+# Detect APFS on the canonical volume. diskutil info wants a mount point or
+# disk id, not an arbitrary path, so we resolve via df first. cp -c falls
+# back silently to a regular copy on non-APFS volumes; the precondition
+# check is what avoids the unobserved 30s tax.
+IS_APFS=0
+if command -v diskutil >/dev/null 2>&1 && command -v df >/dev/null 2>&1; then
+  MOUNT_POINT=$(df -P "$CANONICAL" 2>/dev/null | awk 'NR==2{print $NF}')
+  if [ -n "$MOUNT_POINT" ] && diskutil info "$MOUNT_POINT" 2>/dev/null | grep -q "File System Personality:.*APFS"; then
+    IS_APFS=1
+  fi
+fi
+
+START=$(date +%s)
+METHOD=""
+RESULT="ok"
+
+if [ "$IS_APFS" = "1" ]; then
+  METHOD="cp_clonefile"
+  if cp -c -R "$CANONICAL/node_modules" "$WORKTREE_CWD/node_modules" 2>/dev/null; then
+    :
+  else
+    # Clone failed. Try npm ci as fallback.
+    METHOD="npm_ci_after_clone_fail"
+    if (cd "$WORKTREE_CWD" && npm ci --silent 2>/dev/null); then
+      :
+    else
+      RESULT="failed"
+    fi
+  fi
+else
+  METHOD="npm_ci"
+  if (cd "$WORKTREE_CWD" && npm ci --silent 2>/dev/null); then
+    :
+  else
+    RESULT="failed"
+  fi
+fi
+
+END=$(date +%s)
+ELAPSED=$((END - START))
+
+echo "$TIMESTAMP session=$SESSION_ID method=$METHOD result=$RESULT elapsed_s=$ELAPSED canonical=$CANONICAL worktree=$WORKTREE_CWD" \
+  >> "$LOG_FILE" 2>/dev/null || true
+
+# Marker removal: only on success. On failure, leave the marker so the model
+# can see the gate is still active and can troubleshoot.
+if [ "$RESULT" = "ok" ]; then
+  rm -f "$CANONICAL/.claude/parallel-isolation-required-$SESSION_ID" 2>/dev/null || true
+  jq -n --arg method "$METHOD" --arg elapsed "$ELAPSED" '{
+    systemMessage: ("[parallel-isolation] node_modules provisioned in worktree (" + $method + ", " + $elapsed + "s). Isolation gate cleared.")
+  }'
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Closes #788. Forces per-session git worktree isolation when a sibling claude process is detected on the same repo, ending the working-tree contamination class that's been costing ~5 collision pairs/day across ss-console + crane-console.

- **Detection (kernel-reliable, ~50ms):** `pgrep -x claude` + `lsof -p <pid> -a -d cwd` per peer + `git rev-parse --show-toplevel` comparison. No service in the loop, no heartbeat dependency.
- **Enforcement:** `PreToolUse` matcher `*` denies non-`EnterWorktree` tools while a marker file is present and cwd isn't inside `.claude/worktrees/`. Closes the existing P0 anti-pattern (`verify-worktree-cwd-isolation-does-not-silently-fail`) by trusting observed cwd, not the tool's claim.
- **Provisioning:** `PostToolUse` on `EnterWorktree` clones `node_modules` via APFS `cp -c -R` (484M ss-console clone in 4.9s vs ~30s `npm ci`), with deterministic `npm ci` fallback on non-APFS volumes (Linux fleet). Marker is removed only on success.
- **Branch-naming tripwire:** pre-commit rejects commits from `.claude/worktrees/<id>/` whose branch name doesn't contain `<id>`. Canonical commits unaffected.
- **Launcher integration:** `ensureParallelIsolationHooks()` installs scripts to `~/.claude/parallel-isolation/scripts/` and merges hook entries into user-scope `~/.claude/settings.json`. Same idempotent pattern as `ensureClaudeUserDenyRules` — no per-venture working-tree dirty.

## Pre-ship spikes (per #788, both green)

**APFS clonefile sanity** — synthetic + real-world tests against ss-console:

| Test | Result |
|---|---|
| 158M crane-console clone | 2.3s |
| 484M ss-console clone | 4.9s |
| Symlinks (38) preserved | All resolve |
| `.bin/astro --version` from clone | `astro v6.1.7` |
| `.bin/vitest --version` from clone | `vitest/3.2.4` |
| `.astro/cache/` writes in clone | Don't propagate to canonical |
| Inodes | Separate (CoW) |
| Mutation in clone vs canonical | Independent |

Sharp finding encoded in the hook: `cp -c` falls back **silently** to a regular copy on non-APFS volumes, so `diskutil info` precondition gates the clone path. Without it, the 30s install tax creeps back in unnoticed.

**Fleet mount-flag matrix:**

| Host | OS | FS | Path |
|---|---|---|---|
| m16 | macOS | APFS | `cp -c -R` |
| mac23 | macOS | APFS (sealed/journaled) | `cp -c -R` (verified, separate inodes) |
| mini | Linux | ext4 | `npm ci` fallback |
| mbp27 | Linux | ext4 | `npm ci` fallback |
| think | Linux | ext4 | `npm ci` fallback |

## Pre-launch baseline (from `parallel-isolation-metrics.sh`)

Active-tool-call overlap (sharper than session-range — only counts pairs whose actual tool-use timestamps fall within each other's range, ignoring idle):

| Venture | Sessions | Active-tool-call overlap pairs | Days w/ overlap |
|---|---|---|---|
| ss-console | 20 | 18 | 5 |
| crane-console | 12 | 7 | 4 |
| dfg-console | 2 | 0 | 0 |
| ke-console | 3 | 0 | 0 |

Post-launch we expect both ss-console and crane-console to drop near zero. Clone-fallback rate flags APFS-detection regressions before they bite.

## Test plan

- [x] `npm run verify` passes (601/601 tests, including 7 new `ensureParallelIsolationHooks` cases)
- [x] `detect.sh` smoke test (no-peer case, log line emitted, no marker)
- [x] `gate.sh` smoke test (4 cases: marker+canonical=deny, marker+EnterWorktree=allow, marker+worktree-cwd=allow+cleanup, no marker=allow)
- [x] `provision.sh` end-to-end against a real `git worktree`: APFS clone, separate inodes, mutation isolation verified, marker removal on success
- [x] `branch-check.sh` (4 cases: canonical=skip, worktree-without-prefix=fail, worktree-with-prefix=pass, escape-hatch=pass)
- [x] APFS clonefile spike against ss-console (484M, 4.9s)
- [x] Fleet mount-flag matrix (m16, mac23, mini, mbp27, think)
- [ ] **Smoke test pending Captain validation post-merge:** open two `claude` sessions on the same repo, confirm second is forced into a worktree with cloned `node_modules`, both can ship independent PRs without contamination.
- [ ] **Two-week post-launch metric check:** `parallel-isolation-metrics.sh` weekly. ss-console + crane-console overlap counts should be near zero; clone-fallback rate should be ~0% for macOS sessions.

## Out of scope (deferred)

- Branch-naming hook in other venture repos (this PR ships only `crane-console/.husky/pre-commit`; rollout to other ventures is a follow-up).
- Venture-wide `pnpm` migration (cleaner long-term `node_modules` story; separate project).
- Fleet-dispatch-as-default for parallel sessions (right answer for sprint workers / long-running audits, not daily local work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)