### PR TITLE
fix(ci): align GITHUB_SHA with checkout ref in deploy-staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The checkout step above pins to workflow_run.head_sha. The default
+          # GITHUB_SHA env var is whatever main HEAD is at trigger time, which
+          # can differ if main moves between Verify completing and Deploy
+          # starting (now common after rapid merges). The inject-version.mjs
+          # supply-chain guard refuses to write a build-info that disagrees
+          # with HEAD — so override GITHUB_SHA to match the checked-out ref.
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
   smoke-test:
     name: Smoke tests (staging)


### PR DESCRIPTION
## Summary
Deploy Workers (staging) has been failing the `inject-version.mjs` supply-chain guard since rapid merges started landing on `main`. After PR #810 fixed the Infisical auth in smoke-test, the next failure mode surfaced:

```
error: GITHUB_SHA env var disagrees with `git rev-parse HEAD`
  GITHUB_SHA: 88b3ec9...   (current main HEAD)
  git HEAD:   1fd2f20...   (commit Verify ran on)
```

## Root cause
- `actions/checkout@v6` in deploy-staging pins to `${{ github.event.workflow_run.head_sha }}` — the commit Verify actually ran on. ✓
- GitHub's default `GITHUB_SHA` env var on a `workflow_run` trigger is the branch HEAD at trigger time, **not** the SHA of the upstream workflow run.
- When `main` moves between Verify completing and Deploy starting (now common after rapid merges), the two diverge and the supply-chain guard correctly refuses to write a dishonest `build-info.ts`.

## Fix
Override `GITHUB_SHA` on the wrangler deploy step only, scoped via step-level `env:` rather than job-level, so any other step that legitimately needs trigger-time SHA is unaffected. The guard's invariant — "checkout and recorded SHA must agree" — is preserved.

## Test plan
- [ ] Auto-merge enabled; CI on this PR is green
- [ ] After merge, watch Deploy Workers run end-to-end and confirm `Deploy crane-context to staging` / `crane-watch` / `crane-mcp-remote` all succeed
- [ ] Confirm Smoke tests (staging) succeeds (validates PR #810 too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)