### PR TITLE
feat(verify): crane_verify ledger + claim_origin lookup (PR 1 of 3)

### DIFF
--- a/.github/workflows/sync-docs-to-context-worker.yml
+++ b/.github/workflows/sync-docs-to-context-worker.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/adr/**/*.md'
       - 'docs/infra/**/*.md'
       - 'docs/design-system/**/*.md'
+      - 'docs/global/**/*.md'
   workflow_dispatch: # Allow manual trigger
 
 jobs:
@@ -35,11 +36,11 @@ jobs:
           # Get list of changed markdown files in docs/process/
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Manual trigger: sync all docs in covered paths
-            echo "Manual trigger - syncing all docs in docs/{process,adr,infra,design-system}/"
-            CHANGED_FILES=$(find docs/process docs/adr docs/infra docs/design-system -name "*.md" -type f 2>/dev/null)
+            echo "Manual trigger - syncing all docs in docs/{process,adr,infra,design-system,global}/"
+            CHANGED_FILES=$(find docs/process docs/adr docs/infra docs/design-system docs/global -name "*.md" -type f 2>/dev/null)
           else
             # Automatic trigger: only sync changed docs
-            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr|infra|design-system)/.*\.md$" || true)
+            CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E "^docs/(process|adr|infra|design-system|global)/.*\.md$" || true)
           fi
 
           if [ -z "$CHANGED_FILES" ]; then

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -31,3 +31,12 @@ scripts/ubuntu-bashrc:generic-api-key:29
 scripts/setup-dev-box.sh:generic-api-key:93
 # Test files with curl examples
 workers/crane-context/test-sod.sh:curl-auth-header:4
+
+# Scrub-secrets test fixtures: intentional fake JWT, OPENSSH PRIVATE KEY block,
+# and high-entropy assignment value used to verify the scrubber masks them.
+# These are the test inputs the scrubber must catch — they cannot be made
+# real-secret-shaped without being real secrets, and they cannot be omitted
+# without losing test coverage of the masking paths.
+workers/crane-context/test/scrub.test.ts:jwt:27
+workers/crane-context/test/scrub.test.ts:private-key:42
+workers/crane-context/test/scrub.test.ts:generic-api-key:67

--- a/docs/global/verify.md
+++ b/docs/global/verify.md
@@ -1,0 +1,128 @@
+# crane_verify — Verification Recording Playbook
+
+`crane_verify` records a verification artifact in the cross-session ledger. It does NOT execute commands; the agent runs the actual verification with whatever tool fits, then submits the captured output here for ledgering. Future PR 2 gates check for these records; PR 3 audits sample them and re-run the captured command for integrity.
+
+## When to call it
+
+Call `crane_verify` _before_ you state that something is true based on a check you ran. The pattern that costs sessions later: agent runs `gh pr view 100`, sees "merged", states "PR 100 is merged", but no record exists, so when a regression surfaces three sessions later, no one can find the originating claim.
+
+The four signals that should trigger a `crane_verify` call:
+
+- **You're about to opine on system behavior** based on something you ran or fetched. Record it before opining.
+- **You're committing a fix** for `fix:`, `revert:`, `chore(migration|secrets|env):` change classes. Record the verification that grounded the fix.
+- **You're stating something is current** ("main is at SHA X", "the env var is set", "the worker is deployed") based on a live-state check. Record the check.
+- **You read vendor docs** to inform an integration choice. Record the doc fetch.
+
+## The three methods
+
+| Method          | Use when                                                             | `tool_used` examples         | Required fields      |
+| --------------- | -------------------------------------------------------------------- | ---------------------------- | -------------------- |
+| `live_state`    | You hit a real source — `gh api`, `wrangler tail`, D1 query, env var | `gh_api`, `wrangler`, `Bash` | `command`            |
+| `fresh_process` | You ran a command in a clean shell to verify a runtime claim         | `Bash`                       | `command`            |
+| `vendor_docs`   | You fetched current vendor documentation                             | `Context7`, `WebFetch`       | `output` ≥ 100 chars |
+
+The method is the category. The `tool_used` enum lets audits group across categories. Pick the closest match; use `other` only if none fit.
+
+## Required fields
+
+Every call needs:
+
+- **`method`** — one of the three above
+- **`claim`** — what is supposedly true after this verification (max 300 chars; one-liner)
+- **`output`** — literal output captured from the tool (max 8KB; see truncation below)
+- **`tool_used`** — enum: `Bash | Context7 | WebFetch | gh_api | wrangler | vendor_mcp | other`
+
+For `fresh_process` and `live_state`, **`command` is also required** — it's the audit anchor. Without it, the record is unrecheckable, defeating the integrity story.
+
+For `vendor_docs`, `output` must be ≥ 100 characters. A trivially-empty "I read the docs" record has nothing to attach to when a regression surfaces.
+
+## Optional but recommended
+
+- **`files_touched`** — file paths this verification relates to. PR 3's regression auto-attach reads this column to surface the originating claim. If you're verifying behavior that ties to a file, name it.
+- **`fresh_runtime`** — boolean: did the output come from a fresh process? PR 2's EOS gate reads this for runtime-config changes.
+- **`session_id`** — current session ID if known. Pulled from env if not provided.
+
+## Oversize output — the `head_tail` convention
+
+If your output exceeds 8KB (e.g., full `npm test` output, `wrangler tail` capture, `gh run view --log`), the tool rejects it explicitly rather than silently truncating. Apply this convention:
+
+```
+<first 4KB of output>
+...[truncated]...
+<last 4KB of output>
+```
+
+Then set `output_truncation: "head_tail"`. This preserves the diagnostic head (test names, request lines) and the diagnostic tail (failure stacks, response codes) — the two parts that matter for re-running. PR 3 audit can re-run the command for the middle if needed.
+
+## Examples
+
+### live_state — confirming a PR merged
+
+```ts
+crane_verify({
+  method: 'live_state',
+  claim: 'PR 100 is merged',
+  output: '{"state":"merged","mergedAt":"2026-05-06T17:00:00Z"}',
+  tool_used: 'gh_api',
+  command: 'gh pr view 100 --json state,mergedAt',
+  files_touched: ['packages/crane-mcp/src/index.ts'],
+})
+```
+
+### fresh_process — confirming a runtime config fix
+
+```ts
+crane_verify({
+  method: 'fresh_process',
+  claim: 'MCP launcher exposes new tools to fresh agent',
+  output: 'crane_verify  Record a verification artifact...\ncrane_claim_origin  Look up...',
+  tool_used: 'Bash',
+  command:
+    "echo 'tools/list' | npx @modelcontextprotocol/inspector packages/crane-mcp/dist/index.js | grep crane_verify",
+  fresh_runtime: true,
+  files_touched: ['packages/crane-mcp/src/index.ts'],
+})
+```
+
+### vendor_docs — confirming a vendor API shape
+
+```ts
+crane_verify({
+  method: 'vendor_docs',
+  claim: 'Vercel AI SDK v6 supports streamText with provider/model strings',
+  output:
+    "From context7/vercel-ai: streamText accepts a model string in 'provider/model' format... [more excerpt up to 100+ chars]",
+  tool_used: 'Context7',
+  command:
+    "mcp__plugin_context7_context7__query-docs(libraryId: '/vercel/ai', query: 'streamText provider/model format')",
+  files_touched: ['packages/crane-mcp/src/lib/llm.ts'],
+})
+```
+
+## Looking up prior claims (`crane_claim_origin`)
+
+When investigating a regression, query for prior verifications that touched the same file:
+
+```ts
+crane_claim_origin({
+  file: 'packages/crane-mcp/src/index.ts',
+  since: '90d', // optional; ISO date or "30d"/"90d"
+})
+```
+
+Returns up to 50 claims sorted newest-first, each with `claim`, `verify_id`, `method`, `session_id`, `ts`, and the full `files_touched` array. PR 3's regression flow auto-attaches these to issues; for now, agents can use it manually when triaging.
+
+## What this is not
+
+- **Not a verification execution surface.** You already have Bash and Context7. The tool records the work you did, it doesn't replace it.
+- **Not a gate (yet).** PR 2 will gate on these records at PR/EOS time. PR 1 just builds the substrate.
+- **Not a freeform notepad.** Records below 100 chars on `vendor_docs`, missing `command` on runtime methods, or oversize `output` are rejected with explicit guidance — by design.
+- **Not a place for secrets.** A scrubber masks known leak vectors (PATs, AWS keys, OpenAI keys, JWTs, PEM blocks, `KEY=value` lines) before storage. The result includes `redacted: true` so the audit signal is preserved. Don't rely on the scrubber as a substitute for not pasting secrets in the first place.
+
+## Failure modes
+
+- **`CRANE_CONTEXT_KEY not set`** — launch via `crane <venture>`; the launcher provides the key.
+- **API failure** — best-effort; the tool returns `{ success: false, message }` and never throws. Your work continues.
+- **Validation failure** — Zod refinements reject before the network call. Fix the input shape and retry.
+
+The cost of a missing record is one round-trip; the cost of habituating to "I'll skip the record this time" is the recurring failure mode this whole substrate exists to end.

--- a/docs/instructions/session-reflexes.md
+++ b/docs/instructions/session-reflexes.md
@@ -25,11 +25,19 @@ When the Captain lands an imprecise redirect, decode it before acting. The signa
 | "we're out of sync"                    | "we drifted at some point — locate it, then re-anchor"                              | Re-anchor on framing, not surface. Find the moment of divergence.                                  |
 | "recalibrate"                          | "re-read the most-relevant doc and re-evaluate; or, what mode are we in?"           | Verification or mode reset. Often both.                                                            |
 
+## Verification
+
+Before opining on system behavior, hitting "send" on a fix, or stating that something is current — record the verification. Use `crane_verify` to write the artifact (claim, captured output, tool used, command, files touched) into the cross-session ledger. Future PR 2 gates check for these records at PR/EOS time; PR 3 audits sample them and re-run the captured command for integrity.
+
+The full when-to-call playbook lives at `crane_doc('global', 'verify.md')` (file: `docs/global/verify.md`). Three methods: `live_state` (real source: `gh api`, `wrangler tail`, env), `fresh_process` (clean shell), `vendor_docs` (current docs via Context7/WebFetch). `fresh_process` and `live_state` require `command` — without it, the record is unrecheckable.
+
+This is the cure for reflex #2 ("about to opine on system behavior") becoming structural rather than advisory: instead of relying on the agent self-detecting the moment, the substrate makes recording cheap and the gates make skipping expensive.
+
 ## The Hook
 
 `scripts/redirect-reflex-hook.sh`, wired up via `.claude/settings.json`, fires on **every** user prompt and prepends a one-line primer to the agent's context for that turn:
 
