### PR TITLE
fix(ci): install workspace + build crane-contracts in smoke-test job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      # The smoke-test-e2e.sh script's `sos_real_client_agents` scenario
+      # imports `@venturecrane/crane-contracts` via `node --eval` to compute
+      # the canonical agent-name matrix from the live contract (not hardcoded
+      # strings — drift detection). The package is a workspace member; install
+      # at root so the workspace symlink lands under node_modules/@venturecrane/,
+      # then build dist/ so node-resolve has something to import.
+      - name: Install workspace + build crane-contracts
+        run: |
+          npm install --no-audit --no-fund --include-workspace-root --workspaces
+          npm run build --prefix packages/crane-contracts
+
       - name: Wait for edge propagation
         run: sleep 5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,13 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The checkout step above pins to workflow_run.head_sha. The default
+          # GITHUB_SHA env var is whatever main HEAD is at trigger time, which
+          # can differ if main moves between Verify completing and Deploy
+          # starting (now common after rapid merges). The inject-version.mjs
+          # supply-chain guard refuses to write a build-info that disagrees
+          # with HEAD — so override GITHUB_SHA to match the checked-out ref.
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
   smoke-test:
     name: Smoke tests (staging)


### PR DESCRIPTION
## Summary
The Deploy Workers smoke-test job has been failing the `sos_real_client_agents` scenario with `ERR_MODULE_NOT_FOUND` since #802 added it. The failure was hidden behind the Infisical auth failure until PR #810 unblocked the prior layers.

## Why the scenario needs the package
`scenario_sos_real_client_agents` imports `@venturecrane/crane-contracts` via `node --eval` to compute the canonical agent-name matrix from the live contract (not hardcoded strings — drift detection). It POSTs each (host, agent) pair to `/sos` and asserts HTTP 200. If anyone tightens `buildAgentName()` such that a real fleet hostname is rejected, this catches it.

## Why it fails in CI
The smoke-test job has no `npm install` step. The script runs from repo root but `node_modules/@venturecrane/crane-contracts` (workspace symlink) doesn't exist. Eval fails. Test fails.

## Fix
1. Add `actions/setup-node@v6` to the smoke job.
2. Run `npm install --include-workspace-root --workspaces` at root so the workspace symlink lands under `node_modules/@venturecrane/`.
3. Run `npm run build --prefix packages/crane-contracts` so `dist/index.js` exists for node-resolve.

## Test plan
- [ ] Auto-merge enabled
- [ ] After merge, watch one Deploy Workers run on `main`
- [ ] Confirm `sos_real_client_agents` PASSES (10 PASS, 0 FAIL in smoke)
- [ ] All three workers deploy + Smoke tests (staging) succeeds

This is the third and (almost certainly) final layer of the CI debugging chain that started with the dependabot merge spree:
1. Infisical auth missing → #810
2. GITHUB_SHA mismatch on rapid main moves → #812
3. Smoke needs workspace installed → this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)