### PR TITLE
fix(docs-refresh-workflow): hybrid auth — GITHUB_TOKEN for push, App for PR

### DIFF
--- a/.github/workflows/docs-refresh.yml
+++ b/.github/workflows/docs-refresh.yml
@@ -35,10 +35,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use App token so the auto-PR is authored by venturecrane-github,
-          # not the default github-actions[bot] (which the org policy blocks
-          # from creating PRs).
-          token: ${{ steps.app-token.outputs.token }}
+          # Default GITHUB_TOKEN handles checkout + push (its workflow-level
+          # permissions block has contents: write). The App token is reserved
+          # for the `gh pr create` call which GITHUB_TOKEN can't perform under
+          # the current org policy "Allow GitHub Actions to create PRs".
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -67,9 +67,10 @@ jobs:
 
       - name: Run docs-refresh
         env:
-          # Use App token for the gh CLI calls inside docs-refresh (issue/PR
-          # listing) — keeps a single auth identity across the whole workflow.
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # docs-refresh CLI calls gh issue list / gh pr list — read-only, so
+          # GITHUB_TOKEN is fine. Keep the App token scoped to the PR-create
+          # step where it's actually required.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VENTURES: ${{ steps.targets.outputs.ventures }}
         run: |
           # shellcheck disable=SC2086 — venture codes are sanitized in the targets step
@@ -89,20 +90,12 @@ jobs:
 
       - name: Configure git
         if: steps.changes.outputs.has_changes == 'true'
-        env:
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          # Author commits as the venturecrane-github App so they show up under
-          # the App identity (not github-actions[bot]) and the auto-PR can pass
-          # the org's "no Actions PRs" policy via App-token auth.
-          git config user.name "${APP_SLUG}[bot]"
-          # The numeric user id for the App's bot identity comes back via the
-          # API; for our App (venturecrane-github, App ID 2619905) the bot
-          # commit-noreply email is documented at <id>+<slug>[bot]@users.noreply.github.com.
-          # The App's user id is resolvable via /users/<slug>[bot]; we use the
-          # App-token-authenticated runner so the commit signs cleanly under
-          # whatever identity the token resolves to.
-          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          # Use github-actions[bot] for commits — matches the GITHUB_TOKEN used
+          # for `git push`. The PR itself is created via the App token (next
+          # step) and shows up under venturecrane-github[bot] in the PR UI.
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Compose PR body
         if: steps.changes.outputs.has_changes == 'true'
@@ -130,13 +123,10 @@ jobs:
             echo 'EOF_BODY'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Create branch, commit, and open PR
+      - name: Create branch and push
         if: steps.changes.outputs.has_changes == 'true'
+        id: push
         env:
-          # App token (not GITHUB_TOKEN) so PR creation isn't blocked by the
-          # "Allow GitHub Actions to create and approve pull requests" policy.
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_BODY: ${{ steps.body.outputs.body }}
           # Disable husky in CI — the local pre-commit hook calls gitleaks
           # which isn't installed on GHA runners. Security checks (Semgrep,
           # Secret Detection) run as their own workflow jobs on the resulting PR.
@@ -148,13 +138,27 @@ jobs:
           git add docs/
           git commit -m "docs: weekly docs-refresh ($stamp UTC)"
           git push origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "stamp=$stamp" >> "$GITHUB_OUTPUT"
 
-          # Reuse PR if branch already exists for some reason; otherwise create.
-          if gh pr view "$branch" --json number >/dev/null 2>&1; then
-            echo "PR already open for $branch — skipping create"
+      - name: Open PR via App token
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          # App token, not GITHUB_TOKEN — the org policy blocks Actions's
+          # default token from creating PRs. The App is installed on the repo
+          # with pull-requests: write, so PR creation succeeds via App identity.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_BODY: ${{ steps.body.outputs.body }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          STAMP: ${{ steps.push.outputs.stamp }}
+        run: |
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "PR already open for $BRANCH — skipping create"
           else
             gh pr create \
-              --title "docs: weekly docs-refresh ($stamp UTC)" \
+              --title "docs: weekly docs-refresh ($STAMP UTC)" \
               --body "$PR_BODY" \
-              --label "automation"
+              --label "automation" \
+              --head "$BRANCH" \
+              --base main
           fi


### PR DESCRIPTION
## Summary

Previous PR #809 minted an App token and used it for everything. Workflow run #25412805782 failed at \`git push\` because \`venturecrane-github\` App lacks \`contents: write\` permission on this repo — only \`pull-requests: write\`.

Fix: hybrid auth. GITHUB_TOKEN (which the workflow's \`permissions: contents: write\` block grants) handles checkout + push. App token used only for \`gh pr create\`, which is the one operation GITHUB_TOKEN can't do under the org's "Allow GitHub Actions to create PRs" policy.

## Changes

- Checkout uses GITHUB_TOKEN (default).
- \`Run docs-refresh\` step uses GITHUB_TOKEN for the gh CLI calls (issue/PR list — read only).
- New \`Open PR via App token\` step uses the App token, with explicit \`--head\` and \`--base\` flags.
- Push step uses GITHUB_TOKEN (commits authored by github-actions[bot]; the PR itself shows up under venturecrane-github[bot] in the UI).

## Test plan

- [x] YAML validated
- [ ] After merge, dispatch the workflow and confirm both push and PR create succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)