### PR TITLE
feat(skills): deprecation lifecycle + sunset /sprint and /build-log

### DIFF
--- a/.agents/skills/build-log/SKILL.md
+++ b/.agents/skills/build-log/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: build-log
 description: Draft a Build Log Entry
-version: 1.0.0
+version: 1.1.0
 scope: enterprise
 owner: agent-team
-status: stable
+status: deprecated
+deprecation_date: 2026-05-05
+sunset_date: 2026-08-03
 ---
 
 # /build-log - Draft a Build Log Entry
+
+> **DEPRECATED 2026-05-05 · Sunset 2026-08-03.** This skill is bypassed in practice — build logs are produced regularly (7 shipped in May 2026 alone) but the skill itself has 0 invocations in 180+ days. Drafting flows directly through `/edit-log` and direct authoring against the terminology doc at `~/dev/vc-web/docs/content/terminology.md`. /build-log stays invocable during the grace window; a removal PR will follow on or after the sunset date. See `docs/skills/deprecated.md`.
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "build-log")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 

--- a/.agents/skills/sprint/SKILL.md
+++ b/.agents/skills/sprint/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: sprint
 description: Sequential sprint execution of GitHub issues on separate branches
-version: 1.0.0
+version: 1.1.0
 scope: enterprise
 owner: captain
-status: stable
+status: deprecated
+deprecation_date: 2026-05-05
+sunset_date: 2026-08-03
 ---
 
 # /sprint - Sequential sprint execution
+
+> **DEPRECATED 2026-05-05 · Sunset 2026-08-03.** Use `/auto-build` instead. /auto-build covers the same plan-and-execute flow on pre-vetted issues, has 15 invocations against /sprint's 0, and is owned by Captain. /sprint stays invocable during the grace window; a removal PR will follow on or after the sunset date. See `docs/skills/deprecated.md`.
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "sprint")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 

--- a/.claude/commands/build-log.md
+++ b/.claude/commands/build-log.md
@@ -1,5 +1,7 @@
 # /build-log - Draft a Build Log Entry
 
+> **DEPRECATED 2026-05-05 · Sunset 2026-08-03.** Build logs are now drafted directly with `/edit-log` and the terminology doc at `~/dev/vc-web/docs/content/terminology.md`. See `.agents/skills/build-log/SKILL.md` and `docs/skills/deprecated.md`.
+
 Draft a short operational update (200-1,000 words) about what shipped, broke, or changed. The founder provides a topic and the agent drafts around it.
 
 ## Usage

--- a/.claude/commands/sprint.md
+++ b/.claude/commands/sprint.md
@@ -1,5 +1,7 @@
 # /sprint - Parallel Sprint Execution
 
+> **DEPRECATED 2026-05-05 · Sunset 2026-08-03.** Use `/auto-build` instead. See `.agents/skills/sprint/SKILL.md` and `docs/skills/deprecated.md`.
+
 This command takes a set of pre-selected GitHub issue numbers, builds an optimal wave-based execution plan, and spawns parallel coding agents to implement them simultaneously using git worktrees for isolation.
 
 Works in any venture console repo. The prior step (human or planning agent) selects which issues go into the sprint. This command handles execution.

