### PR TITLE
fix(docs-refresh-workflow): set HUSKY=0 in CI commit step

### DIFF
--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -112,6 +112,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_BODY: ${{ steps.body.outputs.body }}
+          # Disable husky in CI — the local pre-commit hook calls gitleaks
+          # which isn't installed on GHA runners. Security checks (Semgrep,
+          # Secret Detection) run as their own workflow jobs on the resulting PR.
+          HUSKY: '0'
         run: |
           stamp=$(date -u +%Y%m%d-%H%M)
           branch="docs-refresh/auto-$stamp"


### PR DESCRIPTION
## Summary

The first post-merge run of `.github/workflows/docs-refresh.yml` (workflow run #25411988599) successfully refreshed managed blocks and detected real drift, but failed at the `git commit` step because the husky pre-commit hook invokes \`gitleaks\` which isn't installed on the GitHub Actions runner.

```
.husky/pre-commit: 3: gitleaks: not found
husky - pre-commit script failed (code 127)
```

Setting \`HUSKY=0\` in the env block disables husky for the auto-PR commit. The checks the hook would have run (secret scanning, prettier, eslint) all run as separate workflow jobs on the resulting PR, so coverage isn't reduced.

This is the standard husky-in-CI pattern.

## Test plan

- [x] YAML validated
- [ ] After merge, dispatch the workflow again and confirm a real auto-PR opens for the legit drift it already detected (vc/product-overview, dfg/roadmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)