### PR TITLE
feat(skills): aie-onboard — interview transcript → AI-Employee config + onboarding plan

### DIFF
--- a/.agents/skills/aie-onboard/SKILL.md
+++ b/.agents/skills/aie-onboard/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: aie-onboard
+description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+version: 0.1.0
+scope: enterprise
+owner: captain
+status: draft
+---
+
+# /aie-onboard - Author an AI-Employee config from a client interview
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "aie-onboard")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Turns an initial client-interview transcript or notes into two artifacts under the
+venture repo's `ai-employee/customers/<slug>/`:
+
+1. `customer.yaml` — the validated AI-Employee configuration
+2. `onboarding-plan.md` — the specific per-engagement onboarding steps
+
+It then validates the YAML and **stops for Captain review**. It does not provision a
+Machine and it does not commit. This is the operator-side authoring step that precedes
+`ai-employee/bin/provision-customer.sh` in the onboarding runbook
+(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+
+## Canonical sources (read these; do not re-encode them here)
+
+This skill is a thin extractive procedure over docs that already own their content. Load
+them rather than duplicating their rules:
+
+- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
+- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
+- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
+  (per-vertical task taxonomy + cross-vertical patterns)
+- **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
+- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
+  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
+
+## Deltas this skill owns (not covered by the docs above)
+
+1. **Trust-ceiling locking.** The customer.yaml validator does **not** enforce a skill's
+   trust ceiling against the catalog (the `TrustCeilingExceeded` code exists but is never
+   emitted — it is a provision-time check). So the discipline lives here: never raise a
+   skill above its authored `metadata.smd.trust_ceiling`, and any skill whose frontmatter
+   carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
+   promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
+   the skill's `SKILL.md` — never a hardcoded name list.
+2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
+   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+   and are in scope **only** when the customer's `vertical`/addons select that pack. For a
+   `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
+   appear.
+3. **Banned emissions.** Never emit a `composio:` connector backend (doctrine-dropped,
+   ADR 0020). Never emit a `hermes_ref` fork tag — values like `v2026.5.16-smd.0` are
+   rejected; the ref must match `v{YYYY}.{M}.{D}@{40-hex-sha}` (ADR 0024).
+
+## Execution
+
+### Step 1 — Gather inputs
+
+Take the transcript/notes and a target customer slug. Confirm the slug with the user
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+exists, stop and ask whether to overwrite-with-review — never silently clobber.
+
+### Step 2 — Load the contract
+
+Read `references/extraction-contract.md` and restate the no-fabrication rules to yourself
+before extracting anything.
+
+### Step 3 — Extract facts (evidence-bound)
+
+Pull only what the source states: identity, the humans with access and their roles,
+**explicitly-named** tools (→ connectors), described pains (→ skills), any voice signal,
+escalation contacts. Attach the verbatim quote that justifies each non-trivial value.
+Anything undeterminable is a `TBD` / open-item — never an inference. Hold this in the
+conversation; write an `INTENT.md` only if the Captain wants the audit trail.
+
+### Step 4 — Map pains → skills
+
+Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
+candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
+selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
+`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
+enabled skill.
+
+### Step 5 — Decide connectors
+
+MCP-first per ADR 0020. Emit a real `mcp:` / `build:` backend **only when the transcript
+names the tool**. A capability gestured at but unnamed becomes `synthetic:<adapter>` plus
+an onboarding open-item to confirm and swap. Never emit `composio:`.
+
+### Step 6 — Render customer.yaml
+
+Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
+(`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
+`vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
+documented current pin (never synthesize one, never a fork tag); `model: claude-opus-4-7`
+unless overridden. Keep any secret reference as a `token_ref: infisical:/...` — never an
+inline value.
+
+### Step 7 — Review gate (no file written before this)
+
+Present the proposed `customer.yaml`, the per-field quote map, and the open-items list.
+Ask the Captain to approve, revise, or cancel. Write nothing until approved.
+
+### Step 8 — Write the artifacts
+
+On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
+`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+connectors and skills** — a short three-phase list, not a parameterized template:
+
+- **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
+  enabled non-synthetic connector; one "confirm tool, swap synthetic → real" row per
+  `synthetic:` connector; a voice-sample collection row (source TBD until the principal
+  supplies one); a scope/data-audit row from `scope.*`.
+- **Phase 2 — Shadow mode, observe/draft/no-send (Day 6–14):** one enablement row per
+  enabled skill at its ceiling; locked skills noted as draft-for-review forever.
+- **Phase 3 — Graduated autonomy (Day 15+):** promotion candidates = non-locked
+  `draft_for_review` skills, gated on clean shadow runs.
+  Unfilled fields render an explicit `TBD` per `docs/style/empty-state-pattern.md` — never
+  invented copy.
+
+### Step 9 — Validate
+
+Run the canonical validator and require a clean exit:
+
+```bash
+npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+```
+
+On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
+
+### Step 10 — Stop for review
+
+Print the `file://` paths to the generated artifacts and the open-items summary. State
+plainly that the config is **not provisioned and not committed**. If the Captain approves,
+the next steps (a separate branch + PR, then provisioning) are theirs to trigger.
+
+## Guardrails
+
+- **NON-PROVISIONING.** This skill MUST NOT run `provision-customer.sh`, `fly`, `wrangler`,
+  or `infisical`. It creates no Fly app, volume, secret, or remote resource. Provisioning
+  is a separate, Captain-gated step.
+- **NON-COMMITTING.** This skill MUST NOT run `git add`, `git commit`, or `git push`. It
+  writes working-tree files and stops. Landing them is a separate review + PR.
+- **No secret values.** Never write a literal credential into any artifact; secret
+  references use the `token_ref: infisical:/...` form only.
+- **Extractive only.** Honor `references/extraction-contract.md` — undeterminable facts are
+  open-items, never inventions.
+- **Trust ceilings.** Enforce locking here (the validator does not): `trust_ceiling_locked`
+  skills stay `draft_for_review`; never exceed a skill's authored ceiling.
+
+## Reference files
+
+- `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
+- `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
+- `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
+- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)

--- a/.agents/skills/aie-onboard/references/extraction-contract.md
+++ b/.agents/skills/aie-onboard/references/extraction-contract.md
@@ -1,0 +1,56 @@
+# Extraction contract — `aie-onboard`
+
+This is the **P0 no-fabrication contract** for the onboarding skill. It governs how
+facts are pulled from a client-interview transcript/notes into a `customer.yaml` and
+an onboarding plan. It exists because everything this skill produces becomes
+client-facing engagement configuration, and CLAUDE.md's "No fabricated client-facing
+content" rule is absolute: invented config is a compliance risk, not a convenience.
+
+This contract mirrors the enforced enrichment-prompt contracts
+(`src/lib/enrichment/dossier.ts`, asserted by `tests/enrichment-prompt-contracts.test.ts`).
+The same discipline applies here.
+
+## The rule
+
+**Use only facts present in the supplied context.** Every value you write into
+`customer.yaml` or `onboarding-plan.md` must trace to something the interviewee
+actually said or supplied. If it is not in the transcript/notes, it is not a fact you
+have.
+
+**Do not infer management style, communication preference, personality, likely objections, or private business conditions.**
+You are configuring an AI Employee, not profiling a person. Tone descriptors come from
+how the principal describes the voice they want or from supplied writing — never from
+your read of their character.
+
+**When evidence is incomplete, label it as an open question instead of guessing.** A
+missing field is a `TBD`, a `synthetic:` connector, or an explicit onboarding open-item
+— never a plausible-sounding invention. A blank is honest; a fabrication is a defect.
+
+## What this means field by field
+
+- **Identity / people / roles** — only names, emails, and roles stated in the source.
+  Never a placeholder like "Business Owner" standing in for a real signer.
+- **Connectors** — wire a real `mcp:`/`build:` backend **only when the interviewee
+  names the tool** ("we run everything in Gmail"). A capability they gesture at without
+  naming ("some scheduling thing", "our CRM") becomes `synthetic:<adapter>` plus an
+  onboarding open-item to confirm and swap. Never guess a vendor.
+- **Skills / trust ceilings** — enable a skill only when the source describes the pain
+  it addresses. Surface the verbatim quote that justifies it. Never raise a skill above
+  its authored trust ceiling; never promote a `trust_ceiling_locked` skill.
+- **Voice** — if the interviewee did not supply or point to writing samples, voice-sample
+  collection is an **open onboarding item**, not a fabricated corpus or an asserted tone.
+- **Optional fields** (pronouns, business hours, signature) — omit when unstated. Omission
+  is correct; a guess is a violation.
+
+## Evidence binding
+
+For every non-trivial decision, carry the verbatim quote that justifies it (the
+`proposal-drafter` pattern — `ai-employee/skills/proposal-drafter/SKILL.md`). The
+reviewer must be able to see that the config reflects what was said, not what was
+imagined. If you cannot quote a source line for a value, you cannot write that value.
+
+## Hard line
+
+If the transcript is ambiguous, **surface the ambiguity — do not resolve it.** Present
+the open-item to the Captain at the review gate. The skill never closes a gap by
+inventing content.

--- a/.agents/skills/aie-onboard/references/test-cases.md
+++ b/.agents/skills/aie-onboard/references/test-cases.md
@@ -1,0 +1,94 @@
+# Test cases — `aie-onboard`
+
+Synthetic **narrative** intakes used to exercise the skill (and to drive the SMD
+customer-zero dogfood). These are written as kickoff-conversation prose on purpose:
+the skill's job is to _derive_ config from what was said and to leave undeterminable
+fields as `TBD`/`synthetic:`/open-items — not to copy a pre-filled answer key. A test
+that feeds the skill its own output proves only the renderer, never the extractor.
+
+---
+
+## Case 1 — SMD Services (customer-zero, `vertical: mixed`)
+
+This is the dogfood input. It is what Scott would say in a setup conversation. The
+expected-output block below is the assertion target — it must be **derived** from the
+narrative, not pasted in as input.
+
+### Intake notes (narrative)
+
+> I'm Scott Durgan. The legal entity is SMDurgan, LLC — we run as SMD Services, a
+> solutions-consulting shop. This first one is us using our own product before we sell
+> it, so I'm the only person who needs access: smdurgan@venturecrane.com, and I'm the
+> principal — it answers to me and I review everything before it goes anywhere.
+>
+> I want to call the assistant **Crane**. Think of it as a Chief of Staff, not a
+> secretary. The voice should be plainspoken and direct — executive-summary first, no
+> throat-clearing, keep it short. I don't want it sounding like a chipper marketing bot.
+>
+> The one job I want to start with is my inbox. I'm drowning in email and things slip.
+> I want it reading what comes in every morning, sorting it, and drafting replies for
+> me to review — it should never send on its own, I want to be the one who hits send.
+> One thing at a time; we'll add more once this earns its keep.
+>
+> We run everything in Google — Gmail, Google Calendar, and Google Drive. That's the
+> whole stack for now.
+>
+> We're in Phoenix. If anything goes wrong or it spots something urgent, just flag it
+> to me at the same address.
+
+### Expected derived output (assertion target)
+
+`customer.yaml`:
+
+- `customer_id: smd`, `customer_name: 'SMDurgan, LLC'`
+- `vertical: mixed` — SMD is consulting/services; the enum has no `consulting` value, so
+  `mixed` is the honest non-fabricated choice (known PRD open question, #776). Because
+  vertical ≠ `law-firm`, **no `practice_areas`** and **no PI-addon skills**.
+- `fly_region: lax` (closest region to Phoenix; stated location → documented mapping)
+- `model: claude-opus-4-7`; `hermes_ref: v2026.5.16@a91a57fa5a13d516c38b07a141a9ce8a3daabeb0`
+  (operator-supplied current pin — never a `-smd.N` fork tag)
+- `users`: one `principal`, Scott Durgan, smdurgan@venturecrane.com
+- `personas`: one active persona `crane`, title `Chief of Staff`, tone
+  `[plainspoken, direct, executive-summary, concise]` (from how he described the voice —
+  not inferred personality), one skill `inbox-triage` @ `draft_for_review` ("review
+  before it goes anywhere" / "never send on its own")
+- `connectors`: `Email` → `mcp:google-gmail`, `Calendar` → `mcp:google-calendar`,
+  `DocumentStorage` → `mcp:google-drive` (all named explicitly). No `composio:`.
+- `escalation`: red_flag + failure recipients both smdurgan@venturecrane.com
+- `memory`: `d1_namespace: smd`, `r2_vault_path: vaults/smd/`, `vectorize_index: hermes-smd-vault`
+
+### Deliberately-absent facts (must NOT be fabricated)
+
+- **Voice samples** — Scott never supplied or pointed to any writing samples. The skill
+  must NOT assert a tone-from-samples or fabricate a corpus. `voice_library.samples_path`
+  is the deterministic R2 path (structural), but **voice-sample collection is an open
+  onboarding item** in Phase 1, marked TBD until the principal supplies a source.
+- **Pronouns** — never stated → omit the field. Do not guess.
+- This is the proof that the extractor (not just the YAML renderer) honors the contract:
+  a green run must leave these as open-item/omitted, not filled.
+
+---
+
+## Case 2 — Adversarial: unnamed tools must go `synthetic:` (non-SMD)
+
+Guards against the highest-risk failure: guessing a vendor the interviewee never named.
+
+### Intake notes (narrative)
+
+> We're a small real-estate brokerage. The owner is Dana Reyes, dana@example-realty.test,
+> she signs off on everything. Call the assistant Riley. We want it watching the inbox
+> and drafting replies. We use some scheduling thing for showings, and we've got a CRM
+> for leads, but honestly I couldn't tell you the brand off the top of my head.
+
+### Expected derived output
+
+- `Email` → real backend only if a mail vendor were named; here it isn't named beyond
+  "the inbox", so Email is `synthetic:fixture` + open-item OR omitted pending naming.
+- `Calendar` (the "scheduling thing") → **`synthetic:fixture`** + open-item "confirm
+  scheduling tool with client, swap synthetic→real" — NEVER a guessed `mcp:google-calendar`.
+- `IntakeCRM` (the unnamed "CRM") → **`synthetic:fixture`** + open-item — NEVER a guessed
+  `mcp:` adapter.
+- The skill surfaces these as ambiguities at the review gate; it does not resolve them.
+
+A run that emits `mcp:google-calendar` or any named CRM adapter for Case 2 is a contract
+violation, even though the guess might be right.

--- a/.agents/skills/aie-onboard/test_contract.py
+++ b/.agents/skills/aie-onboard/test_contract.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Prompt-contract guard for the aie-onboard skill.
+
+The skill turns a client-interview transcript into a customer.yaml + onboarding
+plan — all client-facing engagement config — so it must stay strictly extractive
+(no fabricated content) and carry the guardrails the customer.yaml validator does
+NOT enforce: trust-ceiling locking, the composio ban, and the hermes_ref fork-tag
+ban.
+
+Mirrors the ss-console enrichment-prompt-contract tests: source-level assertions on
+the skill text, not runtime behavior. Stdlib unittest (matches the estimate skill's
+test convention; no pytest dependency).
+
+Run: python3 .agents/skills/aie-onboard/test_contract.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parent
+SKILL = (_DIR / "SKILL.md").read_text(encoding="utf-8")
+CONTRACT = (_DIR / "references" / "extraction-contract.md").read_text(encoding="utf-8")
+
+
+class ExtractionContract(unittest.TestCase):
+    def test_contract_is_evidence_bound(self) -> None:
+        self.assertIn("Use only facts present in the supplied context.", CONTRACT)
+        self.assertIn(
+            "Do not infer management style, communication preference, personality, "
+            "likely objections, or private business conditions.",
+            CONTRACT,
+        )
+        self.assertIn(
+            "When evidence is incomplete, label it as an open question instead of guessing.",
+            CONTRACT,
+        )
+
+    def test_contract_has_no_inference_sections(self) -> None:
+        for banned in (
+            "## Management Style",
+            "## Communication Preferences",
+            "## Likely Objections",
+            "## Talking Points",
+        ):
+            self.assertNotIn(banned, CONTRACT)
+
+
+class SkillGuardrails(unittest.TestCase):
+    def test_non_provisioning_non_committing(self) -> None:
+        self.assertIn("NON-PROVISIONING", SKILL)
+        self.assertIn("NON-COMMITTING", SKILL)
+        self.assertIn("MUST NOT run `provision-customer.sh`", SKILL)
+        self.assertIn("MUST NOT run `git add`, `git commit`, or `git push`", SKILL)
+
+    def test_trust_ceiling_locking_enforced_in_skill(self) -> None:
+        # The customer.yaml validator never emits TrustCeilingExceeded, so the lock
+        # rule must live in the skill. Assert the mechanism, not a skill-name list.
+        self.assertIn("trust_ceiling_locked", SKILL)
+        self.assertIn("is forced to `draft_for_review`", SKILL)
+
+    def test_bans_composio_and_hermes_fork_tags(self) -> None:
+        self.assertIn("Never emit a `composio:`", SKILL)
+        self.assertIn("v2026.5.16-smd.0", SKILL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/commands/aie-onboard.md
+++ b/.claude/commands/aie-onboard.md
@@ -1,0 +1,153 @@
+---
+name: aie-onboard
+description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+---
+
+# /aie-onboard - Author an AI-Employee config from a client interview
+
+Turns an initial client-interview transcript or notes into two artifacts under the
+venture repo's `ai-employee/customers/<slug>/`:
+
+1. `customer.yaml` — the validated AI-Employee configuration
+2. `onboarding-plan.md` — the specific per-engagement onboarding steps
+
+It then validates the YAML and **stops for Captain review**. It does not provision a
+Machine and it does not commit. This is the operator-side authoring step that precedes
+`ai-employee/bin/provision-customer.sh` in the onboarding runbook
+(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+
+## Canonical sources (read these; do not re-encode them here)
+
+This skill is a thin extractive procedure over docs that already own their content. Load
+them rather than duplicating their rules:
+
+- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
+- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
+- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
+  (per-vertical task taxonomy + cross-vertical patterns)
+- **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
+- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
+  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
+
+## Deltas this skill owns (not covered by the docs above)
+
+1. **Trust-ceiling locking.** The customer.yaml validator does **not** enforce a skill's
+   trust ceiling against the catalog (the `TrustCeilingExceeded` code exists but is never
+   emitted — it is a provision-time check). So the discipline lives here: never raise a
+   skill above its authored `metadata.smd.trust_ceiling`, and any skill whose frontmatter
+   carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
+   promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
+   the skill's `SKILL.md` — never a hardcoded name list.
+2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
+   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+   and are in scope **only** when the customer's `vertical`/addons select that pack. For a
+   `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
+   appear.
+3. **Banned emissions.** Never emit a `composio:` connector backend (doctrine-dropped,
+   ADR 0020). Never emit a `hermes_ref` fork tag — values like `v2026.5.16-smd.0` are
+   rejected; the ref must match `v{YYYY}.{M}.{D}@{40-hex-sha}` (ADR 0024).
+
+## Execution
+
+### Step 1 — Gather inputs
+
+Take the transcript/notes and a target customer slug. Confirm the slug with the user
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+exists, stop and ask whether to overwrite-with-review — never silently clobber.
+
+### Step 2 — Load the contract
+
+Read `references/extraction-contract.md` and restate the no-fabrication rules to yourself
+before extracting anything.
+
+### Step 3 — Extract facts (evidence-bound)
+
+Pull only what the source states: identity, the humans with access and their roles,
+**explicitly-named** tools (→ connectors), described pains (→ skills), any voice signal,
+escalation contacts. Attach the verbatim quote that justifies each non-trivial value.
+Anything undeterminable is a `TBD` / open-item — never an inference. Hold this in the
+conversation; write an `INTENT.md` only if the Captain wants the audit trail.
+
+### Step 4 — Map pains → skills
+
+Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
+candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
+selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
+`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
+enabled skill.
+
+### Step 5 — Decide connectors
+
+MCP-first per ADR 0020. Emit a real `mcp:` / `build:` backend **only when the transcript
+names the tool**. A capability gestured at but unnamed becomes `synthetic:<adapter>` plus
+an onboarding open-item to confirm and swap. Never emit `composio:`.
+
+### Step 6 — Render customer.yaml
+
+Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
+(`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
+`vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
+documented current pin (never synthesize one, never a fork tag); `model: claude-opus-4-7`
+unless overridden. Keep any secret reference as a `token_ref: infisical:/...` — never an
+inline value.
+
+### Step 7 — Review gate (no file written before this)
+
+Present the proposed `customer.yaml`, the per-field quote map, and the open-items list.
+Ask the Captain to approve, revise, or cancel. Write nothing until approved.
+
+### Step 8 — Write the artifacts
+
+On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
+`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+connectors and skills** — a short three-phase list, not a parameterized template:
+
+- **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
+  enabled non-synthetic connector; one "confirm tool, swap synthetic → real" row per
+  `synthetic:` connector; a voice-sample collection row (source TBD until the principal
+  supplies one); a scope/data-audit row from `scope.*`.
+- **Phase 2 — Shadow mode, observe/draft/no-send (Day 6–14):** one enablement row per
+  enabled skill at its ceiling; locked skills noted as draft-for-review forever.
+- **Phase 3 — Graduated autonomy (Day 15+):** promotion candidates = non-locked
+  `draft_for_review` skills, gated on clean shadow runs.
+  Unfilled fields render an explicit `TBD` per `docs/style/empty-state-pattern.md` — never
+  invented copy.
+
+### Step 9 — Validate
+
+Run the canonical validator and require a clean exit:
+
+```bash
+npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+```
+
+On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
+
+### Step 10 — Stop for review
+
+Print the `file://` paths to the generated artifacts and the open-items summary. State
+plainly that the config is **not provisioned and not committed**. If the Captain approves,
+the next steps (a separate branch + PR, then provisioning) are theirs to trigger.
+
+## Guardrails
+
+- **NON-PROVISIONING.** This skill MUST NOT run `provision-customer.sh`, `fly`, `wrangler`,
+  or `infisical`. It creates no Fly app, volume, secret, or remote resource. Provisioning
+  is a separate, Captain-gated step.
+- **NON-COMMITTING.** This skill MUST NOT run `git add`, `git commit`, or `git push`. It
+  writes working-tree files and stops. Landing them is a separate review + PR.
+- **No secret values.** Never write a literal credential into any artifact; secret
+  references use the `token_ref: infisical:/...` form only.
+- **Extractive only.** Honor `references/extraction-contract.md` — undeterminable facts are
+  open-items, never inventions.
+- **Trust ceilings.** Enforce locking here (the validator does not): `trust_ceiling_locked`
+  skills stay `draft_for_review`; never exceed a skill's authored ceiling.
+
+## Reference files
+
+- `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
+- `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
+- `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
+- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)

--- a/.gemini/commands/aie-onboard.toml
+++ b/.gemini/commands/aie-onboard.toml
@@ -1,0 +1,156 @@
+description = "---"
+
+prompt = """
+name: aie-onboard
+description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+---
+
+# /aie-onboard - Author an AI-Employee config from a client interview
+
+Turns an initial client-interview transcript or notes into two artifacts under the
+venture repo's `ai-employee/customers/<slug>/`:
+
+1. `customer.yaml` — the validated AI-Employee configuration
+2. `onboarding-plan.md` — the specific per-engagement onboarding steps
+
+It then validates the YAML and **stops for Captain review**. It does not provision a
+Machine and it does not commit. This is the operator-side authoring step that precedes
+`ai-employee/bin/provision-customer.sh` in the onboarding runbook
+(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+
+## Canonical sources (read these; do not re-encode them here)
+
+This skill is a thin extractive procedure over docs that already own their content. Load
+them rather than duplicating their rules:
+
+- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
+- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
+- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
+  (per-vertical task taxonomy + cross-vertical patterns)
+- **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
+- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
+  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
+
+## Deltas this skill owns (not covered by the docs above)
+
+1. **Trust-ceiling locking.** The customer.yaml validator does **not** enforce a skill's
+   trust ceiling against the catalog (the `TrustCeilingExceeded` code exists but is never
+   emitted — it is a provision-time check). So the discipline lives here: never raise a
+   skill above its authored `metadata.smd.trust_ceiling`, and any skill whose frontmatter
+   carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
+   promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
+   the skill's `SKILL.md` — never a hardcoded name list.
+2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
+   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+   and are in scope **only** when the customer's `vertical`/addons select that pack. For a
+   `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
+   appear.
+3. **Banned emissions.** Never emit a `composio:` connector backend (doctrine-dropped,
+   ADR 0020). Never emit a `hermes_ref` fork tag — values like `v2026.5.16-smd.0` are
+   rejected; the ref must match `v{YYYY}.{M}.{D}@{40-hex-sha}` (ADR 0024).
+
+## Execution
+
+### Step 1 — Gather inputs
+
+Take the transcript/notes and a target customer slug. Confirm the slug with the user
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+exists, stop and ask whether to overwrite-with-review — never silently clobber.
+
+### Step 2 — Load the contract
+
+Read `references/extraction-contract.md` and restate the no-fabrication rules to yourself
+before extracting anything.
+
+### Step 3 — Extract facts (evidence-bound)
+
+Pull only what the source states: identity, the humans with access and their roles,
+**explicitly-named** tools (→ connectors), described pains (→ skills), any voice signal,
+escalation contacts. Attach the verbatim quote that justifies each non-trivial value.
+Anything undeterminable is a `TBD` / open-item — never an inference. Hold this in the
+conversation; write an `INTENT.md` only if the Captain wants the audit trail.
+
+### Step 4 — Map pains → skills
+
+Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
+candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
+selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
+`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
+enabled skill.
+
+### Step 5 — Decide connectors
+
+MCP-first per ADR 0020. Emit a real `mcp:` / `build:` backend **only when the transcript
+names the tool**. A capability gestured at but unnamed becomes `synthetic:<adapter>` plus
+an onboarding open-item to confirm and swap. Never emit `composio:`.
+
+### Step 6 — Render customer.yaml
+
+Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
+(`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
+`vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
+documented current pin (never synthesize one, never a fork tag); `model: claude-opus-4-7`
+unless overridden. Keep any secret reference as a `token_ref: infisical:/...` — never an
+inline value.
+
+### Step 7 — Review gate (no file written before this)
+
+Present the proposed `customer.yaml`, the per-field quote map, and the open-items list.
+Ask the Captain to approve, revise, or cancel. Write nothing until approved.
+
+### Step 8 — Write the artifacts
+
+On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
+`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+connectors and skills** — a short three-phase list, not a parameterized template:
+
+- **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
+  enabled non-synthetic connector; one "confirm tool, swap synthetic → real" row per
+  `synthetic:` connector; a voice-sample collection row (source TBD until the principal
+  supplies one); a scope/data-audit row from `scope.*`.
+- **Phase 2 — Shadow mode, observe/draft/no-send (Day 6–14):** one enablement row per
+  enabled skill at its ceiling; locked skills noted as draft-for-review forever.
+- **Phase 3 — Graduated autonomy (Day 15+):** promotion candidates = non-locked
+  `draft_for_review` skills, gated on clean shadow runs.
+  Unfilled fields render an explicit `TBD` per `docs/style/empty-state-pattern.md` — never
+  invented copy.
+
+### Step 9 — Validate
+
+Run the canonical validator and require a clean exit:
+
+```bash
+npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+```
+
+On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
+
+### Step 10 — Stop for review
+
+Print the `file://` paths to the generated artifacts and the open-items summary. State
+plainly that the config is **not provisioned and not committed**. If the Captain approves,
+the next steps (a separate branch + PR, then provisioning) are theirs to trigger.
+
+## Guardrails
+
+- **NON-PROVISIONING.** This skill MUST NOT run `provision-customer.sh`, `fly`, `wrangler`,
+  or `infisical`. It creates no Fly app, volume, secret, or remote resource. Provisioning
+  is a separate, Captain-gated step.
+- **NON-COMMITTING.** This skill MUST NOT run `git add`, `git commit`, or `git push`. It
+  writes working-tree files and stops. Landing them is a separate review + PR.
+- **No secret values.** Never write a literal credential into any artifact; secret
+  references use the `token_ref: infisical:/...` form only.
+- **Extractive only.** Honor `references/extraction-contract.md` — undeterminable facts are
+  open-items, never inventions.
+- **Trust ceilings.** Enforce locking here (the validator does not): `trust_ceiling_locked`
+  skills stay `draft_for_review`; never exceed a skill's authored ceiling.
+
+## Reference files
+
+- `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
+- `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
+- `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
+- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)
+"""

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -22,7 +22,8 @@
     "go-live",
     "status",
     "update",
-    "heartbeat"
+    "heartbeat",
+    "aie-onboard"
   ],
   "agent-team": [
     "build-log",


### PR DESCRIPTION
## What

New Captain-side onboarding skill `aie-onboard`. It turns an initial client-interview transcript/notes into a **validated `customer.yaml` + `onboarding-plan.md`** in the venture repo, then **stops for Captain review**. Strictly extractive (no fabricated client content), **non-provisioning**, **non-committing**.

- `.claude/commands/aie-onboard.md` — canonical dispatcher (full 10-step procedure + guardrails). SKILL.md + Gemini TOML generated via `sync-commands.sh` (triplet in sync).
- `references/extraction-contract.md` — the P0 no-fabrication contract, with the same verbatim discipline as the enforced enrichment-prompt contracts ("Use only facts present…", "Do not infer management style…", "label as an open question instead of guessing").
- `references/test-cases.md` — synthetic **narrative** intakes: SMD customer-zero (with a deliberately-absent fact that must render as an open-item, exercising the extractor) + an adversarial unnamed-tool case (must map to `synthetic:`, never a guessed `mcp:`).
- `test_contract.py` — stdlib unittest guard (mirrors the `estimate` skill's colocated-test convention): asserts the contract phrases, the `NON-PROVISIONING`/`NON-COMMITTING` guardrails, the `trust_ceiling_locked` lock rule, and the `composio:`/`-smd` bans.
- `config/skill-owners.json` — `owner: captain`.

## Why

The skill encodes two things the `customer.yaml` validator does **not** enforce: trust-ceiling locking (the `TrustCeilingExceeded` code is never emitted — it's a provision-time check) and the connector/`hermes_ref` doctrine bans. It is the reusable onboarding tool behind the productized AI Employee SKU.

## Dogfood

Run on SMD as customer-zero; the generated config lands in companion **ss-console PR #1142** (`ai-employee/customers/smd/`). The SMD `hermes_ref` is corrected to the valid pinned form (the prior #776 draft used the now-invalid `v2026.5.16-smd.0` fork tag).

## Verification

- `sync-commands.sh --check` → triplet in sync
- `skill-review --all --strict` → exit 0, no `aie-onboard` violations
- `python3 .agents/skills/aie-onboard/test_contract.py` → 5/5
- `npm run verify` (pre-push) → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)