### PR TITLE
fix(crane-mcp-remote): auto-refresh GitHub user token via tokenExchangeCallback

### DIFF
--- a/workers/crane-mcp-remote/src/github-handler.ts
+++ b/workers/crane-mcp-remote/src/github-handler.ts
@@ -67,8 +67,9 @@ app.get('/callback', async (c) => {
     return c.text('Invalid OAuth request data', 400)
   }
 
-  // Exchange code for GitHub access token
-  const [accessToken, errResponse] = await fetchUpstreamAuthToken({
+  // Exchange code for GitHub access token (and refresh token, if the App
+  // issues expiring user tokens).
+  const [tokens, errResponse] = await fetchUpstreamAuthToken({
     upstream_url: 'https://github.com/login/oauth/access_token',
     client_id: c.env.GITHUB_CLIENT_ID,
     client_secret: c.env.GITHUB_CLIENT_SECRET,
@@ -80,7 +81,7 @@ app.get('/callback', async (c) => {
   // Get GitHub user info
   const userResp = await fetch('https://api.github.com/user', {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: `Bearer ${tokens.accessToken}`,
       'User-Agent': 'crane-mcp-remote',
       Accept: 'application/vnd.github+json',
     },
@@ -118,7 +119,8 @@ app.get('/callback', async (c) => {
       login: user.login,
       name: user.name || user.login,
       email: user.email || '',
-      github_token: accessToken,
+      github_token: tokens.accessToken,
+      github_refresh_token: tokens.refreshToken ?? undefined,
     },
   })
 

--- a/workers/crane-mcp-remote/src/index.ts
+++ b/workers/crane-mcp-remote/src/index.ts
@@ -29,6 +29,7 @@ import { CraneContextClient } from './crane-api.js'
 import { GitHubApiClient } from './github-api.js'
 import { GitHubHandler } from './github-handler.js'
 import { registerGitHubTools } from './github-tools.js'
+import { makeTokenExchangeCallback } from './token-exchange.js'
 import { registerTools } from './tools.js'
 import { textResult, type ToolResult } from './tools/shared.js'
 import type { Env, Props } from './types.js'
@@ -101,6 +102,7 @@ abstract class CraneMCPBase extends McpAgent<Env, Record<string, never>, Props> 
     const boundAt = this.boundAt
     const env = this.env
     const login = this.props?.login || 'anonymous'
+    const hasRefreshToken = Boolean(this.props?.github_refresh_token)
 
     this.server.tool(
       'crane_health',
@@ -124,6 +126,11 @@ abstract class CraneMCPBase extends McpAgent<Env, Record<string, never>, Props> 
           `- Scopes: ${ghStatus.scopes.length ? ghStatus.scopes.join(', ') : '(none)'}`,
           `- Allowlist member: ${ghStatus.allowlistMember}`,
           ...(ghStatus.lastError ? [`- Last error: ${ghStatus.lastError}`] : []),
+          ...(ghStatus.status === 'ok' && !hasRefreshToken
+            ? [
+                '- Auto-refresh: not enabled for this session — reconnect once via claude.ai Settings > Integrations so the GitHub token renews automatically instead of dying at expiry.',
+              ]
+            : []),
           '',
           `### venture binding`,
           v
@@ -228,23 +235,30 @@ export class CraneMCPDc extends CraneMCPBase {
 
 // ── OAuth + routing ───────────────────────────────────────────────────────────
 
-const oauthHandler = new OAuthProvider({
-  apiHandlers: {
-    '/mcp/vc': CraneMCPVc.serve('/mcp/vc', { binding: 'MCP_OBJECT_VC' }),
-    '/mcp/ss': CraneMCPSs.serve('/mcp/ss', { binding: 'MCP_OBJECT_SS' }),
-    '/mcp/ke': CraneMCPKe.serve('/mcp/ke', { binding: 'MCP_OBJECT_KE' }),
-    '/mcp/dfg': CraneMCPDfg.serve('/mcp/dfg', { binding: 'MCP_OBJECT_DFG' }),
-    '/mcp/dc': CraneMCPDc.serve('/mcp/dc', { binding: 'MCP_OBJECT_DC' }),
-    // Legacy: venture-unbound endpoint, kept for rollback safety. Will be
-    // retired in Phase 6 once all 5 venture projects pass smoke tests.
-    '/mcp': CraneMCP.serve('/mcp'),
-  },
-  authorizeEndpoint: '/authorize',
-  tokenEndpoint: '/token',
-  clientRegistrationEndpoint: '/register',
-  // Hono's fetch signature doesn't exactly match ExportedHandler - safe to cast
-  defaultHandler: GitHubHandler as never,
-})
+// Constructed per request: the token-exchange callback needs env (OAuth client
+// credentials), which the callback API does not supply and which Workers do not
+// expose at module load. Construction is a cheap config object — all grant/token
+// state lives in OAUTH_KV — so per-request avoids any module-level mutable state.
+function buildOAuthHandler(env: Env): OAuthProvider {
+  return new OAuthProvider({
+    apiHandlers: {
+      '/mcp/vc': CraneMCPVc.serve('/mcp/vc', { binding: 'MCP_OBJECT_VC' }),
+      '/mcp/ss': CraneMCPSs.serve('/mcp/ss', { binding: 'MCP_OBJECT_SS' }),
+      '/mcp/ke': CraneMCPKe.serve('/mcp/ke', { binding: 'MCP_OBJECT_KE' }),
+      '/mcp/dfg': CraneMCPDfg.serve('/mcp/dfg', { binding: 'MCP_OBJECT_DFG' }),
+      '/mcp/dc': CraneMCPDc.serve('/mcp/dc', { binding: 'MCP_OBJECT_DC' }),
+      // Legacy: venture-unbound endpoint, kept for rollback safety. Will be
+      // retired in Phase 6 once all 5 venture projects pass smoke tests.
+      '/mcp': CraneMCP.serve('/mcp'),
+    },
+    authorizeEndpoint: '/authorize',
+    tokenEndpoint: '/token',
+    clientRegistrationEndpoint: '/register',
+    tokenExchangeCallback: makeTokenExchangeCallback(env),
+    // Hono's fetch signature doesn't exactly match ExportedHandler - safe to cast
+    defaultHandler: GitHubHandler as never,
+  })
+}
 
 // Plan v3.1 §D.1: intercept /version BEFORE OAuthProvider so it requires
 // no authentication. Everything else falls through to the OAuth-wrapped
@@ -255,6 +269,6 @@ export default {
     if (url.pathname === '/version' && request.method === 'GET') {
       return handleVersion(env)
     }
-    return oauthHandler.fetch(request, env, ctx)
+    return buildOAuthHandler(env).fetch(request, env, ctx)
   },
 }

--- a/workers/crane-mcp-remote/src/token-exchange.ts
+++ b/workers/crane-mcp-remote/src/token-exchange.ts
@@ -1,0 +1,82 @@
+/**
+ * OAuthProvider token-exchange callback for keeping the upstream GitHub user
+ * token alive. Isolated from index.ts so it can be unit-tested without pulling
+ * in the Workers/MCP runtime (this module depends only on utils + types).
+ *
+ * Lib types are imported type-only (erased at runtime) so tests don't load the
+ * oauth-provider package; `grantType` is compared against its string values.
+ */
+
+import type {
+  TokenExchangeCallbackOptions,
+  TokenExchangeCallbackResult,
+} from '@cloudflare/workers-oauth-provider'
+import type { Env, Props } from './types.js'
+import { refreshUpstreamAuthToken } from './utils.js'
+
+// GitHub user access tokens live 8h; refresh tokens 6mo (docs.github.com).
+export const GITHUB_DEFAULT_USER_TOKEN_TTL = 28800
+// Cap the downstream (claude.ai↔worker) token below the upstream lifetime so
+// the client refreshes early — that refresh re-enters the callback and renews
+// the GitHub token while it still has headroom, avoiding an expiry-boundary race.
+export const REFRESH_TTL_FRACTION = 0.75
+// On a transient refresh failure, issue a short-lived downstream token so the
+// client retries the refresh soon and auto-recovers without user action.
+export const TRANSIENT_RETRY_TTL = 300
+
+/**
+ * Build the token-exchange callback. `env` supplies the OAuth client
+ * credentials (the callback args do not carry env); `refresh` is injectable
+ * for tests.
+ *
+ * Inert when the grant has no `github_refresh_token` — i.e. the GitHub App
+ * issues non-expiring tokens, or the session predates refresh support. Those
+ * keep their existing behavior untouched.
+ */
+export function makeTokenExchangeCallback(
+  env: Pick<Env, 'GITHUB_CLIENT_ID' | 'GITHUB_CLIENT_SECRET'>,
+  refresh: typeof refreshUpstreamAuthToken = refreshUpstreamAuthToken
+) {
+  return async (
+    options: TokenExchangeCallbackOptions
+  ): Promise<TokenExchangeCallbackResult | void> => {
+    const props = options.props as Props
+    const refreshToken = props?.github_refresh_token
+    if (!refreshToken) return
+
+    const grantType = options.grantType as string
+
+    if (grantType === 'authorization_code') {
+      // Props (incl. github_token) are already set by the GitHub handler; only
+      // cap the downstream TTL so the refresh loop starts.
+      return { accessTokenTTL: Math.floor(GITHUB_DEFAULT_USER_TOKEN_TTL * REFRESH_TTL_FRACTION) }
+    }
+
+    if (grantType === 'refresh_token') {
+      const result = await refresh({
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        refresh_token: refreshToken,
+      })
+      if (!result.ok) {
+        // transient → short TTL so the client retries soon (auto-recover).
+        // invalid_grant → leave props; next github_* call 401s → reconnect message.
+        return result.kind === 'transient' ? { accessTokenTTL: TRANSIENT_RETRY_TTL } : undefined
+      }
+      const next: Props = {
+        ...props,
+        github_token: result.tokens.accessToken,
+        // GitHub rotates the refresh token on every refresh — persist the new one.
+        github_refresh_token: result.tokens.refreshToken ?? props.github_refresh_token,
+      }
+      const ttlBase = result.tokens.expiresIn ?? GITHUB_DEFAULT_USER_TOKEN_TTL
+      return {
+        accessTokenProps: next,
+        newProps: next,
+        accessTokenTTL: Math.floor(ttlBase * REFRESH_TTL_FRACTION),
+      }
+    }
+
+    return
+  }
+}

--- a/workers/crane-mcp-remote/src/types.ts
+++ b/workers/crane-mcp-remote/src/types.ts
@@ -26,4 +26,8 @@ export type Props = {
   name: string
   email: string
   github_token: string
+  // Present only when the GitHub App issues expiring user tokens. Absent for
+  // non-expiring-App sessions and for any session connected before refresh
+  // support shipped — both cases leave auto-refresh inert (see index.ts).
+  github_refresh_token?: string
 }

--- a/workers/crane-mcp-remote/src/utils.ts
+++ b/workers/crane-mcp-remote/src/utils.ts
@@ -4,6 +4,29 @@
  * no approval dialog (GitHub's own consent page is sufficient).
  */
 
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+
+/**
+ * Tokens returned by GitHub's token endpoint (code exchange or refresh).
+ * `refreshToken`/`expiresIn` are present only when the GitHub App has
+ * "Expire user authorization tokens" enabled; otherwise null (non-expiring
+ * access token).
+ */
+export interface UpstreamTokens {
+  accessToken: string
+  refreshToken: string | null
+  expiresIn: number | null
+}
+
+/**
+ * Result of a refresh attempt. `transient` (5xx/network) is recoverable on a
+ * later retry; `invalid_grant` (refresh token consumed or expired) requires the
+ * user to reconnect the integration.
+ */
+export type RefreshResult =
+  | { ok: true; tokens: UpstreamTokens }
+  | { ok: false; kind: 'invalid_grant' | 'transient' }
+
 /**
  * Build the upstream GitHub authorization URL.
  */
@@ -24,8 +47,47 @@ export function getUpstreamAuthorizeUrl(opts: {
 }
 
 /**
- * Exchange a GitHub authorization code for an access token.
- * Returns [accessToken, null] on success or [null, Response] on error.
+ * Build the urlencoded body for a refresh_token grant. Pure/testable.
+ */
+export function buildRefreshRequestBody(opts: {
+  client_id: string
+  client_secret: string
+  refresh_token: string
+}): string {
+  return new URLSearchParams({
+    client_id: opts.client_id,
+    client_secret: opts.client_secret,
+    grant_type: 'refresh_token',
+    refresh_token: opts.refresh_token,
+  }).toString()
+}
+
+/**
+ * Parse a GitHub token-endpoint JSON body into UpstreamTokens.
+ * Returns null when no access_token is present (error body or malformed).
+ * Pure/testable — no network, no logging.
+ */
+export function parseUpstreamTokenResponse(body: Record<string, unknown>): UpstreamTokens | null {
+  const accessToken = typeof body.access_token === 'string' ? body.access_token : ''
+  if (!accessToken) return null
+
+  const refreshToken = typeof body.refresh_token === 'string' ? body.refresh_token : null
+
+  // expires_in may arrive as a number or a numeric string depending on Accept handling.
+  let expiresIn: number | null = null
+  if (typeof body.expires_in === 'number' && Number.isFinite(body.expires_in)) {
+    expiresIn = body.expires_in
+  } else if (typeof body.expires_in === 'string' && body.expires_in.trim() !== '') {
+    const parsed = Number(body.expires_in)
+    expiresIn = Number.isFinite(parsed) ? parsed : null
+  }
+
+  return { accessToken, refreshToken, expiresIn }
+}
+
+/**
+ * Exchange a GitHub authorization code for tokens.
+ * Returns [tokens, null] on success or [null, Response] on error.
  */
 export async function fetchUpstreamAuthToken(opts: {
   upstream_url: string
@@ -33,7 +95,7 @@ export async function fetchUpstreamAuthToken(opts: {
   client_secret: string
   code: string | undefined
   redirect_uri: string
-}): Promise<[string, null] | [null, Response]> {
+}): Promise<[UpstreamTokens, null] | [null, Response]> {
   if (!opts.code) {
     return [null, new Response('Missing authorization code', { status: 400 })]
   }
@@ -53,15 +115,60 @@ export async function fetchUpstreamAuthToken(opts: {
   })
 
   if (!resp.ok) {
-    console.error('GitHub token exchange failed:', await resp.text())
+    // Status only — never log the response body (may echo the code/secret).
+    console.error('GitHub token exchange failed:', resp.status)
     return [null, new Response('Failed to exchange authorization code', { status: 502 })]
   }
 
-  const body = (await resp.json()) as Record<string, string>
-  const accessToken = body.access_token
-  if (!accessToken) {
+  const body = (await resp.json()) as Record<string, unknown>
+  const tokens = parseUpstreamTokenResponse(body)
+  if (!tokens) {
     return [null, new Response('No access token in GitHub response', { status: 502 })]
   }
 
-  return [accessToken, null]
+  return [tokens, null]
+}
+
+/**
+ * Refresh a GitHub user access token using a refresh_token grant.
+ * Returns a discriminated result so callers can distinguish a genuine
+ * reconnect-required failure (invalid_grant) from a transient one. Never logs
+ * token values.
+ */
+export async function refreshUpstreamAuthToken(opts: {
+  client_id: string
+  client_secret: string
+  refresh_token: string
+}): Promise<RefreshResult> {
+  let resp: Response
+  try {
+    resp = await fetch(GITHUB_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: buildRefreshRequestBody(opts),
+    })
+  } catch {
+    // Network failure — recoverable on a later refresh.
+    return { ok: false, kind: 'transient' }
+  }
+
+  if (!resp.ok) {
+    // 5xx is transient; 4xx means the refresh token is no longer usable.
+    return { ok: false, kind: resp.status >= 500 ? 'transient' : 'invalid_grant' }
+  }
+
+  const body = (await resp.json().catch(() => null)) as Record<string, unknown> | null
+  // GitHub returns 200 with an { error } body for a dead refresh token.
+  if (body && typeof body.error === 'string') {
+    return { ok: false, kind: 'invalid_grant' }
+  }
+  const tokens = body && parseUpstreamTokenResponse(body)
+  if (!tokens) {
+    return { ok: false, kind: 'invalid_grant' }
+  }
+
+  return { ok: true, tokens }
 }

--- a/workers/crane-mcp-remote/test/pure-functions.test.ts
+++ b/workers/crane-mcp-remote/test/pure-functions.test.ts
@@ -8,7 +8,18 @@
 
 import { describe, it, expect } from 'vitest'
 import { validateOwnerRepo, OWNER_REPO_PATTERN } from '../src/github-api'
-import { getUpstreamAuthorizeUrl } from '../src/utils'
+import {
+  getUpstreamAuthorizeUrl,
+  buildRefreshRequestBody,
+  parseUpstreamTokenResponse,
+  type RefreshResult,
+} from '../src/utils'
+import {
+  makeTokenExchangeCallback,
+  GITHUB_DEFAULT_USER_TOKEN_TTL,
+  REFRESH_TTL_FRACTION,
+  TRANSIENT_RETRY_TTL,
+} from '../src/token-exchange'
 
 // ============================================================================
 // validateOwnerRepo
@@ -113,5 +124,180 @@ describe('getUpstreamAuthorizeUrl', () => {
     const url = new URL(getUpstreamAuthorizeUrl(baseOpts))
     expect(url.origin).toBe('https://github.com')
     expect(url.pathname).toBe('/login/oauth/authorize')
+  })
+})
+
+// ============================================================================
+// buildRefreshRequestBody
+// ============================================================================
+
+describe('buildRefreshRequestBody', () => {
+  const opts = {
+    client_id: 'cid',
+    client_secret: 'csecret',
+    refresh_token: 'ghr_abc123',
+  }
+
+  it('sets grant_type=refresh_token and all credentials', () => {
+    const params = new URLSearchParams(buildRefreshRequestBody(opts))
+    expect(params.get('grant_type')).toBe('refresh_token')
+    expect(params.get('client_id')).toBe('cid')
+    expect(params.get('client_secret')).toBe('csecret')
+    expect(params.get('refresh_token')).toBe('ghr_abc123')
+  })
+
+  it('url-encodes special characters in the refresh token', () => {
+    const body = buildRefreshRequestBody({ ...opts, refresh_token: 'a+b/c=d&e' })
+    // Round-trips back to the original value, and the raw body is encoded.
+    expect(new URLSearchParams(body).get('refresh_token')).toBe('a+b/c=d&e')
+    expect(body).not.toContain('a+b/c=d&e')
+  })
+})
+
+// ============================================================================
+// parseUpstreamTokenResponse
+// ============================================================================
+
+describe('parseUpstreamTokenResponse', () => {
+  it('parses a full expiring-token response', () => {
+    expect(
+      parseUpstreamTokenResponse({
+        access_token: 'ghu_x',
+        refresh_token: 'ghr_y',
+        expires_in: 28800,
+      })
+    ).toEqual({ accessToken: 'ghu_x', refreshToken: 'ghr_y', expiresIn: 28800 })
+  })
+
+  it('parses a minimal non-expiring response (access token only) with nulls', () => {
+    expect(parseUpstreamTokenResponse({ access_token: 'gho_x' })).toEqual({
+      accessToken: 'gho_x',
+      refreshToken: null,
+      expiresIn: null,
+    })
+  })
+
+  it('returns null when access_token is missing', () => {
+    expect(parseUpstreamTokenResponse({ token_type: 'bearer' })).toBeNull()
+  })
+
+  it('returns null for a GitHub error-shaped body', () => {
+    expect(parseUpstreamTokenResponse({ error: 'bad_refresh_token' })).toBeNull()
+  })
+
+  it('coerces a numeric-string expires_in', () => {
+    expect(
+      parseUpstreamTokenResponse({ access_token: 'ghu_x', expires_in: '28800' })?.expiresIn
+    ).toBe(28800)
+  })
+
+  it('treats a non-numeric expires_in as null', () => {
+    expect(
+      parseUpstreamTokenResponse({ access_token: 'ghu_x', expires_in: 'soon' })?.expiresIn
+    ).toBeNull()
+  })
+})
+
+// ============================================================================
+// makeTokenExchangeCallback — branch table
+// ============================================================================
+
+describe('makeTokenExchangeCallback', () => {
+  const env = { GITHUB_CLIENT_ID: 'cid', GITHUB_CLIENT_SECRET: 'csecret' }
+  const EXPECTED_AUTH_TTL = Math.floor(GITHUB_DEFAULT_USER_TOKEN_TTL * REFRESH_TTL_FRACTION) // 21600
+
+  // Build a TokenExchangeCallbackOptions-shaped object (callback reads only
+  // grantType + props).
+  const opts = (grantType: string, props: unknown) =>
+    ({ grantType, props, clientId: 'c', userId: 'u', scope: [], requestedScope: [] }) as never
+
+  // Refresh stub matching refreshUpstreamAuthToken's signature.
+  const stub = (result: RefreshResult) => {
+    const calls: Array<{ client_id: string; client_secret: string; refresh_token: string }> = []
+    const fn = async (o: { client_id: string; client_secret: string; refresh_token: string }) => {
+      calls.push(o)
+      return result
+    }
+    return { fn, calls }
+  }
+
+  it('is inert (void) and never refreshes when no refresh token is present', async () => {
+    const s = stub({ ok: false, kind: 'transient' })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    expect(await cb(opts('authorization_code', { github_token: 'ghu_x' }))).toBeUndefined()
+    expect(await cb(opts('refresh_token', { github_token: 'ghu_x' }))).toBeUndefined()
+    expect(s.calls).toHaveLength(0)
+  })
+
+  it('caps TTL on authorization_code when a refresh token exists (no upstream call)', async () => {
+    const s = stub({ ok: false, kind: 'transient' })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    const result = await cb(
+      opts('authorization_code', { github_token: 'ghu_x', github_refresh_token: 'ghr_y' })
+    )
+    expect(result).toEqual({ accessTokenTTL: EXPECTED_AUTH_TTL })
+    expect(s.calls).toHaveLength(0)
+  })
+
+  it('refreshes on refresh_token grant, rotating both tokens and capping TTL', async () => {
+    const s = stub({
+      ok: true,
+      tokens: { accessToken: 'ghu_new', refreshToken: 'ghr_new', expiresIn: 28800 },
+    })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    const result = await cb(
+      opts('refresh_token', {
+        login: 'me',
+        github_token: 'ghu_old',
+        github_refresh_token: 'ghr_old',
+      })
+    )
+    // Passes the stored refresh token + env credentials to GitHub.
+    expect(s.calls[0]).toEqual({
+      client_id: 'cid',
+      client_secret: 'csecret',
+      refresh_token: 'ghr_old',
+    })
+    const expected = {
+      login: 'me',
+      github_token: 'ghu_new',
+      github_refresh_token: 'ghr_new',
+    }
+    expect(result).toEqual({
+      accessTokenProps: expected,
+      newProps: expected,
+      accessTokenTTL: EXPECTED_AUTH_TTL,
+    })
+  })
+
+  it('keeps the old refresh token if GitHub omits a rotated one', async () => {
+    const s = stub({
+      ok: true,
+      tokens: { accessToken: 'ghu_new', refreshToken: null, expiresIn: null },
+    })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    const result = (await cb(
+      opts('refresh_token', { github_token: 'ghu_old', github_refresh_token: 'ghr_old' })
+    )) as { newProps: { github_refresh_token: string }; accessTokenTTL: number }
+    expect(result.newProps.github_refresh_token).toBe('ghr_old')
+    // expires_in null → falls back to default lifetime.
+    expect(result.accessTokenTTL).toBe(EXPECTED_AUTH_TTL)
+  })
+
+  it('returns a short retry TTL on transient failure, leaving props unchanged', async () => {
+    const s = stub({ ok: false, kind: 'transient' })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    const result = await cb(
+      opts('refresh_token', { github_token: 'ghu_old', github_refresh_token: 'ghr_old' })
+    )
+    expect(result).toEqual({ accessTokenTTL: TRANSIENT_RETRY_TTL })
+  })
+
+  it('returns void on invalid_grant (degrades to reconnect)', async () => {
+    const s = stub({ ok: false, kind: 'invalid_grant' })
+    const cb = makeTokenExchangeCallback(env, s.fn)
+    expect(
+      await cb(opts('refresh_token', { github_token: 'ghu_old', github_refresh_token: 'ghr_old' }))
+    ).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Problem

The Crane MCP remote worker's `github_*` tools authenticate with a GitHub **user** OAuth token captured once at claude.ai connect-time and stored in the encrypted session props. The code exchange (`utils.ts`) discarded `refresh_token`/`expires_in`, and the `OAuthProvider` (`index.ts`) wired **no `tokenExchangeCallback`** — so the token was never refreshed. When the `venturecrane-github` App issues expiring (8h) user tokens, the token dies and every agent on the connection hits "GitHub token is invalid or revoked". claude.ai web/iOS agents have no `gh` CLI fallback, so they are fully blocked until a manual reconnect.

This was an incomplete port — `github-handler.ts` notes the worker was "Simplified from Cloudflare's remote-mcp-github-oauth template," and the refresh path was dropped. The installed `@cloudflare/workers-oauth-provider@0.4.0` supports refresh natively via `tokenExchangeCallback`.

## Change

- **`utils.ts`** — capture `refresh_token`/`expires_in` from the code exchange (object return); add pure, network-free `buildRefreshRequestBody` + `parseUpstreamTokenResponse`; add `refreshUpstreamAuthToken` returning a discriminated result (`invalid_grant` vs `transient`). Exchange-failure logging tightened to status only — never bodies/tokens.
- **`types.ts`** — optional `Props.github_refresh_token` (decrypts fine for existing sessions).
- **`github-handler.ts`** — store `github_refresh_token` in the grant props.
- **`token-exchange.ts`** (new) — `makeTokenExchangeCallback`:
  - caps the downstream (claude.ai↔worker) token TTL to **0.75× upstream** so the client refreshes *early*, renewing the GitHub token while it still has headroom (avoids the expiry-boundary race);
  - on the `refresh_token` grant, refreshes and **rotates** the GitHub token (GitHub rotates `ghr_` each call);
  - `transient` failure → short retry TTL (auto-recovers); `invalid_grant` → leave props → next `github_*` call 401s → existing reconnect message;
  - **inert** when the grant has no refresh token, so it is safe whether or not the App has expiring tokens enabled.
- **`index.ts`** — build the `OAuthProvider` per request (the callback needs the OAuth client credentials, which the callback API doesn't supply and Workers don't expose at module load; per-request construction avoids module-level mutable state). Adds a `crane_health` hint when a session lacks a refresh token.
- **tests** — pure-helper coverage plus a callback **branch table** (all five branches with a mocked refresh dependency).

Extracted the callback into its own module so it unit-tests without loading the Workers/MCP runtime.

## ⚠️ Rollout (runbook)

**Existing claude.ai integrations do not self-heal.** Their props have no `github_refresh_token`, so the callback stays inert and they keep dying at 8h **until each is disconnected/reconnected once** post-deploy to seed a refresh token. The new `crane_health` line surfaces this. Rollback is clean: remove the callback — tokens behave exactly as today; the optional prop decrypts harmlessly.

## Premise / dependency (not a code blocker)

The refresh path only activates if the App's **"Expire user authorization tokens"** setting is ON (Captain-owned; not readable via API). If it is currently OFF, this ships inert-safe and the immediate token death was a one-off revocation that a reconnect already fixes. Turning the setting OFF is a zero-code alternative but was rejected — non-expiring user tokens are a worse security posture (valid until manually revoked); refresh gives both security and no-reconnect UX.

## Verification

- `npm run verify` green (typecheck + format + lint + parity + tests + builds).
- `workers/crane-mcp-remote`: typecheck clean, 39 tests pass (+13 new).
- Post-deploy (staging): connect, confirm `github_whoami`; reconnect to seed the refresh token; confirm `github_*` keeps working past 8h without reconnect (never logging token values).

QA grade: B+ — unit-covered and verified locally; the end-to-end refresh loop depends on claude.ai performing the downstream `refresh_token` grant, which is validated by post-deploy smoke test rather than in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
