### PR TITLE
fix(bootstrap): set canonical git identity on every fleet machine

### DIFF
--- a/scripts/bootstrap-machine.sh
+++ b/scripts/bootstrap-machine.sh
@@ -311,6 +311,33 @@ fi
 
 PUBKEY=$(cat "${SSH_KEY}.pub")
 
+# ─── Step 5b: Configure Git Identity ──────────────────────────────
+#
+# Without a configured global git identity, fresh clones (e.g. agent
+# /tmp clones during cross-repo PR work) commit with the auto-detected
+# "<user>@<hostname>" placeholder, leaking machine hostnames into the
+# git history. Setting this on every fleet machine ensures all commits
+# land with the canonical Captain identity.
+#
+# Override via GIT_USER_NAME / GIT_USER_EMAIL environment variables when
+# bootstrapping a non-Captain machine.
+
+GIT_USER_NAME_DEFAULT="SMDurgan"
+GIT_USER_EMAIL_DEFAULT="smdurgan@smdurgan.com"
+GIT_USER_NAME="${GIT_USER_NAME:-$GIT_USER_NAME_DEFAULT}"
+GIT_USER_EMAIL="${GIT_USER_EMAIL:-$GIT_USER_EMAIL_DEFAULT}"
+
+CURRENT_NAME=$(git config --global user.name 2>/dev/null || true)
+CURRENT_EMAIL=$(git config --global user.email 2>/dev/null || true)
+
+if [ "$CURRENT_NAME" = "$GIT_USER_NAME" ] && [ "$CURRENT_EMAIL" = "$GIT_USER_EMAIL" ]; then
+    log_ok "Git identity already configured: $CURRENT_NAME <$CURRENT_EMAIL>"
+else
+    git config --global user.name "$GIT_USER_NAME"
+    git config --global user.email "$GIT_USER_EMAIL"
+    log_ok "Git identity configured: $GIT_USER_NAME <$GIT_USER_EMAIL>"
+fi
+
 # ─── Step 6: Machine Alias ────────────────────────────────────────
 
 DEFAULT_HOSTNAME=$(hostname | tr '[:upper:]' '[:lower:]' | sed 's/\.local$//')

--- a/scripts/bootstrap-machine.sh
+++ b/scripts/bootstrap-machine.sh
@@ -168,13 +168,19 @@ if [ "$OS" = "darwin" ]; then
     # Installs to ~/.claude/plugins/. Idempotent: reinstalls no-op if already present.
     if command -v claude &>/dev/null; then
         log_info "Configuring Claude Code plugin marketplace..."
-        claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null \
-            && log_ok "  marketplace: anthropics/claude-plugins-official" \
-            || log_ok "  marketplace: already configured"
+        if claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null; then
+            log_ok "  marketplace: anthropics/claude-plugins-official"
+        else
+            log_ok "  marketplace: already configured"
+        fi
 
         log_info "Installing Claude Code plugins (enterprise set)..."
         for plugin in context7 typescript-lsp vercel playwright frontend-design; do
-            claude plugin install "$plugin" 2>/dev/null && log_ok "  $plugin" || log_warn "  $plugin (install failed - check manually)"
+            if claude plugin install "$plugin" 2>/dev/null; then
+                log_ok "  $plugin"
+            else
+                log_warn "  $plugin (install failed - check manually)"
+            fi
         done
     else
         log_warn "Skipping plugin install (claude CLI not on PATH)"
@@ -206,17 +212,24 @@ elif [ "$OS" = "linux" ]; then
         log_ok "Node.js $(node -v) already installed"
     fi
 
-    # GitHub CLI
+    # GitHub CLI — install per https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+    # set -e at top of script handles error propagation; explicit linear flow lets
+    # the linter reason about each command independently.
     if ! command -v gh &>/dev/null; then
         log_info "Installing GitHub CLI..."
