### PR TITLE
feat(critique): add Product Strategist perspective + fix stale sync-skill-md.mjs docstring

### DIFF
--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -61,18 +61,19 @@ Do NOT ask for confirmation - proceed immediately.
 
 Select perspectives based on `AGENT_COUNT`. Always assign from the top of this list:
 
-| #   | Perspective               | Focus                                                                                                   |
-| --- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                      |
-| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"               |
-| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?" |
-| 4   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"         |
-| 5   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"   |
-| 6   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                 |
+| #   | Perspective               | Focus                                                                                                              |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                                 |
+| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"                          |
+| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?"            |
+| 4   | Product Strategist        | Scope, ROI, opportunity cost, venture priority fit. "Is this the right thing to build right now, vs. what's next?" |
+| 5   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"                    |
+| 6   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"              |
+| 7   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                            |
 
 - **1 agent** gets "Devil's Advocate" (the comprehensive default - covers risks, gaps, AND simpler alternatives in one pass).
 - **2+ agents** each get a distinct perspective from the list above.
-- **If AGENT_COUNT exceeds 6**, wrap around and assign "Senior" variants (e.g., agent 7 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
+- **If AGENT_COUNT exceeds 7**, wrap around and assign "Senior" variants (e.g., agent 8 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
 
 ### Step 3: Spawn Critic Agents
 

--- a/.claude/commands/critique.md
+++ b/.claude/commands/critique.md
@@ -50,18 +50,19 @@ Do NOT ask for confirmation - proceed immediately.
 
 Select perspectives based on `AGENT_COUNT`. Always assign from the top of this list:
 
-| #   | Perspective               | Focus                                                                                                   |
-| --- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                      |
-| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"               |
-| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?" |
-| 4   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"         |
-| 5   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"   |
-| 6   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                 |
+| #   | Perspective               | Focus                                                                                                              |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                                 |
+| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"                          |
+| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?"            |
+| 4   | Product Strategist        | Scope, ROI, opportunity cost, venture priority fit. "Is this the right thing to build right now, vs. what's next?" |
+| 5   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"                    |
+| 6   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"              |
+| 7   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                            |
 
 - **1 agent** gets "Devil's Advocate" (the comprehensive default - covers risks, gaps, AND simpler alternatives in one pass).
 - **2+ agents** each get a distinct perspective from the list above.
-- **If AGENT_COUNT exceeds 6**, wrap around and assign "Senior" variants (e.g., agent 7 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
+- **If AGENT_COUNT exceeds 7**, wrap around and assign "Senior" variants (e.g., agent 8 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
 
 ### Step 3: Spawn Critic Agents
 

--- a/.gemini/commands/critique.toml
+++ b/.gemini/commands/critique.toml
@@ -52,18 +52,19 @@ Do NOT ask for confirmation - proceed immediately.
 
 Select perspectives based on `AGENT_COUNT`. Always assign from the top of this list:
 
-| #   | Perspective               | Focus                                                                                                   |
-| --- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
-| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                      |
-| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"               |
-| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?" |
-| 4   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"         |
-| 5   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"   |
-| 6   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                 |
+| #   | Perspective               | Focus                                                                                                              |
+| --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| 1   | Devil's Advocate          | Flaws, risks, edge cases, false assumptions, failure modes. "What could go wrong?"                                 |
+| 2   | Simplifier                | Over-engineering, unnecessary complexity, simpler alternatives. "Is there a simpler way?"                          |
+| 3   | Pragmatist                | Feasibility, hidden costs, timeline realism, operational burden. "Will this actually work in practice?"            |
+| 4   | Product Strategist        | Scope, ROI, opportunity cost, venture priority fit. "Is this the right thing to build right now, vs. what's next?" |
+| 5   | Contrarian                | Fundamentally different approaches, paradigm challenges. "What if the entire framing is wrong?"                    |
+| 6   | User/Stakeholder Advocate | End-user impact, UX consequences, stakeholder concerns. "How does this affect the people who use it?"              |
+| 7   | Security & Reliability    | Failure modes, data integrity, security surface, recovery paths. "How does this break?"                            |
 
 - **1 agent** gets "Devil's Advocate" (the comprehensive default - covers risks, gaps, AND simpler alternatives in one pass).
 - **2+ agents** each get a distinct perspective from the list above.
-- **If AGENT_COUNT exceeds 6**, wrap around and assign "Senior" variants (e.g., agent 7 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
+- **If AGENT_COUNT exceeds 7**, wrap around and assign "Senior" variants (e.g., agent 8 = "Senior Devil's Advocate" with instruction to dig deeper than agent 1).
 
 ### Step 3: Spawn Critic Agents
 

--- a/scripts/sync-skill-md.mjs
+++ b/scripts/sync-skill-md.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 // Generate .agents/skills/<name>/SKILL.md from .claude/commands/<name>.md.
 //
-// The Claude Code dispatcher is the canonical body source. Governance
-// frontmatter (version, scope, owner, status, depends_on) lives in the
-// existing SKILL.md or — for new skills — defaults from config/skill-owners.json.
+// Dual-canon design (per PR #762, 2026-04-27): the Claude Code dispatcher is
+// canonical for `name` and `description` frontmatter; governance frontmatter
+// (version, scope, owner, status, depends_on) is canonical in the existing
+// SKILL.md once authored. Body is canonical from the dispatcher ONLY when
+// seeding a brand-new SKILL.md — once a SKILL.md exists, its body is
+// preserved verbatim on every regen. Some skills (e.g., /eos) have authored
+// content in SKILL.md beyond what the dispatcher carries; this script
+// deliberately does not destroy it. Body changes to existing skills are by
+// hand on both files.
 //
 // This replaces the bash convert_to_skill in sync-commands.sh, which stripped
 // every governance field and broke the `review` CI gate.


### PR DESCRIPTION
## Summary

- Adds a 7th critic perspective to `/critique` at slot #4: **Product Strategist** — scope, ROI, opportunity cost, venture priority fit. Fires at `AGENT_COUNT >= 4`; default 1-agent runs and 2-3 agent runs unchanged.
- Corrects a stale comment block on `scripts/sync-skill-md.mjs` that misled an agent (this one) into "fixing" PR #762's intentional dual-canon body behavior.

## Why a 7th perspective

The 6 existing frames cover risks (Devil's Advocate), complexity (Simplifier), feasibility (Pragmatist), framing (Contrarian), users (User/Stakeholder Advocate), reliability (Security). None ask **"is this the right thing to build right now, vs. what's next on the stack?"** — that's the priority / opportunity-cost question. Slot #4 places it in the "important decisions" / "full panel" tier (AGENT_COUNT >= 4), which is exactly where that scrutiny earns its keep.

## Why not three role-labeled critics (PM + Lead Engineer + UX)

Captain rejected the three-role-add as theatre. Lead Engineer overlaps Pragmatist + Devil's Advocate; UX Expert overlaps User/Stakeholder Advocate. Only the genuine gap (priority / opportunity cost) gets a new slot, framed as a cognitive perspective rather than a job title to match the existing table's style.

## Slot #4 rationale

| AGENT_COUNT | Before | After |
|---|---|---|
| 1 | Devil's Advocate | Devil's Advocate |
| 2 | + Simplifier | + Simplifier |
| 3 | + Pragmatist | + Pragmatist |
| 4 | + Contrarian | **+ Product Strategist** |
| 5 | + User Advocate | + Contrarian |
| 6 | + Security | + User Advocate |
| 7 | wrap-around | + Security |

## Secondary fix: sync-skill-md.mjs docstring

The script header claimed "The Claude Code dispatcher is the canonical body source." That sentence is stale — inherited from the bash predecessor it replaced in PR #762. PR #762's actual design is **dual-canon**:
- `name` / `description`: dispatcher wins.
- Governance fields (version, scope, owner, status, depends_on): existing SKILL.md wins.
- Body: dispatcher only on new-skill creation. Once SKILL.md exists, body is preserved verbatim. This is deliberate — `/eos` and others have authored SKILL.md content beyond the dispatcher, and the script must not destroy it.

The corrected docstring spells this out so the next agent doesn't try to "fix" working code (as I nearly did mid-PR).

## Files changed

- `.claude/commands/critique.md` — dispatcher (canon for `description`)
- `.agents/skills/critique/SKILL.md` — Codex SKILL.md mirror (manual edit because dual-canon)
- `.gemini/commands/critique.toml` — regenerated from dispatcher
- `scripts/sync-skill-md.mjs` — docstring correction only; logic unchanged (line ~201 still uses `existingBody`)

## Test plan

- [x] `./scripts/sync-commands.sh --check` exits 0 (no drift between dispatcher and the two mirrors).
- [x] `npm run verify` exits 0 (typecheck + format + lint + test).
- [x] `grep -n "Product Strategist|exceeds 7" .claude/commands/critique.md .agents/skills/critique/SKILL.md .gemini/commands/critique.toml` shows the Product Strategist row and `exceeds 7` line in all three files.
- [x] `git diff scripts/sync-skill-md.mjs` shows only docstring lines changed; line ~201 still references `existingBody`.

## Out of scope

- Not migrating other drifted SKILL.md bodies (eos, skill-review, ui-drift-audit, etc.) against their dispatchers. That's intentional dual-canon.
- Not adding `/skill-review` lint rules around dispatcher↔SKILL.md body parity.
- Not touching `/critique`'s prompt template, synthesis, or revision flow — only the perspective table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)