### PR TITLE
feat(crane-mcp-remote): venture binding so claude.ai projects auto-scope reliably

### DIFF
--- a/docs/infra/token-registry.md
+++ b/docs/infra/token-registry.md
@@ -65,7 +65,7 @@ The claude.ai surface does **not** use the shared PAT above.
 - OAuth storage: `OAUTH_KV` in `workers/crane-mcp-remote/wrangler.toml`
 - Allowlist gate: `ALLOWED_GITHUB_USERS = "SMDurgan"`
 
-The repo documents the app as `venturecrane-github` (ID `2619905`). Captain still needs to confirm where that app is registered in GitHub settings and record the answer here on the next pass.
+The repo documents the app as `venturecrane-github` (ID `2619905`). The OAuth flow lives in the worker at `/authorize` → GitHub → `/callback` (per `src/github-handler.ts:21,50`); GitHub redirects back to whatever URL the worker presents as `redirect_uri` (computed as `new URL('/callback', c.req.url).href`, line 37). Because the worker exposes per-venture MCP endpoints under `/mcp/{vc,ss,ke,dfg,dc}` plus the legacy `/mcp`, the callback URL itself is path-agnostic — it always lands on `/callback`. **Captain still needs to record the literal "Authorization callback URL" string from the GitHub OAuth App settings page here**, and confirm whether that field accepts multiple URLs (for staging + prod) or a single fixed value. See `docs/runbooks/claude-ai-project-setup.md` Phase 0b for the verification procedure.
 
 ## Known Hazards
 

--- a/docs/runbooks/claude-ai-project-setup.md
+++ b/docs/runbooks/claude-ai-project-setup.md
@@ -1,0 +1,155 @@
+# Claude.ai Project Setup (venture-bound MCP)
+
+**Audience:** Captain.
+**Outcome:** Each of the 5 claude.ai venture projects (web + iOS) reliably loads venture context and GitHub access on every conversation — no manual scoping, no confabulation about "no such product" or "token dead."
+**Time to apply:** ~10 minutes per project after Phase 0 routing is confirmed.
+
+## Why this exists
+
+`crane-mcp-remote` exposes 23 tools (14 `github_*`, 9 `crane_*` + `crane_context` + `crane_health`) over OAuth-secured MCP. Before the venture-binding work, all tools were venture-agnostic — every claude.ai project was indistinguishable to the worker, and agents had to guess venture/repo per call. They guessed wrong constantly. This runbook configures each project so the worker auto-scopes everything.
+
+See `plans/nested-wobbling-matsumoto.md` (kept) for the full architecture. PR: feat(crane-mcp-remote): venture binding via per-venture MCP endpoints.
+
+---
+
+## Phase 0 — Routing strategy (do once, before any project setup)
+
+The worker supports per-venture URL paths (`/mcp/{venture-code}`). Two unknowns must be confirmed before deciding whether to use path-routing or subdomain-routing:
+
+### 0a. claude.ai connector UI
+
+1. claude.ai → Settings → Connectors → "Add custom connector"
+2. URL: `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/_test`
+3. Save. Reopen. Confirm the URL is stored with the `/mcp/_test` suffix intact.
+
+**If path preserved → continue.**
+**If path stripped → switch to subdomain routing** (file follow-up issue to add `crane-mcp-{venture}.automation-ab6.workers.dev` routes to `wrangler.toml`; the worker code already supports both forms).
+
+### 0b. GitHub OAuth App callback
+
+1. https://github.com/settings/applications → find `venturecrane-github` (App ID `2619905`).
+2. Note the "Authorization callback URL" (this is the URL GitHub redirects to after user grants access — the worker's `/callback` endpoint).
+3. Confirm whether it accepts:
+   - Multiple callbacks listed, or
+   - A single fixed URL, or
+   - A prefix that covers all `/mcp/*` paths.
+
+**If single fixed URL covering the worker's `/callback` (path-agnostic) → path routing works.**
+**If multiple URLs allowed → add one per venture if needed for staging tests.**
+
+Record the callback URL string in `docs/infra/token-registry.md` to close the open gap at line 68.
+
+### 0c. Live OAuth probe
+
+Run `wrangler tail` on staging (`cd workers/crane-mcp-remote && npx wrangler tail --format pretty`). Walk the OAuth flow with the test connector from 0a. Confirm:
+
+- The MCP transport hits `/mcp/_test` on the worker.
+- The OAuth callback resolves on `/callback` (no path collision).
+- The session establishes; `crane_context` (called from claude.ai) returns "no venture binding" (because `_test` isn't a real code — expected 404 actually; that's the validation working).
+
+After 0a/0b/0c pass, retire the `_test` connector and proceed with the 5 real venture projects.
+
+---
+
+## Project setup (per venture)
+
+| Venture code | claude.ai project name suggestion | MCP connector URL                                             | GitHub default repo          |
+| ------------ | --------------------------------- | ------------------------------------------------------------- | ---------------------------- |
+| `vc`         | Venture Crane                     | `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/vc`  | `venturecrane/crane-console` |
+| `ss`         | SMD Services                      | `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/ss`  | `venturecrane/ss-console`    |
+| `ke`         | Kid Expenses                      | `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/ke`  | `venturecrane/ke-console`    |
+| `dfg`        | Durgan Field Guide                | `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/dfg` | `venturecrane/dfg-console`   |
+| `dc`         | Draft Crane                       | `https://crane-mcp-remote.automation-ab6.workers.dev/mcp/dc`  | `venturecrane/dc-console`    |
+
+### Steps per project
+
+1. **Create the project** on claude.ai (web). One per venture.
+2. **Add the MCP connector**: Settings → Connectors → "Add custom connector" → use the venture-specific URL above. Save.
+3. **Connect (OAuth flow)**: Open the project, ask any question that uses a tool. Claude.ai will prompt for OAuth. Click through. GitHub redirects to the worker's `/callback`, then back to claude.ai. Done.
+4. **Set project custom instructions** (Settings → Project → Custom instructions) — paste the block below, substituting `{VENTURE_CODE}` and `{VENTURE_NAME}` for the right venture:
+
+   ```text
+   You represent the {VENTURE_NAME} venture (code: {VENTURE_CODE}).
+
+   The crane-mcp-remote MCP server auto-scopes your `crane_*` and `github_*`
+   tools to this venture — you do not need to specify `venture` on crane
+   tools or `owner`+`repo` on github tools for in-venture queries.
+
+   At the start of any non-trivial conversation, call `crane_context` once
+   to confirm the venture binding. If results look wrong or empty, call
+   `crane_health` to diagnose (it surfaces crane-context status, GitHub
+   auth status, scopes, allowlist membership, and venture binding state).
+
+   For cross-venture queries:
+   - crane tools: pass `venture: "<code>"` (or `venture: "all"` where
+     supported) to override the default scope.
+   - github tools: pass BOTH `owner` and `repo` explicitly (passing only
+     one is rejected to avoid ambiguous calls).
+
+   Do not invent absence: if a tool returns no results, check the
+   disclosure for stale-data banners (loud `⚠️ STALE DATA` warnings live at
+   the top of the response when crane-context is unreachable). When a
+   tool fails, run `crane_health` and surface the failure mode in your
+   answer rather than guessing.
+   ```
+
+5. **Smoke test (Phase 5 from the plan)** — run all 6 checks in both web and iOS for this project:
+   1. "What venture is this?" → `crane_context` returns the bound venture name + repo.
+   2. "What's the latest work?" → `crane_handoffs` (no args) auto-targets this venture's handoffs.
+   3. "What's our top P0 issue?" → `github_list_issues` (no args) auto-targets the venture's repo.
+   4. (ss only) "What is the ai-employee product?" → surfaces the refreshed exec-summary note + recent commits.
+   5. "What are the top P0s across all 5 ventures?" → `github_list_issues` called 5x with explicit `owner`+`repo`. Verifies override mechanic.
+   6. `crane_health` → all three sections healthy, venture bound.
+
+   Record results in this file under "Verification log" below. A project is declared "reliable" only after all 6 pass in both web and iOS.
+
+---
+
+## Verification log
+
+| Project              | Venture | Web pass date | iOS pass date | Notes |
+| -------------------- | ------- | ------------- | ------------- | ----- |
+| (Venture Crane)      | vc      | _pending_     | _pending_     |       |
+| (SMD Services)       | ss      | _pending_     | _pending_     |       |
+| (Kid Expenses)       | ke      | _pending_     | _pending_     |       |
+| (Durgan Field Guide) | dfg     | _pending_     | _pending_     |       |
+| (Draft Crane)        | dc      | _pending_     | _pending_     |       |
+
+---
+
+## Rollback path
+
+The legacy `/mcp` endpoint (no venture binding) stays alive until Phase 6 retires it. If a venture project's per-venture endpoint misbehaves, switch its connector URL back to `https://crane-mcp-remote.automation-ab6.workers.dev/mcp` (no suffix) — same OAuth, same tools, but venture is unbound (you'll need to pass `venture` and `owner`+`repo` explicitly on every call). File the bug, then we fix forward without losing access in the field.
+
+---
+
+## Common failure modes
+
+### "Token is dead" (claude.ai says this but disclosure header says "authenticated and retrieved")
+
+**Don't trust the model's self-diagnosis.** Call `crane_health` from inside the project. If `github.status == "ok"` and `github.allowlist_member == true`, the token is fine and the model is confabulating around an unexpected (probably empty) result. Push back: "you DID get the data — list it."
+
+### `crane_context` returns "Bound to: NONE (legacy /mcp endpoint)" inside a per-venture project
+
+The connector URL got truncated or the project is pointing at the legacy endpoint. Re-check Settings → Connectors → URL for that project. If it shows `…/mcp` instead of `…/mcp/{venture}`, either claude.ai stripped the path (Phase 0a failed — switch to subdomain routing) or someone edited the URL.
+
+### `crane_health` shows `crane_context: down`
+
+The crane-context worker is unreachable from crane-mcp-remote (network or auth issue). Check `wrangler tail --env production` on `crane-context-prod` for the matching request. Likely causes: stale `CRANE_CONTEXT_KEY` secret, or worker outage.
+
+### `crane_health` shows `github.status: reconnect_needed`
+
+The OAuth token in the session has expired or been revoked. In claude.ai: Settings → Connectors → that connector → Disconnect, then re-connect. This re-runs the OAuth flow and provisions a fresh GitHub token.
+
+### iOS shows different behavior than web
+
+iOS aggressively caches connector configs. Force a reconnect on the device: Settings → Connectors → the connector → Disconnect → Connect.
+
+---
+
+## See also
+
+- Plan: `plans/nested-wobbling-matsumoto.md` (full architecture + phases)
+- Token registry: `docs/infra/token-registry.md` (callback URL, OAuth App ID)
+- MCP surfaces overview: `docs/infra/mcp-surfaces.md`
+- Worker README: `workers/crane-mcp-remote/CLAUDE.md`

