### PR TITLE
fix(ci): treat dependabot PRs as restricted in audit Infisical gate

### DIFF
--- a/.github/workflows/secret-sync-audit.yml
+++ b/.github/workflows/secret-sync-audit.yml
@@ -54,11 +54,15 @@ jobs:
         env:
           INFISICAL_UNIVERSAL_AUTH_CLIENT_ID: ${{ secrets.INFISICAL_UNIVERSAL_AUTH_CLIENT_ID }}
           INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET: ${{ secrets.INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET }}
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          # Treat both fork PRs and dependabot PRs as "restricted" — neither
+          # has access to repo secrets by default, so the strict-gate must
+          # skip rather than hard-fail. Dependabot uses a separate secret
+          # store this workflow doesn't depend on.
+          IS_RESTRICTED: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
         run: |
           if [ -z "$INFISICAL_UNIVERSAL_AUTH_CLIENT_ID" ] || [ -z "$INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET" ]; then
-            if [ "$IS_FORK" = "true" ]; then
-              echo "::warning::Skipping on fork PR (secrets not available to forks)."
+            if [ "$IS_RESTRICTED" = "true" ]; then
+              echo "::warning::Skipping on restricted PR (fork or dependabot — secrets not available)."
               echo "INFISICAL_SKIP=1" >> $GITHUB_ENV
               exit 0
             else

--- a/.github/workflows/system-readiness-audit.yml
+++ b/.github/workflows/system-readiness-audit.yml
@@ -59,11 +59,15 @@ jobs:
         env:
           INFISICAL_UNIVERSAL_AUTH_CLIENT_ID: ${{ secrets.INFISICAL_UNIVERSAL_AUTH_CLIENT_ID }}
           INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET: ${{ secrets.INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET }}
-          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          # Treat both fork PRs and dependabot PRs as "restricted" — neither
+          # has access to repo secrets by default, so the strict-gate must
+          # skip rather than hard-fail. Dependabot uses a separate secret
+          # store this workflow doesn't depend on.
+          IS_RESTRICTED: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
         run: |
           if [ -z "$INFISICAL_UNIVERSAL_AUTH_CLIENT_ID" ] || [ -z "$INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET" ]; then
-            if [ "$IS_FORK" = "true" ]; then
-              echo "::warning::Skipping on fork PR (secrets not available to forks)."
+            if [ "$IS_RESTRICTED" = "true" ]; then
+              echo "::warning::Skipping on restricted PR (fork or dependabot — secrets not available)."
               echo "INFISICAL_SKIP=1" >> $GITHUB_ENV
               exit 0
             else


### PR DESCRIPTION
## Summary
PR #802's strict-gate hard-fails when \`INFISICAL_UNIVERSAL_AUTH_CLIENT_ID\` is missing on non-fork PRs — but GitHub doesn't expose repo Actions secrets to dependabot PRs by default. Result: **every open dependabot PR fails Readiness audit and Secret Sync audit** at the auth-gate, blocking the entire drain queue.

## Root cause
\`\`\`yaml
IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
\`\`\`

Dependabot pushes branches to the same repo (\`head.repo.full_name == github.repository\`), so \`IS_FORK = false\`. The else branch then hard-fails. Pre-#802 the audit silently skipped (the bug #802 was correctly fixing); post-#802 it errors. We need a third state: **skip-with-warning** for PRs that legitimately can't see secrets.

## Fix
Rename \`IS_FORK\` → \`IS_RESTRICTED\` and OR in \`github.actor == 'dependabot[bot]'\`. Same pattern applied to both audit workflows:
- \`.github/workflows/system-readiness-audit.yml\`
- \`.github/workflows/secret-sync-audit.yml\`

The strict-gate intent is preserved for internal PRs (missing secrets is still a real bug worth hard-failing on); only restricted PRs (forks and dependabot) get the warning skip.

## Test plan
- [ ] Auto-merge enabled
- [ ] After merge, watch one open dependabot PR's Readiness audit go from FAILURE → SUCCESS (skipped with warning)
- [ ] Bonus: confirm a future internal-not-bot PR with missing secrets would still hard-fail (skipping for now since we have no test scenario)

## Layer in the cleanup chain
1. Infisical auth missing in deploy smoke → #810
2. GITHUB_SHA mismatch on rapid main moves → #812
3. Smoke needs workspace installed → #813
4. Audit gate doesn't recognize dependabot PRs → this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)