--- a/.gemini/commands/build-log.toml
+++ b/.gemini/commands/build-log.toml
@@ -2,6 +2,8 @@ description = "Draft a Build Log Entry"
 
 prompt = """
 
+> **DEPRECATED 2026-05-05 · Sunset 2026-08-03.** Build logs are now drafted directly with `/edit-log` and the terminology doc at `~/dev/vc-web/docs/content/terminology.md`. See `.agents/skills/build-log/SKILL.md` and `docs/skills/deprecated.md`.
+
 Draft a short operational update (200-1,000 words) about what shipped, broke, or changed. The founder provides a topic and the agent drafts around it.
 
 ## Usage

--- a/docs/skills/deprecated.md
+++ b/docs/skills/deprecated.md
@@ -1,0 +1,47 @@
+# Deprecated Skills
+
+Skills that have been marked `status: deprecated` per the lifecycle defined in `docs/skills/governance.md`. Deprecated skills remain invocable for a 90-day grace period, then are removed in a follow-up PR.
+
+Append new entries at the top.
+
+## 2026-05-05
+
+### `/sprint` — Sequential sprint execution
+
+| Field            | Value                            |
+| ---------------- | -------------------------------- |
+| Skill path       | `.agents/skills/sprint/SKILL.md` |
+| Dispatcher       | `.claude/commands/sprint.md`     |
+| Owner            | captain                          |
+| Deprecation date | 2026-05-05                       |
+| Sunset date      | 2026-08-03                       |
+| Replacement      | `/auto-build`                    |
+| Trigger          | `/skill-audit` zero-usage report |
+
+**Reason.** /sprint had zero invocations in the last 180 days. /auto-build covers the same plan-and-execute flow on pre-vetted issues, has 15 invocations in the same window, and is owned by Captain. Wave-based dependency planning in /sprint was never used in practice — Captain selects issues case by case and runs /auto-build.
+
+**Removal-PR scope.** When the sunset date arrives, the cleanup PR will:
+
+- Delete `.agents/skills/sprint/`, `.claude/commands/sprint.md`, `.claude/agents/sprint-worker.md` (if still present), and any sprint-state cache schema.
+- Update `docs/process/fleet-orchestration.md`, `docs/process/fleet-decision-framework.md`, `docs/process/multi-agent-coordination.md`, `docs/process/agent-persona-briefs.md`, and `docs/process/slash-commands-guide.md` to remove /sprint references and replace the local-vs-fleet decision framework with /auto-build vs /orchestrate.
+- Remove the `docs/reviews/2026-04-12-platform-audit.md` follow-up references to /sprint, if any.
+
+### `/build-log` — Draft a Build Log Entry
+
+| Field            | Value                               |
+| ---------------- | ----------------------------------- |
+| Skill path       | `.agents/skills/build-log/SKILL.md` |
+| Dispatcher       | `.claude/commands/build-log.md`     |
+| Owner            | agent-team                          |
+| Deprecation date | 2026-05-05                          |
+| Sunset date      | 2026-08-03                          |
+| Replacement      | direct authoring + `/edit-log`      |
+| Trigger          | `/skill-audit` zero-usage report    |
+
+**Reason.** /build-log had zero invocations in the last 180 days, but seven build logs shipped in May 2026 alone (PRs #121-127, #129). The skill is bypassed: drafting flows directly through the terminology doc at `~/dev/vc-web/docs/content/terminology.md` and editorial review via `/edit-log`. The skill's interactive "Save as draft? (y/n)" flow added ceremony without participation. The 2026-04-12 platform audit (finding #5) already flagged genericization-rule duplication across build-log, edit-log, and edit-article — consolidation into the terminology doc is the durable path; the skill is not.
+
+**Removal-PR scope.** When the sunset date arrives, the cleanup PR will:
+
+- Delete `.agents/skills/build-log/` and `.claude/commands/build-log.md`.
+- Update `docs/ventures/vc/website.md`, `docs/process/agent-persona-briefs.md`, and `docs/process/slash-commands-guide.md` to drop /build-log references.
+- Confirm the genericization rules and stealth-venture filter live exclusively in the terminology doc (closing the 2026-04-12 platform-audit finding #5).

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -38,7 +38,7 @@ depends_on:
 | `version`     | semver string | `MAJOR.MINOR.PATCH`. Bump MINOR on additive changes, MAJOR on breaking restructures, PATCH on fixes                                         |
 | `scope`       | enum          | `enterprise` (crane-console workflow), `global` (usable in any venture context), or `venture:<code>` (venture-specific, e.g., `venture:ss`) |
 | `owner`       | string        | MUST be a key from `config/skill-owners.json`. Currently: `captain` or `agent-team`                                                         |
-| `status`      | enum          | `draft` (in-progress, not yet stable), `stable` (production)                                                                                |
+| `status`      | enum          | `draft` (in-progress, not yet stable), `stable` (production), `deprecated` (sunset announced — see Lifecycle below)                         |
 
 ### Optional fields
 
@@ -48,6 +48,8 @@ depends_on:
 | `depends_on.files`     | string[] | File references, **scope-prefixed**: `crane-console:<path>`, `venture:<path>`, or `global:<path>`. The `/skill-review` validator enforces the correct scope when checking existence |
 | `depends_on.commands`  | string[] | External shell commands the skill invokes. Checked as PATH warnings only                                                                                                            |
 | `backend_only`         | boolean  | If `true`, the skill has no matching `.claude/commands/<name>.md` dispatcher. Default `false`                                                                                       |
+| `deprecation_date`     | ISO date | **Required when `status: deprecated`.** The day the skill was marked deprecated. Format: `YYYY-MM-DD`                                                                               |
+| `sunset_date`          | ISO date | **Required when `status: deprecated`.** The day the removal PR is expected to land. Must be strictly after `deprecation_date`. Format: `YYYY-MM-DD`                                 |
 
 ### Deliberately not in the schema
 
@@ -62,19 +64,21 @@ depends_on:
 | `global`         | `~/.agents/skills/<name>/`              | Mirrored from `crane-console/.agents/skills/<name>/` to home via `config/global-skills.json` + launcher `syncGlobalSkills()` (see PR #528) |
 | `venture:<code>` | `<venture-repo>/.agents/skills/<name>/` | Venture-specific. Not synced from crane-console. Example: a skill only useful in ss-console                                                |
 
-## Lifecycle: draft → stable → removed
+## Lifecycle: draft → stable → deprecated → removed
 
 ```
-  draft ────── /skill-review passes ────▶ stable
-                                             │
-                                             │ Captain directive
-                                             ▼
-                                          removed (separate PR)
+  draft ─── /skill-review passes ──▶ stable
+                                        │
+                                        │ Captain directive +
+                                        │ /skill-deprecate flow
+                                        ▼
+                                    deprecated  ──── 90-day grace ────▶ removed (separate PR)
 ```
 
 - **draft** — in progress. `/skill-review` surfaces issues but the skill isn't advertised.
 - **stable** — production. The default status after a passing review.
-- **removed** — deletion PR cut on Captain directive. `guardrails.md` forbids removing features without one, so this is always manual. There is no staged "deprecated" grace period — skills are retired in a single PR that updates dispatchers, config, and any code references along with the SKILL.md delete.
+- **deprecated** — sunset announced. `deprecation_date` and `sunset_date` are required (sunset 90 days after deprecation by convention). The skill stays invocable during the grace window so existing workflows aren't broken mid-flight. A sunset banner is injected at the top of the SKILL.md body and the dispatcher. Logged in `docs/skills/deprecated.md`.
+- **removed** — deletion PR cut on or after `sunset_date`. `guardrails.md` forbids removing features without Captain directive, so this is always manual. The removal PR updates dispatchers, config, and any code references along with the SKILL.md delete.
 
 ## Review gate
 

--- a/packages/crane-mcp/src/cli/skill-review.test.ts
+++ b/packages/crane-mcp/src/cli/skill-review.test.ts
@@ -30,6 +30,7 @@ import { spawnSync } from 'node:child_process'
 import {
   parseFrontmatter,
   checkFrontmatterConformance,
+  checkDeprecationSanity,
   checkDispatcherParity,
   checkReferenceValidity,
   checkStructuralLint,
@@ -165,6 +166,12 @@ describe('checkFrontmatterConformance', () => {
     expect(v!.severity).toBe('error')
   })
 
+  it('accepts status: deprecated as a valid enum value', () => {
+    const fm = { ...goodFrontmatter(), status: 'deprecated' }
+    const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
+    expect(violations.filter((v) => v.rule === 'frontmatter.invalid-status')).toHaveLength(0)
+  })
+
   it('errors on unknown owner', () => {
     const fm = { ...goodFrontmatter(), owner: 'unknown-team' }
     const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', KNOWN_OWNERS)
@@ -185,6 +192,100 @@ describe('checkFrontmatterConformance', () => {
     const fm = { ...goodFrontmatter(), owner: 'anything' }
     const violations = checkFrontmatterConformance(SKILL_PATH, SKILL_PATH, fm, 'foo', [])
     expect(violations.filter((v) => v.rule === 'frontmatter.unknown-owner')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkDeprecationSanity
+// ---------------------------------------------------------------------------
+
+describe('checkDeprecationSanity', () => {
+  it('returns no violations when status is not deprecated', () => {
+    const fm = { ...goodFrontmatter() }
+    expect(checkDeprecationSanity(SKILL_PATH, fm)).toHaveLength(0)
+  })
+
+  it('passes for a well-formed deprecation block', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2026-05-05',
+      sunset_date: '2026-08-03',
+    }
+    expect(checkDeprecationSanity(SKILL_PATH, fm)).toHaveLength(0)
+  })
+
+  it('errors when deprecation_date is missing', () => {
+    const fm = { ...goodFrontmatter(), status: 'deprecated', sunset_date: '2026-08-03' }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.deprecation-date-missing'
+    )
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when sunset_date is missing', () => {
+    const fm = { ...goodFrontmatter(), status: 'deprecated', deprecation_date: '2026-05-05' }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.sunset-date-missing'
+    )
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors on non-ISO deprecation_date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '5/5/2026',
+      sunset_date: '2026-08-03',
+    }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.deprecation-date-invalid'
+    )
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors on non-ISO sunset_date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2026-05-05',
+      sunset_date: 'next quarter',
+    }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.sunset-date-invalid'
+    )
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when sunset_date is not strictly after deprecation_date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2026-08-03',
+      sunset_date: '2026-08-03',
+    }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.sunset-not-after-deprecation'
+    )
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('error')
+  })
+
+  it('errors when sunset_date is before deprecation_date', () => {
+    const fm = {
+      ...goodFrontmatter(),
+      status: 'deprecated',
+      deprecation_date: '2026-08-03',
+      sunset_date: '2026-05-05',
+    }
+    const v = checkDeprecationSanity(SKILL_PATH, fm).find(
+      (x) => x.rule === 'frontmatter.sunset-not-after-deprecation'
+    )
+    expect(v).toBeDefined()
   })
 })
 

--- a/packages/crane-mcp/src/cli/skill-review.ts
+++ b/packages/crane-mcp/src/cli/skill-review.ts
@@ -52,6 +52,8 @@ interface Frontmatter {
   scope?: unknown
   owner?: unknown
   status?: unknown
+  deprecation_date?: unknown
+  sunset_date?: unknown
   backend_only?: unknown
   depends_on?: {
     mcp_tools?: unknown
@@ -247,9 +249,10 @@ export function loadMcpToolManifest(manifestPath: string): string[] {
 // ---------------------------------------------------------------------------
 
 const REQUIRED_FIELDS = ['name', 'description', 'version', 'scope', 'owner', 'status'] as const
-const VALID_STATUSES = ['draft', 'stable'] as const
+const VALID_STATUSES = ['draft', 'stable', 'deprecated'] as const
 const SEMVER_RE = /^\d+\.\d+\.\d+$/
 const SCOPE_RE = /^(enterprise|global|venture:[a-z]+)$/
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 const FILE_SCOPE_PREFIXES = ['crane-console:', 'venture:', 'global:']
 
 export function checkFrontmatterConformance(
@@ -318,8 +321,8 @@ export function checkFrontmatterConformance(
         rule: 'frontmatter.invalid-status',
         severity: 'error',
         path: skillPath,
-        message: `status "${String(fm.status)}" is invalid. Must be one of: draft, stable`,
-        fix: 'Set status to `draft` or `stable`.',
+        message: `status "${String(fm.status)}" is invalid. Must be one of: ${VALID_STATUSES.join(', ')}`,
+        fix: `Set status to one of: ${VALID_STATUSES.map((s) => `\`${s}\``).join(', ')}.`,
       })
     }
   }
@@ -335,6 +338,75 @@ export function checkFrontmatterConformance(
         fix: `Add the skill under an existing owner key (${knownOwners.join(', ')}) in config/skill-owners.json, or add a new owner key.`,
       })
     }
+  }
+
+  return violations
+}
+
+export function checkDeprecationSanity(skillPath: string, fm: Frontmatter): Violation[] {
+  if (fm.status !== 'deprecated') return []
+
+  const violations: Violation[] = []
+  const depRaw = fm.deprecation_date
+  const sunRaw = fm.sunset_date
+
+  const depMissing = depRaw === undefined || depRaw === null || depRaw === ''
+  const sunMissing = sunRaw === undefined || sunRaw === null || sunRaw === ''
+
+  if (depMissing) {
+    violations.push({
+      rule: 'frontmatter.deprecation-date-missing',
+      severity: 'error',
+      path: skillPath,
+      message: 'status: deprecated requires a `deprecation_date` field',
+      fix: 'Add `deprecation_date: YYYY-MM-DD` (the day the skill was marked deprecated).',
+    })
+  }
+
+  if (sunMissing) {
+    violations.push({
+      rule: 'frontmatter.sunset-date-missing',
+      severity: 'error',
+      path: skillPath,
+      message: 'status: deprecated requires a `sunset_date` field',
+      fix: 'Add `sunset_date: YYYY-MM-DD` (the day the removal PR is expected to land — typically deprecation_date + 90 days).',
+    })
+  }
+
+  if (!depMissing && !ISO_DATE_RE.test(String(depRaw))) {
+    violations.push({
+      rule: 'frontmatter.deprecation-date-invalid',
+      severity: 'error',
+      path: skillPath,
+      message: `deprecation_date "${String(depRaw)}" is not in YYYY-MM-DD format`,
+      fix: 'Use ISO date format, e.g. `deprecation_date: 2026-05-05`.',
+    })
+  }
+
+  if (!sunMissing && !ISO_DATE_RE.test(String(sunRaw))) {
+    violations.push({
+      rule: 'frontmatter.sunset-date-invalid',
+      severity: 'error',
+      path: skillPath,
+      message: `sunset_date "${String(sunRaw)}" is not in YYYY-MM-DD format`,
+      fix: 'Use ISO date format, e.g. `sunset_date: 2026-08-03`.',
+    })
+  }
+
+  if (
+    !depMissing &&
+    !sunMissing &&
+    ISO_DATE_RE.test(String(depRaw)) &&
+    ISO_DATE_RE.test(String(sunRaw)) &&
+    String(sunRaw) <= String(depRaw)
+  ) {
+    violations.push({
+      rule: 'frontmatter.sunset-not-after-deprecation',
+      severity: 'error',
+      path: skillPath,
+      message: `sunset_date "${String(sunRaw)}" must be after deprecation_date "${String(depRaw)}"`,
+      fix: 'Set `sunset_date` to a date later than `deprecation_date` (typically 90 days later).',
+    })
   }
 
   return violations
@@ -613,6 +685,7 @@ export function reviewSkill(
 
   const violations: Violation[] = [
     ...checkFrontmatterConformance(relPath, relPath, fm, dirName, knownOwners),
+    ...checkDeprecationSanity(relPath, fm),
     ...checkDispatcherParity(relPath, fm, repoRoot),
     ...checkReferenceValidity(relPath, fm, repoRoot, manifestTools),
     ...checkStructuralLint(relPath, fm, content),


### PR DESCRIPTION
## Summary

Closes the governance gap between **governance.md** (which assumed single-PR removal) and the **/skill-deprecate** skill + **crane_skill_audit** "Deprecation queue" (which both assume a `deprecated` state with a 90-day grace window). The two were documented but the validator rejected `status: deprecated`, blocking the flow on first use. Triggered by today's `/skill-audit` zero-usage findings.

Two changes in one PR:

1. **Validator + governance** — extend the lifecycle to include `deprecated` as a real state.
2. **Sunset two zero-usage skills** — `/sprint` and `/build-log`, both at 0 invocations / 180d.

## Validator changes (`skill-review`)

- Add `'deprecated'` to `VALID_STATUSES`
- Add `deprecation_date` and `sunset_date` to the `Frontmatter` interface
- New `checkDeprecationSanity()`:
  - When `status: deprecated`, both dates are **required**
  - Both must be ISO `YYYY-MM-DD`
  - `sunset_date` must be **strictly after** `deprecation_date`
- 8 new unit tests covering: well-formed deprecation, missing dates, invalid date formats, sunset-equals-deprecation, sunset-before-deprecation
- Updated error message for invalid status to derive the enum list from the constant

## Governance doc changes

- `status` enum row now lists `deprecated` with a pointer to the lifecycle section
- `deprecation_date` and `sunset_date` added to the optional-fields table, marked as conditional-required when `status: deprecated`
- Lifecycle diagram updated: `draft → stable → deprecated → removed`, with the 90-day grace edge labeled
- Replaced the prior "no staged deprecated grace period" text with the actual flow

## Skills sunset (2026-05-05 → 2026-08-03)

| Skill | Replacement | Reason |
| --- | --- | --- |
| `/sprint` | `/auto-build` | 0 invocations / 180d vs /auto-build's 15. Wave-based dependency planning was never used in practice. |
| `/build-log` | direct authoring + `/edit-log` | 0 invocations / 180d, but 7 build logs shipped in May 2026 alone — all drafted directly via the terminology doc. The skill's interactive flow added ceremony without participation. The 2026-04-12 platform audit (finding #5) already flagged genericization-rule duplication as a separate concern; consolidation into the terminology doc is the durable path. |

Both skills:
- Have `status: deprecated`, `deprecation_date: 2026-05-05`, `sunset_date: 2026-08-03`
- Carry a sunset banner at the top of the SKILL.md body **and** the dispatcher `.claude/commands/<name>.md`
- **Remain invocable** during the 90-day grace window
- Are logged in `docs/skills/deprecated.md` with the cleanup-PR scope (which docs to update at sunset)

## Out of scope

- Doc references to `/sprint` and `/build-log` in `docs/process/fleet-orchestration.md`, `docs/process/slash-commands-guide.md`, `docs/ventures/vc/website.md`, etc. — captured in the deprecated.md cleanup-PR scope. Will be cleaned up at sunset.
- Genericization-rule consolidation into the terminology doc (2026-04-12 platform-audit finding #5) — separate ticket.

## Test plan

- [x] `npm run skill-review -- --all` — 0 errors (was 2 errors before validator fix)
- [x] `npm test` — 724 tests pass (skill-review.test.ts: 55 → 63)
- [x] `npm run verify` — typecheck, format, lint, test all green
- [x] `/sprint` and `/build-log` SKILL.md still parse and pass the new sanity check
- [ ] Reviewer: confirm the sunset date (2026-08-03 = today + 90d) is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)