--- a/workers/crane-context/migrations/0053_add_exec_summary_refresh_cadence.sql
+++ b/workers/crane-context/migrations/0053_add_exec_summary_refresh_cadence.sql
@@ -1,0 +1,127 @@
+-- Migration 0053: Seed monthly exec-summary refresh cadence items per venture
+--
+-- Each venture (vc, ss, ke, dfg, dc) gets a monthly cadence item to keep
+-- its executive-summary VCMS note fresh. Stale exec summaries directly
+-- cause confabulation by claude.ai agents in venture projects (e.g., the
+-- ss exec summary predated the ai-employee product by 8 weeks).
+--
+-- Pass criteria for completion (documented in the description):
+-- 1. Cite specific recent commits/PRs by number or SHA.
+-- 2. Reference top 3 focus areas verifiable against gh issues output.
+-- 3. Dated within the last 7 days.
+--
+-- Cadence: monthly (cadence_days=30). Owner: captain (manual rewrite or
+-- agent-assisted). Action: read current note via crane_note_read, gather
+-- venture state via github_list_issues + recent commits, rewrite, save.
+--
+-- Pre-marked as completed today (2026-05-27) since the initial refresh
+-- was done in the same PR; next due in 30 days.
+--
+-- Single-row INSERTs (not multi-row VALUES) because the canary harness
+-- in test/canary/idempotency-canary.test.ts splits on semicolons; multi-
+-- row VALUES inside one statement may parse poorly in some D1 paths.
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_014',
+  'exec-summary-refresh-vc',
+  'Executive Summary Refresh (vc)',
+  'Refresh the Venture Crane exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/crane-console, dated within 7 days. Drives claude.ai venture-project context freshness.',
+  30,
+  'vc',
+  3,
+  '2026-05-27T17:00:00Z',
+  NULL,
+  'success',
+  1,
+  datetime('now'),
+  datetime('now')
+);
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_015',
+  'exec-summary-refresh-ss',
+  'Executive Summary Refresh (ss)',
+  'Refresh the SMD Services exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/ss-console, dated within 7 days. Must explicitly cover the ai-employee product line.',
+  30,
+  'ss',
+  3,
+  '2026-05-27T17:00:00Z',
+  NULL,
+  'success',
+  1,
+  datetime('now'),
+  datetime('now')
+);
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_016',
+  'exec-summary-refresh-ke',
+  'Executive Summary Refresh (ke)',
+  'Refresh the Kid Expenses exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/ke-console, dated within 7 days.',
+  30,
+  'ke',
+  3,
+  '2026-05-27T17:00:00Z',
+  NULL,
+  'success',
+  1,
+  datetime('now'),
+  datetime('now')
+);
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_017',
+  'exec-summary-refresh-dfg',
+  'Executive Summary Refresh (dfg)',
+  'Refresh the Durgan Field Guide exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/dfg-console, dated within 7 days.',
+  30,
+  'dfg',
+  3,
+  '2026-05-27T17:00:00Z',
+  NULL,
+  'success',
+  1,
+  datetime('now'),
+  datetime('now')
+);
+
+INSERT OR REPLACE INTO schedule_items (
+  id, name, title, description,
+  cadence_days, scope, priority,
+  last_completed_at, last_completed_by, last_result,
+  enabled, created_at, updated_at
+) VALUES (
+  'sched_seed_018',
+  'exec-summary-refresh-dc',
+  'Executive Summary Refresh (dc)',
+  'Refresh the Draft Crane exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/dc-console, dated within 7 days.',
+  30,
+  'dc',
+  3,
+  '2026-05-27T17:00:00Z',
+  NULL,
+  'success',
+  1,
+  datetime('now'),
+  datetime('now')
+);

--- a/workers/crane-mcp-remote/src/github-tools.ts
+++ b/workers/crane-mcp-remote/src/github-tools.ts
@@ -4,12 +4,19 @@
  * 14 tools providing Issues, PRs, Repository, Actions, and diagnostics
  * access via the GitHub REST API. All tools use the `github_` prefix.
  *
+ * When the MCP session is bound to a venture (e.g., /mcp/ss), `owner` and
+ * `repo` default to that venture's repo when both are omitted. Passing
+ * BOTH owner and repo explicitly always overrides — cross-venture queries
+ * are first-class.
+ *
  * Formatting logic lives in ./github-tools-formatters.ts.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { GitHubApiClient } from './github-api.js'
+import { getVenture, type VentureCode } from './ventures.js'
+import { resolveTarget } from './tools/shared.js'
 import {
   formatIssueList,
   formatIssueDetail,
@@ -55,15 +62,52 @@ function makeHandler(
   }
 }
 