-        (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-          && sudo mkdir -p -m 755 /etc/apt/keyrings \
-          && out=$(mktemp) && wget -nv -O"$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-          && cat "$out" | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-          && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-          && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-          && sudo apt update \
-          && sudo apt install gh -y
+        if ! type -p wget >/dev/null; then
+            sudo apt update
+            sudo apt-get install -y wget
+        fi
+        sudo mkdir -p -m 755 /etc/apt/keyrings
+        out=$(mktemp)
+        wget -nv -O "$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        sudo install -m 644 "$out" /etc/apt/keyrings/githubcli-archive-keyring.gpg
+        rm -f "$out"
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt update
+        sudo apt install -y gh
     else
         log_ok "GitHub CLI already installed"
     fi
@@ -242,13 +255,19 @@ elif [ "$OS" = "linux" ]; then
     # Installs to ~/.claude/plugins/. Idempotent: reinstalls no-op if already present.
     if command -v claude &>/dev/null; then
         log_info "Configuring Claude Code plugin marketplace..."
-        claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null \
-            && log_ok "  marketplace: anthropics/claude-plugins-official" \
-            || log_ok "  marketplace: already configured"
+        if claude plugin marketplace add anthropics/claude-plugins-official 2>/dev/null; then
+            log_ok "  marketplace: anthropics/claude-plugins-official"
+        else
+            log_ok "  marketplace: already configured"
+        fi
 
         log_info "Installing Claude Code plugins (enterprise set)..."
         for plugin in context7 typescript-lsp vercel playwright frontend-design; do
-            claude plugin install "$plugin" 2>/dev/null && log_ok "  $plugin" || log_warn "  $plugin (install failed - check manually)"
+            if claude plugin install "$plugin" 2>/dev/null; then
+                log_ok "  $plugin"
+            else
+                log_warn "  $plugin (install failed - check manually)"
+            fi
         done
     else
         log_warn "Skipping plugin install (claude CLI not on PATH)"
@@ -277,6 +296,7 @@ if [ -d "$NPM_BIN" ]; then
     if ! echo "$PATH" | grep -q "$NPM_BIN"; then
         export PATH="$NPM_BIN:$PATH"
         if [ -n "$SHELL_PROFILE" ] && ! grep -q ".npm-global/bin" "$SHELL_PROFILE" 2>/dev/null; then
+            # shellcheck disable=SC2016 # deliberate: $HOME/$PATH must expand at sourcing time, not write time
             echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$SHELL_PROFILE"
             log_ok "Added ~/.npm-global/bin to $SHELL_PROFILE"
         fi
@@ -292,6 +312,7 @@ if [ -d "$LOCAL_BIN" ]; then
         export PATH="$LOCAL_BIN:$PATH"
     fi
     if [ -n "$SHELL_PROFILE" ] && ! grep -q ".local/bin" "$SHELL_PROFILE" 2>/dev/null; then
+        # shellcheck disable=SC2016 # deliberate: $HOME/$PATH must expand at sourcing time, not write time
         echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$SHELL_PROFILE"
         log_ok "Added ~/.local/bin to $SHELL_PROFILE"
     fi


### PR DESCRIPTION
## Summary

Without a configured global git identity, fresh clones (notably the `/tmp` clones parallel agents use during cross-repo PR rollouts) commit with the auto-detected `<user>@<hostname>` placeholder. This session's 6 venture AGENTS.md PRs landed with author email `scottdurgan@m16.local` because m16 had no global git identity set, leaking the machine hostname into git history.

## Changes

Adds Step 5b to `bootstrap-machine.sh` between SSH key generation and machine alias selection:

- Sets `user.name` and `user.email` globally on the bootstrapped machine.
- Defaults to the canonical Captain identity (`SMDurgan <smdurgan@smdurgan.com>` — verified against recent author identities on every venturecrane repo via `gh api .../commits`).
- Overridable via `GIT_USER_NAME` / `GIT_USER_EMAIL` environment variables for non-Captain machines.
- Idempotent: re-running on a configured machine is a no-op + `log_ok`.

Also cleans up 7 pre-existing shellcheck violations in `bootstrap-machine.sh` that the fleet-artifact shellcheck probe surfaced once any fleet artifact was touched: 4× SC2015 (A&&B||C ambiguity in plugin install loops), 1× SC2002 (useless cat in GH CLI keyring install — restructured the entire 8-line `&&` chain to explicit linear flow with `sudo install`), 2× SC2016 (deliberate single-quote PATH exports — added `# shellcheck disable=SC2016` with explanatory comment).

## Linked issue

None — discovered during the parallel-agent venture PR rollout this session (vc-web#134, ss-console#742, sc-console#131, dc-console#542, ke-console#249, dfg-console#333).

## Test plan

- [x] Diff scoped to a single new step + shellcheck cleanup; no behavioral changes to existing steps beyond restructuring the GH CLI install for shellcheck compliance.
- [x] `shellcheck -e SC1090,SC1091,SC2155,SC2181 scripts/bootstrap-machine.sh` exits 0.
- [x] `bash -n scripts/bootstrap-machine.sh` passes.
- [x] Manually applied the same `git config --global` settings to m16 in this session before opening this PR.
- [ ] CI green
- [ ] Fleet rollout: re-run `bootstrap-machine.sh` on remaining fleet machines (mac23, mini, mbp27, think) — idempotent.

## Verifications

- `vfy_01KR1YXSRNN9ZSD2NPTESDAR1C` · fresh_process · shellcheck (CI flags) exits 0 on bootstrap-machine.sh after PR #885 cleanup
- `vfy_01KR1YY35F2QTEFRW97XG2T2ZR` · live_state · Canonical author identity verified on origin/main of all 7 venturecrane repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)