### PR TITLE
fix(crane-context): use json_each for session-id IN clauses

### DIFF
--- a/workers/crane-context/src/endpoints/queries/session-history.ts
+++ b/workers/crane-context/src/endpoints/queries/session-history.ts
@@ -185,7 +185,7 @@ async function fetchActivityBySessionId(
     .prepare(
       `SELECT session_id, minute_bucket
        FROM session_activity
-       WHERE session_id IN (SELECT value FROM json_each(?1))
+       WHERE session_id IN (SELECT value FROM json_each(?))
        ORDER BY session_id, minute_bucket ASC`
     )
     .bind(JSON.stringify(sessionIds))
@@ -314,7 +314,7 @@ export async function handleGetSessionHistory(request: Request, env: Env): Promi
        FROM sessions
        WHERE status = 'ended'
          AND ended_at IS NOT NULL
-         AND created_at >= ?1
+         AND created_at >= ?
        ORDER BY created_at ASC`
     )
       .bind(cutoff)

--- a/workers/crane-context/src/endpoints/queries/session-history.ts
+++ b/workers/crane-context/src/endpoints/queries/session-history.ts
@@ -177,15 +177,18 @@ async function fetchActivityBySessionId(
   if (rows.length === 0) return activityBySessionId
 
   const sessionIds = rows.map((r) => r.id)
-  const placeholders = sessionIds.map(() => '?').join(',')
+  // D1 caps a single statement at 100 bound parameters, so the session-id
+  // list is passed as a JSON array and expanded via json_each() instead of
+  // a parameterized IN list. Without this, windows that touch >100 ended
+  // sessions return HTTP 500 ("too many SQL variables").
   const actResult = await db
     .prepare(
       `SELECT session_id, minute_bucket
        FROM session_activity
-       WHERE session_id IN (${placeholders})
+       WHERE session_id IN (SELECT value FROM json_each(?1))
        ORDER BY session_id, minute_bucket ASC`
     )
-    .bind(...sessionIds)
+    .bind(JSON.stringify(sessionIds))
     .all<{ session_id: string; minute_bucket: string }>()
 
   for (const a of actResult.results || []) {

--- a/workers/crane-context/src/sessions-crud.ts
+++ b/workers/crane-context/src/sessions-crud.ts
@@ -253,9 +253,9 @@ export async function markSessionsSuperseded(db: D1Database, sessionIds: string[
     .prepare(
       `UPDATE sessions
        SET status = 'ended',
-           ended_at = ?1,
+           ended_at = ?,
            end_reason = 'superseded'
-       WHERE id IN (SELECT value FROM json_each(?2))`
+       WHERE id IN (SELECT value FROM json_each(?))`
     )
     .bind(now, JSON.stringify(sessionIds))
     .run()

