### PR TITLE
chore(cadence): drop gbp-weekly-post — pre-launch SS has no GBP substrate

### DIFF
--- a/docs/operations/operating-cadence.md
+++ b/docs/operations/operating-cadence.md
@@ -46,7 +46,6 @@ Handoffs are the continuity mechanism. They ensure no context is lost between se
 | Item                    | Scope       | Purpose                                               |
 | ----------------------- | ----------- | ----------------------------------------------------- |
 | Portfolio Review        | VC          | Review venture stages, metrics, and Go/Kill decisions |
-| GBP Weekly Post         | SS          | SMD Services Google Business Profile content          |
 | Code Reviews            | Per venture | Codebase health check on active ventures              |
 | Secrets Rotation Review | CRANE       | Verify no expired or compromised credentials          |
 

--- a/workers/crane-context/migrations/0049_drop_gbp_weekly_post_cadence.sql
+++ b/workers/crane-context/migrations/0049_drop_gbp_weekly_post_cadence.sql
@@ -1,0 +1,22 @@
+-- Migration 0049: Drop the 'gbp-weekly-post' cadence item.
+--
+-- Context: Per PM team review on ss-console (issue #650, 2026-05-05),
+-- SMD Services is pre-launch with zero clients. There is no work product,
+-- no photos, no events, no case studies — no substrate for a credible
+-- Google Business Profile post. The skill /gbp-weekly-post does not
+-- exist (was never built; cadence was firing dead).
+--
+-- The cadence is being retired here. The skill build is recaptured under
+-- ss-console#713 ("build /gbp-weekly-post skill (post-first-client)"),
+-- gated on first delivered client engagement with a publishable artifact.
+-- When that gate clears, this seed will be reintroduced via a new
+-- migration.
+--
+-- Idempotent: re-running finds no matching row and DELETE is a no-op.
+-- Fresh deployments still run 0022's INSERT OR IGNORE seed (which
+-- re-creates the row), but 0049 runs immediately after and removes it,
+-- leaving the DB in the same state as an existing, migrated environment.
+--
+-- Pattern mirrors migration 0036 (drop weekly-plan cadence).
+
+DELETE FROM schedule_items WHERE name = 'gbp-weekly-post';


### PR DESCRIPTION
## Summary

- Migration 0049 deletes the `gbp-weekly-post` cadence row from `schedule_items`. The skill was never built; the cadence was firing into a dead command.
- Removes the row from `docs/operations/operating-cadence.md`.
- Pattern mirrors migration 0036 (drop weekly-plan).

Per ss-console PM team review on issue #650 (2026-05-05). Skill rebuild recaptured under ss-console#713 ("build /gbp-weekly-post skill (post-first-client)"), gated on first delivered client engagement with a publishable artifact.

## Why

SMD Services is pre-launch with zero clients. There is no work product, no photos, no events, no case studies — no substrate for a credible GBP post. Authoring a placeholder skill that drafts copy from "what we believe" would produce the corporate-AI register Captain has rejected (per ss-console memory \`feedback_voice_copy_from_captain_not_generate.md\`) and risks Pattern A/B fabrication on a public surface. Weekly cadence noise also actively erodes SOS signal — every overdue ping conditions Captain to ignore real cadence items.

## Idempotency

- Re-running migration 0049 against an already-cleaned DB: DELETE matches no rows, no-op.
- Fresh deployment: 0022 runs first (seeds the row via INSERT OR IGNORE), 0049 immediately removes it. Final state matches existing migrated environments.

## Schema impact

None. This migration only deletes a row, no DDL change. \`schema.hash\` does not need regeneration.

## Test plan

- [x] \`npm test\` in \`workers/crane-context/\` — 519 passed
- [ ] Apply to staging: \`npm run db:migrate:apply\`
- [ ] Verify staging: \`npx wrangler d1 execute crane-context-db-staging --remote --command "SELECT * FROM schedule_items WHERE name = 'gbp-weekly-post'"\` returns zero rows
- [ ] Apply to production: \`npm run db:migrate:apply:prod\`
- [ ] Verify production same way
- [ ] Confirm next \`crane_sos(venture: "ss")\` does not surface gbp-weekly-post overdue

🤖 Generated with [Claude Code](https://claude.com/claude-code)