### PR TITLE
fix(skills): /eos removes worktree on exit; /sos backstops orphans

### DIFF
--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -28,6 +28,61 @@ gh pr list --author @me --state all --json number,title,state,updatedAt --jq '.[
 gh issue list --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
 ```
 
+### 1.5 Inspect Worktree State (Read-Only)
+
+Determine whether this session is running inside a `.claude/worktrees/<id>/` worktree, and pre-compute the cleanup decision so Step 2 can write an accurate handoff. **No destructive actions in this step.**
+
+```bash
+PWD_OUT=$(pwd)
+if [[ "$PWD_OUT" != *"/.claude/worktrees/"* ]]; then
+  WORKTREE_DECISION=n/a
+else
+  WORKTREE_PATH="$PWD_OUT"
+  WORKTREE_ID="${WORKTREE_PATH##*/}"
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  STATUS=$(git status --porcelain)
+
+  # Refresh main; ignore failure (offline OK — fall through to PR check)
+  git fetch origin main --quiet 2>/dev/null
+
+  # Squash-merge-aware ahead check (canonical post-squash idiom; offline-safe).
+  # `git cherry` outputs `+` for commits NOT on main, `-` for patch-equivalent on main.
+  CHERRY=$(git cherry origin/main "$BRANCH" 2>/dev/null)
+  MERGED_VIA_CHERRY=false
+  if [ -z "$CHERRY" ] || ! echo "$CHERRY" | grep -q '^+'; then
+    MERGED_VIA_CHERRY=true
+  fi
+
+  # Direct-ancestor check (fast-forward / rebase merges)
+  AHEAD=$(git log "$BRANCH" --not origin/main --oneline 2>/dev/null)
+  MERGED_VIA_LOG=false
+  [ -z "$AHEAD" ] && MERGED_VIA_LOG=true
+
+  # PR-merged tertiary check (network-dependent)
+  PR_NUM=$(gh pr list --head "$BRANCH" --state merged --json number --jq '.[0].number // empty' 2>/dev/null)
+  PR_MERGED=false
+  [ -n "$PR_NUM" ] && PR_MERGED=true
+
+  if [ -z "$STATUS" ]; then
+    if [ "$MERGED_VIA_CHERRY" = true ] || [ "$MERGED_VIA_LOG" = true ] || [ "$PR_MERGED" = true ]; then
+      WORKTREE_DECISION=remove
+    else
+      WORKTREE_DECISION=keep_unpushed
+    fi
+  else
+    WORKTREE_DECISION=keep_dirty
+    DIRTY_FILE_COUNT=$(echo "$STATUS" | wc -l | tr -d ' ')
+  fi
+fi
+```
+
+Stash `WORKTREE_DECISION`, `WORKTREE_PATH`, `BRANCH`, and `DIRTY_FILE_COUNT` for use in Steps 2 and 5.5. Decision values:
+
+- `n/a` — not in a worktree (skip cleanup)
+- `remove` — clean tree AND merged via cherry, log, or PR
+- `keep_unpushed` — clean tree, commits ahead of main, no merged PR (work needs follow-up)
+- `keep_dirty` — uncommitted changes present
+
 ### 2. Synthesize Handoff (Agent Task)
 
 Using conversation history and gathered context, the agent generates a summary covering:
@@ -57,6 +112,11 @@ Using conversation history and gathered context, the agent generates a summary c
 - "1. Open src/foo.ts and complete the retryWithBackoff() function"
 - "2. Run npm test — expect 2 new tests to pass"
 - "3. Create PR for issue #123"
+
+**Worktree-aware resume guidance:**
+
+- If `WORKTREE_DECISION` from Step 1.5 is `keep_unpushed` or `keep_dirty`, the **In Progress** and **Next Session** sections MUST start with `cd $WORKTREE_PATH && git checkout $BRANCH` so an agent with no context resumes in the right place. For `keep_dirty`, also list the modified files.
+- If `WORKTREE_DECISION` is `remove` or `n/a`, do NOT reference the worktree path or branch in the handoff — the worktree will be gone after Step 5.5 and the reference would mislead the next session.
 
 ### 3. Display and Save (Auto-Save)
 
@@ -96,11 +156,54 @@ crane_handoff(summary: "Added /ship skill, command sync...", status: "done", ven
 
 Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
+### 5.5 Execute Worktree Decision
+
+Acts on `WORKTREE_DECISION` from Step 1.5. For cross-venture sessions, this runs **once**, after the FINAL `crane_handoff` call (the one without `final: false`). Earlier per-venture handoffs do NOT trigger cleanup — the session is still active.
+
+1. **`WORKTREE_DECISION=n/a`** — skip; jump to Step 6.
+
+2. **`WORKTREE_DECISION=remove`** — call:
+
+   ```
+   ExitWorktree(action: "remove", discard_changes: true)
+   ```
+
+   `discard_changes: true` is required when local commits exist (post-squash case): the substance is already on main as a squash commit, but the original branch commits are not ancestors of `origin/main` and the harness needs explicit consent to discard them.
+
+3. **`WORKTREE_DECISION=keep_unpushed`** or **`keep_dirty`** — call:
+
+   ```
+   ExitWorktree(action: "keep")
+   ```
+
+   Worktree stays, branch stays, next session resumes via the handoff text written in Step 2.
+
+4. **Fallback on `ExitWorktree` failure** (rare — running outside the harness, session-state mismatch, etc.):
+   - For `remove`: attempt raw cleanup. Identify canonical repo path (`git rev-parse --git-common-dir` then resolve up two levels from `.git`, or use the path before `/.claude/worktrees/` in `WORKTREE_PATH`). Then:
+     ```bash
+     CANONICAL="${WORKTREE_PATH%/.claude/worktrees/*}"
+     cd "$CANONICAL"
+     git worktree remove --force "$WORKTREE_PATH" \
+       && git branch -D "$BRANCH"
+     ```
+     If raw cleanup also fails, capture both error messages for Step 6 — do NOT crash `/eos`.
+   - For `keep_unpushed` or `keep_dirty`: ExitWorktree failure is non-fatal; the worktree was going to stay anyway.
+
 ### 6. Report Completion
 
+Build the closing line based on `WORKTREE_DECISION` and the actual outcome of Step 5.5:
+
 ```