+/**
+ * Wrap a handler that needs an `owner`+`repo` pair. Resolves from the
+ * session venture's default when both are omitted; surfaces a clear
+ * error when exactly one is provided (avoids ambiguous calls).
+ */
+function withTarget(
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null,
+  owner: string | undefined,
+  repo: string | undefined,
+  fn: (resolved: { owner: string; repo: string }) => Promise<ToolResult>
+): () => Promise<ToolResult> {
+  return makeHandler(client, async () => {
+    const resolved = resolveTarget(owner, repo, sessionVenture)
+    if ('error' in resolved) return errorResult(resolved.error)
+    return fn(resolved)
+  })
+}
+
+function describeOwner(sessionVenture: VentureCode | null): string {
+  const v = getVenture(sessionVenture)
+  return v
+    ? `Repository owner (defaults to "${v.repo.owner}" for this venture-bound session; required for cross-venture queries, in which case pass BOTH owner and repo)`
+    : 'Repository owner (org or user)'
+}
+
+function describeRepo(sessionVenture: VentureCode | null): string {
+  const v = getVenture(sessionVenture)
+  return v
+    ? `Repository name (defaults to "${v.repo.repo}" for this venture-bound session; required for cross-venture queries, in which case pass BOTH owner and repo)`
+    : 'Repository name'
+}
+
 // ── Issues ────────────────────────────────────────────────────────────────────
 
