### PR TITLE
feat(crane-mcp): crane_secret_set leak-proof capture + fix crane_secret_check

### DIFF
--- a/docs/instructions/secrets.md
+++ b/docs/instructions/secrets.md
@@ -13,11 +13,20 @@ infisical run --path /sc -- npm run dev     # Silicon Crane
 infisical run --path /dfg -- npm run dev    # Durgan Field Guide
 ```
 
-**Adding secrets:**
+**Adding secrets (Captain's shell):**
 
 ```bash
 infisical secrets set NEW_KEY="value" --path /vc --env dev
 ```
+
+**Adding secrets (agents — capture without leaking):** agents can't run `infisical secrets set` from the Bash tool (deny-blocked, by design). Use the MCP tool, which reads the value SERVER-SIDE and never puts it in the transcript:
+
+```
+crane_secret_set({ path: '/vc', env: 'prod', name: 'ELEVENLABS_API_KEY' })   // value from clipboard (pbpaste)
+crane_secret_set({ path: '/vc', env: 'prod', name: 'GH_PRIVATE_KEY_PEM', source: 'file', file: '/tmp/key.pem' })  // from a file (shredded after write)
+```
+
+The Captain copies the key (or drops it in a file); the agent calls the tool; the value moves clipboard/file → Infisical without ever entering chat. Returns a masked confirmation (name, path, char count) — never the value. Confirm with `crane_secret_check`.
 
 **Verifying secrets are set (presence check, no values):**
 

--- a/packages/crane-mcp/src/registry/dispatch.ts
+++ b/packages/crane-mcp/src/registry/dispatch.ts
@@ -48,6 +48,7 @@ import {
 } from '../tools/verify.js'
 import { verifyAuditInputSchema, executeVerifyAudit } from '../tools/verify-audit.js'
 import { secretCheckInputSchema, executeSecretCheck } from '../tools/secret-check.js'
+import { secretSetInputSchema, executeSecretSet } from '../tools/secret-set.js'
 
 export type ToolResult = {
   isError?: true
@@ -176,6 +177,10 @@ const HANDLERS: Record<string, Handler> = {
   },
   crane_secret_check: async (args) => {
     const result = await executeSecretCheck(secretCheckInputSchema.parse(args))
+    return text(result.message)
+  },
+  crane_secret_set: async (args) => {
+    const result = await executeSecretSet(secretSetInputSchema.parse(args))
     return text(result.message)
   },
 }

--- a/packages/crane-mcp/src/registry/tool-schemas-core.ts
+++ b/packages/crane-mcp/src/registry/tool-schemas-core.ts
@@ -448,35 +448,6 @@ export const CORE_TOOL_SCHEMAS = [
     },
   },
   {
-    name: 'crane_secret_check',
-    description:
-      'Verify Infisical secret presence WITHOUT returning values. Use this for "is this set?" queries instead of `infisical secrets` (which leaks values into the transcript). Returns key names only.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        path: {
-          type: 'string',
-          description: 'Infisical path, e.g. /vc/api',
-        },
-        env: {
-          type: 'string',
-          description: 'Infisical environment slug, e.g. prod',
-        },
-        names: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Specific keys to check; omit to list all keys at the path',
-        },
-        includeImports: {
-          type: 'boolean',
-          description:
-            'Include imported secrets from linked paths. Default false; imports can surface secrets from paths the caller did not intend.',
-        },
-      },
-      required: ['path', 'env'],
-    },
-  },
-  {
     name: 'crane_worktree_doctor',
     description:
       'Orphan-worktree backstop for /sos. Classifies worktrees under .claude/worktrees/ through four safety gates (lock-triage, lsof, fresh-HEAD, clean+merged) and (when apply=true) removes the safe ones. Returns JSON: { scanned, deferred_by_cap, cleaned[], needs_review[], errors[], apply }.',

--- a/packages/crane-mcp/src/registry/tool-schemas-secrets.ts
+++ b/packages/crane-mcp/src/registry/tool-schemas-secrets.ts
@@ -1,0 +1,65 @@
+/**
+ * Secret-management tool schema declarations (presence check + capture).
+ * No logic, no imports. Part of the ListTools response; see tool-schemas.ts.
+ */
+
+export const SECRETS_TOOL_SCHEMAS = [
+  {
+    name: 'crane_secret_check',
+    description:
+      'Verify Infisical secret presence WITHOUT returning values. Use this for "is this set?" queries instead of `infisical secrets` (which leaks values into the transcript). Returns key names only.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Infisical path, e.g. /vc/api',
+        },
+        env: {
+          type: 'string',
+          description: 'Infisical environment slug, e.g. prod',
+        },
+        names: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Specific keys to check; omit to list all keys at the path',
+        },
+        includeImports: {
+          type: 'boolean',
+          description:
+            'Include imported secrets from linked paths. Default false; imports can surface secrets from paths the caller did not intend.',
+        },
+      },
+      required: ['path', 'env'],
+    },
+  },
+  {
+    name: 'crane_secret_set',
+    description:
+      'Store an Infisical secret WITHOUT the value entering the transcript. Reads the value server-side from the macOS clipboard (source=clipboard, default) or a local file (source=file), writes it to Infisical, and returns only a masked confirmation. Use this to capture keys/tokens — `infisical secrets set` is blocked from raw Bash and pasting a value into chat leaks it. Pair with crane_secret_check to verify.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Infisical path, e.g. /vc' },
+        env: { type: 'string', description: 'Infisical environment slug, e.g. prod' },
+        name: { type: 'string', description: 'Secret key name, e.g. ELEVENLABS_API_KEY' },
+        source: {
+          type: 'string',
+          enum: ['clipboard', 'file'],
+          description:
+            'Where to read the value server-side. Default clipboard (pbpaste). The value never enters the transcript.',
+        },
+        file: {
+          type: 'string',
+          description: 'Absolute path to a file holding the value (required when source=file).',
+        },
+        deleteSource: {
+          type: 'boolean',
+          description:
+            'When source=file, delete the file after a successful write (secure by default). Default true.',
+        },
+      },
+      required: ['path', 'env', 'name'],
+    },
+  },
+] as const

--- a/packages/crane-mcp/src/registry/tool-schemas.ts
+++ b/packages/crane-mcp/src/registry/tool-schemas.ts
@@ -5,6 +5,11 @@
  */
 
 import { CORE_TOOL_SCHEMAS } from './tool-schemas-core.js'
+import { SECRETS_TOOL_SCHEMAS } from './tool-schemas-secrets.js'
 import { TELEMETRY_TOOL_SCHEMAS } from './tool-schemas-telemetry.js'
 
-export const TOOL_SCHEMAS = [...CORE_TOOL_SCHEMAS, ...TELEMETRY_TOOL_SCHEMAS] as const
+export const TOOL_SCHEMAS = [
+  ...CORE_TOOL_SCHEMAS,
+  ...SECRETS_TOOL_SCHEMAS,
+  ...TELEMETRY_TOOL_SCHEMAS,
+] as const

--- a/packages/crane-mcp/src/tools/secret-check.ts
+++ b/packages/crane-mcp/src/tools/secret-check.ts
@@ -12,6 +12,7 @@
  * memory — projection happens on the JSON parser output, not on returned data.
  */
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { z } from 'zod'
 
 export const secretCheckInputSchema = z.object({
@@ -41,6 +42,26 @@ export interface SecretCheckResult {
 }
 
 const EXEC_TIMEOUT_MS = 15_000
+
+/**
+ * Resolve the real Infisical binary, bypassing the PATH-shadow wrapper
+ * (~/.local/bin/infisical) that blocks bare `infisical secrets` listing for
+ * agents (CRANE_AGENT=1). This tool is trusted: it projects to keys-only and
+ * never returns a value, so it is exempt from the anti-leak listing block —
+ * but only if it calls the real binary directly. Falls back to bare `infisical`
+ * when no known-good path exists (preserving prior behavior off-fleet).
+ */
+function resolveInfisicalBinary(): string {
+  const candidates = [
+    '/opt/homebrew/bin/infisical',
+    '/usr/local/bin/infisical',
+    '/usr/bin/infisical',
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate
+  }
+  return 'infisical'
+}
 
 interface InfisicalSecretRecord {
   secretKey?: string
@@ -95,7 +116,8 @@ export async function executeSecretCheck(input: SecretCheckInput): Promise<Secre
 
   let stdout: string
   try {
-    stdout = execSync(`infisical ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')}`, {
+    const bin = resolveInfisicalBinary()
+    stdout = execSync(`'${bin}' ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')}`, {
       encoding: 'utf-8',
       timeout: EXEC_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/crane-mcp/src/tools/secret-set.test.ts
+++ b/packages/crane-mcp/src/tools/secret-set.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for crane_secret_set.
+ *
+ * Critical assertion: the result MUST NEVER contain the secret value — not on
+ * success (only a masked confirmation + char count), and not on failure (any
+ * child-process output is redacted). The value is read server-side and never
+ * crosses the agent's context boundary.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }))
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+  readFileSync: vi.fn(() => ''),
+  unlinkSync: vi.fn(),
+}))
+
+const getModule = async () => {
+  vi.resetModules()
+  return import('./secret-set.js')
+}
+
+const ret = (o: Record<string, unknown>): any => o
+
+describe('crane_secret_set', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reads clipboard, writes to infisical, returns a masked confirmation', async () => {
+    const { spawnSync } = await import('node:child_process')
+    const { executeSecretSet } = await getModule()
+    const VALUE = 'sk-elevenlabs-deadbeef-secret'
+
+    vi.mocked(spawnSync).mockImplementation((cmd: string) =>
+      cmd === 'pbpaste'
+        ? ret({ status: 0, stdout: VALUE, stderr: '' })
+        : ret({ status: 0, stdout: 'created', stderr: '' })
+    )
+
+    const result = await executeSecretSet({
+      path: '/vc',
+      env: 'prod',
+      name: 'ELEVENLABS_API_KEY',
+      source: 'clipboard',
+      deleteSource: true,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('ELEVENLABS_API_KEY')
+    expect(result.message).toContain(`${VALUE.length} chars`)
+    // The whole point: the value never appears in the result.
+    expect(result.message).not.toContain(VALUE)
+
+    // infisical was called with the KEY=VALUE arg (correct wiring).
+    const infisicalCall = vi.mocked(spawnSync).mock.calls.find((c) => c[0] !== 'pbpaste')
+    expect(infisicalCall).toBeDefined()
+    expect(infisicalCall?.[1]).toContain('set')
+    expect(infisicalCall?.[1]).toContain(`ELEVENLABS_API_KEY=${VALUE}`)
+    expect(infisicalCall?.[1]).toEqual(expect.arrayContaining(['--path', '/vc', '--env', 'prod']))
+  })
+
+  it('reads from a file and shreds it after a successful write', async () => {
+    const { spawnSync } = await import('node:child_process')
+    const { readFileSync, unlinkSync } = await import('node:fs')
+    const { executeSecretSet } = await getModule()
+
+    vi.mocked(readFileSync).mockReturnValue('file-held-secret\n')
+    vi.mocked(spawnSync).mockReturnValue(ret({ status: 0, stdout: 'ok', stderr: '' }))
+
+    const result = await executeSecretSet({
+      path: '/vc',
+      env: 'prod',
+      name: 'GH_PRIVATE_KEY_PEM',
+      source: 'file',
+      file: '/tmp/secret-inbox',
+      deleteSource: true,
+    })
+
+    expect(result.success).toBe(true)
+    // trailing newline stripped -> 16 chars
+    expect(result.message).toContain('16 chars')
+    expect(result.message).not.toContain('file-held-secret')
+    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith('/tmp/secret-inbox')
+    expect(result.message).toContain('source file deleted')
+  })
+
+  it('stores nothing when the clipboard is empty', async () => {
+    const { spawnSync } = await import('node:child_process')
+    const { executeSecretSet } = await getModule()
+
+    vi.mocked(spawnSync).mockImplementation((cmd: string) =>
+      cmd === 'pbpaste' ? ret({ status: 0, stdout: '', stderr: '' }) : ret({ status: 0 })
+    )
+
+    const result = await executeSecretSet({
+      path: '/vc',
+      env: 'prod',
+      name: 'API_KEY',
+      source: 'clipboard',
+      deleteSource: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('Nothing stored')
+    // Only pbpaste ran; infisical was never invoked.
+    expect(vi.mocked(spawnSync).mock.calls.every((c) => c[0] === 'pbpaste')).toBe(true)
+  })
+
+  it('redacts the value from infisical error output', async () => {
+    const { spawnSync } = await import('node:child_process')
+    const { executeSecretSet } = await getModule()
+    const VALUE = 'leakme-supersecret-1234'
+
+    vi.mocked(spawnSync).mockImplementation((cmd: string) =>
+      cmd === 'pbpaste'
+        ? ret({ status: 0, stdout: VALUE, stderr: '' })
+        : ret({ status: 1, stdout: '', stderr: `failed to set ${VALUE} at /vc` })
+    )
+
+    const result = await executeSecretSet({
+      path: '/vc',
+      env: 'prod',
+      name: 'API_KEY',
+      source: 'clipboard',
+      deleteSource: true,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('exited 1')
+    expect(result.message).not.toContain(VALUE)
+    expect(result.message).toContain('***')
+  })
+})
+
+describe('crane_secret_set — input validation', () => {
+  it('rejects bad key names and paths', async () => {
+    const { secretSetInputSchema } = await getModule()
+    expect(() =>
+      secretSetInputSchema.parse({ path: '/vc', env: 'prod', name: 'bad name' })
+    ).toThrow()
+    expect(() =>
+      secretSetInputSchema.parse({ path: '/vc; rm', env: 'prod', name: 'API_KEY' })
+    ).toThrow()
+  })
+
+  it('requires an absolute file path when source=file', async () => {
+    const { secretSetInputSchema } = await getModule()
+    expect(() =>
+      secretSetInputSchema.parse({ path: '/vc', env: 'prod', name: 'API_KEY', source: 'file' })
+    ).toThrow()
+    expect(() =>
+      secretSetInputSchema.parse({
+        path: '/vc',
+        env: 'prod',
+        name: 'API_KEY',
+        source: 'file',
+        file: 'relative/path',
+      })
+    ).toThrow()
+  })
+
+  it('accepts canonical clipboard input', async () => {
+    const { secretSetInputSchema } = await getModule()
+    expect(() =>
+      secretSetInputSchema.parse({ path: '/vc', env: 'prod', name: 'ELEVENLABS_API_KEY' })
+    ).not.toThrow()
+  })
+})

--- a/packages/crane-mcp/src/tools/secret-set.ts
+++ b/packages/crane-mcp/src/tools/secret-set.ts
@@ -1,0 +1,136 @@
+/**
+ * crane_secret_set — store an Infisical secret WITHOUT the value entering the
+ * transcript. The sanctioned "capture" counterpart to crane_secret_check
+ * ("retrieve presence").
+ *
+ * The recurring failure mode this solves: agents need to store keys daily, but
+ * `infisical secrets set` is (correctly) blocked from the agent's raw Bash tool,
+ * and pasting a value into chat leaks it. This tool reads the value SERVER-SIDE
+ * — from the macOS clipboard (`pbpaste`) or a local file — writes it to Infisical
+ * via `spawnSync` (args array, no shell string), and returns only a masked
+ * confirmation. The value never passes through the agent's context, a shell
+ * command line, or the returned message. The deny rules stay fully intact; this
+ * is an additive secure door, not a hole in the wall.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, unlinkSync } from 'node:fs'
+import { z } from 'zod'
+
+export const secretSetInputSchema = z
+  .object({
+    path: z
+      .string()
+      .regex(/^\/[A-Za-z0-9._/-]*$/, 'path must start with / and contain only [A-Za-z0-9._/-]')
+      .describe('Infisical path, e.g. /vc'),
+    env: z
+      .string()
+      .regex(/^[a-z0-9-]+$/, 'env must be lowercase alphanumeric (e.g. dev, prod, staging)')
+      .describe('Infisical environment slug, e.g. prod'),
+    name: z
+      .string()
+      .regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'invalid secret key name')
+      .describe('Secret key name, e.g. ELEVENLABS_API_KEY'),
+    source: z
+      .enum(['clipboard', 'file'])
+      .default('clipboard')
+      .describe(
+        'Where to read the value SERVER-SIDE: the macOS clipboard (pbpaste) or a local file. The value never enters the transcript.'
+      ),
+    file: z
+      .string()
+      .optional()
+      .describe('Absolute path to a file holding the value (required when source=file).'),
+    deleteSource: z
+      .boolean()
+      .default(true)
+      .describe('When source=file, delete the file after a successful write (secure by default).'),
+  })
+  .superRefine((val, ctx) => {
+    if (val.source === 'file' && (!val.file || !val.file.startsWith('/'))) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'source=file requires an absolute `file` path',
+        path: ['file'],
+      })
+    }
+  })
+
+export type SecretSetInput = z.infer<typeof secretSetInputSchema>
+
+export interface SecretSetResult {
+  success: boolean
+  message: string
+}
+
+const EXEC_TIMEOUT_MS = 15_000
+
+/** Read the secret value from the chosen server-side source. Never logged. */
+function readValue(input: SecretSetInput): { value?: string; error?: string } {
+  if (input.source === 'file') {
+    if (!input.file || !existsSync(input.file)) {
+      return { error: `file not found: ${input.file ?? '(none)'}` }
+    }
+    try {
+      // Strip a single trailing newline (editors add one); preserve internal content.
+      return { value: readFileSync(input.file, 'utf-8').replace(/\r?\n$/, '') }
+    } catch (err) {
+      return { error: `failed to read file: ${err instanceof Error ? err.message : String(err)}` }
+    }
+  }
+  const res = spawnSync('pbpaste', [], { encoding: 'utf-8', timeout: EXEC_TIMEOUT_MS })
+  if (res.error || res.status !== 0) {
+    return {
+      error: `clipboard read failed (pbpaste): ${res.error?.message ?? `exit ${res.status}`}`,
+    }
+  }
+  return { value: res.stdout ?? '' }
+}
+
+export async function executeSecretSet(input: SecretSetInput): Promise<SecretSetResult> {
+  const { value, error } = readValue(input)
+  if (error) return { success: false, message: error }
+  if (value === undefined || value.length === 0) {
+    const where = input.source === 'clipboard' ? 'clipboard (empty?)' : 'file'
+    return { success: false, message: `No value found in ${where}. Nothing stored.` }
+  }
+
+  // Guarantee the value never surfaces in any returned text, even if a child
+  // process echoes it back on error.
+  const redact = (s: string): string => s.split(value).join('***')
+
+  // `infisical secrets set` is permitted by the PATH wrapper (writes don't leak
+  // vault contents); call it directly. Only value-reading is restricted.
+  const res = spawnSync(
+    'infisical',
+    ['secrets', 'set', `${input.name}=${value}`, '--path', input.path, '--env', input.env],
+    { encoding: 'utf-8', timeout: EXEC_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'pipe'] }
+  )
+
+  if (res.error) {
+    return {
+      success: false,
+      message: `infisical set failed: ${redact(res.error.message).slice(0, 200)}`,
+    }
+  }
+  if (res.status !== 0) {
+    const stderr = redact((res.stderr ?? '').toString()).slice(0, 200)
+    return { success: false, message: `infisical set exited ${res.status}: ${stderr}` }
+  }
+
+  let shredNote = ''
+  if (input.source === 'file' && input.deleteSource && input.file) {
+    try {
+      unlinkSync(input.file)
+      shredNote = ' (source file deleted)'
+    } catch {
+      shredNote = ' (warning: could not delete source file — remove it manually)'
+    }
+  }
+
+  return {
+    success: true,
+    message:
+      `Stored ${input.name} at ${input.path} (env: ${input.env}) — ${value.length} chars from ${input.source}${shredNote}. ` +
+      `Value not shown. Verify: crane_secret_check({ path: '${input.path}', env: '${input.env}', names: ['${input.name}'] }).`,
+  }
+}


### PR DESCRIPTION
Agents need to store keys daily, but `infisical secrets set` is deny-blocked
from the Bash tool and pasting a value into chat leaks it. Add crane_secret_set:
reads the value SERVER-SIDE (clipboard via pbpaste, or a file shredded after) and
writes it to Infisical, returning only a masked confirmation. The value never
enters the transcript, a shell string, or the result. Deny rules stay intact.

Also fix crane_secret_check: it hit its own PATH wrapper (which blocks listing)
and errored under CRANE_AGENT=1; it now calls the real binary directly (it
already projects to keys-only and never returns a value).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
