### PR TITLE
chore(skills): remove enhance-prompt and react-components from owners

### DIFF
--- a/.agents/skills/nav-spec/README.md
+++ b/.agents/skills/nav-spec/README.md
@@ -42,7 +42,6 @@ Ventures generating design artifacts (via `product-design` or hand-authored code
 
 - **product-design** reads `.design/NAVIGATION.md`, requires 5 classification tags (`surface`, `archetype`, `viewport`, `task`, `pattern`), injects essential + extended NAV CONTRACT block, runs `validate.py` post-generation. Graceful-degradation when spec absent.
 - **ux-brief** reads spec in Phase 1; injects NAV CONTRACT in Phase 7 concept prompts; generates REMOVE/PRESERVE lists from anti-patterns in Phase 11.
-- **react-components** (future) reads the chrome contracts to produce aligned Astro components.
 
 ## Key files
 

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -37,8 +37,6 @@
     "design-brief",
     "ux-brief",
     "product-design",
-    "react-components",
-    "enhance-prompt",
     "ui-drift-audit",
     "analytics",
     "auth-setup",

--- a/docs/instructions/claude-design.md
+++ b/docs/instructions/claude-design.md
@@ -21,7 +21,7 @@ Claude Design is an Anthropic Labs product (launched 2026-04-17, powered by Clau
 | Brand-new venture, no design system yet                          | `/design-brief` → produce `design-spec.md` first                |
 | Generating production-aligned screens for an established venture | **Claude Design** (picks up the onboarded system automatically) |
 | Token refresh or spec-only changes                               | Edit `docs/ventures/{code}/design-spec.md` directly             |
-| Implementing a design into code                                  | `/product-design` → `/react-components` → PR                    |
+| Implementing a design into code                                  | `/product-design` → manual implementation → PR                  |
 | Sharing a static mockup in-browser quickly                       | **Claude Design** (export to PPTX/PDF/Canva)                    |
 
 Claude Design **supplements** `/design-brief` and `/product-design`; it does not replace them. The charter and spec remain the source of truth for tokens.

--- a/docs/instructions/design-system.md
+++ b/docs/instructions/design-system.md
@@ -131,7 +131,7 @@ design-spec.md (canonical, in crane-console)
 .design/designs/ (generated screens, in venture repo)
     |
     v
-Implementation (via /react-components or manual coding)
+Implementation (manual coding against the design spec)
 ```
 
 ## Versioning


### PR DESCRIPTION
## Summary

Both skills were declared in `config/skill-owners.json` under `agent-team` but had no `SKILL.md` in this repo, no dispatcher, no `crane_skill_invoked` directive, and zero invocations in the last 90 days. Source files live only at `~/.agents/skills/` from an external Stitch import that bypassed the standard mirror flow (`config/global-skills.json` does not list them).

The 2026-04-12 platform audit already flagged `enhance-prompt` as a phantom skill (see `docs/reviews/2026-04-12-platform-audit.md:84`). The `/skill-audit` run today resurfaced both as schema gaps with `status: unknown`.

Removing from governance rather than promoting — they have no demonstrated maintenance investment, and `nav-spec/README.md` already marked `react-components` as `(future)`.

## Changes

- `config/skill-owners.json` — drop `enhance-prompt` and `react-components` from `agent-team`
- `docs/instructions/design-system.md` — replace `/react-components` reference with manual coding
- `docs/instructions/claude-design.md` — same in the implementation-path table
- `.agents/skills/nav-spec/README.md` — drop the `(future)` `react-components` line

## Test plan

- [x] `npm run skill-review -- --all` — 0 errors (warnings/info pre-existing)
- [x] `npx prettier --check` on edited files — clean
- [x] No SKILL.md edited; no dispatcher orphaned (neither skill had one)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)