-> `[reflex] Verify before opining; decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing; before stating duration estimates, run /estimate. See docs/instructions/session-reflexes.md.`
+> `[reflex] Verify before opining (record with crane_verify); decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing; before stating duration estimates, run /estimate. See docs/instructions/session-reflexes.md.`
 
 The primer maps to the four reflexes plus the estimation reflex (see below) in clause order. It's the forcing function — without it, "real-time" is just retrospective work in present-tense costume.
 
@@ -83,7 +91,7 @@ We did the corpus work that should have happened the first time:
 
 The UserPromptSubmit hook sees the user's prompt before the agent generates its turn. That means the primer can prime reflexes #1 (decode redirects) and #4 (respect mode framing) directly — both are user-prompt-side signals.
 
-Reflexes #2 (about to opine on system behavior) and #3 (about to ask a clarifying question) fire on **agent state**, not prompt content. The primer can remind the agent to consider them, but the hook cannot detect when the agent is about to violate them. If reflexes #2/#3 remain the dominant drift mode after the 30-day review, the next layer is a `PreToolUse` hook on Edit (read-before-edit forcing function). Out of scope for v2.
+Reflexes #2 (about to opine on system behavior) and #3 (about to ask a clarifying question) fire on **agent state**, not prompt content. The primer can remind the agent to consider them, but the hook cannot detect when the agent is about to violate them. The PR 1 `crane_verify` substrate is the first layer of structural rather than advisory cure for reflex #2: it makes recording cheap (one MCP call, predictable shape, ledgered cross-session). PR 2 adds the matching gate — a PreToolUse hook on high-blast-radius paths plus an EOS Layer 4c structured-verification gate — that converts skipping into a mechanical cost rather than relying on agent self-detection.
 
 ### 30-day review window
 

--- a/packages/crane-mcp/src/index.ts
+++ b/packages/crane-mcp/src/index.ts
@@ -44,6 +44,12 @@ import {
 import { memoryAuditInputSchema, executeMemoryAudit } from './tools/memory-audit.js'
 import { docsDriftAuditInputSchema, executeDocsDriftAudit } from './tools/docs-drift-audit.js'
 import { worktreeDoctorInputSchema, executeWorktreeDoctor } from './tools/worktree-doctor.js'
+import {
+  verifyInputSchema,
+  executeVerify,
+  claimOriginInputSchema,
+  executeClaimOrigin,
+} from './tools/verify.js'
 import { logTokenUsage } from './lib/token-tracker.js'
 import { refreshSessionHeartbeatIfNeeded, startHeartbeatTimer } from './lib/heartbeat-refresh.js'
 
@@ -704,6 +710,98 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: 'crane_verify',
+        description:
+          'Record a verification artifact in the cross-session ledger. Use when checking root cause, hitting live state, running fresh process, or fetching vendor docs — capture output with whatever tool fits (Bash/Context7/gh_api/wrangler), then submit here. Methods: live_state, fresh_process, vendor_docs. fresh_process and live_state require `command`. Best-effort telemetry; never blocks. See docs/global/verify.md for the playbook.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            method: {
+              type: 'string',
+              enum: ['live_state', 'fresh_process', 'vendor_docs'],
+              description:
+                'live_state: hit a real source (gh api, wrangler tail, env var). fresh_process: run a command in a clean shell. vendor_docs: fetched current docs (Context7).',
+            },
+            claim: {
+              type: 'string',
+              description: 'What is supposedly true after this verification. Max 300 chars.',
+            },
+            output: {
+              type: 'string',
+              description:
+                'Literal output captured by the agent. Max 8KB; oversize must use head_tail convention (first 4KB + sentinel + last 4KB).',
+            },
+            tool_used: {
+              type: 'string',
+              enum: ['Bash', 'Context7', 'WebFetch', 'gh_api', 'wrangler', 'vendor_mcp', 'other'],
+              description:
+                'Which tool produced the output. Pick the closest match; "other" only if none fit.',
+            },
+            command: {
+              type: 'string',
+              description:
+                'The command/query that produced output. REQUIRED for fresh_process and live_state.',
+            },
+            files_touched: {
+              type: 'array',
+              items: { type: 'string' },
+              description:
+                'File paths this verification relates to. Used by claim_origin lookups when regressions surface.',
+            },
+            fresh_runtime: {
+              type: 'boolean',
+              description:
+                'Did output come from a fresh process? PR 2 EOS gate reads this for runtime-config claims.',
+            },
+            fresh_runtime_justification: {
+              type: 'string',
+              description:
+                'Required by PR 2 gate when fresh_runtime is false on a runtime-config claim.',
+            },
+            output_truncation: {
+              type: 'string',
+              enum: ['none', 'head', 'tail', 'head_tail'],
+              description:
+                'Set to head_tail when applying truncation convention for oversize output.',
+            },
+            source: {
+              type: 'string',
+              enum: ['manual', 'tool', 'hook'],
+              description: 'Defaults to "tool". Use "manual" for Captain-initiated records.',
+            },
+            session_id: {
+              type: 'string',
+              description: 'Current session ID if known',
+            },
+          },
+          required: ['method', 'claim', 'output', 'tool_used'],
+        },
+      },
+      {
+        name: 'crane_claim_origin',
+        description:
+          'Look up prior verifications that touched a given file path. Used when investigating a regression to find the originating session/claim. Returns claim text, verify_id, method, session_id, and timestamp for the most recent N records (capped at 50).',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            file: {
+              type: 'string',
+              description: 'File path to look up prior claims for',
+            },
+            since: {
+              type: 'string',
+              description:
+                'Lookback window: ISO date OR relative format like "30d"/"90d". Default: 90d.',
+            },
+            limit: {
+              type: 'number',
+              description: 'Max results (1-50). Default: 50.',
+            },
+          },
+          required: ['file'],
+        },
+      },
     ],
   }
 })
@@ -952,6 +1050,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'crane_worktree_doctor': {
         const input = worktreeDoctorInputSchema.parse(args)
         const result = await executeWorktreeDoctor(input)
+        const response = { content: [{ type: 'text' as const, text: result.message }] }
+        logToolTokens(name, args, response, startMs)
+        return response
+      }
+
+      case 'crane_verify': {
+        const input = verifyInputSchema.parse(args)
+        const result = await executeVerify(input)
+        return {
+          content: [{ type: 'text', text: result.message }],
+        }
+      }
+
+      case 'crane_claim_origin': {
+        const input = claimOriginInputSchema.parse(args)
+        const result = await executeClaimOrigin(input)
         const response = { content: [{ type: 'text' as const, text: result.message }] }
         logToolTokens(name, args, response, startMs)
         return response

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -656,6 +656,81 @@ export interface GetMemoryUsageResponse {
 }
 
 // ============================================================================
+// Verification Ledger (crane_verify)
+// ============================================================================
+
+export type VerifyMethod = 'live_state' | 'fresh_process' | 'vendor_docs'
+export type VerifySource = 'manual' | 'tool' | 'hook'
+export type VerifyToolUsed =
+  | 'Bash'
+  | 'Context7'
+  | 'WebFetch'
+  | 'gh_api'
+  | 'wrangler'
+  | 'vendor_mcp'
+  | 'other'
+export type VerifyTruncation = 'none' | 'head' | 'tail' | 'head_tail'
+
+export interface RecordVerificationRequest {
+  method: VerifyMethod
+  claim: string
+  output: string
+  tool_used: VerifyToolUsed
+  command?: string
+  files_touched?: string[]
+  fresh_runtime?: boolean
+  fresh_runtime_justification?: string
+  output_truncation?: VerifyTruncation
+  source?: VerifySource
+  session_id?: string
+  venture?: string
+  repo?: string
+}
+
+export interface VerificationRecord {
+  id: string
+  method: VerifyMethod
+  source: VerifySource
+  redacted: boolean
+  output_truncation: VerifyTruncation
+  files_touched: string[]
+}
+
+export interface RecordVerificationResponse {
+  verify: VerificationRecord
+  correlation_id?: string
+}
+
+export interface ClaimOriginEntry {
+  verify_id: string
+  session_id: string | null
+  claim: string
+  method: VerifyMethod
+  ts: string
+  files_touched: string[]
+}
+
+export interface GetClaimOriginParams {
+  file: string
+  since?: string
+  limit?: number
+}
+
+export interface GetClaimOriginResponse {
+  file: string
+  since: string
+  limit: number
+  claims: ClaimOriginEntry[]
+  correlation_id?: string
+}
+
+export interface GetVerifySessionCountResponse {
+  session_id: string
+  count: number
+  correlation_id?: string
+}
+
+// ============================================================================
 // Deploy heartbeats (Plan §B.6)
 // ============================================================================
 
@@ -1649,6 +1724,63 @@ export class CraneApi {
     }
 
     return (await response.json()) as { handoff: HandoffRecord }
+  }
+
+  // ============================================================================
+  // Verification Ledger (crane_verify)
+  // ============================================================================
+
+  async recordVerification(params: RecordVerificationRequest): Promise<VerificationRecord> {
+    const response = await fetch(`${this.apiBase}/verify`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Relay-Key': this.apiKey,
+      },
+      body: JSON.stringify(params),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Record verification failed (${response.status}): ${text}`)
+    }
+
+    const data = (await response.json()) as RecordVerificationResponse
+    return data.verify
+  }
+
+  async getClaimOrigin(params: GetClaimOriginParams): Promise<GetClaimOriginResponse> {
+    const queryParts: string[] = [`file=${encodeURIComponent(params.file)}`]
+    if (params.since) queryParts.push(`since=${encodeURIComponent(params.since)}`)
+    if (params.limit !== undefined) queryParts.push(`limit=${params.limit}`)
+
+    const response = await fetch(`${this.apiBase}/verify/origin?${queryParts.join('&')}`, {
+      headers: { 'X-Relay-Key': this.apiKey },
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Get claim origin failed (${response.status}): ${text}`)
+    }
+
+    return (await response.json()) as GetClaimOriginResponse
+  }
+
+  async getVerifySessionCount(sessionId: string): Promise<number> {
+    const response = await fetch(
+      `${this.apiBase}/verify/session-count?session_id=${encodeURIComponent(sessionId)}`,
+      {
+        headers: { 'X-Relay-Key': this.apiKey },
+      }
+    )
+
+    if (!response.ok) {
+      // Best-effort: SOS shouldn't fail because of a count query.
+      return 0
+    }
+
+    const data = (await response.json()) as GetVerifySessionCountResponse
+    return data.count
   }
 
   // ============================================================================