-Handoff saved to D1. Next session will see this via crane_sos.
+Handoff saved to D1. Worktree: {removed | kept (unpushed: <branch>) | kept (dirty: <N> file(s)) | n/a | remove failed (see above)}. Next session will see this via crane_sos.
 ```
+
+Examples:
+
+- `Handoff saved to D1. Worktree: removed. Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: kept (unpushed: feat/some-thing). Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: kept (dirty: 3 file(s)). Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: n/a. Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: remove failed (ExitWorktree: <err>; raw cleanup: <err>). Next session will see this via crane_sos.`
 
 ## Key Principle
 

--- a/.claude/commands/sos.md
+++ b/.claude/commands/sos.md
@@ -2,9 +2,76 @@
 
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
-3. Display briefing. Highlight any Resume block or P0 issues.
-4. If cadence items overdue, ask: "Execute any now, or skip?"
-5. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
+3. **Orphan worktree backstop** — see below. Auto-remove provably-safe orphans from sessions that ended unnaturally; surface the rest. Compute a one-line worktree status line for the briefing.
+4. Display briefing. Prepend the worktree status line from Step 3 (omit if no orphans found and no warning). Highlight any Resume block or P0 issues.
+5. If cadence items overdue, ask: "Execute any now, or skip?"
+6. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
+
+## Step 3 — Orphan Worktree Backstop
+
+Closes the exit-side gap from PR #789's parallel-isolation system. `/eos` is the deterministic primary path; this step handles sessions that ended unnaturally (closed terminal, force-quit, kernel panic).
+
+**Scope.** Worktrees under `.claude/worktrees/` only. Skip the worktree this session is currently in (if any) — that's `/eos`'s responsibility.
+
+**Cap.** If more than 20 orphans found, process the 20 most recent by mtime and surface a one-line warning:
+
+```
+Worktrees: <N> orphans found, processing 20 most recent. Run `git worktree list` and clean manually if intentional.
+```
+
+**Single-shot setup** (run once at top of step):
+
+```bash
+git fetch origin main --quiet 2>/dev/null
+
+# One batched gh call; cache the headRefName→PR-number map locally
+MERGED_PRS_JSON=$(gh pr list --state merged --limit 100 --json number,headRefName 2>/dev/null || echo '[]')
+# Use jq to lookup later: echo "$MERGED_PRS_JSON" | jq -r --arg b "$BRANCH" '.[] | select(.headRefName == $b) | .number'
+
+CURRENT_PWD=$(pwd)
+NOW_TS=$(date +%s)
+SIXTY_MIN_AGO=$((NOW_TS - 3600))
+```
+
+**For each orphan worktree path**, classify in this exact order:
+
+1. **Skip if it's this session's own worktree.** `[[ "$CURRENT_PWD" == "$WORKTREE_PATH"* ]]` → skip (it's `/eos`'s job).
+
+2. **Skip if anything is using the directory.** `lsof +D "$WORKTREE_PATH" 2>/dev/null` — if exit code is 0 AND output non-empty, treat as live and skip. This catches all process names (`claude`, `claude-code`, `node /path/to/cli.js`, wrappers, shells with that cwd) and all FD types (cwd, mmap, log, any).
+
+3. **Skip if HEAD is fresh.** `HEAD_TS=$(git -C "$WORKTREE_PATH" log -1 --format=%ct HEAD 2>/dev/null)` — if `$HEAD_TS -gt $SIXTY_MIN_AGO`, refuse auto-remove and add to "needs review" with reason "fresh HEAD". Third independent staleness signal.
+
+4. **Provably safe — auto-remove.** Required: ALL of the following.
+   - `git -C "$WORKTREE_PATH" status --porcelain` empty (clean tree).
+   - One of: (a) `git -C "$WORKTREE_PATH" cherry origin/main "$BRANCH"` returns no `+`-prefixed lines (squash-merged or empty); or (b) `git -C "$WORKTREE_PATH" log "$BRANCH" --not origin/main --oneline` is empty (direct merge); or (c) `echo "$MERGED_PRS_JSON" | jq -e --arg b "$BRANCH" 'any(.headRefName == $b)'` returns 0 (PR was merged).
+
+   Action:
+
+   ```bash
+   git worktree remove --force "$WORKTREE_PATH" \
+     && git branch -D "$BRANCH" 2>/dev/null
+   ```
+
+   Add to "cleaned" list with the worktree id (last path segment).
+
+5. **Has work — surface, do not touch.** Add to "needs review" with reason:
+   - dirty tree → "dirty: \<file count\>"
+   - unmerged commits → "\<commit count\> commit(s) ahead"
+   - fresh HEAD → "fresh HEAD"
+
+**Compose the briefing line** (omit entirely if both lists are empty AND no warning):
+
+```
+Worktrees: cleaned <N> orphan(s) [<id1>, <id2>]; <M> needs review [<id3>: <reason>, <id4>: <reason>]
+```
+
+If only one half applies, omit the empty half. Examples:
+
+- `Worktrees: cleaned 2 orphan(s) [robust-fluttering-oasis, shiny-toasting-prism]`
+- `Worktrees: 1 needs review [test-pending: 1 commit(s) ahead]`
+- `Worktrees: cleaned 1 orphan(s) [test-squash]; 1 needs review [test-pending: 1 commit(s) ahead]`
+
+**Conservative auto-remove rationale:** clean tree + merged-via-cherry-or-log-or-PR + no active FD usage + HEAD older than 60 min. Four independent signals before any destructive action. False positive (a live worktree gets removed) requires all four to be wrong simultaneously.
 
 ## Rules
 

--- a/.gemini/commands/eos.toml
+++ b/.gemini/commands/eos.toml
@@ -30,6 +30,61 @@ gh pr list --author @me --state all --json number,title,state,updatedAt --jq '.[
 gh issue list --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
 ```
 
