### PR TITLE
docs: weekly docs-refresh (20260506-0158 UTC)

### DIFF
--- a/docs/ventures/dfg/roadmap.md
+++ b/docs/ventures/dfg/roadmap.md
@@ -17,12 +17,8 @@ _No work in progress._
 
 <!-- docs-refresh:activity-near-term -->
 
-- #177 TECH: Replace manual API routing with itty-router + Zod validation
-- #143 Clean up \_2 suffix files and archived code
-- #131 FIX-008: Scout D1 Write Storm [P1]
-- #130 FIX-007: R2 Snapshots Not Versioned [P1]
-- #129 FIX-005: Staleness Snapshot Uses Live Values [P1]
-- #128 FIX-006: UI Hardcoded Fee Heuristics [P1]
+_Nothing queued up next._
+
 <!-- /docs-refresh:activity-near-term -->
 
 ## Future

--- a/docs/ventures/vc/product-overview.md
+++ b/docs/ventures/vc/product-overview.md
@@ -58,9 +58,9 @@ All roles run through Claude Code CLI. Dev agents handle implementation and PRs.
 
 <!-- docs-refresh:activity-shipped -->
 
+- #806 EOS surface verification gate (4 layers) _(2026-05-06)_
 - #781 git-authority rubric (always-loaded + module) _(2026-05-01)_
 - #782 fleet-branch-protection script + canonical-profile flip _(2026-05-01)_
 - #514 documentation framework standardization _(2026-04-12)_
 - #737 clerk + playwright auth bootstrap template _(2026-04-25)_
-- #779 session reflex primer v2 (always-on, corpus-driven) _(2026-05-01)_
 <!-- /docs-refresh:activity-shipped -->


### PR DESCRIPTION
## Summary

First auto-PR from the new `.github/workflows/docs-refresh.yml` weekly cron. The workflow successfully ran the refresh CLI, committed, and pushed the branch — but failed at `gh pr create` because the repo setting "Allow GitHub Actions to create and approve pull requests" is currently off. Opening the PR manually now to land the legitimate drift this run detected.

The closed loop is working at the code level — what's left is one repo-policy decision (see "next step" below).

## Changed files

- `docs/ventures/dfg/roadmap.md` — `activity-near-term` empties (the 6 dfg issues that were `status:ready` have all closed since markers were seeded)
- `docs/ventures/vc/product-overview.md` — `activity-shipped` adds `#806` (most recent feat: PR), drops `#779` (rolled past the 5-item window)

This is genuine, derivable-from-canonical-source drift. Diff stat:

```
 docs/ventures/dfg/roadmap.md         | 8 ++------
 docs/ventures/vc/product-overview.md | 2 +-
 2 files changed, 3 insertions(+), 7 deletions(-)
```

## Next step (Captain action — one of these)

To make the workflow's auto-PR step succeed without manual intervention, pick one:

**Option A — flip the repo setting (~10 seconds).**
Settings > Actions > General > Workflow permissions: set "Allow GitHub Actions to create and approve pull requests" to ON.

**Option B — switch to GitHub App auth (~5 min).**
Add `GH_APP_ID` and `GH_APP_PRIVATE_KEY` as repo secrets (the venturecrane-github App's PEM lives in Infisical `/vc` as `GH_PRIVATE_KEY_PEM`). Then update the workflow to mint an App token via `actions/create-github-app-token` and use that for `gh pr create`. More scoped, no repo-wide policy change.

Recommendation: Option A unless you'd rather keep that policy locked down.

## Test plan

- [x] `npm run verify` passes (per #805)
- [x] Workflow ran the refresh CLI cleanly (this is the run's output)
- [x] Branch pushed, commit landed
- [ ] Merge this PR — verify the new content publishes via `Deploy Crane Command`
- [ ] After Captain enables option A or B, dispatch the workflow again with `gh workflow run docs-refresh.yml --ref main` and confirm the auto-PR opens without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)