### PR TITLE
fix(secret-leak-detector): suppress macOS notifications during tests

### DIFF
--- a/scripts/secret-leak-detector.sh
+++ b/scripts/secret-leak-detector.sh
@@ -103,8 +103,11 @@ emit_alert() {
       first_chars: $first
     }' >>"$ALERT_LOG"
 
-  # Best-effort macOS desktop notification.
-  if command -v osascript >/dev/null 2>&1; then
+  # Best-effort macOS desktop notification. Gated on
+  # SECRET_LEAK_DETECTOR_NOTIFY — defaults to 1 (notify) so production
+  # hook invocations alarm Captain. Test harness sets this to 0 to
+  # avoid spamming the macOS notification center on every test run.
+  if [ "${SECRET_LEAK_DETECTOR_NOTIFY:-1}" != "0" ] && command -v osascript >/dev/null 2>&1; then
     osascript -e "display notification \"Secret-shaped value (${pattern_name}: ${first_chars}…) in ${TOOL} output. See ${ALERT_LOG}.\" with title \"⚠ Secret leak detected\"" 2>/dev/null || true
   fi
 }

--- a/scripts/secret-leak-detector.test.sh
+++ b/scripts/secret-leak-detector.test.sh
@@ -17,6 +17,13 @@ PASS=0
 FAIL=0
 FAILED_CASES=()
 
+# Suppress macOS notifications during testing — every test fixture would
+# otherwise fire a real desktop notification on the developer's machine,
+# spamming the notification center with synthetic-token alerts that point
+# at the test's tmp dir. Production invocations of the hook still notify
+# (default is on); only this test harness opts out.
+export SECRET_LEAK_DETECTOR_NOTIFY=0
+
 # Use a per-test log file via env override (the hook hardcodes the path, so
 # we redirect by symlink in a tmp dir for testing).
 TMPDIR_TEST=$(mktemp -d)


### PR DESCRIPTION
## Summary

The 8 macOS desktop notifications Captain saw labeled "Secret leak detected" weren't real leaks — they were synthetic test fixtures from `scripts/secret-leak-detector.test.sh` firing real `osascript` notifications on every test run. The paths in those notifications (`/var/folders/jy/.../tmp.XXXXXX/.claude/secret-leak-alerts...`) are `mktemp -d` outputs from the test harness, not the canonical `~/.claude/secret-leak-alerts.jsonl` (which doesn't exist on Captain's machine — zero real leaks have ever been detected).

Root cause: the test harness redirects `HOME=$TMPDIR_TEST` to isolate the JSONL log writes, but `osascript -e 'display notification …'` doesn't honor `$HOME` — it talks to the macOS notification daemon directly and fires regardless.

## Fix

`scripts/secret-leak-detector.sh`: gate the `osascript` call on `SECRET_LEAK_DETECTOR_NOTIFY` (default `1`, notify). Production hook invocations still alarm Captain as designed.

`scripts/secret-leak-detector.test.sh`: export `SECRET_LEAK_DETECTOR_NOTIFY=0` at the top so the test harness goes silent.

## Verify

- [x] `bash ~/.claude/hooks/secret-leak-detector.test.sh` — 13/13 green, zero notifications fired
- [x] `npm run verify` passes
- [ ] Fleet redeploy via `scripts/deploy-crane-mcp.sh` after merge (so future test runs on fleet machines also stay silent)
