### PR TITLE
chore: portfolio review 2026-05-05

### DIFF
--- a/config/ventures.json
+++ b/config/ventures.json
@@ -4,7 +4,7 @@
     "state": "Arizona",
     "operatorRole": "Captain"
   },
-  "lastPortfolioReview": "2026-04-02",
+  "lastPortfolioReview": "2026-05-05",
   "portfolioReviewCadenceDays": 7,
   "sharedSecrets": {
     "source": "/vc",


### PR DESCRIPTION
## Summary

- Stamps `lastPortfolioReview` from 2026-04-02 → 2026-05-05.
- No per-venture status changes proposed this round.
- Captain approved on 2026-05-05.

## Findings (no action this PR)

- 57 open dependabot PRs on crane-console (oldest 13 days) — cleanup pass overdue.
- Draft Crane code-review scorecard is 43 days old (stale).
- Silicon Crane has no code-review scorecard on record.
- All four product ventures (sc/dfg/ke/dc) have URL → 200, but `building → beta` requires non-founder access; private alpha gates remain → status stays `building`.

## Data caveats

- `crane_schedule(action: "session-history", days: 30)` 500'd; the activity table used a 10-day window (sessions still confirm SS > VC priority).
- Code-review note bodies aren't reachable via the MCP/HTTP surface in this run — letter grades couldn't be extracted, only review dates.

## Companion PR

- venturecrane/vc-web#131 — derivative `lastReviewed` bump

## Test plan

- [ ] CI green
- [ ] vc-web companion PR merged after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)