### PR TITLE
fix(crane_memory): use ESM import for gray-matter; defensive supersedes guards

### DIFF
--- a/packages/crane-mcp/src/tools/memory.test.ts
+++ b/packages/crane-mcp/src/tools/memory.test.ts
@@ -110,6 +110,62 @@ Body text`
     const result = parseFrontmatter('Just plain text without frontmatter')
     expect(result).toEqual({})
   })
+
+  // Regression: #829 — empty inline-array `supersedes: []` must parse as a real
+  // empty array (not the literal string "[]"), so downstream `.join()` calls don't crash.
+  it('parses empty inline-array supersedes as a real array', async () => {
+    const { parseFrontmatter } = await import('./memory.js')
+    const content = `---
+name: test
+description: "test"
+kind: lesson
+scope: enterprise
+status: stable
+captain_approved: false
+version: 1.0.0
+supersedes: []
+---
+Body`
+    const result = parseFrontmatter(content)
+    expect(Array.isArray(result.supersedes)).toBe(true)
+    expect(result.supersedes).toEqual([])
+  })
+
+  it('parses non-empty inline-array supersedes as a real array', async () => {
+    const { parseFrontmatter } = await import('./memory.js')
+    const content = `---
+name: test
+description: "test"
+kind: lesson
+scope: enterprise
+status: stable
+captain_approved: false
+version: 1.0.0
+supersedes: [note_a, note_b]
+---
+Body`
+    const result = parseFrontmatter(content)
+    expect(Array.isArray(result.supersedes)).toBe(true)
+    expect(result.supersedes).toEqual(['note_a', 'note_b'])
+  })
+
+  it('normalizes ISO date scalar to YYYY-MM-DD string', async () => {
+    const { parseFrontmatter } = await import('./memory.js')
+    const content = `---
+name: test
+description: "test"
+kind: lesson
+scope: enterprise
+status: stable
+captain_approved: false
+version: 1.0.0
+last_validated_on: 2026-05-05
+---
+Body`
+    const result = parseFrontmatter(content)
+    expect(typeof result.last_validated_on).toBe('string')
+    expect(result.last_validated_on).toBe('2026-05-05')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -399,6 +455,41 @@ describe('serializeFrontmatter', () => {
     expect(parsed.kind).toBe('lesson')
     expect(parsed.captain_approved).toBe(true)
   })
+
+  // Regression: #829 — defensive coercion should keep serializer from crashing
+  // even if a non-array supersedes leaks through.
+  it('does not crash when supersedes is the literal string "[]" (legacy data)', async () => {
+    const { serializeFrontmatter } = await import('./memory.js')
+    const fm = {
+      name: 'test',
+      kind: 'lesson' as const,
+      scope: 'enterprise' as const,
+      status: 'stable' as const,
+      captain_approved: false,
+      version: '1.0.0',
+      // Force the broken shape past the type system to simulate legacy data
+      supersedes: '[]' as unknown as string[],
+    }
+    const serialized = serializeFrontmatter(fm)
+    expect(serialized).toMatch(/supersedes: \[\]/)
+  })
+
+  it('round-trips supersedes with values', async () => {
+    const { serializeFrontmatter, parseFrontmatter } = await import('./memory.js')
+    const fm = {
+      name: 'test',
+      kind: 'lesson' as const,
+      scope: 'enterprise' as const,
+      status: 'stable' as const,
+      captain_approved: true,
+      version: '1.0.0',
+      supersedes: ['note_a', 'note_b'],
+    }
+    const serialized = serializeFrontmatter(fm)
+    expect(serialized).toMatch(/supersedes: \[note_a, note_b\]/)
+    const parsed = parseFrontmatter(`${serialized}\n\nBody`)
+    expect(parsed.supersedes).toEqual(['note_a', 'note_b'])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -434,6 +525,74 @@ describe('executeMemory', () => {
     expect(result.message).toMatch(/CRANE_CONTEXT_KEY/)
 
     if (savedKey) process.env.CRANE_CONTEXT_KEY = savedKey
+  })
+
+  // Regression: #829 — get/update both crashed with `fm.supersedes.join is not a function`
+  // because parseFrontmatter's `require('gray-matter')` always threw in the ESM dist
+  // and the simple-YAML fallback returned `supersedes` as the literal string "[]".
+  it('get succeeds for a note with empty inline-array supersedes', async () => {
+    process.env.CRANE_CONTEXT_KEY = 'test-key'
+    const note = makeNote({
+      id: 'note-supersedes-empty',
+      content: `---
+name: agent-owns-commit-push-merge-deploy
+description: "User is the Captain; I'm the agent."
+kind: lesson
+scope: enterprise
+owner: agent-team
+status: stable
+captain_approved: false
+version: 1.0.0
+supersedes: []
+last_validated_on: 2026-05-05
+---
+
+Body content.`,
+    })
+    mockApi.getNote.mockResolvedValue(note)
+
+    const { executeMemory } = await import('./memory.js')
+    const result = await executeMemory({ action: 'get', id: 'note-supersedes-empty' })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toMatch(/agent-owns-commit-push-merge-deploy/)
+    expect(result.message).not.toMatch(/fm\.supersedes\.join/)
+  })
+
+  it('update succeeds for a note with empty inline-array supersedes', async () => {
+    process.env.CRANE_CONTEXT_KEY = 'test-key'
+    const note = makeNote({
+      id: 'note-supersedes-empty',
+      content: `---
+name: agent-owns-commit-push-merge-deploy
+description: "User is the Captain; I'm the agent."
+kind: lesson
+scope: enterprise
+owner: agent-team
+status: stable
+captain_approved: false
+version: 1.0.0
+supersedes: []
+---
+
+Body content.`,
+    })
+    mockApi.getNote.mockResolvedValue(note)
+    mockApi.updateNote.mockImplementation(async (_id, body) => ({ ...note, ...body }))
+
+    const { executeMemory } = await import('./memory.js')
+    const result = await executeMemory({
+      action: 'update',
+      id: 'note-supersedes-empty',
+      description: 'Updated description',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).not.toMatch(/fm\.supersedes\.join/)
+    expect(mockApi.updateNote).toHaveBeenCalledOnce()
+    const [, updateBody] = mockApi.updateNote.mock.calls[0]
+    expect(updateBody.content).toMatch(/supersedes: \[\]/)
+    expect(updateBody.content).toMatch(/description: "Updated description"/)
   })
 
   it('save rejects body that fails actionable test', async () => {

--- a/packages/crane-mcp/src/tools/memory.ts
+++ b/packages/crane-mcp/src/tools/memory.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod'
+import matter from 'gray-matter'
 import { CraneApi } from '../lib/crane-api.js'
 import { getApiBase } from '../lib/config.js'
 import type { Note } from '../lib/crane-api.js'
@@ -88,13 +89,42 @@ interface RawFrontmatter {
   [key: string]: unknown
 }
 
+// Coerce parsed YAML values to a string array. gray-matter returns proper arrays;
+// the simple-YAML fallback returns the literal string "[]" — without coercion,
+// downstream `.join()` calls crash on it (#829).
+function asStringArray(v: unknown): string[] | undefined {
+  if (v === undefined || v === null) return undefined
+  if (Array.isArray(v)) return v.filter((x): x is string => typeof x === 'string')
+  return []
+}
+
+// gray-matter parses ISO date scalars as Date objects; downstream code template-strings
+// the value back into YAML, which would emit `Wed May 06 2026 ...`. Normalize to YYYY-MM-DD.
+function asISODateString(v: unknown): string | undefined {
+  if (typeof v === 'string') return v
+  if (v instanceof Date && !isNaN(v.getTime())) return v.toISOString().split('T')[0]
+  return undefined
+}
+
+function normalizeFrontmatter(raw: RawFrontmatter): RawFrontmatter {
+  const out: RawFrontmatter = { ...raw }
+  const supersedes = asStringArray(raw.supersedes)
+  const supersedesSource = asStringArray(raw.supersedes_source)
+  const lastValidated = asISODateString(raw.last_validated_on)
+  if (supersedes !== undefined) out.supersedes = supersedes
+  else delete out.supersedes
+  if (supersedesSource !== undefined) out.supersedes_source = supersedesSource
+  else delete out.supersedes_source
+  if (lastValidated !== undefined) out.last_validated_on = lastValidated
+  else delete out.last_validated_on
+  return out
+}
+
 export function parseFrontmatter(content: string): RawFrontmatter {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const matter = require('gray-matter')
-    return matter(content).data as RawFrontmatter
+    return normalizeFrontmatter(matter(content).data as RawFrontmatter)
   } catch {
-    return parseSimpleFrontmatter(content)
+    return normalizeFrontmatter(parseSimpleFrontmatter(content))
   }
 }
 
@@ -115,8 +145,18 @@ function parseSimpleFrontmatter(content: string): RawFrontmatter {
       result[key] = true
     } else if (rawVal === 'false') {
       result[key] = false
+    } else if (rawVal === '[]') {
+      result[key] = []
     } else {
-      result[key] = rawVal.replace(/^['"]|['"]$/g, '')
+      const arrayMatch = rawVal.match(/^\[(.*)\]$/)
+      if (arrayMatch) {
+        result[key] = arrayMatch[1]
+          .split(',')
+          .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+          .filter(Boolean)
+      } else {
+        result[key] = rawVal.replace(/^['"]|['"]$/g, '')
+      }
     }
   }
   return result
@@ -207,15 +247,17 @@ function serializeFrontmatter(fm: Partial<MemoryFrontmatter>): string {
     }
   }
 
-  if (fm.supersedes?.length) {
-    lines.push(`supersedes: [${fm.supersedes.join(', ')}]`)
+  const supersedes = asStringArray(fm.supersedes) ?? []
+  if (supersedes.length) {
+    lines.push(`supersedes: [${supersedes.join(', ')}]`)
   } else {
     lines.push('supersedes: []')
   }
 
-  if (fm.supersedes_source?.length) {
+  const supersedesSource = asStringArray(fm.supersedes_source) ?? []
+  if (supersedesSource.length) {
     lines.push('supersedes_source:')
-    for (const s of fm.supersedes_source) {
+    for (const s of supersedesSource) {
       lines.push(`  - ${s}`)
     }
   }
@@ -512,7 +554,8 @@ function formatMemoryRecord(record: MemoryRecord): string {
     if (parts.length) lines.push(`Applies when: ${parts.join(' | ')}`)
   }
 
-  if (fm.supersedes?.length) lines.push(`Supersedes: ${fm.supersedes.join(', ')}`)
+  const supersedes = asStringArray(fm.supersedes) ?? []
+  if (supersedes.length) lines.push(`Supersedes: ${supersedes.join(', ')}`)
   if (fm.last_validated_on) lines.push(`Last validated: ${fm.last_validated_on}`)
 
   lines.push('')

--- a/packages/crane-mcp/src/tools/skill-audit.ts
+++ b/packages/crane-mcp/src/tools/skill-audit.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod'
+import matter from 'gray-matter'
 import { execSync } from 'node:child_process'
 import { readdirSync, readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
@@ -105,11 +106,7 @@ interface Frontmatter {
 }
 
 function parseFrontmatter(content: string): Frontmatter {
-  // Try gray-matter first (may not be installed yet during dev)
   try {
-    // Dynamic require to avoid hard dep at module load time
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const matter = require('gray-matter')
     return matter(content).data as Frontmatter
   } catch {
     // Fallback: minimal YAML parser for simple key: value pairs


### PR DESCRIPTION
## Summary

Closes #829.

`crane_memory get`/`update` were crashing with `fm.supersedes.join is not a function`. Investigation showed `parseFrontmatter` has been silently broken since it shipped: it wrapped `require('gray-matter')` in a try/catch, but the package is `"type": "module"` (ESM) — `require` is not defined, so the call always threw. The catch fell through to `parseSimpleFrontmatter`, which parsed `supersedes: []` as the literal string `"[]"` (length 2, truthy, no `.join`).

Every `crane_memory get`/`update` has been silently going through the simple-YAML fallback. The bug only surfaced on `supersedes` because the simple parser handled the other (string/bool) fields well enough; the array fields were the trip wire.

## Changes

- `memory.ts`: top-level `import matter from 'gray-matter'` (matches the existing pattern in `docs-drift-audit.ts`)
- `memory.ts`: new `normalizeFrontmatter()` coerces `supersedes` / `supersedes_source` to `string[]` and converts the `Date` object that gray-matter produces for `last_validated_on` back to a `YYYY-MM-DD` string (gray-matter's date promotion would otherwise corrupt round-trip serialization)
- `memory.ts`: `parseSimpleFrontmatter` now handles inline YAML arrays (`[]`, `[a, b, c]`), so the fallback path is no longer the latent bomb that produced #829
- `memory.ts`: `serializeFrontmatter` and `formatMemoryRecord` run `supersedes` / `supersedes_source` through `asStringArray` before `.join`. Defense in depth — any future non-array value (legacy stored data, future caller bug) can't crash the formatter
- `skill-audit.ts`: same `require → import` fix. Same root cause; field access there is string-only so the bug was silent but real

## Verified

End-to-end against the live API after rebuild:

```
$ crane_memory(action: 'get', id: 'note_01KQX3MFRABNA3G12G4VZJM6V0')
**agent-owns-commit-push-merge-deploy** (note_01KQX3MFRABNA3G12G4VZJM6V0)
Kind: lesson | Scope: enterprise | Status: stable | ...
Last validated: 2026-05-05    ← clean YYYY-MM-DD, not Date.toString()
```

(Previously: `Failed to get memory: fm.supersedes.join is not a function`)

## Test plan

- [x] Unit: parseFrontmatter parses empty and non-empty inline-array `supersedes` as real arrays
- [x] Unit: parseFrontmatter normalizes ISO date scalars to `YYYY-MM-DD` strings
- [x] Unit: serializeFrontmatter does not crash when `supersedes` is the literal string `"[]"` (legacy data shape)
- [x] Unit: serializeFrontmatter round-trips `supersedes` with values
- [x] Integration: `executeMemory` get/update succeed against the exact failure note from #829
- [x] `npm run verify` clean
- [x] Live MCP after rebuild — `crane_memory(action: 'get', id: 'note_01KQX3MFRABNA3G12G4VZJM6V0')` returns the record

🤖 Generated with [Claude Code](https://claude.com/claude-code)