--- a/packages/crane-mcp/src/tools/sos.ts
+++ b/packages/crane-mcp/src/tools/sos.ts
@@ -616,6 +616,20 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
           }
         }
 
+        // Verify-ledger session count (PR 1 visibility — closes the
+        // "write-only table" risk before PR 2's gates ship). Best-effort:
+        // returns 0 if the worker route isn't deployed yet or the call
+        // fails; the section quietly absent is the failure mode, not a
+        // crash.
+        let verifyCount: number | undefined
+        if (!isFleet) {
+          try {
+            verifyCount = await api.getVerifySessionCount(session.session.id)
+          } catch {
+            verifyCount = undefined
+          }
+        }
+
         // Build message
         const message = buildSosMessage({
           venture,
@@ -642,6 +656,7 @@ export async function executeSos(input: SosInput): Promise<SosResult> {
           criticalAntiPatterns,
           relevantLessons,
           memoryAuditDaysSince,
+          verifyCount,
         })
 
         return {
@@ -874,6 +889,13 @@ interface BuildSosMessageParams {
    * Days since /memory-audit last ran. undefined = no data. >30 = alarm. >60 = pause injection.
    */
   memoryAuditDaysSince?: number | null
+  /**
+   * Count of crane_verify ledger writes attributed to this session_id.
+   * Surfaced in the Session block so agents see the ledger as visibly used
+   * from PR 1 — closes the "write-only table until PR 2" risk by giving
+   * the substrate immediate visibility before the gates ship.
+   */
+  verifyCount?: number
 }
 
 export function buildSosMessage(params: BuildSosMessageParams): string {
@@ -902,6 +924,7 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
     criticalAntiPatterns,
     relevantLessons,
     memoryAuditDaysSince,
+    verifyCount,
   } = params
 
   // Unwrap the Truncated wrappers ONCE at the top so the rest of the
@@ -936,7 +959,11 @@ export function buildSosMessage(params: BuildSosMessageParams): string {
   message += `| Branch | ${branch} |\n`
   message += `| Sync | ${formatRepoSync(repoSyncStatus)} |\n`
   message += `| Deps | ${formatDepsDrift(nodeModulesDrift)} |\n`
-  message += `| Session | ${sessionId} |\n\n`
+  message += `| Session | ${sessionId} |\n`
+  if (typeof verifyCount === 'number') {
+    message += `| Verifications | ${verifyCount} recorded this session |\n`
+  }
+  message += `\n`
 
   // --- Directives ---
   message += `## Directives\n\n`

--- a/packages/crane-mcp/src/tools/verify.test.ts
+++ b/packages/crane-mcp/src/tools/verify.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for crane_verify and crane_claim_origin.
+ *
+ * Coverage:
+ *   - Zod refinements: command required for fresh_process/live_state,
+ *     vendor_docs minimum output, oversize output rejection
+ *   - Best-effort error handling: missing CRANE_CONTEXT_KEY, API failures
+ *   - executeVerify happy path returns verify_id
+ *   - executeClaimOrigin formats results
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../lib/crane-api.js', () => {
+  const mockApi = {
+    recordVerification: vi.fn(),
+    getClaimOrigin: vi.fn(),
+  }
+  function MockCraneApi() {
+    return mockApi
+  }
+  return {
+    CraneApi: MockCraneApi,
+    _mockApi: mockApi,
+  }
+})
+
+vi.mock('../lib/config.js', () => ({ getApiBase: () => 'https://api.example.com' }))
+
+beforeEach(() => {
+  process.env.CRANE_CONTEXT_KEY = 'test-key'
+})
+
+// ----------------------------------------------------------------------------
+// Zod refinements (integrity bindings)
+// ----------------------------------------------------------------------------
+
+describe('verifyInputSchema integrity bindings', () => {
+  it('rejects fresh_process without command', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const result = verifyInputSchema.safeParse({
+      method: 'fresh_process',
+      claim: 'main is green',
+      output: 'ok',
+      tool_used: 'Bash',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain('command is required')
+    }
+  })
+
+  it('rejects live_state without command', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const result = verifyInputSchema.safeParse({
+      method: 'live_state',
+      claim: 'PR 100 is merged',
+      output: 'merged',
+      tool_used: 'gh_api',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts vendor_docs without command (command is optional for vendor_docs)', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const longOutput = 'x'.repeat(150)
+    const result = verifyInputSchema.safeParse({
+      method: 'vendor_docs',
+      claim: 'AI SDK supports streaming',
+      output: longOutput,
+      tool_used: 'Context7',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects vendor_docs with output shorter than minimum', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const result = verifyInputSchema.safeParse({
+      method: 'vendor_docs',
+      claim: 'I read the docs',
+      output: 'ok',
+      tool_used: 'Context7',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain('output.length >=')
+    }
+  })
+
+  it('rejects oversize output with head_tail guidance', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const huge = 'a'.repeat(8 * 1024 + 1)
+    const result = verifyInputSchema.safeParse({
+      method: 'fresh_process',
+      claim: 'tests passed',
+      output: huge,
+      command: 'npm test',
+      tool_used: 'Bash',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain('head_tail')
+    }
+  })
+
+  it('rejects non-enum tool_used', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const result = verifyInputSchema.safeParse({
+      method: 'live_state',
+      claim: 'x',
+      output: 'y',
+      command: 'gh api',
+      tool_used: 'random_thing',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a fully-formed live_state record', async () => {
+    const { verifyInputSchema } = await import('./verify.js')
+    const result = verifyInputSchema.safeParse({
+      method: 'live_state',
+      claim: 'PR 100 is merged',
+      output: '{"state":"merged","mergedAt":"2026-05-06T17:00:00Z"}',
+      tool_used: 'gh_api',
+      command: 'gh pr view 100 --json state,mergedAt',
+      files_touched: ['packages/crane-mcp/src/index.ts'],
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ----------------------------------------------------------------------------
+// executeVerify
+// ----------------------------------------------------------------------------
+
+describe('executeVerify', () => {
+  it('returns warning when CRANE_CONTEXT_KEY is missing', async () => {
+    delete process.env.CRANE_CONTEXT_KEY
+    const { executeVerify } = await import('./verify.js')
+    const result = await executeVerify({
+      method: 'fresh_process',
+      claim: 'test',
+      output: 'ok',
+      command: 'echo ok',
+      tool_used: 'Bash',
+    })
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('CRANE_CONTEXT_KEY not set')
+  })
+
+  it('returns verify_id on happy path', async () => {
+    const { _mockApi } = (await import('../lib/crane-api.js')) as unknown as {
+      _mockApi: { recordVerification: ReturnType<typeof vi.fn> }
+    }
+    _mockApi.recordVerification.mockResolvedValueOnce({
+      id: 'vfy_01HQXVABCDEFGHIJK',
+      method: 'fresh_process',
+      source: 'tool',
+      redacted: false,
+      output_truncation: 'none',
+      files_touched: [],
+    })
+
+    const { executeVerify } = await import('./verify.js')
+    const result = await executeVerify({
+      method: 'fresh_process',
+      claim: 'test',
+      output: 'ok',
+      command: 'echo ok',
+      tool_used: 'Bash',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.verify_id).toBe('vfy_01HQXVABCDEFGHIJK')
+    expect(result.message).toContain('vfy_')
+  })
+
+  it('surfaces redacted flag in success message when scrubber fired', async () => {
+    const { _mockApi } = (await import('../lib/crane-api.js')) as unknown as {
+      _mockApi: { recordVerification: ReturnType<typeof vi.fn> }
+    }
+    _mockApi.recordVerification.mockResolvedValueOnce({
+      id: 'vfy_AAA',
+      method: 'fresh_process',
+      source: 'tool',
+      redacted: true,
+      output_truncation: 'none',
+      files_touched: [],
+    })
+
+    const { executeVerify } = await import('./verify.js')
+    const result = await executeVerify({
+      method: 'fresh_process',
+      claim: 'env dump',
+      output: 'API_KEY=hunter2',
+      command: 'env',
+      tool_used: 'Bash',
+    })
+    expect(result.success).toBe(true)
+    expect(result.redacted).toBe(true)
+    expect(result.message).toContain('secrets masked')
+  })
+
+  it('returns success:false on API failure (best-effort, never throws)', async () => {
+    const { _mockApi } = (await import('../lib/crane-api.js')) as unknown as {
+      _mockApi: { recordVerification: ReturnType<typeof vi.fn> }
+    }
+    _mockApi.recordVerification.mockRejectedValueOnce(new Error('Worker 500'))
+
+    const { executeVerify } = await import('./verify.js')
+    const result = await executeVerify({
+      method: 'fresh_process',
+      claim: 'test',
+      output: 'ok',
+      command: 'echo ok',
+      tool_used: 'Bash',
+    })
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Failed to record verification')
+  })
+})
+
+// ----------------------------------------------------------------------------
+// executeClaimOrigin
+// ----------------------------------------------------------------------------
+
+describe('executeClaimOrigin formatter', () => {
+  it('renders empty-state message when no claims found', async () => {
+    const { _mockApi } = (await import('../lib/crane-api.js')) as unknown as {
+      _mockApi: { getClaimOrigin: ReturnType<typeof vi.fn> }
+    }
+    _mockApi.getClaimOrigin.mockResolvedValueOnce({
+      file: 'src/foo.ts',
+      since: '2026-02-05T00:00:00Z',
+      limit: 50,
+      claims: [],
+    })
+
+    const { executeClaimOrigin } = await import('./verify.js')
+    const result = await executeClaimOrigin({ file: 'src/foo.ts' })
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('No prior claims')
+  })
+
+  it('formats prior claims with verify_id and method', async () => {
+    const { _mockApi } = (await import('../lib/crane-api.js')) as unknown as {
+      _mockApi: { getClaimOrigin: ReturnType<typeof vi.fn> }
+    }
+    _mockApi.getClaimOrigin.mockResolvedValueOnce({
+      file: 'src/foo.ts',
+      since: '2026-02-05T00:00:00Z',
+      limit: 50,
+      claims: [
+        {
+          verify_id: 'vfy_AAA',
+          session_id: 'sess_BBB',
+          claim: 'foo() returns the cached value',
+          method: 'fresh_process',
+          ts: '2026-04-15T10:00:00Z',
+          files_touched: ['src/foo.ts'],
+        },
+      ],
+    })
+
+    const { executeClaimOrigin } = await import('./verify.js')
+    const result = await executeClaimOrigin({ file: 'src/foo.ts' })
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('vfy_AAA')
+    expect(result.message).toContain('fresh_process')
+    expect(result.message).toContain('foo() returns the cached value')
+  })
+})

--- a/packages/crane-mcp/src/tools/verify.ts
+++ b/packages/crane-mcp/src/tools/verify.ts
@@ -1,0 +1,273 @@
+/**
+ * crane_verify / crane_claim_origin tools — verification ledger surface.
+ *
+ * crane_verify: Record a verification artifact. The agent runs the actual
+ *   verification with whatever tool fits (Bash, Context7, gh api, wrangler)
+ *   and submits the captured output here for ledgering. PR 2 gates check
+ *   for these records; PR 3 audits sample them and re-run the captured
+ *   command for integrity.
+ *
+ * crane_claim_origin: Look up prior verifications that touched a file path.
+ *   Used by PR 3's regression auto-attach flow.
+ *
+ * Design: ledger writer, not executor. Agents already have execution surface
+ * (Bash); the value here is the structured cross-session record + integrity
+ * bindings (output_hash, command_hash) that make claim↔output re-checkable.
+ *
+ * Best-effort telemetry — failure returns { success: false, message } and
+ * never throws, mirroring memory_invoke. The agent's work continues even
+ * if the ledger write fails.
+ */
+
+import { z } from 'zod'
+import { CraneApi } from '../lib/crane-api.js'
+import { getApiBase } from '../lib/config.js'
+import type {
+  ClaimOriginEntry,
+  VerifyMethod,
+  VerifySource,
+  VerifyToolUsed,
+  VerifyTruncation,
+} from '../lib/crane-api.js'
+
+// ============================================================================
+// Constants — kept in sync with workers/crane-context/src/constants.ts
+// ============================================================================
+
+const VERIFY_METHODS = ['live_state', 'fresh_process', 'vendor_docs'] as const
+const VERIFY_SOURCES = ['manual', 'tool', 'hook'] as const
+const VERIFY_TOOLS_USED = [
+  'Bash',
+  'Context7',
+  'WebFetch',
+  'gh_api',
+  'wrangler',
+  'vendor_mcp',
+  'other',
+] as const
+const VERIFY_TRUNCATIONS = ['none', 'head', 'tail', 'head_tail'] as const
+
+const MAX_VERIFY_OUTPUT_BYTES = 8 * 1024
+const MAX_VERIFY_CLAIM_CHARS = 300
+const VERIFY_VENDOR_DOCS_MIN_OUTPUT = 100
+const VERIFY_ORIGIN_LIMIT_CAP = 50
+
+// ============================================================================
+// crane_verify
+// ============================================================================
+
+/**
+ * Base shape (no refinements). Refinements applied via .superRefine below
+ * so multiple integrity bindings can fire with field-specific error paths.
+ */
+const verifyBaseSchema = z.object({
+  method: z.enum(VERIFY_METHODS).describe('Verification method category'),
+  claim: z
+    .string()
+    .min(1)
+    .max(MAX_VERIFY_CLAIM_CHARS)
+    .describe(
+      `What is supposedly true after this verification (max ${MAX_VERIFY_CLAIM_CHARS} chars)`
+    ),
+  output: z
+    .string()
+    .describe(
+      `Literal output captured by the agent (max ${MAX_VERIFY_OUTPUT_BYTES} bytes; oversize must use head_tail convention)`
+    ),
+  tool_used: z
+    .enum(VERIFY_TOOLS_USED)
+    .describe(
+      'Which tool the agent used to capture output (enum forces audit-grouping; pick "other" only if none fit)'
+    ),
+  command: z
+    .string()
+    .optional()
+    .describe('Command/query that produced output. REQUIRED for fresh_process and live_state.'),
+  files_touched: z
+    .array(z.string())
+    .optional()
+    .describe('File paths this verification relates to (used by claim_origin lookup)'),
+  fresh_runtime: z
+    .boolean()
+    .optional()
+    .describe('Did output come from a fresh process? PR 2 gate reads this.'),
+  fresh_runtime_justification: z
+    .string()
+    .optional()
+    .describe('Required by PR 2 gate when fresh_runtime is false on a runtime-config claim.'),
+  output_truncation: z
+    .enum(VERIFY_TRUNCATIONS)
+    .optional()
+    .describe('Set to head_tail when applying truncation convention for oversize output.'),
+  source: z
+    .enum(VERIFY_SOURCES)
+    .optional()
+    .describe('Defaults to "tool". Use "manual" for Captain-initiated records.'),
+  session_id: z.string().optional().describe('Current session ID if known'),
+})
+
+export const verifyInputSchema = verifyBaseSchema.superRefine((data, ctx) => {
+  // Integrity binding 1: fresh_process and live_state require command —
+  // a record without command is unrecheckable, defeating the audit story.
+  if ((data.method === 'fresh_process' || data.method === 'live_state') && !data.command) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['command'],
+      message: `command is required for method=${data.method} (PR 3 audit re-runs it for integrity)`,
+    })
+  }
+
+  // Integrity binding 2: vendor_docs requires non-trivial output.
+  if (data.method === 'vendor_docs' && data.output.length < VERIFY_VENDOR_DOCS_MIN_OUTPUT) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['output'],
+      message: `vendor_docs requires output.length >= ${VERIFY_VENDOR_DOCS_MIN_OUTPUT}; paste the actual doc excerpt`,
+    })
+  }
+
+  // Reject oversize output explicitly with head_tail guidance.
+  if (Buffer.byteLength(data.output, 'utf8') > MAX_VERIFY_OUTPUT_BYTES) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['output'],
+      message: `output exceeds ${MAX_VERIFY_OUTPUT_BYTES} bytes; capture command + apply head_tail (first 4KB + "\\n...[truncated]...\\n" + last 4KB) and set output_truncation:"head_tail"`,
+    })
+  }
+})
+
+export type VerifyInput = z.infer<typeof verifyInputSchema>
+
+export interface VerifyResult {
+  success: boolean
+  message: string
+  verify_id?: string
+  redacted?: boolean
+}
+
+export async function executeVerify(input: VerifyInput): Promise<VerifyResult> {
+  const apiKey = process.env.CRANE_CONTEXT_KEY
+  if (!apiKey) {
+    return {
+      success: false,
+      message: 'Warning: CRANE_CONTEXT_KEY not set — verification not recorded.',
+    }
+  }
+
+  const venture = process.env.CRANE_VENTURE_CODE
+  const repo = process.env.CRANE_REPO
+
+  try {
+    const api = new CraneApi(apiKey, getApiBase())
+    const record = await api.recordVerification({
+      method: input.method as VerifyMethod,
+      claim: input.claim,
+      output: input.output,
+      tool_used: input.tool_used as VerifyToolUsed,
+      ...(input.command !== undefined ? { command: input.command } : {}),
+      ...(input.files_touched ? { files_touched: input.files_touched } : {}),
+      ...(input.fresh_runtime !== undefined ? { fresh_runtime: input.fresh_runtime } : {}),
+      ...(input.fresh_runtime_justification !== undefined
+        ? { fresh_runtime_justification: input.fresh_runtime_justification }
+        : {}),
+      ...(input.output_truncation
+        ? { output_truncation: input.output_truncation as VerifyTruncation }
+        : {}),
+      ...(input.source ? { source: input.source as VerifySource } : { source: 'tool' as const }),
+      ...(input.session_id ? { session_id: input.session_id } : {}),
+      ...(venture ? { venture } : {}),
+      ...(repo ? { repo } : {}),
+    })
+
+    const redactedNote = record.redacted ? ' (output had secrets masked before storage)' : ''
+    return {
+      success: true,
+      message: `Verification recorded: ${record.id}${redactedNote}`,
+      verify_id: record.id,
+      redacted: record.redacted,
+    }
+  } catch (error) {
+    // Best-effort: never block agent work on telemetry failure.
+    const reason = error instanceof Error ? error.message : 'Unknown error'
+    return {
+      success: false,
+      message: `Warning: Failed to record verification — ${reason}`,
+    }
+  }
+}
+
+// ============================================================================
+// crane_claim_origin
+// ============================================================================
+
+export const claimOriginInputSchema = z.object({
+  file: z.string().describe('File path to look up prior claims for'),
+  since: z
+    .string()
+    .optional()
+    .describe('Lookback window: ISO date OR relative format like "30d"/"90d". Default: 90d.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(VERIFY_ORIGIN_LIMIT_CAP)
+    .optional()
+    .describe(`Max results, hard-capped at ${VERIFY_ORIGIN_LIMIT_CAP}.`),
+})
+
+export type ClaimOriginInput = z.infer<typeof claimOriginInputSchema>
+
+export interface ClaimOriginResult {
+  success: boolean
+  message: string
+}
+
+function formatClaimOrigin(file: string, since: string, claims: ClaimOriginEntry[]): string {
+  if (claims.length === 0) {
+    return `No prior claims for **${file}** since ${since.split('T')[0]}.`
+  }
+
+  const lines: string[] = [
+    `**Prior claims for \`${file}\`** since ${since.split('T')[0]} (${claims.length}):\n`,
+  ]
+  for (const c of claims) {
+    const sessTag = c.session_id ? ` · sess=${c.session_id}` : ''
+    const dateTag = c.ts.split('T')[0]
+    lines.push(`- ${dateTag} · **${c.method}**${sessTag}`)
+    lines.push(`  - claim: ${c.claim}`)
+    lines.push(`  - verify_id: \`${c.verify_id}\``)
+    if (c.files_touched.length > 1) {
+      lines.push(`  - also touched: ${c.files_touched.filter((f) => f !== file).join(', ')}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+export async function executeClaimOrigin(input: ClaimOriginInput): Promise<ClaimOriginResult> {
+  const apiKey = process.env.CRANE_CONTEXT_KEY
+  if (!apiKey) {
+    return {
+      success: false,
+      message: 'CRANE_CONTEXT_KEY not found. Cannot query claim origin.',
+    }
+  }
+
+  try {
+    const api = new CraneApi(apiKey, getApiBase())
+    const result = await api.getClaimOrigin({
+      file: input.file,
+      ...(input.since ? { since: input.since } : {}),
+      ...(input.limit !== undefined ? { limit: input.limit } : {}),
+    })
+
+    return {
+      success: true,
+      message: formatClaimOrigin(input.file, result.since, result.claims),
+    }
+  } catch (error) {
+    return {
+      success: false,
+      message: `Failed to query claim origin: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    }
+  }
+}

--- a/scripts/redirect-reflex-hook.sh
+++ b/scripts/redirect-reflex-hook.sh
@@ -37,6 +37,6 @@ fi
 PROMPT=$(jq -r '.prompt // empty' 2>/dev/null) || exit 0
 [ -z "$PROMPT" ] && exit 0
 
-echo "[reflex] Verify before opining; decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing; before stating duration estimates, run /estimate. See docs/instructions/session-reflexes.md."
+echo "[reflex] Verify before opining (record with crane_verify); decode redirects precisely; classify questions (factual=read, judgment=decide, Captain-only=ask); respect mode framing; before stating duration estimates, run /estimate. See docs/instructions/session-reflexes.md."
 
 exit 0

--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -116,10 +116,13 @@ else
   # Auto-determine scope
   IS_GLOBAL=false
 
-  # Path-prefix rule: anything under docs/design-system/ is a global enterprise
-  # design-system asset (foundations, tokens taxonomy, patterns, components,
-  # governance, etc.) and should sync as scope=global.
+  # Path-prefix rules: anything under docs/design-system/ or docs/global/
+  # is global enterprise content and should sync as scope=global.
+  # design-system: foundations, tokens, patterns, components, governance.
+  # global: enterprise-wide playbooks and instructions (verify.md, etc.).
   if [[ "$DOC_PATH" == docs/design-system/* ]]; then
+    IS_GLOBAL=true
+  elif [[ "$DOC_PATH" == docs/global/* ]]; then
     IS_GLOBAL=true
   else
     # Otherwise check basename whitelist

--- a/workers/crane-context/migrations/0050_add_verify_ledger.sql
+++ b/workers/crane-context/migrations/0050_add_verify_ledger.sql
@@ -1,0 +1,51 @@
+-- Migration 0050: Add verify_ledger + verify_files for crane_verify telemetry
+--
+-- Records claim/output evidence for verification calls so PR 2 gates can
+-- check artifact presence and PR 3 can auto-attach prior claims onto
+-- regression issues. Designed as a ledger writer: agents capture output
+-- with whatever tool fits (Bash, Context7, gh api, wrangler) and submit;
+-- the table is the cross-session record, not an execution surface.
+--
+-- Integrity columns (output_hash, command_hash) let the PR 3 audit sample
+-- rows and re-run the captured command to verify the claim↔output binding
+-- mechanically rather than by honor system. The verify_files join table
+-- avoids LIKE-on-JSON scanning when /verify/origin lookups grow.
+--
+-- The `source` column distinguishes manual (Captain-initiated), tool
+-- (agent-initiated via the MCP tool), and hook (PR 2's PreToolUse hook
+-- writes). PR 1 only emits 'tool' and 'manual'; PR 2 can sample/rate-limit
+-- 'hook' writes without a schema migration.
+
+CREATE TABLE IF NOT EXISTS verify_ledger (
+  id TEXT PRIMARY KEY,
+  session_id TEXT,
+  venture TEXT,
+  repo TEXT,
+  method TEXT NOT NULL CHECK (method IN ('live_state', 'fresh_process', 'vendor_docs')),
+  source TEXT NOT NULL DEFAULT 'tool' CHECK (source IN ('manual', 'tool', 'hook')),
+  claim TEXT NOT NULL,
+  output_scrubbed TEXT NOT NULL,
+  output_hash TEXT NOT NULL,
+  output_redacted INTEGER NOT NULL DEFAULT 0,
+  output_truncation TEXT NOT NULL DEFAULT 'none' CHECK (output_truncation IN ('none', 'head', 'tail', 'head_tail')),
+  tool_used TEXT NOT NULL,
+  command TEXT,
+  command_hash TEXT,
+  fresh_runtime INTEGER,
+  fresh_runtime_justification TEXT,
+  actor_key_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_verify_session_time ON verify_ledger (session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_verify_method_time  ON verify_ledger (method, created_at);
+CREATE INDEX IF NOT EXISTS idx_verify_created      ON verify_ledger (created_at);
+
+CREATE TABLE IF NOT EXISTS verify_files (
+  verify_id TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  PRIMARY KEY (file_path, verify_id),
+  FOREIGN KEY (verify_id) REFERENCES verify_ledger(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_verify_files_verify ON verify_files (verify_id);

--- a/workers/crane-context/src/constants.ts
+++ b/workers/crane-context/src/constants.ts
@@ -97,7 +97,73 @@ export const ID_PREFIXES = {
   SCHEDULE: 'sched_',
   NOTIFICATION: 'notif_',
   PLANNED_EVENT: 'pe_',
+  VERIFY: 'vfy_',
 } as const
+
+// ============================================================================
+// Verification Ledger (crane_verify)
+// ============================================================================
+
+/**
+ * Maximum scrubbed-output bytes stored per verify_ledger row.
+ * Raw input is rejected upstream above this size; the agent must apply the
+ * head_tail truncation convention before submission.
+ */
+export const MAX_VERIFY_OUTPUT_BYTES = 8 * 1024
+
+/**
+ * Maximum claim length in characters for verify_ledger.claim.
+ */
+export const MAX_VERIFY_CLAIM_CHARS = 300
+
+/**
+ * Hard cap on /verify/origin lookup results. Keeps PR 3 auto-attach
+ * consumers bounded-list-shape regardless of caller-supplied limit.
+ */
+export const VERIFY_ORIGIN_LIMIT_CAP = 50
+
+/**
+ * Methods accepted by the verify ledger. Drop-down explicitly enumerated
+ * so the SQL CHECK and the application-layer validators stay in lock-step.
+ */
+export const VERIFY_METHODS = ['live_state', 'fresh_process', 'vendor_docs'] as const
+export type VerifyMethod = (typeof VERIFY_METHODS)[number]
+
+/**
+ * Sources distinguishing manual (Captain), tool (agent via MCP), and
+ * hook (PR 2's PreToolUse hook) writes.
+ */
+export const VERIFY_SOURCES = ['manual', 'tool', 'hook'] as const
+export type VerifySource = (typeof VERIFY_SOURCES)[number]
+
+/**
+ * Tool-used enum (audit groupability). Free-form text would let agents
+ * fragment the same underlying tool across many strings; the enum forces
+ * a canonical bucket.
+ */
+export const VERIFY_TOOLS_USED = [
+  'Bash',
+  'Context7',
+  'WebFetch',
+  'gh_api',
+  'wrangler',
+  'vendor_mcp',
+  'other',
+] as const
+export type VerifyToolUsed = (typeof VERIFY_TOOLS_USED)[number]
+
+/**
+ * Truncation flags. `head_tail` is the documented convention for outputs
+ * that exceed MAX_VERIFY_OUTPUT_BYTES — first 4KB + sentinel + last 4KB.
+ */
+export const VERIFY_TRUNCATIONS = ['none', 'head', 'tail', 'head_tail'] as const
+export type VerifyTruncation = (typeof VERIFY_TRUNCATIONS)[number]
+
+/**
+ * Minimum output length for `vendor_docs` records. Catches trivially-empty
+ * "I read the docs" claims with no evidence to attach to.
+ */
+export const VERIFY_VENDOR_DOCS_MIN_OUTPUT = 100
 
 // ============================================================================
 // Notes

--- a/workers/crane-context/src/endpoints/verify-ledger.ts
+++ b/workers/crane-context/src/endpoints/verify-ledger.ts
@@ -1,0 +1,448 @@
+/**
+ * Crane Context Worker - Verify Ledger Endpoints
+ *
+ * POST /verify          — record a verification artifact (the claim, what
+ *                         tool produced what output, with integrity hashes
+ *                         so PR 3 audit can re-run the command).
+ *
+ * GET  /verify/origin   — look up prior verifications that touched a given
+ *                         file path. Used by PR 3's regression auto-attach
+ *                         flow to surface the originating session/claim.
+ *
+ * Design: ledger writer, not executor. The agent runs the verification
+ * with whatever tool fits (Bash, Context7, gh api, wrangler) and submits
+ * the captured output here. The worker scrubs secrets, hashes pre-scrub
+ * output for integrity, and persists. Mirrored on memory-invocations.ts.
+ */
+
+import type { Env } from '../types'
+import { buildRequestContext, isResponse } from '../auth'
+import {
+  jsonResponse,
+  errorResponse,
+  validationErrorResponse,
+  payloadTooLargeResponse,
+  sha256,
+  sizeInBytes,
+} from '../utils'
+import {
+  HTTP_STATUS,
+  ID_PREFIXES,
+  MAX_VERIFY_OUTPUT_BYTES,
+  MAX_VERIFY_CLAIM_CHARS,
+  VERIFY_METHODS,
+  VERIFY_SOURCES,
+  VERIFY_TOOLS_USED,
+  VERIFY_TRUNCATIONS,
+  VERIFY_VENDOR_DOCS_MIN_OUTPUT,
+  VERIFY_ORIGIN_LIMIT_CAP,
+  type VerifyMethod,
+  type VerifySource,
+  type VerifyToolUsed,
+  type VerifyTruncation,
+} from '../constants'
+import { scrubSecrets } from '../lib/scrub'
+import { ulid } from 'ulidx'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface RecordVerificationBody {
+  method: VerifyMethod
+  claim: string
+  output: string
+  tool_used: VerifyToolUsed
+  command?: string
+  files_touched?: string[]
+  fresh_runtime?: boolean
+  fresh_runtime_justification?: string
+  output_truncation?: VerifyTruncation
+  source?: VerifySource
+  session_id?: string
+  venture?: string
+  repo?: string
+}
+
+interface ClaimRecord {
+  verify_id: string
+  session_id: string | null
+  claim: string
+  method: VerifyMethod
+  ts: string
+  files_touched: string[]
+}
+
+// ============================================================================
+// POST /verify — Record a Verification
+// ============================================================================
+
+export async function handleRecordVerification(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) {
+    return context
+  }
+
+  let body: RecordVerificationBody
+  try {
+    body = (await request.json()) as RecordVerificationBody
+  } catch {
+    return errorResponse('Invalid JSON body', HTTP_STATUS.BAD_REQUEST, context.correlationId)
+  }
+
+  // ---- Mechanical validation (mirrors Zod refinements in MCP layer) ----
+
+  if (!body.method || !VERIFY_METHODS.includes(body.method)) {
+    return validationErrorResponse(
+      [{ field: 'method', message: `Must be one of: ${VERIFY_METHODS.join(', ')}` }],
+      context.correlationId
+    )
+  }
+
+  if (!body.tool_used || !VERIFY_TOOLS_USED.includes(body.tool_used)) {
+    return validationErrorResponse(
+      [{ field: 'tool_used', message: `Must be one of: ${VERIFY_TOOLS_USED.join(', ')}` }],
+      context.correlationId
+    )
+  }
+
+  if (typeof body.claim !== 'string' || body.claim.length === 0) {
+    return validationErrorResponse(
+      [{ field: 'claim', message: 'Required non-empty string' }],
+      context.correlationId
+    )
+  }
+  if (body.claim.length > MAX_VERIFY_CLAIM_CHARS) {
+    return validationErrorResponse(
+      [
+        {
+          field: 'claim',
+          message: `claim exceeds ${MAX_VERIFY_CLAIM_CHARS} chars; trim to a one-line statement of what is supposedly true`,
+        },
+      ],
+      context.correlationId
+    )
+  }
+
+  if (typeof body.output !== 'string') {
+    return validationErrorResponse(
+      [{ field: 'output', message: 'Required string field' }],
+      context.correlationId
+    )
+  }
+
+  // Reject oversize output explicitly with head_tail guidance — never
+  // silently truncate, since silent truncation produces a ledger row
+  // that lies about what was observed.
+  if (sizeInBytes(body.output) > MAX_VERIFY_OUTPUT_BYTES) {
+    return payloadTooLargeResponse(
+      `output exceeds ${MAX_VERIFY_OUTPUT_BYTES} bytes; capture the command + apply head_tail truncation (first 4KB + "\\n...[truncated]...\\n" + last 4KB) and set output_truncation:"head_tail"`,
+      context.correlationId
+    )
+  }
+
+  // Integrity binding 1: fresh_process and live_state require command —
+  // a record without command is an unrechecked claim, the exact pattern
+  // PR 3 audit needs to re-run for mismatch detection.
+  if ((body.method === 'fresh_process' || body.method === 'live_state') && !body.command) {
+    return validationErrorResponse(
+      [
+        {
+          field: 'command',
+          message: `command is required for method=${body.method} (PR 3 audit re-runs it for integrity)`,
+        },
+      ],
+      context.correlationId
+    )
+  }
+
+  // Integrity binding 2: vendor_docs requires non-trivial output. A
+  // trivially-empty "I read the docs" record has nothing to attach to
+  // when PR 3 surfaces it on a regression.
+  if (body.method === 'vendor_docs' && body.output.length < VERIFY_VENDOR_DOCS_MIN_OUTPUT) {
+    return validationErrorResponse(
+      [
+        {
+          field: 'output',
+          message: `vendor_docs requires output.length >= ${VERIFY_VENDOR_DOCS_MIN_OUTPUT}; paste the actual doc excerpt`,
+        },
+      ],
+      context.correlationId
+    )
+  }
+
+  if (body.output_truncation && !VERIFY_TRUNCATIONS.includes(body.output_truncation)) {
+    return validationErrorResponse(
+      [
+        {
+          field: 'output_truncation',
+          message: `Must be one of: ${VERIFY_TRUNCATIONS.join(', ')}`,
+        },
+      ],
+      context.correlationId
+    )
+  }
+
+  if (body.source && !VERIFY_SOURCES.includes(body.source)) {
+    return validationErrorResponse(
+      [{ field: 'source', message: `Must be one of: ${VERIFY_SOURCES.join(', ')}` }],
+      context.correlationId
+    )
+  }
+
+  if (body.files_touched && !Array.isArray(body.files_touched)) {
+    return validationErrorResponse(
+      [{ field: 'files_touched', message: 'Must be an array of strings' }],
+      context.correlationId
+    )
+  }
+
+  // ---- Compute integrity hashes BEFORE scrubbing ----
+
+  const outputHash = await sha256(body.output)
+  const commandHash = body.command ? await sha256(body.command) : null
+
+  // ---- Scrub secrets from output before persistence ----
+
+  const { scrubbed, redacted } = scrubSecrets(body.output)
+
+  const id = `${ID_PREFIXES.VERIFY}${ulid()}`
+  const source: VerifySource = body.source ?? 'tool'
+  const truncation: VerifyTruncation = body.output_truncation ?? 'none'
+  const filesTouched = (body.files_touched ?? []).filter(
+    (f) => typeof f === 'string' && f.length > 0
+  )
+
+  // ---- Atomic write: ledger row + per-file rows ----
+
+  try {
+    const stmts = [
+      env.DB.prepare(
+        `INSERT INTO verify_ledger
+           (id, session_id, venture, repo, method, source, claim,
+            output_scrubbed, output_hash, output_redacted, output_truncation,
+            tool_used, command, command_hash,
+            fresh_runtime, fresh_runtime_justification, actor_key_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        id,
+        body.session_id ?? null,
+        body.venture ?? null,
+        body.repo ?? null,
+        body.method,
+        source,
+        body.claim,
+        scrubbed,
+        outputHash,
+        redacted ? 1 : 0,
+        truncation,
+        body.tool_used,
+        body.command ?? null,
+        commandHash,
+        body.fresh_runtime === undefined ? null : body.fresh_runtime ? 1 : 0,
+        body.fresh_runtime_justification ?? null,
+        context.actorKeyId
+      ),
+      ...filesTouched.map((path) =>
+        env.DB.prepare(
+          `INSERT OR IGNORE INTO verify_files (verify_id, file_path) VALUES (?, ?)`
+        ).bind(id, path)
+      ),
+    ]
+
+    await env.DB.batch(stmts)
+
+    return jsonResponse(
+      {
+        verify: {
+          id,
+          method: body.method,
+          source,
+          redacted,
+          output_truncation: truncation,
+          files_touched: filesTouched,
+        },
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.CREATED,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('POST /verify error:', error)
+    return errorResponse(
+      error instanceof Error ? error.message : 'Internal server error',
+      HTTP_STATUS.INTERNAL_ERROR,
+      context.correlationId
+    )
+  }
+}
+
+// ============================================================================
+// GET /verify/origin?file=...&since=30d&limit=50 — Claim Origin Lookup
+// ============================================================================
+
+export async function handleGetVerificationOrigin(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) {
+    return context
+  }
+
+  const url = new URL(request.url)
+  const file = url.searchParams.get('file')
+  const sinceParam = url.searchParams.get('since') ?? '90d'
+  const limitParam = url.searchParams.get('limit')
+
+  if (!file) {
+    return validationErrorResponse(
+      [{ field: 'file', message: 'Required query parameter' }],
+      context.correlationId
+    )
+  }
+
+  const sinceDate = resolveSinceParam(sinceParam)
+  if (!sinceDate) {
+    return validationErrorResponse(
+      [{ field: 'since', message: 'Must be ISO date string or relative format like "30d"' }],
+      context.correlationId
+    )
+  }
+
+  let limit = VERIFY_ORIGIN_LIMIT_CAP
+  if (limitParam) {
+    const parsed = parseInt(limitParam, 10)
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return validationErrorResponse(
+        [{ field: 'limit', message: 'Must be a positive integer' }],
+        context.correlationId
+      )
+    }
+    limit = Math.min(parsed, VERIFY_ORIGIN_LIMIT_CAP)
+  }
+
+  try {
+    // GROUP_CONCAT pulls all files_touched per ledger row in one query
+    // so the response can include the full file set without a fan-out.
+    // Sentinel '|' is used because file paths can contain commas; '|' is
+    // less likely (would be quoted/escaped in a real path).
+    const result = await env.DB.prepare(
+      `SELECT vl.id          AS verify_id,
+              vl.session_id  AS session_id,
+              vl.claim       AS claim,
+              vl.method      AS method,
+              vl.created_at  AS ts,
+              GROUP_CONCAT(DISTINCT vf2.file_path) AS files_concat
+       FROM verify_files vf
+       JOIN verify_ledger vl ON vl.id = vf.verify_id
+       LEFT JOIN verify_files vf2 ON vf2.verify_id = vl.id
+       WHERE vf.file_path = ?
+         AND vl.created_at >= ?
+       GROUP BY vl.id
+       ORDER BY vl.created_at DESC
+       LIMIT ?`
+    )
+      .bind(file, sinceDate, limit)
+      .all<{
+        verify_id: string
+        session_id: string | null
+        claim: string
+        method: VerifyMethod
+        ts: string
+        files_concat: string | null
+      }>()
+
+    const claims: ClaimRecord[] = (result.results ?? []).map((row) => ({
+      verify_id: row.verify_id,
+      session_id: row.session_id,
+      claim: row.claim,
+      method: row.method,
+      ts: row.ts,
+      files_touched: row.files_concat ? row.files_concat.split(',').filter(Boolean) : [],
+    }))
+
+    return jsonResponse(
+      {
+        file,
+        since: sinceDate,
+        limit,
+        claims,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('GET /verify/origin error:', error)
+    return errorResponse(
+      error instanceof Error ? error.message : 'Internal server error',
+      HTTP_STATUS.INTERNAL_ERROR,
+      context.correlationId
+    )
+  }
+}
+
+// ============================================================================
+// GET /verify/session-count?session_id=... — SOS one-liner support
+// ============================================================================
+
+export async function handleGetVerificationSessionCount(
+  request: Request,
+  env: Env
+): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) {
+    return context
+  }
+
+  const url = new URL(request.url)
+  const sessionId = url.searchParams.get('session_id')
+
+  if (!sessionId) {
+    return validationErrorResponse(
+      [{ field: 'session_id', message: 'Required query parameter' }],
+      context.correlationId
+    )
+  }
+
+  try {
+    const row = await env.DB.prepare(`SELECT COUNT(*) AS n FROM verify_ledger WHERE session_id = ?`)
+      .bind(sessionId)
+      .first<{ n: number }>()
+
+    return jsonResponse(
+      {
+        session_id: sessionId,
+        count: row?.n ?? 0,
+        correlation_id: context.correlationId,
+      },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('GET /verify/session-count error:', error)
+    return errorResponse(
+      error instanceof Error ? error.message : 'Internal server error',
+      HTTP_STATUS.INTERNAL_ERROR,
+      context.correlationId
+    )
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function resolveSinceParam(sinceParam: string): string | null {
+  const relativeMatch = sinceParam.match(/^(\d+)d$/)
+  if (relativeMatch) {
+    const days = parseInt(relativeMatch[1], 10)
+    if (!Number.isFinite(days) || days < 0) return null
+    const d = new Date()
+    d.setDate(d.getDate() - days)
+    return d.toISOString()
+  }
+  const parsed = new Date(sinceParam)
+  if (isNaN(parsed.getTime())) {
+    return null
+  }
+  return parsed.toISOString()
+}

--- a/workers/crane-context/src/index.ts
+++ b/workers/crane-context/src/index.ts
@@ -108,6 +108,11 @@ import {
   handleGetMemoryInvocations,
   handleGetAllMemoryInvocations,
 } from './endpoints/memory-invocations'
+import {
+  handleRecordVerification,
+  handleGetVerificationOrigin,
+  handleGetVerificationSessionCount,
+} from './endpoints/verify-ledger'
 import { handleGetVersion } from './endpoints/version'
 import { handleVerifySchema } from './endpoints/admin-verify'
 import { handleSecretHash } from './endpoints/admin-secret-hash'
@@ -672,6 +677,22 @@ export default {
 
       if (pathname === '/memory/invocations' && method === 'GET') {
         return await handleGetMemoryInvocations(request, env)
+      }
+
+      // ========================================================================
+      // Verify Ledger Endpoints (crane_verify)
+      // ========================================================================
+
+      if (pathname === '/verify' && method === 'POST') {
+        return await handleRecordVerification(request, env)
+      }
+
+      if (pathname === '/verify/origin' && method === 'GET') {
+        return await handleGetVerificationOrigin(request, env)
+      }
+
+      if (pathname === '/verify/session-count' && method === 'GET') {
+        return await handleGetVerificationSessionCount(request, env)
       }
 
       // ========================================================================

--- a/workers/crane-context/src/lib/scrub.ts
+++ b/workers/crane-context/src/lib/scrub.ts
@@ -1,0 +1,145 @@
+/**
+ * Secret scrubber for verify_ledger.output_scrubbed.
+ *
+ * Two layers, in order:
+ *
+ *   1. Regex masks for the known leak vectors (PATs, AWS keys, OpenAI keys,
+ *      JWTs, PEM blocks, KEY=value lines). These are the patterns we have
+ *      direct evidence of agents pasting verbatim into command output.
+ *
+ *   2. A targeted entropy check that fires ONLY inside an assignment shape
+ *      (`name = high-entropy-value` or `name: high-entropy-value`). The
+ *      blanket entropy gate considered earlier was rejected because git
+ *      SHAs, ULIDs, container digests, and Cloudflare account IDs are all
+ *      legitimately high-entropy and represent the very evidence agents
+ *      need to capture. Smearing [REDACTED] across them collapses the
+ *      ledger's audit value.
+ *
+ * `redacted: true` is set on the result when any mask fired so the ledger
+ * row records that scrubbing happened — useful as an audit signal in PR 3.
+ */
+
+const REDACTED = '[REDACTED]'
+
+// Shannon entropy threshold. Empirically, base64-shaped secrets land in
+// the 4.5-5.5 range; legitimate hex-only IDs (git SHAs, ULIDs) sit below.
+// A targeted assignment-shape rule using this threshold catches secrets
+// without flagging IDs because IDs aren't usually written as `name = id`.
+const ENTROPY_THRESHOLD = 4.5
+
+// Regex patterns. Order matters slightly — JWTs need to match before the
+// generic assignment pattern because the dot structure is JWT-specific.
+const PEM_BLOCK = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g
+const JWT = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g
+const GH_PAT = /\bgh[ps]_[A-Za-z0-9]{36,}/g
+const OPENAI_KEY = /\bsk-[A-Za-z0-9]{20,}/g
+const AWS_ACCESS_KEY = /\bAKIA[A-Z0-9]{16}\b/g
+// KEY=value, KEY: value, with quoted or unquoted values. The key can be a
+// full identifier whose root token is one of the secret-shaped words
+// (e.g., `webhook_secret`, `gh_token`, `api_password` all match). The
+// whole key is captured so the replacement preserves it on the left of
+// the assignment for audit visibility.
+const KV_SECRET =
+  /\b(\w*(?:API[_-]?KEY|APIKEY|SECRET|TOKEN|PASSWORD|PASSWD|PWD|PEM|PRIVATE[_-]?KEY|CREDENTIAL)\w*)\s*([:=])\s*("[^"]+"|'[^']+'|\S+)/gi
+// Targeted entropy: any name=value where value is 32+ chars of base64-ish.
+// Captures the value so we can entropy-check it before deciding to mask.
+const ASSIGN_HIGH_ENTROPY_CANDIDATE = /(\b\w+\s*[:=]\s*)([A-Za-z0-9+/=_-]{32,})/g
+
+/**
+ * Compute Shannon entropy in bits per character. Higher = more random.
+ */
+function shannonEntropy(s: string): number {
+  if (s.length === 0) return 0
+  const counts = new Map<string, number>()
+  for (const ch of s) {
+    counts.set(ch, (counts.get(ch) ?? 0) + 1)
+  }
+  let h = 0
+  for (const c of counts.values()) {
+    const p = c / s.length
+    h -= p * Math.log2(p)
+  }
+  return h
+}
+
+export interface ScrubResult {
+  scrubbed: string
+  redacted: boolean
+}
+
+/**
+ * Scrub secrets from a string. Returns the masked text and a boolean
+ * indicating whether any mask fired.
+ */
+export function scrubSecrets(input: string): ScrubResult {
+  if (!input) {
+    return { scrubbed: input, redacted: false }
+  }
+
+  let out = input
+  let redacted = false
+
+  // 1. PEM blocks — must run before JWT/AWS to avoid mid-block matches.
+  out = out.replace(PEM_BLOCK, () => {
+    redacted = true
+    return REDACTED
+  })
+
+  // 2. JWTs.
+  out = out.replace(JWT, () => {
+    redacted = true
+    return REDACTED
+  })
+
+  // 3. GH PATs.
+  out = out.replace(GH_PAT, () => {
+    redacted = true
+    return REDACTED
+  })
+
+  // 4. OpenAI / sk-prefixed keys.
+  out = out.replace(OPENAI_KEY, () => {
+    redacted = true
+    return REDACTED
+  })
+
+  // 5. AWS access keys.
+  out = out.replace(AWS_ACCESS_KEY, () => {
+    redacted = true
+    return REDACTED
+  })
+
+  // 6. KEY=value style — explicit secret-name match (incl. suffix/prefix
+  //    forms like `webhook_secret`, `api_password`). Preserve the full
+  //    key name and the original separator on the left so audit can see
+  //    what field was masked; only the value becomes [REDACTED].
+  //    Idempotence: skip if the captured value is already the sentinel
+  //    so re-running the scrubber on already-scrubbed output does not
+  //    re-flip the redacted flag (audit double-count protection).
+  out = out.replace(KV_SECRET, (match, key: string, sep: string, value: string) => {
+    const inner = value.startsWith('"') || value.startsWith("'") ? value.slice(1, -1) : value
+    if (inner === REDACTED) {
+      return match
+    }
+    redacted = true
+    return `${key}${sep}${REDACTED}`
+  })
+
+  // 7. Targeted entropy: name=value where value is 32+ char base64-ish
+  //    AND the value's Shannon entropy crosses the threshold. This is
+  //    the narrow rule that does not catch git SHAs / ULIDs / digests
+  //    in standalone form (they don't look like `name = value`).
+  //    Same idempotence guard as KV_SECRET above.
+  out = out.replace(ASSIGN_HIGH_ENTROPY_CANDIDATE, (full, prefix: string, value: string) => {
+    if (value === REDACTED) {
+      return full
+    }
+    if (shannonEntropy(value) > ENTROPY_THRESHOLD) {
+      redacted = true
+      return `${prefix}${REDACTED}`
+    }
+    return full
+  })
+
+  return { scrubbed: out, redacted }
+}

--- a/workers/crane-context/test/scrub.test.ts
+++ b/workers/crane-context/test/scrub.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import { scrubSecrets } from '../src/lib/scrub'
+
+describe('scrubSecrets', () => {
+  describe('positive cases — known leak vectors are masked', () => {
+    it('masks AWS access keys', () => {
+      const input = 'Found in env: AKIAIOSFODNN7EXAMPLE'
+      const r = scrubSecrets(input)
+      expect(r.scrubbed).not.toContain('AKIAIOSFODNN7EXAMPLE')
+      expect(r.scrubbed).toContain('[REDACTED]')
+      expect(r.redacted).toBe(true)
+    })
+
+    it('masks GitHub PATs (ghp_/ghs_)', () => {
+      const ghp = 'token: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const ghs = 'GHS=ghs_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+      const a = scrubSecrets(ghp)
+      const b = scrubSecrets(ghs)
+      expect(a.scrubbed).not.toMatch(/ghp_[a-z]{36}/)
+      expect(b.scrubbed).not.toMatch(/ghs_[a-z]{36}/)
+      expect(a.redacted).toBe(true)
+      expect(b.redacted).toBe(true)
+    })
+
+    it('masks JWTs', () => {
+      const jwt =
+        'header eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c trailer'
+      const r = scrubSecrets(jwt)
+      expect(r.scrubbed).not.toContain('eyJhbGc')
+      expect(r.scrubbed).toContain('header [REDACTED] trailer')
+      expect(r.redacted).toBe(true)
+    })
+
+    it('masks OpenAI sk- keys', () => {
+      const r = scrubSecrets('OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz123456')
+      expect(r.scrubbed).not.toContain('sk-abc')
+      expect(r.redacted).toBe(true)
+    })
+
+    it('masks SSH-shaped PRIVATE KEY blocks', () => {
+      const key = `before
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAt
+-----END OPENSSH PRIVATE KEY-----
+after`
+      const r = scrubSecrets(key)
+      expect(r.scrubbed).not.toContain('BEGIN OPENSSH')
+      expect(r.scrubbed).toContain('before\n[REDACTED]\nafter')
+      expect(r.redacted).toBe(true)
+    })
+
+    it('masks generic KEY=value secret fields', () => {
+      const cases = [
+        'API_KEY=hunter2deadbeefcafe',
+        'PASSWORD: "p4ssw0rd"',
+        "TOKEN='abcdef1234'",
+        'SECRET=somethingverylong',
+      ]
+      for (const c of cases) {
+        const r = scrubSecrets(c)
+        expect(r.redacted).toBe(true)
+        expect(r.scrubbed).toContain('[REDACTED]')
+      }
+    })
+
+    it('masks high-entropy base64 values inside assignment shapes', () => {
+      const r = scrubSecrets('webhook_secret=ZmFrZWJ1dGhpZ2hlbnRyb3B5dmFsdWVoZXJlYWFhYWFhYWFhYQ==')
+      expect(r.redacted).toBe(true)
+      expect(r.scrubbed).toContain('webhook_secret=[REDACTED]')
+    })
+  })
+
+  describe('negative cases — legitimate evidence is NOT mangled', () => {
+    it('does not mask standalone git SHAs', () => {
+      const sha = 'commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'
+      const r = scrubSecrets(sha)
+      expect(r.scrubbed).toBe(sha)
+      expect(r.redacted).toBe(false)
+    })
+
+    it('does not mask ULIDs in flowing text', () => {
+      const ulid = 'session_id=01HQXV3NK8YXM3G5ZXQXQXQXQX returned'
+      const r = scrubSecrets(ulid)
+      // session_id is not in the explicit secret-name set, but the value
+      // is only 26 chars and entropy is hex-only — under threshold, no mask.
+      expect(r.scrubbed).toBe(ulid)
+      expect(r.redacted).toBe(false)
+    })
+
+    it('does not mask container image digests', () => {
+      const digest = 'image sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'
+      const r = scrubSecrets(digest)
+      expect(r.scrubbed).toBe(digest)
+      expect(r.redacted).toBe(false)
+    })
+
+    it('does not mask Cloudflare-style account/database IDs in narrative output', () => {
+      const text = 'Database: crane-context-db (id: 11111111222233334444555566667777)'
+      const r = scrubSecrets(text)
+      // ID is hex only, not in an assignment shape, so entropy gate does not fire.
+      expect(r.scrubbed).toBe(text)
+      expect(r.redacted).toBe(false)
+    })
+
+    it('does not mask normal command output', () => {
+      const out = 'wrangler tail returned 200 OK with no errors at 2026-05-06T18:00:00Z'
+      const r = scrubSecrets(out)
+      expect(r.scrubbed).toBe(out)
+      expect(r.redacted).toBe(false)
+    })
+  })
+
+  describe('idempotence + edge cases', () => {
+    it('returns empty input untouched', () => {
+      const r = scrubSecrets('')
+      expect(r.scrubbed).toBe('')
+      expect(r.redacted).toBe(false)
+    })
+
+    it('is idempotent — scrubbing twice produces same result', () => {
+      const input = 'OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz1234567890'
+      const once = scrubSecrets(input)
+      const twice = scrubSecrets(once.scrubbed)
+      expect(twice.scrubbed).toBe(once.scrubbed)
+      expect(twice.redacted).toBe(false) // already masked, no new mask fired
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Ships **Prong 1** of a three-prong durable cure for the recurring failure mode in MEMORY.md: AI agents skipping cheap verification (live state, fresh process, vendor docs) and shipping inferences that fail many sessions later. PR 1 adds the structured cross-session ledger (`crane_verify`) and origin-lookup (`crane_claim_origin`) that Prong 2 (mechanical gates at PR/EOS time) and Prong 3 (regression auto-attach + audit cadence + memory→gate promotion) build on. PR 1 earns its keep on its own — `crane_sos` now surfaces a one-line "Verifications recorded this session: N" so the substrate is immediately visible from day one.

## Linked issue

None — Captain-directed, Auto Mode session under `/auto-build` with `/critique 1` (Devil's Advocate). The cure was scoped, critiqued, revised, and approved before implementation; the plan file is at `/Users/scottdurgan/.claude/plans/bubbly-popping-cook.md` (local-only, not committed).

## Acceptance criteria status

The plan defined explicit criteria for PR 1; checked here against the diff:

| AC | Status | Evidence |
| --- | --- | --- |
| New MCP tools `crane_verify` + `crane_claim_origin` registered, schemas Zod-validated | met | `packages/crane-mcp/src/tools/verify.ts`; `packages/crane-mcp/src/index.ts:registerTools` |
| Integrity bindings: `tool_used` enum, `command` required for `fresh_process`/`live_state`, `vendor_docs` ≥100 chars, oversize→head_tail | met | `tools/verify.ts:verifyInputSchema` superRefine; mirrored in `endpoints/verify-ledger.ts` validation |
| D1 schema: `verify_ledger` + `verify_files` join, `output_hash` + `command_hash`, `source` enum, indexes | met | `workers/crane-context/migrations/0050_add_verify_ledger.sql` |
| Worker endpoints: `POST /verify`, `GET /verify/origin` (LIMIT 50 cap), `GET /verify/session-count` | met | `workers/crane-context/src/endpoints/verify-ledger.ts`; routes in `src/index.ts` |
| Secret scrubber: regex set + targeted entropy on assignment shapes only (no blanket entropy gate) | met | `workers/crane-context/src/lib/scrub.ts` |
| Scrubber test coverage: 14 cases (positive AWS/PAT/JWT/OpenAI/PEM/KEY=value/suffix-named + negative SHA/ULID/digest/account-id + idempotence + empty) | met | `workers/crane-context/test/scrub.test.ts` (all 14 pass) |
| MCP tool test coverage: Zod refinements + happy path + best-effort error + claim_origin formatter | met | `packages/crane-mcp/src/tools/verify.test.ts` (14 cases, all pass) |
| `docs/global/verify.md` playbook with method decision tree, `tool_used` guidance, `head_tail` convention | met | `docs/global/verify.md` |
| Docs-sync workflow extended for `docs/global/**/*.md` (no side-channel admin upload) | met | `.github/workflows/sync-docs-to-context-worker.yml` + `scripts/upload-doc-to-context-worker.sh` path-prefix rule |
| Reflex doc + always-on primer string updated to point at `crane_verify` | met | `docs/instructions/session-reflexes.md`, `scripts/redirect-reflex-hook.sh` |
| `crane_sos` surfaces session verify count | met | `packages/crane-mcp/src/tools/sos.ts` (best-effort, returns `undefined` if route not deployed yet) |

## Test plan

- [x] `npm run verify` passes (typecheck + format + lint + tests + canary + builds across all packages and workers)
- [x] Scrubber tests cover both positive masking AND negative anti-masking (the over-redaction concern flagged in critique is enforced by the test suite)
- [x] Zod refinements rejected expected bad inputs in tests (no `command` for `fresh_process` → 400; oversize output → 400 with `head_tail` guidance; `vendor_docs` <100 chars → 400)
- [ ] After staging deploy: `wrangler tail` shows POST /verify → 201 on a curl probe; `wrangler d1 execute crane-context-db-staging --command "SELECT count(*) FROM verify_ledger"` increments
- [ ] After merge to main: `Sync Docs to Context Worker` workflow runs; `crane_doc('global', 'verify.md')` returns the playbook in a fresh session

## Security Checklist

- [x] No secrets in code or comments — the only fake secrets are intentional test fixtures in `scrub.test.ts`, suppressed via `.gitleaksignore` with comment-justified fingerprints
- [x] No PII exposed in frontend responses — endpoints record agent-supplied output, scrubbed for known leak vectors before persistence
- [x] Input validation on new endpoints — `buildRequestContext` early-return + body shape + enum + length validation; mirrored in MCP-layer Zod refinements
- [x] Parameterized queries for any SQL — all writes use `.bind()` (D1 prepared statements); no string interpolation
- [x] Auth required on new endpoints — `X-Relay-Key` via existing `validateRelayKey`/`buildRequestContext`
- [x] No internal IDs that enable enumeration — ledger IDs are prefixed ULIDs (`vfy_<26-char-ULID>`), unguessable

## Feature Impact

**Feature impact:** None — purely additive. New MCP tools, new D1 tables, new endpoints, new docs, new test files. Existing endpoints, schemas, and tools untouched. The only edits to existing behavior are: (a) reflex primer string adds the `crane_verify` reference, (b) `crane_sos` adds an additional Session-block row (graceful absence if worker route isn't deployed yet), (c) docs-sync workflow accepts an additional path prefix.

## Deployment Notes

1. **D1 migration required** — `migrations/0050_add_verify_ledger.sql` adds two new tables (`verify_ledger`, `verify_files`). Apply with `npm run db:migrate` (staging) and `npm run db:migrate:prod` (production) **before** the worker code that references them is deployed. The migration is purely additive (CREATE TABLE IF NOT EXISTS); zero-downtime.
2. **Worker deploy after migration** — `cd workers/crane-context && npm run deploy` (staging) then `npm run deploy:prod`.
3. **Sync workflow runs automatically on merge** — `.github/workflows/sync-docs-to-context-worker.yml` uploads `docs/global/verify.md` to prod D1 on push to `main` (path filter extended in this PR). Staging D1 is intentionally empty per the workflow's own comment; `crane_doc('global', 'verify.md')` returns "not found" in staging until manual upload — accepted condition.
4. **No env var or secret changes** — uses existing `CONTEXT_RELAY_KEY` and `CRANE_ADMIN_KEY`.
5. **Rollback** — revert the PR; the new tables remain (harmless). The MCP tool registration disappears with the revert.

## Out of PR 1 (deferred to follow-on PRs)

- **PR 2:** PreToolUse hook on high-blast-radius paths + EOS Layer 4c structured-verification gate + PR template Verification section + cross-venture hook propagation
- **PR 3:** Claim-origin auto-attach on regression issues + weekly verify-audit cadence + memory governance "structural" lifecycle state
- **Method expansion:** `corpus` and `spike` methods will land if PR 2 telemetry shows agents miscategorizing (expansion on signal, not pre-classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)