+### 1.5 Inspect Worktree State (Read-Only)
+
+Determine whether this session is running inside a `.claude/worktrees/<id>/` worktree, and pre-compute the cleanup decision so Step 2 can write an accurate handoff. **No destructive actions in this step.**
+
+```bash
+PWD_OUT=$(pwd)
+if [[ "$PWD_OUT" != *"/.claude/worktrees/"* ]]; then
+  WORKTREE_DECISION=n/a
+else
+  WORKTREE_PATH="$PWD_OUT"
+  WORKTREE_ID="${WORKTREE_PATH##*/}"
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  STATUS=$(git status --porcelain)
+
+  # Refresh main; ignore failure (offline OK — fall through to PR check)
+  git fetch origin main --quiet 2>/dev/null
+
+  # Squash-merge-aware ahead check (canonical post-squash idiom; offline-safe).
+  # `git cherry` outputs `+` for commits NOT on main, `-` for patch-equivalent on main.
+  CHERRY=$(git cherry origin/main "$BRANCH" 2>/dev/null)
+  MERGED_VIA_CHERRY=false
+  if [ -z "$CHERRY" ] || ! echo "$CHERRY" | grep -q '^+'; then
+    MERGED_VIA_CHERRY=true
+  fi
+
+  # Direct-ancestor check (fast-forward / rebase merges)
+  AHEAD=$(git log "$BRANCH" --not origin/main --oneline 2>/dev/null)
+  MERGED_VIA_LOG=false
+  [ -z "$AHEAD" ] && MERGED_VIA_LOG=true
+
+  # PR-merged tertiary check (network-dependent)
+  PR_NUM=$(gh pr list --head "$BRANCH" --state merged --json number --jq '.[0].number // empty' 2>/dev/null)
+  PR_MERGED=false
+  [ -n "$PR_NUM" ] && PR_MERGED=true
+
+  if [ -z "$STATUS" ]; then
+    if [ "$MERGED_VIA_CHERRY" = true ] || [ "$MERGED_VIA_LOG" = true ] || [ "$PR_MERGED" = true ]; then
+      WORKTREE_DECISION=remove
+    else
+      WORKTREE_DECISION=keep_unpushed
+    fi
+  else
+    WORKTREE_DECISION=keep_dirty
+    DIRTY_FILE_COUNT=$(echo "$STATUS" | wc -l | tr -d ' ')
+  fi
+fi
+```
+
+Stash `WORKTREE_DECISION`, `WORKTREE_PATH`, `BRANCH`, and `DIRTY_FILE_COUNT` for use in Steps 2 and 5.5. Decision values:
+
+- `n/a` — not in a worktree (skip cleanup)
+- `remove` — clean tree AND merged via cherry, log, or PR
+- `keep_unpushed` — clean tree, commits ahead of main, no merged PR (work needs follow-up)
+- `keep_dirty` — uncommitted changes present
+
 ### 2. Synthesize Handoff (Agent Task)
 
 Using conversation history and gathered context, the agent generates a summary covering:
