### PR TITLE
chore(template): gitignore launcher-mirrored skill triplet

### DIFF
--- a/templates/venture/.gitignore
+++ b/templates/venture/.gitignore
@@ -31,3 +31,20 @@ coverage/
 # Logs
 *.log
 npm-debug.log*
+
+# Enterprise skill triplet synced from crane-console on every `crane <venture>` launch
+# (see syncVentureSkills in crane-console/packages/crane-mcp/src/cli/launch-lib.ts).
+# Source of truth lives in crane-console; tracking here would produce a
+# large dirty tree on every canon update.
+.claude/commands/
+.gemini/commands/
+.agents/skills/
+
+# Claude Code per-session runtime artifacts (machine-local, do not commit)
+.claude/worktrees/
+.claude/parallel-isolation-log/
+.claude/parallel-isolation-required-*
+.claude/scheduled_tasks.lock
+.claude/agents/
+.claude/handoff.md
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

The crane launcher mirrors the enterprise skill triplet from this repo's canon into every venture checkout on each `crane <venture>` launch:

- `.claude/commands/` (Claude Code slash commands)
- `.gemini/commands/` (Gemini TOML mirror)
- `.agents/skills/` (Codex SKILL.md mirror)

`templates/venture/.gitignore` was missing these entries, so freshly bootstrapped ventures would track all three mirror dirs and produce a dirty tree on every canon update.

Also adds the `.claude/` per-session runtime artifacts (worktrees, isolation markers, lock files, handoff cache, local settings) that are present in the canon's per-directory `.claude/.gitignore` but missing from the template.

## Companion PRs

This is the prevention side. The five existing ventures each have a parallel PR applying the same fix:

- venturecrane/ss-console#717
- venturecrane/dc-console#540
- venturecrane/ke-console#246
- venturecrane/sc-console#129
- venturecrane/dfg-console#331

## Changes

- `templates/venture/.gitignore`: 17 lines added covering launcher mirrors and `.claude/` runtime

## Test plan

- [x] Diff is template-only, no behavior change in this repo
- [ ] After merge: `/new-venture` smoke check the next time a venture is bootstrapped

🤖 Generated with [Claude Code](https://claude.com/claude-code)