### PR TITLE
chore(crane-mcp): bump to 0.4.0 for fleet rollout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7817,7 +7817,7 @@
     },
     "packages/crane-mcp": {
       "name": "@venturecrane/crane-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/crane-mcp/package-lock.json
+++ b/packages/crane-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@venturecrane/crane-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@venturecrane/crane-mcp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/crane-mcp/package.json
+++ b/packages/crane-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@venturecrane/crane-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for Venture Crane development workflow",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bumps `@venturecrane/crane-mcp` from 0.3.0 → 0.4.0 to ship the work merged in PR #952 (`crane_secret_check` MCP tool + governance) and PR #956 (launcher auto-provisioning of the secret-leak hooks + wrapper) to fleet machines.

Currently the registry has 0.3.0; everything since (including both feature PRs) sits unpublished on main. Fleet machines update via `npm update -g @venturecrane/crane-mcp` after this tag publishes.

## Rollout

1. Merge this PR.
2. Tag `crane-mcp-v0.4.0` on main and push — triggers `publish-crane-mcp.yml`.
3. Fleet machines pick up the new launcher (which auto-installs the hooks + wrapper) on next `npm update -g` followed by next venture launch.

## Verify ledger

- vfy_01KSKQJ8EE8227C16KZ482EWNX (PR #956 hook+detector+tool tests pass; npm run verify green)
