### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -7,3 +7,6 @@ worktrees/
 # Per-session isolation markers and logs (parallel-isolation feature, #788)
 parallel-isolation-required-*
 parallel-isolation-log/
+
+# Harness runtime lock file for in-session scheduled tasks (CronCreate)
+scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Adds `scheduled_tasks.lock` to `.claude/.gitignore` so the harness runtime lock file for CronCreate scheduled tasks no longer surfaces as untracked in every session.

## Test plan
- [x] `git check-ignore -v .claude/scheduled_tasks.lock` resolves to the new rule
- [x] `git status` clean after `touch .claude/scheduled_tasks.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)