### PR TITLE
docs(pr-workflow): align Linked issue heading with template

### DIFF
--- a/docs/process/pr-workflow.md
+++ b/docs/process/pr-workflow.md
@@ -21,9 +21,16 @@ gh pr create \
 
 - {what this PR does, 1-3 bullets}
 
-## Related Issues
+## Linked issue
 
-Closes #{issue_number}
+<!--
+Use one of:
+  Closes #NNN     — this PR fully resolves the issue
+  Refs #NNN       — this PR is partial; the issue stays open
+  None            — only for chores with no associated issue (rare; explain)
+-->
+
+Closes #
 
 ## Changes
 


### PR DESCRIPTION
## Summary

- Align the Quick Reference's `gh pr create` body block in `docs/process/pr-workflow.md` with the actual `.github/PULL_REQUEST_TEMPLATE.md`.
- Heading: `## Related Issues` -> `## Linked issue`.
- Body: replace the single `Closes #{issue_number}` placeholder with the template's structured options block (`Closes #NNN` / `Refs #NNN` / `None`).

## Linked issue

None - surfaced by audit reconciliation, no parent issue.

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence                                                                                |
| ------------------------ | ------ | --------------------------------------------------------------------------------------- |
| (none — no parent issue) | n/a    | hygiene change uncovered while reconciling an SS backlog audit; not tracked as an issue |

## Changes

- `docs/process/pr-workflow.md` lines 24-26: heading aligned to template, options block added.

## Test Plan

- [x] Tests added/updated for changed code (n/a - doc change)
- [x] Typecheck passes (`npm run verify` clean)
- [x] Lint passes
- [x] Documentation updated if needed

## Feature Impact

**Feature impact:** None

## Instruction Module Impact

`docs/process/pr-workflow.md` is in scope for `.github/workflows/sync-docs-to-context-worker.yml` (line 12: `docs/process/**/*.md`), so this content auto-syncs to crane-context on push to main. `crane_doc('global', 'pr-workflow.md')` will reflect the updated heading on the next sync run.

## Deployment Notes

None. Doc-only change; sync workflow propagates content automatically.

## Context

Surfaced during reconciliation of an SS backlog-audit finding. The audit reported portfolio-wide PR-authoring discipline issues; verification against live state showed all 8 venture repos already host the canonical template and `pr-workflow.md` already prescribes `Closes #N` in three places. The only real drift was this heading mismatch between the doc's Quick Reference example and the actual template. The audit's other findings traced to tooling false positives (case-sensitive `.github/` API lookup, Dependabot alert ID collision with issue numbers, bare cross-repo `#N` parsing); those are captured in a separate enterprise lesson memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)