@@ -59,6 +114,11 @@ Using conversation history and gathered context, the agent generates a summary c
 - "1. Open src/foo.ts and complete the retryWithBackoff() function"
 - "2. Run npm test — expect 2 new tests to pass"
 - "3. Create PR for issue #123"
+
+**Worktree-aware resume guidance:**
+
+- If `WORKTREE_DECISION` from Step 1.5 is `keep_unpushed` or `keep_dirty`, the **In Progress** and **Next Session** sections MUST start with `cd $WORKTREE_PATH && git checkout $BRANCH` so an agent with no context resumes in the right place. For `keep_dirty`, also list the modified files.
+- If `WORKTREE_DECISION` is `remove` or `n/a`, do NOT reference the worktree path or branch in the handoff — the worktree will be gone after Step 5.5 and the reference would mislead the next session.
 
 ### 3. Display and Save (Auto-Save)
 
@@ -98,11 +158,54 @@ crane_handoff(summary: "Added /ship skill, command sync...", status: "done", ven
 
 Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
 
+### 5.5 Execute Worktree Decision
+
+Acts on `WORKTREE_DECISION` from Step 1.5. For cross-venture sessions, this runs **once**, after the FINAL `crane_handoff` call (the one without `final: false`). Earlier per-venture handoffs do NOT trigger cleanup — the session is still active.
+
+1. **`WORKTREE_DECISION=n/a`** — skip; jump to Step 6.
+
+2. **`WORKTREE_DECISION=remove`** — call:
+
+   ```
+   ExitWorktree(action: "remove", discard_changes: true)
+   ```
+
+   `discard_changes: true` is required when local commits exist (post-squash case): the substance is already on main as a squash commit, but the original branch commits are not ancestors of `origin/main` and the harness needs explicit consent to discard them.
+
+3. **`WORKTREE_DECISION=keep_unpushed`** or **`keep_dirty`** — call:
+
+   ```
+   ExitWorktree(action: "keep")
+   ```
+
+   Worktree stays, branch stays, next session resumes via the handoff text written in Step 2.
+
+4. **Fallback on `ExitWorktree` failure** (rare — running outside the harness, session-state mismatch, etc.):
+   - For `remove`: attempt raw cleanup. Identify canonical repo path (`git rev-parse --git-common-dir` then resolve up two levels from `.git`, or use the path before `/.claude/worktrees/` in `WORKTREE_PATH`). Then:
+     ```bash
+     CANONICAL="${WORKTREE_PATH%/.claude/worktrees/*}"
+     cd "$CANONICAL"
+     git worktree remove --force "$WORKTREE_PATH" \
+       && git branch -D "$BRANCH"
+     ```
+     If raw cleanup also fails, capture both error messages for Step 6 — do NOT crash `/eos`.
+   - For `keep_unpushed` or `keep_dirty`: ExitWorktree failure is non-fatal; the worktree was going to stay anyway.
+
 ### 6. Report Completion
 
+Build the closing line based on `WORKTREE_DECISION` and the actual outcome of Step 5.5:
+
 ```
-Handoff saved to D1. Next session will see this via crane_sos.
+Handoff saved to D1. Worktree: {removed | kept (unpushed: <branch>) | kept (dirty: <N> file(s)) | n/a | remove failed (see above)}. Next session will see this via crane_sos.
 ```
+
+Examples:
+
+- `Handoff saved to D1. Worktree: removed. Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: kept (unpushed: feat/some-thing). Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: kept (dirty: 3 file(s)). Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: n/a. Next session will see this via crane_sos.`
+- `Handoff saved to D1. Worktree: remove failed (ExitWorktree: <err>; raw cleanup: <err>). Next session will see this via crane_sos.`
 
 ## Key Principle
 

--- a/.gemini/commands/sos.toml
+++ b/.gemini/commands/sos.toml
@@ -4,9 +4,76 @@ prompt = """
 
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
-3. Display briefing. Highlight any Resume block or P0 issues.
-4. If cadence items overdue, ask: "Execute any now, or skip?"
-5. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
+3. **Orphan worktree backstop** — see below. Auto-remove provably-safe orphans from sessions that ended unnaturally; surface the rest. Compute a one-line worktree status line for the briefing.
+4. Display briefing. Prepend the worktree status line from Step 3 (omit if no orphans found and no warning). Highlight any Resume block or P0 issues.
+5. If cadence items overdue, ask: "Execute any now, or skip?"
+6. **STOP.** If Resume block: "Previous session was working on [summary]. Resume or focus elsewhere?" Otherwise: "What would you like to focus on?"
+
+## Step 3 — Orphan Worktree Backstop
+
+Closes the exit-side gap from PR #789's parallel-isolation system. `/eos` is the deterministic primary path; this step handles sessions that ended unnaturally (closed terminal, force-quit, kernel panic).
+
+**Scope.** Worktrees under `.claude/worktrees/` only. Skip the worktree this session is currently in (if any) — that's `/eos`'s responsibility.
+
+**Cap.** If more than 20 orphans found, process the 20 most recent by mtime and surface a one-line warning:
+
+```
+Worktrees: <N> orphans found, processing 20 most recent. Run `git worktree list` and clean manually if intentional.
+```
+
+**Single-shot setup** (run once at top of step):
+
+```bash
+git fetch origin main --quiet 2>/dev/null
+
+# One batched gh call; cache the headRefName→PR-number map locally
+MERGED_PRS_JSON=$(gh pr list --state merged --limit 100 --json number,headRefName 2>/dev/null || echo '[]')
+# Use jq to lookup later: echo "$MERGED_PRS_JSON" | jq -r --arg b "$BRANCH" '.[] | select(.headRefName == $b) | .number'
+
+CURRENT_PWD=$(pwd)
+NOW_TS=$(date +%s)
+SIXTY_MIN_AGO=$((NOW_TS - 3600))
+```
+
+**For each orphan worktree path**, classify in this exact order:
+
+1. **Skip if it's this session's own worktree.** `[[ "$CURRENT_PWD" == "$WORKTREE_PATH"* ]]` → skip (it's `/eos`'s job).
+
+2. **Skip if anything is using the directory.** `lsof +D "$WORKTREE_PATH" 2>/dev/null` — if exit code is 0 AND output non-empty, treat as live and skip. This catches all process names (`claude`, `claude-code`, `node /path/to/cli.js`, wrappers, shells with that cwd) and all FD types (cwd, mmap, log, any).
+
+3. **Skip if HEAD is fresh.** `HEAD_TS=$(git -C "$WORKTREE_PATH" log -1 --format=%ct HEAD 2>/dev/null)` — if `$HEAD_TS -gt $SIXTY_MIN_AGO`, refuse auto-remove and add to "needs review" with reason "fresh HEAD". Third independent staleness signal.
+
+4. **Provably safe — auto-remove.** Required: ALL of the following.
+   - `git -C "$WORKTREE_PATH" status --porcelain` empty (clean tree).
+   - One of: (a) `git -C "$WORKTREE_PATH" cherry origin/main "$BRANCH"` returns no `+`-prefixed lines (squash-merged or empty); or (b) `git -C "$WORKTREE_PATH" log "$BRANCH" --not origin/main --oneline` is empty (direct merge); or (c) `echo "$MERGED_PRS_JSON" | jq -e --arg b "$BRANCH" 'any(.headRefName == $b)'` returns 0 (PR was merged).
+
+   Action:
+
+   ```bash
+   git worktree remove --force "$WORKTREE_PATH" \
+     && git branch -D "$BRANCH" 2>/dev/null
+   ```
+
+   Add to "cleaned" list with the worktree id (last path segment).
+
+5. **Has work — surface, do not touch.** Add to "needs review" with reason:
+   - dirty tree → "dirty: \<file count\>"
+   - unmerged commits → "\<commit count\> commit(s) ahead"
+   - fresh HEAD → "fresh HEAD"
+
+**Compose the briefing line** (omit entirely if both lists are empty AND no warning):
+
+```
+Worktrees: cleaned <N> orphan(s) [<id1>, <id2>]; <M> needs review [<id3>: <reason>, <id4>: <reason>]
+```
+
+If only one half applies, omit the empty half. Examples:
+
+- `Worktrees: cleaned 2 orphan(s) [robust-fluttering-oasis, shiny-toasting-prism]`
+- `Worktrees: 1 needs review [test-pending: 1 commit(s) ahead]`
+- `Worktrees: cleaned 1 orphan(s) [test-squash]; 1 needs review [test-pending: 1 commit(s) ahead]`
+
+**Conservative auto-remove rationale:** clean tree + merged-via-cherry-or-log-or-PR + no active FD usage + HEAD older than 60 min. Four independent signals before any destructive action. False positive (a live worktree gets removed) requires all four to be wrong simultaneously.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Closes #798. Closes the exit-side gap left by PR #789's parallel-session worktree isolation. `/eos` now deterministically cleans up the worktree it was working in (when safe). `/sos` backstops sessions that ended unnaturally.

- **`/eos` Step 1.5 (read-only inspection):** detects whether session is in `.claude/worktrees/<id>/`, pre-computes `WORKTREE_DECISION` (`n/a` | `remove` | `keep_unpushed` | `keep_dirty`).
- **`/eos` Step 2 (handoff synthesis):** worktree-aware — includes `cd $WORKTREE_PATH && git checkout $BRANCH` only when keeping; omits the reference when removing so next session isn't pointed at dead state.
- **`/eos` Step 5.5 (execution):** calls `ExitWorktree(action: "remove", discard_changes: true)` for `remove`, `ExitWorktree(action: "keep")` otherwise. Raw `git worktree remove --force` fallback if `ExitWorktree` itself fails.
- **`/sos` Step 3 (orphan backstop):** scans `.claude/worktrees/`, skips this session's own and any directory with active FD usage (`lsof +D`). Auto-removes provably-safe orphans (clean tree + merged-via-cherry/log/PR + HEAD older than 60 min — four independent staleness signals). Surfaces the rest as "needs review" in the briefing.

## Why `git cherry`

The load-bearing decision: post-squash-merge orphans (which is what we have right now — both `robust-fluttering-oasis` and `shiny-toasting-prism` are squash-merged) fail the `git log <branch> --not origin/main` check because the squash commit on main has a different SHA than the original branch commits. `git cherry origin/main <branch>` is the canonical post-squash-equivalence idiom: each output line is `+ <sha>` (commit not on main) or `- <sha>` (patch-equivalent on main). Offline-safe; no network round-trip.

## Self-validation built in

Two pre-existing orphans on this repo become live test data:

```
.claude/worktrees/robust-fluttering-oasis  — squash-merged via PR #796
.claude/worktrees/shiny-toasting-prism     — squash-merged via PR #797
```

Once this PR merges, the next `/sos` auto-cleans both via the `git cherry` arm. If they stay, the fix is wrong and visible in the next session's briefing — no waiting for a synthetic test.

## Critique-driven revisions

Plan went through Devil's Advocate critique. Six issues adopted:

1. **Squash-merge detection** via `git cherry` (the bug that would have made the headline self-validation case fail silently).
2. **Worktree decision moved BEFORE handoff synthesis** so handoff text reflects accurate state instead of having to predict the cleanup outcome.
3. **`lsof +D <path>`** replaces `pgrep -x claude` + per-pid lsof — direct directory-occupancy check catches all process names and FD types, no detection race.
4. **HEAD-recency check** (60 min) as third independent staleness signal.
5. **`ExitWorktree` raw-cleanup fallback** so leaks don't move from harness to `/sos`.
6. **Batched `gh pr list`** (one call, local filter) and 20-orphan ceiling to bound cost in degenerate states.

Single critique-acknowledged-but-not-adopted: cooperative `flock` lockfiles. Four-signal staleness check is sufficient for the actual failure modes; lockfiles add a new failure surface (stale locks).

## Test plan

- [x] `npm run verify` green (typecheck + format + lint + test + builds; 605 crane-mcp tests + 36 worker tests + 519 contracts tests + canary tests + harness tests pass)
- [x] `scripts/sync-commands.sh --check` for `eos.toml`, `sos.toml`, `eos/SKILL.md`, `sos/SKILL.md` all OK
- [ ] Smoke test the `/eos` removal path end-to-end (squash-merge case): trivial edit → push → squash-merge → `/eos`. Step 6 reports `Worktree: removed`.
- [ ] Smoke test the `/eos` keep-dirty path: uncommitted change present → `/eos`. Step 6 reports `Worktree: kept (dirty: 1 file(s))`.
- [ ] Smoke test the `/eos` keep-unpushed path: local commit + no PR → `/eos`. Step 6 reports `Worktree: kept (unpushed: <branch>)`.
- [ ] Smoke test `/sos` auto-clean (squash-merge orphan): manually create orphan, squash-merge it, start fresh session. Briefing shows `cleaned 1 orphan(s)`.
- [ ] Smoke test `/sos` preservation (unpushed): orphan with unpushed commit → fresh session → briefing shows `1 needs review` and worktree persists.
- [ ] Smoke test `/sos` fresh-HEAD safety: just-merged orphan → immediate session → refused with `fresh HEAD` reason.
- [ ] **Self-validation post-merge:** next `/sos` auto-cleans `robust-fluttering-oasis` and `shiny-toasting-prism`.

## Pre-existing concerns (not in scope)

- `.agents/skills/auto-build/SKILL.md` shows DRIFT in `sync-commands.sh --check` — pre-existing from PR #787 era; canonical `.claude/commands/auto-build.md` lacks frontmatter while `.agents` cache has rich frontmatter manually maintained. Not introduced by this PR. Same condition PR #795 noted.

## Out of scope (deferred)

- **Marker file cleanup** (`.claude/parallel-isolation-required-$SESSION_ID`) when `provision.sh` fails — entry-side concern, separate fix.
- **Branch-naming hook rollout to other venture repos** — already deferred from PR #789.
- **Cross-session lockfile / cooperative locking** — invasive; the four-signal staleness check is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)