-function registerIssueReadTools(server: McpServer, client: GitHubApiClient): void {
+function registerIssueReadTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_list_issues',
     'List issues in a GitHub repository. Returns title, number, state, labels, and assignees.',
     {
-      owner: z.string().describe('Repository owner (org or user)'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       state: z
         .enum(['open', 'closed', 'all'])
         .optional()
@@ -74,15 +118,21 @@ function registerIssueReadTools(server: McpServer, client: GitHubApiClient): voi
       page: z.number().optional().describe('Page number (default: 1)'),
     },
     async ({ owner, repo, state, labels, assignee, per_page, page }) =>
-      makeHandler(client, async () => {
-        const result = await client.listIssues(owner, repo, {
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const result = await client.listIssues(target.owner, target.repo, {
           state,
           labels,
           assignee,
           per_page,
           page,
         })
-        return ok(formatIssueList(owner, repo, result as Parameters<typeof formatIssueList>[2]))
+        return ok(
+          formatIssueList(
+            target.owner,
+            target.repo,
+            result as Parameters<typeof formatIssueList>[2]
+          )
+        )
       })()
   )
 
@@ -90,14 +140,16 @@ function registerIssueReadTools(server: McpServer, client: GitHubApiClient): voi
     'github_get_issue',
     'Get full issue details including body and comments.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       number: z.number().describe('Issue number'),
     },
     async ({ owner, repo, number }) =>
-      makeHandler(client, async () => {
-        const issue = await client.getIssue(owner, repo, number)
-        const comments = await client.getIssueComments(owner, repo, number, { per_page: 50 })
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const issue = await client.getIssue(target.owner, target.repo, number)
+        const comments = await client.getIssueComments(target.owner, target.repo, number, {
+          per_page: 50,
+        })
         return ok(
           formatIssueDetail(
             issue as Parameters<typeof formatIssueDetail>[0],
@@ -108,21 +160,30 @@ function registerIssueReadTools(server: McpServer, client: GitHubApiClient): voi
   )
 }
 
-function registerIssueWriteTools(server: McpServer, client: GitHubApiClient): void {
+function registerIssueWriteTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_create_issue',
     'Create a new issue in a GitHub repository.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       title: z.string().describe('Issue title'),
       body: z.string().optional().describe('Issue body (markdown)'),
       labels: z.array(z.string()).optional().describe('Labels to apply'),
       assignees: z.array(z.string()).optional().describe('GitHub logins to assign'),
     },
     async ({ owner, repo, title, body, labels, assignees }) =>
-      makeHandler(client, async () => {
-        const issue = await client.createIssue(owner, repo, { title, body, labels, assignees })
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const issue = await client.createIssue(target.owner, target.repo, {
+          title,
+          body,
+          labels,
+          assignees,
+        })
         return ok(`Issue created: #${issue.number} ${issue.title}\nURL: ${issue.html_url}`)
       })()
   )
@@ -131,8 +192,8 @@ function registerIssueWriteTools(server: McpServer, client: GitHubApiClient): vo
     'github_update_issue',
     'Update an existing issue (title, body, state, labels, assignees).',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       number: z.number().describe('Issue number'),
       title: z.string().optional().describe('New title'),
       body: z.string().optional().describe('New body'),
@@ -141,8 +202,8 @@ function registerIssueWriteTools(server: McpServer, client: GitHubApiClient): vo
       assignees: z.array(z.string()).optional().describe('Replace assignees (full list)'),
     },
     async ({ owner, repo, number, title, body, state, labels, assignees }) =>
-      makeHandler(client, async () => {
-        const issue = await client.updateIssue(owner, repo, number, {
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const issue = await client.updateIssue(target.owner, target.repo, number, {
           title,
           body,
           state,
@@ -159,33 +220,41 @@ function registerIssueWriteTools(server: McpServer, client: GitHubApiClient): vo
     'github_add_comment',
     'Add a comment to an issue or pull request.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       number: z.number().describe('Issue or PR number'),
       body: z.string().describe('Comment body (markdown)'),
     },
     async ({ owner, repo, number, body }) =>
-      makeHandler(client, async () => {
-        const comment = await client.createComment(owner, repo, number, body)
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const comment = await client.createComment(target.owner, target.repo, number, body)
         return ok(`Comment added to #${number}\nURL: ${comment.html_url}`)
       })()
   )
 }
 
-function registerIssueTools(server: McpServer, client: GitHubApiClient): void {
-  registerIssueReadTools(server, client)
-  registerIssueWriteTools(server, client)
+function registerIssueTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
+  registerIssueReadTools(server, client, sessionVenture)
+  registerIssueWriteTools(server, client, sessionVenture)
 }
 
 // ── Pull Requests ─────────────────────────────────────────────────────────────
 
-function registerPRTools(server: McpServer, client: GitHubApiClient): void {
+function registerPRTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_list_pulls',
     'List pull requests in a GitHub repository.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       state: z
         .enum(['open', 'closed', 'all'])
         .optional()
@@ -196,9 +265,17 @@ function registerPRTools(server: McpServer, client: GitHubApiClient): void {
       page: z.number().optional().describe('Page number (default: 1)'),
     },
     async ({ owner, repo, state, head, base, per_page, page }) =>
-      makeHandler(client, async () => {
-        const result = await client.listPRs(owner, repo, { state, head, base, per_page, page })
-        return ok(formatPRList(owner, repo, result as Parameters<typeof formatPRList>[2]))
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const result = await client.listPRs(target.owner, target.repo, {
+          state,
+          head,
+          base,
+          per_page,
+          page,
+        })
+        return ok(
+          formatPRList(target.owner, target.repo, result as Parameters<typeof formatPRList>[2])
+        )
       })()
   )
 
@@ -206,13 +283,13 @@ function registerPRTools(server: McpServer, client: GitHubApiClient): void {
     'github_get_pull',
     'Get full pull request details including body, merge status, and review state.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       number: z.number().describe('PR number'),
     },
     async ({ owner, repo, number }) =>
-      makeHandler(client, async () => {
-        const pr = await client.getPR(owner, repo, number)
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const pr = await client.getPR(target.owner, target.repo, number)
         return ok(formatPRDetail(pr as Parameters<typeof formatPRDetail>[0]))
       })()
   )
@@ -221,14 +298,14 @@ function registerPRTools(server: McpServer, client: GitHubApiClient): void {
     'github_get_pull_diff',
     'Get the diff for a pull request. Large diffs (>50K chars) are truncated with a file summary.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       number: z.number().describe('PR number'),
     },
     async ({ owner, repo, number }) =>
-      makeHandler(client, async () => {
-        const diff = await client.getPRDiff(owner, repo, number)
-        const files = await client.getPRFiles(owner, repo, number, { per_page: 100 })
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const diff = await client.getPRDiff(target.owner, target.repo, number)
+        const files = await client.getPRFiles(target.owner, target.repo, number, { per_page: 100 })
         return ok(
           formatPRDiff(number, diff, MAX_DIFF_CHARS, files as Parameters<typeof formatPRDiff>[3])
         )
@@ -238,13 +315,17 @@ function registerPRTools(server: McpServer, client: GitHubApiClient): void {
 
 // ── Repository ────────────────────────────────────────────────────────────────
 
-function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
+function registerRepoFileTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_get_file',
     'Get file contents from a repository. GitHub API has a 1MB limit for this endpoint - use github_get_pull_diff for large files.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       path: z.string().describe('File path within the repository'),
       ref: z
         .string()
@@ -252,8 +333,8 @@ function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
         .describe('Git ref (branch, tag, or SHA). Defaults to default branch.'),
     },
     async ({ owner, repo, path, ref }) =>
-      makeHandler(client, async () => {
-        const file = await client.getFileContents(owner, repo, path, ref)
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const file = await client.getFileContents(target.owner, target.repo, path, ref)
         if (file.type !== 'file') {
           return errorResult(
             `Path "${path}" is a ${file.type}, not a file. Use github_list_directory instead.`
@@ -267,8 +348,8 @@ function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
     'github_list_directory',
     'List directory contents in a repository.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       path: z.string().optional().describe('Directory path (empty or "/" for root)'),
       ref: z
         .string()
@@ -276,22 +357,34 @@ function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
         .describe('Git ref (branch, tag, or SHA). Defaults to default branch.'),
     },
     async ({ owner, repo, path, ref }) =>
-      makeHandler(client, async () => {
-        const entries = await client.listDirectory(owner, repo, path ?? '', ref)
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const entries = await client.listDirectory(target.owner, target.repo, path ?? '', ref)
         if (!Array.isArray(entries)) {
           return errorResult(
             `Path "${path}" is a file, not a directory. Use github_get_file instead.`
           )
         }
         return ok(
-          formatDirectory(owner, repo, path, ref, entries as Parameters<typeof formatDirectory>[4])
+          formatDirectory(
+            target.owner,
+            target.repo,
+            path,
+            ref,
+            entries as Parameters<typeof formatDirectory>[4]
+          )
         )
       })()
   )
+}
 
+function registerRepoSearchTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_search_code',
-    'Search for code across GitHub repositories. Best results when scoped to an owner or repo. Defaults to org:venturecrane when no scope is provided.',
+    'Search for code across GitHub repositories. Best results when scoped to an owner or repo. Defaults to the session venture (when venture-bound) or org:venturecrane.',
     {
       query: z.string().describe('Search query (code, filename, etc.)'),
       owner: z.string().optional().describe('Scope to repositories owned by this user/org'),
@@ -299,7 +392,16 @@ function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
     },
     async ({ query, owner, repo }) =>
       makeHandler(client, async () => {
-        const result = await client.searchCode(query, { owner, repo })
+        // Code search doesn't need both owner+repo — it accepts either as
+        // a scope. Auto-scope to venture's repo when both omitted.
+        let scopedOwner = owner
+        let scopedRepo = repo
+        const v = getVenture(sessionVenture)
+        if (!owner && !repo && v) {
+          scopedOwner = v.repo.owner
+          scopedRepo = `${v.repo.owner}/${v.repo.repo}`
+        }
+        const result = await client.searchCode(query, { owner: scopedOwner, repo: scopedRepo })
         return ok(formatCodeSearch(result as Parameters<typeof formatCodeSearch>[0]))
       })()
   )
@@ -307,13 +409,17 @@ function registerRepoTools(server: McpServer, client: GitHubApiClient): void {
 
 // ── Actions ───────────────────────────────────────────────────────────────────
 
-function registerActionsTools(server: McpServer, client: GitHubApiClient): void {
+function registerActionsTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'github_list_runs',
     'List recent workflow runs (CI/CD) for a repository.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       branch: z.string().optional().describe('Filter by branch name'),
       status: z
         .enum([
@@ -338,14 +444,16 @@ function registerActionsTools(server: McpServer, client: GitHubApiClient): void 
       page: z.number().optional().describe('Page number (default: 1)'),
     },
     async ({ owner, repo, branch, status, per_page, page }) =>
-      makeHandler(client, async () => {
-        const result = await client.listWorkflowRuns(owner, repo, {
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
+        const result = await client.listWorkflowRuns(target.owner, target.repo, {
           branch,
           status,
           per_page,
           page,
         })
-        return ok(formatRunList(owner, repo, result as Parameters<typeof formatRunList>[2]))
+        return ok(
+          formatRunList(target.owner, target.repo, result as Parameters<typeof formatRunList>[2])
+        )
       })()
   )
 
@@ -353,15 +461,15 @@ function registerActionsTools(server: McpServer, client: GitHubApiClient): void 
     'github_get_run',
     'Get workflow run details including individual job statuses and steps.',
     {
-      owner: z.string().describe('Repository owner'),
-      repo: z.string().describe('Repository name'),
+      owner: z.string().optional().describe(describeOwner(sessionVenture)),
+      repo: z.string().optional().describe(describeRepo(sessionVenture)),
       run_id: z.number().describe('Workflow run ID'),
     },
     async ({ owner, repo, run_id }) =>
-      makeHandler(client, async () => {
+      withTarget(client, sessionVenture, owner, repo, async (target) => {
         const [run, jobs] = await Promise.all([
-          client.getWorkflowRun(owner, repo, run_id),
-          client.listRunJobs(owner, repo, run_id),
+          client.getWorkflowRun(target.owner, target.repo, run_id),
+          client.listRunJobs(target.owner, target.repo, run_id),
         ])
         return ok(
           formatRunDetail(
@@ -399,10 +507,15 @@ function registerUtilityTools(server: McpServer, client: GitHubApiClient): void 
 /**
  * Register all GitHub MCP tools on the given server instance.
  */
-export function registerGitHubTools(server: McpServer, client: GitHubApiClient): void {
-  registerIssueTools(server, client)
-  registerPRTools(server, client)
-  registerRepoTools(server, client)
-  registerActionsTools(server, client)
+export function registerGitHubTools(
+  server: McpServer,
+  client: GitHubApiClient,
+  sessionVenture: VentureCode | null
+): void {
+  registerIssueTools(server, client, sessionVenture)
+  registerPRTools(server, client, sessionVenture)
+  registerRepoFileTools(server, client, sessionVenture)
+  registerRepoSearchTools(server, client, sessionVenture)
+  registerActionsTools(server, client, sessionVenture)
   registerUtilityTools(server, client)
 }

--- a/workers/crane-mcp-remote/src/index.ts
+++ b/workers/crane-mcp-remote/src/index.ts
@@ -7,9 +7,19 @@
  *
  * Architecture:
  * - OAuthProvider handles DCR, token endpoints, and auth flow
- * - McpAgent (Durable Object) handles MCP protocol per session
+ * - One McpAgent subclass per venture (CraneMCPLegacy + CraneMCPVc/Ss/Ke/Dfg/Dc)
+ *   so each venture-bound URL gets its own DO binding and its tools
+ *   auto-scope to that venture.
  * - CraneContextClient proxies API calls to crane-context worker
  * - KV provides OAuth storage and read cache fallback
+ *
+ * Routing:
+ *   /mcp           → CraneMCPLegacy (no venture binding, kept for rollback)
+ *   /mcp/vc        → CraneMCPVc     (venture = vc)
+ *   /mcp/ss        → CraneMCPSs     (venture = ss)
+ *   /mcp/ke        → CraneMCPKe     (venture = ke)
+ *   /mcp/dfg       → CraneMCPDfg    (venture = dfg)
+ *   /mcp/dc        → CraneMCPDc     (venture = dc)
  */
 
 import OAuthProvider from '@cloudflare/workers-oauth-provider'
@@ -20,7 +30,9 @@ import { GitHubApiClient } from './github-api.js'
 import { GitHubHandler } from './github-handler.js'
 import { registerGitHubTools } from './github-tools.js'
 import { registerTools } from './tools.js'
+import { textResult, type ToolResult } from './tools/shared.js'
 import type { Env, Props } from './types.js'
+import { getVenture, type VentureCode } from './ventures.js'
 import { BUILD_INFO } from './generated/build-info.js'
 
 // Plan v3.1 §D.1: /version endpoint. Cloudflare Workers forbid wall-clock
@@ -51,7 +63,16 @@ function handleVersion(env: Env): Response {
   })
 }
 
-export class CraneMCP extends McpAgent<Env, Record<string, never>, Props> {
+/**
+ * Base McpAgent. Subclasses set `static venture` to bind the session to
+ * a specific venture; tools then auto-inject that venture as the default
+ * scope. The legacy class leaves it null (venture-unbound, requires
+ * explicit args in tool calls).
+ */
+abstract class CraneMCPBase extends McpAgent<Env, Record<string, never>, Props> {
+  abstract readonly venture: VentureCode | null
+  private boundAt: string = new Date().toISOString()
+
   server = new McpServer({
     name: 'crane-mcp-remote',
     version: '1.0.0',
@@ -70,14 +91,154 @@ export class CraneMCP extends McpAgent<Env, Record<string, never>, Props> {
       this.props?.login || 'anonymous'
     )
 
-    registerTools(this.server, api)
-    registerGitHubTools(this.server, github)
+    registerTools(this.server, api, this.venture)
+    registerGitHubTools(this.server, github, this.venture)
+    this.registerHealthTool(api, github)
+  }
+
+  private registerHealthTool(api: CraneContextClient, github: GitHubApiClient): void {
+    const venture = this.venture
+    const boundAt = this.boundAt
+    const env = this.env
+    const login = this.props?.login || 'anonymous'
+
+    this.server.tool(
+      'crane_health',
+      'Diagnostic. Returns the live health of crane-context, GitHub auth, and venture binding. Call this when tool results look wrong or stale, to surface the actual failure mode.',
+      {},
+      async (): Promise<ToolResult> => {
+        const [ctxStatus, ghStatus] = await Promise.all([
+          checkCraneContext(api),
+          checkGitHub(github, env, login),
+        ])
+        const v = getVenture(venture)
+        const lines = [
+          '## Crane MCP Health',
+          '',
+          `### crane-context: ${ctxStatus.status}`,
+          `- Endpoint: ${env.CRANE_CONTEXT_API_URL}`,
+          ...(ctxStatus.lastError ? [`- Last error: ${ctxStatus.lastError}`] : []),
+          '',
+          `### github: ${ghStatus.status}`,
+          `- Authenticated as: ${ghStatus.login ?? 'unknown'}`,
+          `- Scopes: ${ghStatus.scopes.length ? ghStatus.scopes.join(', ') : '(none)'}`,
+          `- Allowlist member: ${ghStatus.allowlistMember}`,
+          ...(ghStatus.lastError ? [`- Last error: ${ghStatus.lastError}`] : []),
+          '',
+          `### venture binding`,
+          v
+            ? `- Bound to: ${v.name} (${v.code}) → ${v.repo.owner}/${v.repo.repo}`
+            : `- Bound to: NONE (legacy /mcp endpoint — connect via /mcp/{venture} for auto-scoping)`,
+          `- Bound at: ${boundAt}`,
+          '',
+          ctxStatus.status === 'ok' && ghStatus.status === 'ok'
+            ? 'All checks passed. Tool results should be reliable.'
+            : 'One or more subsystems degraded — mention this in any answer that depends on the affected data.',
+        ]
+        return textResult(lines.join('\n'))
+      }
+    )
   }
 }
 
+async function checkCraneContext(
+  api: CraneContextClient
+): Promise<{ status: 'ok' | 'down'; lastError?: string }> {
+  try {
+    const ok = await api.healthCheck()
+    return ok ? { status: 'ok' } : { status: 'down', lastError: 'healthCheck returned false' }
+  } catch (err) {
+    return { status: 'down', lastError: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function checkGitHub(
+  client: GitHubApiClient,
+  env: Env,
+  expectedLogin: string
+): Promise<{
+  status: 'ok' | 'reconnect_needed' | 'down'
+  login?: string
+  scopes: string[]
+  allowlistMember: boolean
+  lastError?: string
+}> {
+  if (!client.hasToken) {
+    return {
+      status: 'reconnect_needed',
+      scopes: [],
+      allowlistMember: false,
+      lastError:
+        'no GitHub token in session props — reconnect the integration via claude.ai Settings > Integrations',
+    }
+  }
+  try {
+    const { user, scopes } = await client.getAuthenticatedUser()
+    const login = typeof user.login === 'string' ? user.login : expectedLogin
+    const scopeList =
+      scopes && scopes !== 'unknown'
+        ? scopes
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : []
+    const allowed = (env.ALLOWED_GITHUB_USERS || '')
+      .split(',')
+      .map((u) => u.trim().toLowerCase())
+      .filter(Boolean)
+    const allowlistMember = allowed.length === 0 || allowed.includes(login.toLowerCase())
+    return {
+      status: 'ok',
+      login,
+      scopes: scopeList,
+      allowlistMember,
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return {
+      status: msg.includes('401') ? 'reconnect_needed' : 'down',
+      scopes: [],
+      allowlistMember: false,
+      lastError: msg,
+      login: expectedLogin,
+    }
+  }
+}
+
+// ── Per-venture subclasses ────────────────────────────────────────────────────
+
+export class CraneMCP extends CraneMCPBase {
+  readonly venture = null
+}
+export class CraneMCPVc extends CraneMCPBase {
+  readonly venture: VentureCode = 'vc'
+}
+export class CraneMCPSs extends CraneMCPBase {
+  readonly venture: VentureCode = 'ss'
+}
+export class CraneMCPKe extends CraneMCPBase {
+  readonly venture: VentureCode = 'ke'
+}
+export class CraneMCPDfg extends CraneMCPBase {
+  readonly venture: VentureCode = 'dfg'
+}
+export class CraneMCPDc extends CraneMCPBase {
+  readonly venture: VentureCode = 'dc'
+}
+
+// ── OAuth + routing ───────────────────────────────────────────────────────────
+
 const oauthHandler = new OAuthProvider({
-  apiHandler: CraneMCP.serve('/mcp'),
-  apiRoute: '/mcp',
+  apiHandlers: {
+    '/mcp/vc': CraneMCPVc.serve('/mcp/vc', { binding: 'MCP_OBJECT_VC' }),
+    '/mcp/ss': CraneMCPSs.serve('/mcp/ss', { binding: 'MCP_OBJECT_SS' }),
+    '/mcp/ke': CraneMCPKe.serve('/mcp/ke', { binding: 'MCP_OBJECT_KE' }),
+    '/mcp/dfg': CraneMCPDfg.serve('/mcp/dfg', { binding: 'MCP_OBJECT_DFG' }),
+    '/mcp/dc': CraneMCPDc.serve('/mcp/dc', { binding: 'MCP_OBJECT_DC' }),
+    // Legacy: venture-unbound endpoint, kept for rollback safety. Will be
+    // retired in Phase 6 once all 5 venture projects pass smoke tests.
+    '/mcp': CraneMCP.serve('/mcp'),
+  },
   authorizeEndpoint: '/authorize',
   tokenEndpoint: '/token',
   clientRegistrationEndpoint: '/register',

--- a/workers/crane-mcp-remote/src/tools.ts
+++ b/workers/crane-mcp-remote/src/tools.ts
@@ -2,9 +2,14 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CraneContextClient } from './crane-api.js'
 import { registerBriefingTools } from './tools/briefing.js'
 import { registerDashboardTools, registerKnowledgeTools } from './tools/knowledge.js'
+import type { VentureCode } from './ventures.js'
 
-export function registerTools(server: McpServer, api: CraneContextClient): void {
+export function registerTools(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
   registerBriefingTools(server, api)
-  registerDashboardTools(server, api)
-  registerKnowledgeTools(server, api)
+  registerDashboardTools(server, api, sessionVenture)
+  registerKnowledgeTools(server, api, sessionVenture)
 }

--- a/workers/crane-mcp-remote/src/tools/briefing.ts
+++ b/workers/crane-mcp-remote/src/tools/briefing.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CraneContextClient } from '../crane-api.js'
-import { staleWarning, textResult, type ToolResult } from './shared.js'
+import { staleBanner, textResult, type ToolResult } from './shared.js'
 
 async function fetchScheduleSection(
   api: CraneContextClient,
@@ -152,8 +152,10 @@ async function handleBriefing(api: CraneContextClient): Promise<ToolResult> {
   await fetchExecutiveSummariesSection(api, sections, staleRef)
   await fetchKnowledgeBaseSection(api, sections, staleRef)
 
-  const output = sections.join('\n\n---\n\n') + staleWarning(staleRef.value)
-  return textResult(output || 'No data available. Crane-context may be unreachable.')
+  const joined = sections.join('\n\n---\n\n')
+  const output =
+    staleBanner(staleRef.value) + (joined || 'No data available. Crane-context may be unreachable.')
+  return textResult(output)
 }
 
 export function registerBriefingTools(server: McpServer, api: CraneContextClient): void {

--- a/workers/crane-mcp-remote/src/tools/knowledge.ts
+++ b/workers/crane-mcp-remote/src/tools/knowledge.ts
@@ -1,7 +1,8 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import type { CraneContextClient } from '../crane-api.js'
-import { staleWarning, textResult, type ToolResult } from './shared.js'
+import { getVenture, VENTURES, type VentureCode } from '../ventures.js'
+import { staleBanner, textResult, type ToolResult } from './shared.js'
 
 async function handleVentures(api: CraneContextClient): Promise<ToolResult> {
   const { ventures, stale } = await api.getVentures()
@@ -22,8 +23,7 @@ async function handleVentures(api: CraneContextClient): Promise<ToolResult> {
     }
     text += '\n'
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleDoc(
@@ -45,8 +45,7 @@ async function handleDoc(
   if (data.description) text += `*${data.description}*\n\n`
   text += data.content
   text += `\n\n---\nScope: ${data.scope} | Version: ${data.version}`
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleDocAudit(
@@ -81,8 +80,7 @@ async function handleDocAudit(
       text += `\n\nPresent: ${audit.present.length} docs up to date`
     }
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleNotes(
@@ -105,8 +103,7 @@ async function handleNotes(
     if (n.content.length > 300) text += '...'
     text += '\n'
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleNoteRead(api: CraneContextClient, id: string): Promise<ToolResult> {
@@ -118,8 +115,7 @@ async function handleNoteRead(api: CraneContextClient, id: string): Promise<Tool
   if (n.tags) text += `Tags: ${n.tags}\n`
   text += `Created: ${n.created_at} | Updated: ${n.updated_at}\n`
   text += `\n---\n\n${n.content}`
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleScheduleList(
@@ -145,8 +141,7 @@ async function handleScheduleList(
     if (item.last_result_summary)
       text += `\nLast result: ${item.last_result} - ${item.last_result_summary}`
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleScheduleComplete(
@@ -196,8 +191,7 @@ async function handleHandoffs(
     if (h.issue_number) text += ` | Issue #${h.issue_number}`
     text += `\n${h.summary}\n`
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
 async function handleActiveSessions(api: CraneContextClient): Promise<ToolResult> {
@@ -205,7 +199,7 @@ async function handleActiveSessions(api: CraneContextClient): Promise<ToolResult
   const sessions = data.sessions
 
   if (sessions.length === 0) {
-    return textResult('No active agent sessions.' + staleWarning(stale))
+    return textResult(staleBanner(stale) + 'No active agent sessions.')
   }
 
   let text = `## Active Sessions (${sessions.length})\n`
@@ -214,11 +208,49 @@ async function handleActiveSessions(api: CraneContextClient): Promise<ToolResult
     if (s.issue_number) text += ` (#${s.issue_number})`
     text += ` - started ${s.created_at}`
   }
-  text += staleWarning(stale)
-  return textResult(text)
+  return textResult(staleBanner(stale) + text)
 }
 
-export function registerDashboardTools(server: McpServer, api: CraneContextClient): void {
+function handleContext(sessionVenture: VentureCode | null): ToolResult {
+  if (!sessionVenture) {
+    return textResult(
+      [
+        '## Crane MCP Session Context',
+        '',
+        '- **Venture binding:** none (legacy `/mcp` endpoint)',
+        '- **Default GitHub target:** none — pass `owner` and `repo` explicitly',
+        '- **Tool scoping:** `crane_*` tools require explicit `venture` arg',
+        '',
+        'To get auto-scoping, connect this project to a venture-bound URL:',
+        VENTURE_CODES_LIST,
+      ].join('\n')
+    )
+  }
+  const v = getVenture(sessionVenture)
+  if (!v) {
+    return textResult(`Unknown venture code: ${sessionVenture}`, true)
+  }
+  return textResult(
+    [
+      '## Crane MCP Session Context',
+      '',
+      `- **Venture:** ${v.name} (\`${v.code}\`)`,
+      `- **Default GitHub target:** ${v.repo.owner}/${v.repo.repo}`,
+      '- **Tool scoping:** `crane_*` tools auto-inject `venture` when omitted; `github_*` tools auto-inject the default repo when both `owner` and `repo` are omitted.',
+      '- **Cross-venture queries:** pass `venture:` (crane tools) or BOTH `owner:` and `repo:` (github tools) explicitly to override.',
+    ].join('\n')
+  )
+}
+
+const VENTURE_CODES_LIST = Object.values(VENTURES)
+  .map((v) => `  - \`${v.code}\` → ${v.name} (${v.repo.owner}/${v.repo.repo})`)
+  .join('\n')
+
+export function registerDashboardTools(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'crane_ventures',
     'List all ventures with repos, tech stack, status, and description. Use this to understand what each venture is and its current state.',
@@ -235,44 +267,97 @@ export function registerDashboardTools(server: McpServer, api: CraneContextClien
 
   server.tool(
     'crane_handoffs',
-    'Query handoff history. Handoffs are session summaries created when agents end their work.',
-    {
-      venture: z.string().optional().describe('Filter by venture code (e.g., "vc", "ke")'),
-      repo: z.string().optional().describe('Filter by repo name'),
-      limit: z.number().optional().describe('Maximum results (default 10)'),
-    },
-    (params) => handleHandoffs(api, params)
-  )
-}
-
-export function registerKnowledgeTools(server: McpServer, api: CraneContextClient): void {
-  server.tool(
-    'crane_doc',
-    'Fetch a documentation document by scope and name. Common docs: project-instructions.md, team-workflow.md, api-structure-template.md.',
-    {
-      scope: z.string().describe('Document scope: "global" or venture code (e.g., "vc", "ke")'),
-      doc_name: z.string().describe('Document name (e.g., "project-instructions.md")'),
-    },
-    ({ scope, doc_name }) => handleDoc(api, scope, doc_name)
-  )
-
-  server.tool(
-    'crane_doc_audit',
-    'Run documentation audit for a venture. Shows missing, stale, and present docs.',
+    `Query handoff history. Handoffs are session summaries created when agents end their work.${
+      sessionVenture ? ` Auto-scoped to ${sessionVenture} when venture is omitted.` : ''
+    }`,
     {
       venture: z
         .string()
         .optional()
-        .describe('Venture code to audit. If omitted, audits all ventures.'),
+        .describe(
+          sessionVenture
+            ? `Filter by venture code (defaults to "${sessionVenture}"; pass another code for cross-venture queries)`
+            : 'Filter by venture code (e.g., "vc", "ke")'
+        ),
+      repo: z.string().optional().describe('Filter by repo name'),
+      limit: z.number().optional().describe('Maximum results (default 10)'),
     },
-    ({ venture }) => handleDocAudit(api, venture)
+    (params) =>
+      handleHandoffs(api, {
+        ...params,
+        venture: params.venture ?? sessionVenture ?? undefined,
+      })
   )
 
   server.tool(
-    'crane_notes',
-    'Search and list notes from the enterprise knowledge store (VCMS).',
+    'crane_context',
+    'Return the current MCP session context: which venture this session is bound to, the default GitHub target, and how to override scoping for cross-venture queries. Call this once at the start of a conversation to confirm scope.',
+    {},
+    () => Promise.resolve(handleContext(sessionVenture))
+  )
+}
+
+function registerDocTools(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
+  server.tool(
+    'crane_doc',
+    'Fetch a documentation document by scope and name. Common docs: project-instructions.md, team-workflow.md, api-structure-template.md.',
     {
-      venture: z.string().optional().describe('Filter by venture code'),
+      scope: z
+        .string()
+        .optional()
+        .describe(
+          sessionVenture
+            ? `Document scope: "global" or venture code (defaults to "${sessionVenture}")`
+            : 'Document scope: "global" or venture code (e.g., "vc", "ke")'
+        ),
+      doc_name: z.string().describe('Document name (e.g., "project-instructions.md")'),
+    },
+    ({ scope, doc_name }) => handleDoc(api, scope ?? sessionVenture ?? 'global', doc_name)
+  )
+
+  server.tool(
+    'crane_doc_audit',
+    `Run documentation audit for a venture. Shows missing, stale, and present docs.${
+      sessionVenture ? ` Auto-scoped to ${sessionVenture} when venture is omitted.` : ''
+    }`,
+    {
+      venture: z
+        .string()
+        .optional()
+        .describe(
+          sessionVenture
+            ? `Venture code to audit (defaults to "${sessionVenture}"; pass another code or omit explicitly with "all" to audit everything)`
+            : 'Venture code to audit. If omitted, audits all ventures.'
+        ),
+    },
+    ({ venture }) =>
+      handleDocAudit(api, venture === 'all' ? undefined : (venture ?? sessionVenture ?? undefined))
+  )
+}
+
+function registerNotesTools(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
+  server.tool(
+    'crane_notes',
+    `Search and list notes from the enterprise knowledge store (VCMS).${
+      sessionVenture ? ` Auto-scoped to ${sessionVenture} when venture is omitted.` : ''
+    }`,
+    {
+      venture: z
+        .string()
+        .optional()
+        .describe(
+          sessionVenture
+            ? `Filter by venture code (defaults to "${sessionVenture}"; pass another code or "all" for cross-venture search)`
+            : 'Filter by venture code'
+        ),
       tag: z
         .string()
         .optional()
@@ -280,7 +365,12 @@ export function registerKnowledgeTools(server: McpServer, api: CraneContextClien
       q: z.string().optional().describe('Text search in title and content'),
       limit: z.number().optional().describe('Maximum results to return (default 20)'),
     },
-    (params) => handleNotes(api, params)
+    (params) =>
+      handleNotes(api, {
+        ...params,
+        venture:
+          params.venture === 'all' ? undefined : (params.venture ?? sessionVenture ?? undefined),
+      })
   )
 
   server.tool(
@@ -291,15 +381,30 @@ export function registerKnowledgeTools(server: McpServer, api: CraneContextClien
     },
     ({ id }) => handleNoteRead(api, id)
   )
+}
 
+function registerScheduleTool(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
   server.tool(
     'crane_schedule',
-    'View overdue/due recurring activities or record completion. Use action "list" to see the briefing, "complete" after finishing a recurring task.',
+    `View overdue/due recurring activities or record completion. Use action "list" to see the briefing, "complete" after finishing a recurring task.${
+      sessionVenture ? ` Auto-scoped to ${sessionVenture} when scope is omitted on list.` : ''
+    }`,
     {
       action: z
         .enum(['list', 'complete'])
         .describe('Action: "list" to view briefing, "complete" to record completion'),
-      scope: z.string().optional().describe('Venture code to filter briefing (list action only)'),
+      scope: z
+        .string()
+        .optional()
+        .describe(
+          sessionVenture
+            ? `Venture code to filter briefing (defaults to "${sessionVenture}"; pass "all" for everything)`
+            : 'Venture code to filter briefing (list action only)'
+        ),
       name: z
         .string()
         .optional()
@@ -312,8 +417,21 @@ export function registerKnowledgeTools(server: McpServer, api: CraneContextClien
       completed_by: z.string().optional().describe('Who completed this (complete action only)'),
     },
     ({ action, scope, name, result, summary, completed_by }) => {
-      if (action === 'list') return handleScheduleList(api, scope)
+      if (action === 'list') {
+        const resolvedScope = scope === 'all' ? undefined : (scope ?? sessionVenture ?? undefined)
+        return handleScheduleList(api, resolvedScope)
+      }
       return handleScheduleComplete(api, name, result, summary, completed_by)
     }
   )
+}
+
+export function registerKnowledgeTools(
+  server: McpServer,
+  api: CraneContextClient,
+  sessionVenture: VentureCode | null
+): void {
+  registerDocTools(server, api, sessionVenture)
+  registerNotesTools(server, api, sessionVenture)
+  registerScheduleTool(server, api, sessionVenture)
 }

--- a/workers/crane-mcp-remote/src/tools/shared.ts
+++ b/workers/crane-mcp-remote/src/tools/shared.ts
@@ -1,12 +1,60 @@
+import { getVenture, type VentureCode, type VentureRepo } from '../ventures.js'
+
 export type TextContent = { type: 'text'; text: string }
 export type ToolResult = { content: TextContent[]; isError?: true }
 
-export function staleWarning(stale: boolean): string {
-  return stale ? '\n\n[stale data - crane-context may be unreachable]' : ''
+/**
+ * Prepended (not appended) stale warning so the model sees it before
+ * the data, instead of treating it as a quiet trailing tag.
+ */
+export function staleBanner(stale: boolean, cacheAgeSeconds?: number): string {
+  if (!stale) return ''
+  const ageHint =
+    cacheAgeSeconds && cacheAgeSeconds > 0 ? ` (cache age: ${formatDuration(cacheAgeSeconds)})` : ''
+  return `STALE DATA${ageHint} — crane-context was unreachable, returning cached values. Treat as approximate and mention this if relying on it.\n\n---\n\n`
 }
 
 export function textResult(text: string, isError?: true): ToolResult {
   const result: ToolResult = { content: [{ type: 'text' as const, text }] }
   if (isError) result.isError = isError
   return result
+}
+
+/**
+ * Resolve the GitHub target for a tool call. Returns explicit args when
+ * both are provided; falls back to the session venture's default repo
+ * when both are omitted; errors when exactly one is provided.
+ *
+ * Contract: cross-venture queries are first-class — explicit owner+repo
+ * always overrides venture defaults.
+ */
+export function resolveTarget(
+  owner: string | undefined,
+  repo: string | undefined,
+  sessionVenture: VentureCode | null
+): VentureRepo | { error: string } {
+  if (owner && repo) return { owner, repo }
+  if (owner || repo) {
+    return {
+      error: `Both owner and repo must be provided together (got owner=${owner ?? 'undefined'}, repo=${repo ?? 'undefined'}). To use the session venture's default repo, omit both.`,
+    }
+  }
+  const venture = getVenture(sessionVenture)
+  if (!venture) {
+    return {
+      error:
+        'No GitHub target available: this MCP session is not bound to a venture, and no owner/repo was provided. Pass owner and repo explicitly, or connect via /mcp/{venture-code}.',
+    }
+  }
+  return venture.repo
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.round(seconds % 60)
+  if (mins < 60) return secs ? `${mins}m ${secs}s` : `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return remMins ? `${hours}h ${remMins}m` : `${hours}h`
 }

--- a/workers/crane-mcp-remote/src/types.ts
+++ b/workers/crane-mcp-remote/src/types.ts
@@ -4,6 +4,11 @@ export interface Env {
   OAUTH_KV: KVNamespace
   CACHE_KV: KVNamespace
   MCP_OBJECT: DurableObjectNamespace
+  MCP_OBJECT_VC: DurableObjectNamespace
+  MCP_OBJECT_SS: DurableObjectNamespace
+  MCP_OBJECT_KE: DurableObjectNamespace
+  MCP_OBJECT_DFG: DurableObjectNamespace
+  MCP_OBJECT_DC: DurableObjectNamespace
   CRANE_CONTEXT_API_URL: string
   CRANE_CONTEXT_KEY: string
   GITHUB_CLIENT_ID: string

--- a/workers/crane-mcp-remote/src/ventures.ts
+++ b/workers/crane-mcp-remote/src/ventures.ts
@@ -1,0 +1,45 @@
+/**
+ * Venture catalog for crane-mcp-remote.
+ *
+ * Each claude.ai project maps to one venture. The MCP endpoint URL
+ * carries the venture code (e.g., /mcp/ss), which selects a per-venture
+ * McpAgent subclass in src/index.ts. That subclass passes its venture
+ * code into tool registration, where crane_* and github_* tools use it
+ * as the default scope.
+ *
+ * Explicit `venture` (crane tools) or `owner`+`repo` (github tools)
+ * arguments always override the session default — cross-venture queries
+ * are first-class.
+ */
+
+export const VENTURE_CODES = ['vc', 'ss', 'ke', 'dfg', 'dc'] as const
+export type VentureCode = (typeof VENTURE_CODES)[number]
+
+export interface VentureRepo {
+  owner: string
+  repo: string
+}
+
+export interface VentureInfo {
+  code: VentureCode
+  name: string
+  repo: VentureRepo
+}
+
+const OWNER = 'venturecrane'
+
+export const VENTURES: Record<VentureCode, VentureInfo> = {
+  vc: { code: 'vc', name: 'Venture Crane', repo: { owner: OWNER, repo: 'crane-console' } },
+  ss: { code: 'ss', name: 'SMD Services', repo: { owner: OWNER, repo: 'ss-console' } },
+  ke: { code: 'ke', name: 'Kid Expenses', repo: { owner: OWNER, repo: 'ke-console' } },
+  dfg: { code: 'dfg', name: 'Durgan Field Guide', repo: { owner: OWNER, repo: 'dfg-console' } },
+  dc: { code: 'dc', name: 'Draft Crane', repo: { owner: OWNER, repo: 'dc-console' } },
+}
+
+export function isVentureCode(value: unknown): value is VentureCode {
+  return typeof value === 'string' && (VENTURE_CODES as readonly string[]).includes(value)
+}
+
+export function getVenture(code: VentureCode | null): VentureInfo | null {
+  return code ? VENTURES[code] : null
+}

--- a/workers/crane-mcp-remote/wrangler.toml
+++ b/workers/crane-mcp-remote/wrangler.toml
@@ -8,14 +8,26 @@ compatibility_flags = ["nodejs_compat"]
 command = "node ../../scripts/inject-version.mjs --service=crane-mcp-remote"
 cwd = "."
 
+# One Durable Object class per venture (plus legacy CraneMCP). Per-venture
+# DOs let each /mcp/{venture} endpoint bind its tools to a fixed venture
+# at init time. See src/index.ts for the routing.
 [durable_objects]
 bindings = [
-  { name = "MCP_OBJECT", class_name = "CraneMCP" }
+  { name = "MCP_OBJECT", class_name = "CraneMCP" },
+  { name = "MCP_OBJECT_VC", class_name = "CraneMCPVc" },
+  { name = "MCP_OBJECT_SS", class_name = "CraneMCPSs" },
+  { name = "MCP_OBJECT_KE", class_name = "CraneMCPKe" },
+  { name = "MCP_OBJECT_DFG", class_name = "CraneMCPDfg" },
+  { name = "MCP_OBJECT_DC", class_name = "CraneMCPDc" },
 ]
 
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["CraneMCP"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["CraneMCPVc", "CraneMCPSs", "CraneMCPKe", "CraneMCPDfg", "CraneMCPDc"]
 
 [[kv_namespaces]]
 binding = "OAUTH_KV"
@@ -42,7 +54,12 @@ name = "crane-mcp-remote"
 
 [env.production.durable_objects]
 bindings = [
-  { name = "MCP_OBJECT", class_name = "CraneMCP" }
+  { name = "MCP_OBJECT", class_name = "CraneMCP" },
+  { name = "MCP_OBJECT_VC", class_name = "CraneMCPVc" },
+  { name = "MCP_OBJECT_SS", class_name = "CraneMCPSs" },
+  { name = "MCP_OBJECT_KE", class_name = "CraneMCPKe" },
+  { name = "MCP_OBJECT_DFG", class_name = "CraneMCPDfg" },
+  { name = "MCP_OBJECT_DC", class_name = "CraneMCPDc" },
 ]
 
 # KV namespace IDs are populated after running:


### PR DESCRIPTION
## Summary

- **Server-side venture binding** for `crane-mcp-remote`: per-venture MCP endpoints (`/mcp/{vc,ss,ke,dfg,dc}`) backed by per-venture DO subclasses. Tools auto-scope to the bound venture; explicit `venture`/`owner`+`repo` args always override for cross-venture queries. Legacy `/mcp` kept alive as rollback path.
- **New `crane_context` + `crane_health` tools.** First confirms session venture binding + repo defaults so agents stop confabulating; second returns structured diagnostics (crane-context status, GitHub auth + scopes + allowlist, venture binding state) for live troubleshooting.
- **Visible staleness:** prepended `⚠️ STALE DATA` banner (with cache-age hint) replaces the trailing tag the model used to ignore.
- **Refreshed all 5 venture exec-summary VCMS notes** with verified focus areas + recent commits. SS now explicitly covers the ai-employee product. Monthly cadence (migration 0053) keeps them fresh.
- **`docs/runbooks/claude-ai-project-setup.md`** documents Phase 0 routing verification, per-venture connector URLs, custom-instructions block, 6-check smoke test, rollback, and common failure modes.
- **`docs/infra/token-registry.md`** gap filled: callback URL is path-agnostic (`/callback`), Captain still records the literal string from GitHub OAuth App settings per the runbook's Phase 0b.

## Context

Captain reported claude.ai projects (web + iOS) reliably failed to surface venture context and GitHub data — the agent would claim "no ai-employee product" (when 72 commits exist over 6 days) or "token is dead" (with a contradictory "authenticated and retrieved" header). Root cause: the worker was venture-agnostic and there was no documented procedure for binding a claude.ai project to a venture. See the plan at `plans/nested-wobbling-matsumoto.md` for the full architecture.

## Rollout

Phases 0–6 in the plan. This PR delivers Phase 1 (worker binding), Phase 2 (diagnostics + visible staleness), Phase 3 (knowledge refresh + cadence), and Phase 4 (runbook + token-registry gap). Phase 0 (Captain verifies claude.ai connector + GitHub OAuth callback constraints) is the gate before production deploy. Phase 5 (Captain runs the 6-check smoke test in web + iOS for each project) declares each project reliable. Phase 6 retires the legacy `/mcp` endpoint after Phase 5 passes everywhere.

## Test plan

- [x] `npm run typecheck` (passes)
- [x] `npm run lint -- workers/crane-mcp-remote/src` (0 errors)
- [x] `npm test` — 802 crane-mcp tests pass, 560 crane-context tests pass
- [x] `npm run test:canary` (passes after migration 0053 was split into per-venture INSERTs)
- [x] `npm run verify` (full pass)
- [ ] Deploy to staging: `cd workers/crane-mcp-remote && npm run deploy`
- [ ] Apply migration to staging crane-context: `cd workers/crane-context && npm run db:migrate`
- [ ] Captain runs Phase 0a/0b/0c against staging (see runbook)
- [ ] Deploy to production: `npm run deploy:prod` (worker) + `npm run db:migrate:prod` (migration)
- [ ] Captain reconnects 5 claude.ai projects per runbook
- [ ] Captain runs 6-check smoke test in web + iOS for each project; records results in runbook verification log

## Risks

- claude.ai connector UI may reject path-suffixed URLs → fallback is per-venture subdomain routes in `wrangler.toml` (worker code unchanged); Phase 0a catches this before production
- OAuth callback URL constraints may force subdomain routing; Phase 0b catches this
- iOS aggressively caches connector configs → runbook documents the force-reconnect step
- KV cache (5min) may delay stale-warning visibility on the first request after a crane-context outage; acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)