### PR TITLE
docs(anthropic-partnership): link CCA-Foundations curriculum to crane-foundations companion repo

### DIFF
--- a/docs/anthropic-partnership/README.md
+++ b/docs/anthropic-partnership/README.md
@@ -50,6 +50,8 @@ This framing is an asset, not a liability. Anthropic's own Dario made the predic
 | `gap-ledger.md`      | Gap analysis between current state and published CPN requirements. What's needed, what's already done. Produced by parallel agent.                             |
 | `session-notes.md`   | Running log of CPN-related session activity, Karl broadcasts, and decision points. Update after each relevant session.                                         |
 
+**Hands-on companion repo:** [`venturecrane/crane-foundations`](https://github.com/venturecrane/crane-foundations) — Python + JupyterLab environment for working through Anthropic's official course notebooks ([`anthropics/courses`](https://github.com/anthropics/courses)). Doc-based study (`curriculum.md`) handles concept coverage and exam-question framing; `crane-foundations` handles hands-on coding and reference implementations for `smd.services` engagements.
+
 ---
 
 ## Next Step

--- a/docs/anthropic-partnership/curriculum.md
+++ b/docs/anthropic-partnership/curriculum.md
@@ -21,6 +21,10 @@ Four phases across 30 days. Weekdays only for scheduled sessions (flex weekends 
 
 ---
 
+## Hands-On Companion
+
+This curriculum is doc-based: read Anthropic docs, oral recall, exam-style questions. Hands-on coding lives in [`venturecrane/crane-foundations`](https://github.com/venturecrane/crane-foundations) — a `uv` + JupyterLab project that wraps Anthropic's official course notebooks ([`anthropics/courses`](https://github.com/anthropics/courses)). Use the notebooks alongside the doc reading on any day where coding the concept will accelerate retention (Days 1, 3, 4, 5, 7 are obvious candidates).
+
 ## Working Assumptions
 
 - **Session length:** 45-60 min per weekday session.


### PR DESCRIPTION
## Summary

- Adds a cross-link from `docs/anthropic-partnership/README.md` to the new [`venturecrane/crane-foundations`](https://github.com/venturecrane/crane-foundations) repo as the hands-on companion to the doc-based study plan
- Adds a "Hands-On Companion" section near the top of `curriculum.md` so the link is discoverable from the daily-use document, not just the directory README

## Context

The Captain is preparing for the Claude Certified Architect Foundations exam (sit window May 20-22). The existing curriculum.md is doc-based - read Anthropic docs, oral recall, exam-style questions. Anthropic also ships [official course Jupyter notebooks](https://github.com/anthropics/courses) that need a Python environment to run.

Rather than embed Python toolchain inside this TS-heavy repo, we created a sibling repo `venturecrane/crane-foundations` with `uv` + JupyterLab. This PR just wires the two together.

## Test plan

- [x] Both updated docs render correctly on GitHub
- [x] Links resolve to the new repo (it exists, was created in this session)
- [ ] No code changes - no CI/test impact beyond docs lint

QA grade: A (docs-only, low-risk cross-link)