### PR TITLE
docs(save-lesson): broaden scope guidance and add scope/name consistency check

### DIFF
--- a/.agents/skills/save-lesson/SKILL.md
+++ b/.agents/skills/save-lesson/SKILL.md
@@ -108,7 +108,7 @@ If a venture marker appears in the name despite an enterprise scope, either rena
 Call `crane_memory(action: 'save', ...)` with:
 
 ```yaml
-name: { kebab-case identifier derived from body — strip venture markers if scope is enterprise/global }
+name: { kebab-case from body; strip venture markers if scope is enterprise or global }
 description: { one-sentence purpose, same as body sentence 1 }
 kind: { inferred kind }
 scope: { inferred scope }

--- a/.agents/skills/save-lesson/SKILL.md
+++ b/.agents/skills/save-lesson/SKILL.md
@@ -44,7 +44,9 @@ Infer the following fields from the session transcript and environment:
 
 **kind** — default `lesson`. Use `anti-pattern` if the summary contains "don't", "never", "avoid", "stop", or "do not".
 
-**scope** — default `enterprise`. Use `venture:<code>` only if the learning is clearly specific to one venture's code (e.g., references a venture-specific API contract or data model). Use `global` if the learning applies outside the Venture Crane enterprise (e.g., a third-party tool gotcha).
+**scope** — default `enterprise`. Use `venture:<code>` for any rule that only applies inside one venture, including: marketing voice and positioning, business-model rules, page-level copy patterns, and venture-specific code (API contracts, data models). Use `global` if the learning applies outside the Venture Crane enterprise (e.g., a third-party tool gotcha).
+
+**Why scope matters:** the SOS injection path filters by `scope === 'enterprise' || scope === 'global' || scope === 'venture:<active_venture>'` (`packages/crane-mcp/src/tools/memory.ts` recall path). An enterprise-scoped memory surfaces in **every** venture's session. A SMD-positioning rule filed at `enterprise` scope will inject into KE/VC/SC/etc sessions where it does not apply. When in doubt about whether a rule generalizes across ventures, narrow to `venture:<code>` — Captain can promote it to `enterprise` later via `/memory-audit`.
 
 **severity** — required only for `anti-pattern`. Infer:
 
@@ -92,15 +94,25 @@ Before calling save, verify all three tests hold:
 
 If any test fails, report which one failed and explain why, then suggest a refinement. Do not proceed to save until the draft passes all three or the Captain explicitly overrides.
 
+### Step 5b: Scope/name consistency check
+
+Before calling save, verify both:
+
+1. **If `scope: enterprise` or `global`:** the proposed `name` must NOT encode a single venture's code (current codes: `vc`, `sc`, `dfg`, `ke`, `smd`, `ss`, `dc`) as a prefix or suffix (e.g., `ke-`, `ss-`, `-for-ke`, `-for-ss`). The name should be venture-agnostic. If the rule truly applies cross-venture, the name must read as such.
+2. **If `scope: venture:<code>`:** the `venture` field (passed to `crane_memory(action: 'save')`) must equal `<code>`. Both fields populated, both consistent.
+
+If a venture marker appears in the name despite an enterprise scope, either rename (drop the marker) or rescope (narrow to `venture:<code>`). Mismatched name and scope is the failure mode that surfaces SMD-positioning rules in KE sessions.
+
 ### Step 6: Save
 
 Call `crane_memory(action: 'save', ...)` with:
 
 ```yaml
-name: { kebab-case identifier derived from body }
+name: { kebab-case identifier derived from body — strip venture markers if scope is enterprise/global }
 description: { one-sentence purpose, same as body sentence 1 }
 kind: { inferred kind }
 scope: { inferred scope }
+venture: { the venture code, e.g. "ss" — REQUIRED when scope is venture:<code>; omit otherwise }
 owner: captain
 status: draft
 captain_approved: false


### PR DESCRIPTION
## Summary

Three additions to the `/save-lesson` skill, prompted by an audit of existing memories that revealed a recurring failure mode: SMD-specific positioning rules filed at `scope: enterprise` that surface in every venture's SOS briefing.

- **Step 3 (scope) broadened.** The current text scopes `venture:<code>` to "venture-specific code (API contract or data model)." That excludes marketing voice, positioning, and business-model rules — the most common venture-specific case for SS. Add explicit categories. Also add a "Why scope matters" note pointing at the recall filter so future agents understand the failure mode.
- **New Step 5b: scope/name consistency check.** Catches the two patterns seen in the live memory inventory:
  - Venture marker in `name` + `scope: enterprise` (e.g., `agent-owns-commit-push-merge-deploy-for-ke` at enterprise scope)
  - `scope: venture:<code>` without the `venture` field populated
- **Step 6 template: document the `venture` parameter.** It's defined in the save action schema (`packages/crane-mcp/src/tools/memory.ts:399`) but absent from the skill's documented save call template, so agents don't populate it. Also add a name-field comment reminding to strip venture markers when scope is enterprise/global.

## Why now

Audit during 2026-05-06 ss-console session found:

- 5 SMD-positioning memories at `scope: enterprise` whose bodies explicitly cite SMD targets/positioning ("SMD positioning law," "Phoenix SMB owners," "10-25 employee business owners"). These get injected into KE/VC/SC/DC sessions today.
- 2 enterprise rules with venture markers in their names (`agent-owns-commit-push-merge-deploy-for-ke`, `ke-vercel-deploy-needs-smdurgan-smdurgan-com-author`) where the body itself says the rule is general.

Rescoping/renaming those memories is a follow-up gated on #829 (an `fm.supersedes.join is not a function` bug blocking `crane_memory get`/`update` on affected notes). This PR addresses the *upstream* concern: the skill should prevent agents from making the same scope/name mistake again.

## Verified before writing

The cross-venture spill is real, not inferred. `packages/crane-mcp/src/tools/memory.ts` lines 810 and 858 (query recall and SOS injection paths) both apply:

```js
if (scope === 'enterprise' || scope === 'global') return true
if (ventureCode && scope === \`venture:\${ventureCode}\`) return true
return false
```

So enterprise memories pass to every venture session. Direct read of source.

## Scope

Docs-only change to a single skill file. No code, no schema, no tests touched.

## Test plan

- [ ] CI passes (skill-review lint, any docs validation)
- [ ] Visual review of the rendered skill — Step 3 reads naturally with the scope expansion, Step 5b is clear, Step 6 template is unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)