### PR TITLE
fix(docs): clear 4 dead internal links surfaced by /docs-audit

### DIFF
--- a/docs/instructions/index.md
+++ b/docs/instructions/index.md
@@ -31,7 +31,6 @@ Agent directives are governance docs - the rules agents must follow when working
 
 ### Design
 
-- **[Wireframe Guidelines](wireframe-guidelines.md)** - When to generate wireframes, file conventions, quality bar, and conflict resolution between ACs and wireframes.
 - **[Design System](design-system.md)** - How to load venture design specs, token naming conventions, and design maturity tiers.
 
 ### Infrastructure

--- a/docs/process/index.md
+++ b/docs/process/index.md
@@ -35,7 +35,6 @@ The essential development cycle processes every agent uses:
 - **[Team Workflow](team-workflow.md)** - Complete workflow specification: issue lifecycle, QA grading, status labels, communication patterns
 - **[PR Workflow](pr-workflow.md)** - Pull request requirements for agents: branch naming, commit format, QA grades, post-merge verification
 - **[EOD/SOD Process](eos-sos-process.md)** - Session lifecycle discipline: start of day briefing, end of day handoffs, session state management
-- **[QA Checklists](qa-checklists.md)** - Grade-specific verification checklists and evidence requirements
 
 ### Agent Roles & Coordination
 

--- a/docs/ventures/vc/design-charter.md
+++ b/docs/ventures/vc/design-charter.md
@@ -2,7 +2,7 @@
 
 > Governance document for the Venture Crane design system. Establishes how design decisions are made, enforced, and extended.
 >
-> Generated 2026-02-13. Companion to [Design Brief](design-brief.md) and [PRD](../../pm/prd.md).
+> Generated 2026-02-13. Companion to [Design Brief](design-brief.md).
 
 ---
 
@@ -270,4 +270,4 @@ The founder reviews PRs and has final authority on all design decisions. The cha
 
 ---
 
-_Companion documents: [Design Brief](design-brief.md) | [PRD](../../pm/prd.md)_
+_Companion documents: [Design Brief](design-brief.md)_


### PR DESCRIPTION
## Summary

`/docs-audit` flagged 4 dead internal links across 3 files. All target docs were intentionally removed in prior commits — these are stale references to delete.

| File | Line | Target | Why broken |
|------|------|--------|-----------|
| `docs/instructions/index.md` | 34 | `wireframe-guidelines.md` | Doc lives in global doc store via `crane_doc('global', 'wireframe-guidelines.md')`, not in `docs/` tree |
| `docs/process/index.md` | 38 | `qa-checklists.md` | QA grading system removed in 7a71eec |
| `docs/ventures/vc/design-charter.md` | 5 | `../../pm/prd.md` | PRD deleted in 05b5eca as stale and superseded |
| `docs/ventures/vc/design-charter.md` | 273 | `../../pm/prd.md` | Same deletion as above |

Wireframe-guidelines is still listed in CLAUDE.md's instruction-modules table (correctly fetched via `crane_doc()`) — that reference is valid and untouched.

## Test plan

- [x] `npm run verify` passes
- [ ] Re-run `/docs-audit` after merge → ERROR count goes from 4 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)