--- a/workers/crane-context/src/sessions-crud.ts
+++ b/workers/crane-context/src/sessions-crud.ts
@@ -245,19 +245,19 @@ export async function markSessionsSuperseded(db: D1Database, sessionIds: string[
   if (sessionIds.length === 0) return
 
   const now = nowIso()
-  const placeholders = sessionIds.map(() => '?').join(',')
 
-  const query = `
-    UPDATE sessions
-    SET status = 'ended',
-        ended_at = ?,
-        end_reason = 'superseded'
-    WHERE id IN (${placeholders})
-  `
-
+  // D1 caps a single statement at 100 bound parameters; expand the id list
+  // via json_each() so this stays safe regardless of how many duplicates
+  // /sos found for the tuple.
   await db
-    .prepare(query)
-    .bind(now, ...sessionIds)
+    .prepare(
+      `UPDATE sessions
+       SET status = 'ended',
+           ended_at = ?1,
+           end_reason = 'superseded'
+       WHERE id IN (SELECT value FROM json_each(?2))`
+    )
+    .bind(now, JSON.stringify(sessionIds))
     .run()
 }
 

--- a/workers/crane-context/test/harness/session-history.test.ts
+++ b/workers/crane-context/test/harness/session-history.test.ts
@@ -1,0 +1,114 @@
+/**
+ * GET /sessions/history regression — D1 bound-parameter limit.
+ *
+ * Cloudflare D1 caps a single statement at 100 bound parameters. The
+ * handler used to fetch session_activity rows with `id IN (?,?,?,...)`,
+ * binding one parameter per ended session in the window. Once >100 ended
+ * sessions fell inside the window, D1 returned an internal error and the
+ * endpoint responded 500 ("API error: 500" surfaced through crane-mcp).
+ *
+ * This test seeds 150 ended sessions inside the window and asserts the
+ * endpoint returns 200 with all sessions accounted for. The fix routes
+ * the id list through json_each(?1), collapsing the N-param IN list into
+ * a single JSON-array bind.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createTestD1,
+  runMigrations,
+  discoverNumericMigrations,
+  invoke,
+  installWorkerdPolyfills,
+} from '@venturecrane/crane-test-harness'
+import worker from '../../src/index'
+import type { Env } from '../../src/types'
+import type { D1Database } from '@cloudflare/workers-types'
+
+beforeAll(() => {
+  installWorkerdPolyfills()
+})
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsDir = join(__dirname, '..', '..', 'migrations')
+
+interface SessionHistoryResponse {
+  entries: Array<{
+    venture: string
+    work_date: string
+    blocks: Array<{ start: string; end: string; session_count: number }>
+    total_sessions: number
+  }>
+  count: number
+}
+
+describe('GET /sessions/history — D1 bound-parameter limit (via harness)', () => {
+  let db: D1Database
+  let env: Env
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    env = {
+      DB: db,
+      CONTEXT_RELAY_KEY: 'test-relay-key',
+      CONTEXT_ADMIN_KEY: 'test-admin-key',
+      CONTEXT_SESSION_STALE_MINUTES: '45',
+      IDEMPOTENCY_TTL_SECONDS: '3600',
+      HEARTBEAT_INTERVAL_SECONDS: '600',
+      HEARTBEAT_JITTER_SECONDS: '120',
+    }
+  })
+
+  it('returns 200 when the window contains >100 ended sessions', async () => {
+    const auth = { 'X-Relay-Key': 'test-relay-key' }
+
+    // Seed 150 ended sessions inside a 7-day window. We insert directly
+    // rather than POST /sos + /eos because we only care about the SELECT
+    // path here — not the full lifecycle.
+    const SESSION_COUNT = 150
+    const baseTime = Date.now() - 3 * 86400000 // 3 days ago
+    const stmts = []
+    for (let i = 0; i < SESSION_COUNT; i++) {
+      const created = new Date(baseTime + i * 60_000).toISOString()
+      const ended = new Date(baseTime + i * 60_000 + 5 * 60_000).toISOString()
+      stmts.push(
+        db
+          .prepare(
+            `INSERT INTO sessions
+             (id, agent, venture, repo, status, created_at, started_at, last_heartbeat_at,
+              ended_at, end_reason, actor_key_id, creation_correlation_id)
+             VALUES (?, 'cc-cli-host', 'vc', 'venturecrane/crane-console', 'ended',
+                     ?, ?, ?, ?, 'manual', 'test_actor_key_id', 'corr_test_regression')`
+          )
+          .bind(`sess_test_${i.toString().padStart(4, '0')}`, created, created, ended, ended)
+      )
+    }
+    await db.batch(stmts)
+
+    // Sanity: the seed landed.
+    const seedCount = await db
+      .prepare("SELECT COUNT(*) as c FROM sessions WHERE status = 'ended'")
+      .first<{ c: number }>()
+    expect(seedCount?.c).toBe(SESSION_COUNT)
+
+    // The pre-fix endpoint would 500 here once it hit the IN clause.
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: '/sessions/history?days=7',
+      headers: auth,
+      env,
+    })
+    expect(res.status).toBe(200)
+
+    const body = (await res.json()) as SessionHistoryResponse
+    // All seeded sessions share venture=vc, so they collapse into 1+ venture-day
+    // groups depending on how the timestamps fall across the Arizona-time
+    // workday boundary. The sum of total_sessions across all groups must
+    // equal the number we inserted.
+    const summed = body.entries.reduce((acc, e) => acc + e.total_sessions, 0)
+    expect(summed).toBe(SESSION_COUNT)
+  })
+})


### PR DESCRIPTION
## Summary

D1 caps a single statement at 100 bound parameters. The session-history handler and `markSessionsSuperseded` both spread one parameter per session id into the IN clause, which 500'd once the list exceeded the limit. The bug surfaced today running `crane_schedule(action: "session-history", days: 30)` and `days: 60` (both returned `API error: 500`), while `days: 7` and `days: 14` worked because they touched fewer than 100 ended sessions.

- Replaces the parameterized IN list with `IN (SELECT value FROM json_each(?1))` and a single JSON-array bind at both call sites (`workers/crane-context/src/endpoints/queries/session-history.ts:179` and `workers/crane-context/src/sessions-crud.ts:244`)
- Adds a harness regression that seeds 150 ended sessions and asserts `GET /sessions/history?days=7` returns 200 with all sessions accounted for

The pattern is Cloudflare's documented workaround for the 100-bound-param limit (D1 docs).

## Test plan

- [x] `npm run --prefix workers/crane-context test` — 560 passed (incl. new test)
- [x] `npm run verify` — green (typecheck, format, lint, tests, canary, builds)
- [ ] After deploy: confirm `crane_schedule(action: "session-history", days: 30)` returns 200 instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)