### PR TITLE
docs(agents): point Codex at CLAUDE.md + coding-standards.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,27 @@ venturecrane/crane-console - shared infrastructure for all Venture Crane venture
 
 ## Automatic Session Start
 
-When you begin a session, immediately call these MCP tools in order before doing anything else:
+When you begin a session, immediately do these in order before any work:
 
-1. Call `crane_preflight` (no arguments) - validates environment
-2. Call `crane_sos` with `venture: "vc"` - initializes session, shows P0 issues, cadence briefing, active sessions
+1. Call `crane_preflight` (no arguments) - validates environment.
+2. Call `crane_sos` with `venture: "vc"` - initializes session, shows P0 issues, cadence briefing, active sessions.
+3. Read `CLAUDE.md` at the repo root - canonical Instruction Modules table (coding standards, guardrails, secrets, tooling, PR workflow, etc.).
+4. Read `docs/instructions/coding-standards.md` before editing any TypeScript or JavaScript.
 
-Do not start any work until both calls succeed. If preflight fails, show the error and stop.
+Do not start any work until preflight + sos succeed and CLAUDE.md is loaded. If preflight fails, show the error and stop.
+
+## Coding Standards
+
+All code edits MUST follow `docs/instructions/coding-standards.md` - the portable Venture Crane coding standard. Key directives that apply on every change:
+
+- Parse external inputs with Zod; never `as` cast at trust boundaries.
+- No floating Promises; explicitly `await` or attach a `.catch`.
+- No module-level state in Cloudflare Workers (per-isolate state leaks across requests).
+- File/function ceilings: 500 lines/file, 75 lines/function, complexity 15, depth 4, params 5.
+- No default exports outside framework-required positions (Astro pages, Next.js App Router files, Workers entry).
+- See `docs/instructions/coding-standards.md` for the full 12 directives with good/bad examples and per-stack notes.
+
+Mechanical enforcement: `npm run lint` runs the rule set defined in `eslint.config.js`. Several ventures (vc-web, ss-console) inline the rule set; the shared package `@venturecrane/eslint-config` is also published. Either path, lint and CI fail on violations.
 
 ## Development Workflow
 
@@ -80,4 +95,4 @@ All 14 tools are available via the `crane` MCP server. Call them directly - do n
 
 ## Reference
 
-See CLAUDE.md for environment variables, QA grades, instruction modules, secrets management, and other reference material.
+CLAUDE.md (loaded at session start per step 3 above) contains the full Instruction Modules table and reference material covering environment variables, QA grades, secrets management, git authority, and per-domain runbooks. Fetch any module on demand via `crane_doc('global', '<module>')`.


### PR DESCRIPTION
## Summary

AGENTS.md (Codex CLI's instruction file at the repo root) had no reference to the portable coding standard published by PR #864. Codex does not auto-load `CLAUDE.md` the way Claude Code does, so the standards table that PR #864 added to CLAUDE.md was effectively invisible to Codex sessions on this repo.

This PR closes that gap on `crane-console`.

## Changes

- **Session-start now requires loading the standard.** `Automatic Session Start` adds two new steps: read `CLAUDE.md` (canonical Instruction Modules table) and read `docs/instructions/coding-standards.md` before editing TypeScript or JavaScript.
- **New "Coding Standards" top-level section.** Names the standard, lists the five directives that bite hardest in agent code (Zod parsing, no floating Promises, no Workers module-level state, structural caps, no default exports), and explains the lint enforcement path so Codex knows that `npm run lint` and CI will catch violations.
- **Reference paragraph reframed.** The closing pointer to CLAUDE.md is now consistent with the new session-start flow rather than dangling.

## Why this matters

Codex sessions on `crane-console` will now consult the standard before editing code, and the same enforcement path that catches Claude Code (lint + CI) will catch Codex.

## Scope

This PR only touches `crane-console/AGENTS.md`. The venture repos are a separate problem:

| Repo | AGENTS.md | Standard in lint |
| --- | --- | --- |
| crane-console | this PR fixes it | NO (own >500 LOC files, deliberately not flipped per PR #864) |
| vc-web | missing | YES (inlined) |
| ss-console | missing | YES (inlined) |
| sc-console | missing | NO |
| dc-console | missing | NO |
| ke-console | missing | NO |
| dfg-console | exists (DFG-specific) | NO |

vc-web and ss-console get backstopped by lint today. The other four ventures need both an AGENTS.md and a lint adoption. That work is tracked separately as part of the per-venture adoption initiative.

## Test plan

- [x] `npx prettier --check AGENTS.md` passes
- [ ] CI green
- [ ] Manual: open the rendered AGENTS.md on GitHub and confirm the new sections render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)