### PR TITLE
feat(skills): video production suite + house-style doc

### DIFF
--- a/.agents/skills/video-build/SKILL.md
+++ b/.agents/skills/video-build/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: video-build
+description: Scaffolds a videos/<slug> Remotion composition, locks beat timing via Whisper forced alignment, and renders the explainer.
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /video-build - Scaffold, Align & Render an Explainer
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-build")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Takes an approved script + an approved voice take and produces a rendered
+explainer: scaffolds `videos/<slug>/`, locks beat timing with Whisper forced
+alignment, guides scene authoring against the house style, and renders. The
+highest-leverage video skill.
+
+## Usage
+
+```
+/video-build <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required; matches `videos/<slug>/script.md`).
+If empty, stop: "Usage: `/video-build <slug>` — run `/video-script` first."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. If not a git repo / wrong dir, stop.
+2. Load the house style: `crane_doc('vc', 'video-production.md')` — Composition
+   spec, Motion & legibility rules, and Narration & sync govern this skill.
+3. Verify inputs:
+   - `videos/<slug>/script.md` exists (from `/video-script`).
+   - The **approved voice take** is at `public/<slug>/vo/narration_*.mp3` and is
+     read-only (`chmod 444`). If absent, stop — VO is the fixed input (see VO gap).
+4. If `videos/<slug>/` already has scenes, treat as a re-run: align + author, do
+   not re-scaffold over authored work.
+
+## Step 1 — Scaffold from the template
+
+Use `videos/agent-context/` as the structural template. Create for `<slug>`:
+
+- `timing.ts` — `FPS=30`, `HEAD_FRAMES=12`, `TAIL_FRAMES=26`, `AUDIO_SEC` (from
+  the mp3), `TOTAL_FRAMES = ceil(AUDIO_SEC*30)+HEAD+TAIL`, and a `BEATS` array
+  with one entry per script beat (`start` filled in Step 2).
+- `Explainer.tsx` — one `<Audio src={staticFile("<slug>/vo/...")}/>` inside
+  `<Sequence from={HEAD_FRAMES}>`, then a `<Sequence>` per beat mapping to scenes.
+- `layout.ts` + `Diagram.tsx` — diagram coordinates for this video (adapt or
+  replace the agent-context diagram to fit the new content).
+- `scenes/<Beat>.tsx` — one stub per beat.
+
+Register the composition in `src/Root.tsx` with **id === `<slug>`** (and add it to
+the per-video section). Use **relative imports** (`../../src/...`, `../../../src/...`).
+
+## Step 2 — Lock beat timing (forced alignment)
+
+Set the beat anchors (from `script.md`) in `scripts/whisper-align.mjs`'s `ANCHORS`,
+then run:
+
+```bash
+infisical run --env prod --path /vc -- node scripts/whisper-align.mjs <slug>
+```
+
+(`OPENAI_API_KEY` lives at `/vc` prod; the audio is never modified.) Paste the
+printed 30fps boundaries into `timing.ts` `BEATS`. **Never eyeball boundaries** —
+proportional guesses drift up to ~1s/beat.
+
+## Step 3 — Author the scenes
+
+Author each scene against its real boundary and the script's `visual` note:
+
+- **Legibility floor:** no functional text below ~24px at 1080p; stagger labels
+  in time rather than shrink. Verify by scaling a still to 360px wide.
+- Use the shared `ENTRANCE` easing; springs settle (no bouncing UI).
+- **Cool → warm:** structure is `accent` while explaining, shifts to `gold` for
+  the payoff; the gold `DataPulse` is the one hero motion.
+- Beats sharing a diagram render the settled `StaticDiagram` for seamless cuts.
+- One narration track only — no overlapping audio.
+
+## Step 4 — Draft render & check sync
+
+```bash
+npm run render -- src/index.ts <slug> videos/<slug>/out/draft.mp4 --gl=angle --scale=0.5
+```
+
+Scrub in `npm run studio` (or sample frames) and confirm each beat's content lands
+on its narration line. Fix timing/scene issues; re-draft until clean.
+
+## Step 5 — Final render
+
+```bash
+remotion render src/index.ts <slug> videos/<slug>/out/explainer.mp4 --gl=angle --crf 16
+```
+
+## Verification
+
+- `npx remotion compositions src/index.ts` lists `<slug>` and bundles with no
+  import errors.
+- Rendered duration ≈ `AUDIO_SEC + (HEAD+TAIL)/30`.
+- Legibility: a 360px-wide still — every functional label readable.
+- Every color/font traces to `src/theme.ts`; the approved mp3 is untouched.
+
+## Notes
+
+- Hand off to `/video-package` once the final render passes taste review.
+- VO generation is blocked on `ELEVENLABS_API_KEY` (not in vault) — this skill
+  assumes the take already exists and is approved.

--- a/.agents/skills/video-package/SKILL.md
+++ b/.agents/skills/video-package/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: video-package
+description: Packages a final render for publishing — SRT captions, YouTube chapters, youtube.md, and thumbnail candidates.
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /video-package - Caption, Chapter & Package an Explainer
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-package")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Turns a final render into the publish bundle: SRT captions, YouTube chapters, a
+filled-in `youtube.md` (title / description / tags), and thumbnail candidates.
+Deterministic — the exact bundle `/video-publish` consumes.
+
+## Usage
+
+```
+/video-package <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop:
+"Usage: `/video-package <slug>`."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. Load the house style: `crane_doc('vc', 'video-production.md')`
+   (§"Captions & chapters" and §"Packaging").
+2. Verify `videos/<slug>/out/explainer.mp4` and `public/<slug>/vo/roger.align.json`
+   exist. If the final render is missing, stop — run `/video-build` first.
+
+## Step 1 — Captions
+
+```bash
+node scripts/captions.mjs <slug>
+```
+
+Writes `videos/<slug>/out/explainer.srt` (Whisper segments, offset by HEAD_FRAMES,
+≤9 words/cue). Spot-check the first and last cue line up with the audio.
+
+## Step 2 — Chapters
+
+From `videos/<slug>/timing.ts` `BEATS`, convert each `start` frame to `mm:ss`
+(`floor(start/30)`), label each beat, and ensure the first chapter is `0:00`
+(YouTube requires it). Produce lines like `0:00 The cold-start problem`.
+
+## Step 3 — `youtube.md`
+
+Write `videos/<slug>/youtube.md` with:
+
+- **Title** — a hook, not a label (the curiosity gap or the payoff).
+- **Description** — 2–3 lines of context, then the chapter list, then the article
+  link as a **bare `https://venturecrane.com/articles/<slug>/` URL on its own
+  line**, then the channel tagline.
+- **Tags** — topical keywords.
+
+## Step 4 — Thumbnail candidates
+
+Render 2–3 stills at strong frames (the **warm payoff frame** is the proven
+primary; a clean architecture frame is a good alternate):
+
+```bash
+remotion still src/index.ts <slug> videos/<slug>/out/thumb-<label>.png --frame=<F>
+```
+
+## Output
+
+List the bundle for `/video-publish`:
+
+```
+videos/<slug>/out/explainer.mp4   — video
+videos/<slug>/out/explainer.srt   — captions
+videos/<slug>/youtube.md          — title / description / chapters / tags
+videos/<slug>/out/thumb-*.png     — thumbnail candidates (primary: warm)
+```
+
+## Notes
+
+- The description article link must be bare `https://` on its own line — YouTube
+  only linkifies https, and only once the channel is verified (see publish
+  gotchas in the house-style doc).
+- Captions and chapters are reproducible; never hand-edit the SRT — fix the
+  alignment and re-run.

--- a/.agents/skills/video-publish/SKILL.md
+++ b/.agents/skills/video-publish/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: video-publish
+description: Uploads a packaged explainer to the @venturecrane YouTube channel via Playwright and wires bidirectional cross-promotion with venturecrane.com.
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /video-publish - Upload to YouTube & Cross-Promote
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-publish")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Publishes a packaged explainer to the Venture Crane channel via Playwright and
+wires the bidirectional cross-promotion with venturecrane.com. The human performs
+the Google login/2FA; the agent drives Studio and opens the vc-web PR.
+
+## Usage
+
+```
+/video-publish <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')` (§"Publishing").
+2. Verify the bundle exists: `videos/<slug>/out/explainer.mp4`,
+   `explainer.srt`, `videos/<slug>/youtube.md`, and at least one
+   `videos/<slug>/out/thumb-*.png`. If missing, stop — run `/video-package`.
+3. **Confirm before publishing.** Uploading is an outward, public action. Unless
+   the Captain has clearly authorized it this turn, ask which **visibility**
+   (public / unlisted / private) and confirm go/no-go before any upload.
+
+## Channel facts (don't rediscover)
+
+- Channel **Venture Crane**, handle **@venturecrane**, id `UCGL5cJSNWxPKQ-XHaUE_vPg`.
+- On the `smdurgan@smdurgan.com` Workspace account (not a Brand Account).
+  `@venturecrane.com` is a domain alias — the human signs in with `@smdurgan.com`.
+
+## Step 1 — Upload (Playwright MCP)
+
+- **The human enters all credentials, 2FA, and phone codes — never the agent.**
+- Stage any file to upload under `crane-console/.playwright-mcp/upload/` (Playwright
+  sandboxes uploads to the repo tree); remove the copy afterward.
+- In YouTube Studio: upload `explainer.mp4`; set title + description from
+  `youtube.md` (chapters live in the description); set the thumbnail (primary =
+  warm); upload `explainer.srt` as captions; set visibility.
+- Re-snapshot before each click — refs go stale after DOM re-renders.
+
+## Step 2 — Capture the result
+
+Record the video id and `https://youtu.be/<id>` URL.
+
+## Step 3 — Cross-promote (both directions)
+
+- **Video → article:** already present as the bare article URL in the description.
+- **Article → video:** branch `vc-web`, add a callout near the top of
+  `src/content/articles/<slug>.md` linking the video (and bump `updatedDate`),
+  then `gh pr create` + merge. Never push to `main`.
+
+## Step 4 — Note the feature gotchas
+
+- **Custom thumbnail** needs phone verification (Intermediate features) — already
+  satisfied for this channel.
+- **Clickable description links** need one-time channel verification **plus a 4–6h
+  propagation delay**; links must be `https://`. A freshly verified channel shows
+  the link as plain text until the window elapses — this is expected, not a bug.
+
+## Step 5 — Record
+
+Update the project memory (`project_vc_video_explainer`) with the new video's
+slug, id, and URL so future sessions have the channel inventory.
+
+## Notes
+
+- Use the `gh` CLI for the vc-web PR (not MCP github\_\*).
+- If the upload is interrupted, the draft persists in Studio — resume rather than
+  re-upload.

--- a/.agents/skills/video-script/SKILL.md
+++ b/.agents/skills/video-script/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: video-script
+description: Drafts a house-format 6-beat narration script with visual notes and alignment anchors, from a topic or a vc-web article. Input to /video-build.
+version: 1.0.0
+scope: enterprise
+owner: agent-team
+status: stable
+---
+
+# /video-script - Explainer Script Drafting
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-script")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Turns a topic or an existing vc-web article into a house-format **6-beat narration
+script** with per-beat visual notes and alignment anchors — the input to
+`/video-build`. Drafting only; it does not generate audio or render anything.
+
+## Usage
+
+```
+/video-script <topic>                       # from a topic phrase
+/video-script articles/<slug>.md            # from a vc-web article
+/video-script https://venturecrane.com/...  # from a published article URL
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- A path under `articles/` or a `venturecrane.com/articles/...` URL → **article source**.
+- Any other non-empty string → **topic source** (use verbatim as the seed).
+- Empty → list recent vc-web articles (`~/dev/vc-web/src/content/articles/*.md`, newest 5) and ask the Captain to pick one or supply a topic via AskUserQuestion.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')`. The narrative
+   shape (§"Narrative shape: 6 beats"), brand voice, and pacing rules below come
+   from there — re-read if unsure.
+2. If the source is an article, read the markdown
+   (`~/dev/vc-web/src/content/articles/<slug>.md`) — body and frontmatter.
+
+## Step 1 — Find the spine
+
+State, in one sentence each: the **problem**, the **system** that solves it, and
+the **payoff**. If you can't, the topic isn't ready — say so and stop. For an
+article, extract the decision/surprise it documents; that's usually the spine.
+
+## Step 2 — Draft the 6 beats
+
+Follow the arc: (1) cold-open problem, (2) reveal "so we built X", (3) mechanism A,
+(4) mechanism B, (5) the non-obvious benefit, (6) payoff + brand end card.
+
+- **One idea per beat.** No beat does two jobs.
+- **Pacing:** ~12–22 spoken words/beat. Total target **60–120s** at ~2.5 words/sec.
+- **TTS spelling:** spell numerals and acronyms as spoken — "M C P", "D one",
+  "A.P.I.", "C.L.I." Keep a clean prose version for captions.
+- **Voice:** confident, technical, transparent. No hype, no apology. Agent work
+  shown as agent work (matches the venturecrane.com article voice).
+
+## Step 3 — Per beat, produce three things
+
+| Field       | What                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `narration` | the spoken line (TTS-spelled)                                                            |
+| `visual`    | what's on screen + the motion (blueprint boxes, the gold pulse, terminal, etc.)          |
+| `anchor`    | the first 1–2 words, lowercased — used by `/video-build` to locate the beat in the audio |
+
+Anchors must be **unique in order** (no two beats starting with the same word in
+a way the sequential matcher can't resolve).
+
+## Step 4 — Sanity-check duration
+
+Sum the word counts ÷ 2.5 → estimated seconds. If outside 60–120s, tighten or
+expand and say what you changed.
+
+## Step 5 — Present, then write on approval
+
+Output the script as a markdown table (beat | narration | visual | anchor) plus a
+proposed **slug** (kebab-case, matches the article slug when sourced from one).
+Ask the Captain to approve or adjust.
+
+On approval, write `~/dev/vc-video/videos/<slug>/script.md` containing the beats,
+anchors, the clean caption text, and the source link. That file is the contract
+`/video-build` consumes.
+
+## Notes
+
+- **Voice selection is separate and manual.** This skill does not pick or generate
+  a voice take — see the VO gap in the house-style doc. Hand the approved script
+  to voice production, then to `/video-build` once the take is approved.
+- This is a creative drafting skill: it reads the source and the house style, and
+  writes prose. It does not call render or alignment tooling.

--- a/.claude/commands/video-build.md
+++ b/.claude/commands/video-build.md
@@ -1,0 +1,99 @@
+# /video-build - Scaffold, Align & Render an Explainer
+
+Takes an approved script + an approved voice take and produces a rendered
+explainer: scaffolds `videos/<slug>/`, locks beat timing with Whisper forced
+alignment, guides scene authoring against the house style, and renders. The
+highest-leverage video skill.
+
+## Usage
+
+```
+/video-build <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required; matches `videos/<slug>/script.md`).
+If empty, stop: "Usage: `/video-build <slug>` — run `/video-script` first."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. If not a git repo / wrong dir, stop.
+2. Load the house style: `crane_doc('vc', 'video-production.md')` — Composition
+   spec, Motion & legibility rules, and Narration & sync govern this skill.
+3. Verify inputs:
+   - `videos/<slug>/script.md` exists (from `/video-script`).
+   - The **approved voice take** is at `public/<slug>/vo/narration_*.mp3` and is
+     read-only (`chmod 444`). If absent, stop — VO is the fixed input (see VO gap).
+4. If `videos/<slug>/` already has scenes, treat as a re-run: align + author, do
+   not re-scaffold over authored work.
+
+## Step 1 — Scaffold from the template
+
+Use `videos/agent-context/` as the structural template. Create for `<slug>`:
+
+- `timing.ts` — `FPS=30`, `HEAD_FRAMES=12`, `TAIL_FRAMES=26`, `AUDIO_SEC` (from
+  the mp3), `TOTAL_FRAMES = ceil(AUDIO_SEC*30)+HEAD+TAIL`, and a `BEATS` array
+  with one entry per script beat (`start` filled in Step 2).
+- `Explainer.tsx` — one `<Audio src={staticFile("<slug>/vo/...")}/>` inside
+  `<Sequence from={HEAD_FRAMES}>`, then a `<Sequence>` per beat mapping to scenes.
+- `layout.ts` + `Diagram.tsx` — diagram coordinates for this video (adapt or
+  replace the agent-context diagram to fit the new content).
+- `scenes/<Beat>.tsx` — one stub per beat.
+
+Register the composition in `src/Root.tsx` with **id === `<slug>`** (and add it to
+the per-video section). Use **relative imports** (`../../src/...`, `../../../src/...`).
+
+## Step 2 — Lock beat timing (forced alignment)
+
+Set the beat anchors (from `script.md`) in `scripts/whisper-align.mjs`'s `ANCHORS`,
+then run:
+
+```bash
+infisical run --env prod --path /vc -- node scripts/whisper-align.mjs <slug>
+```
+
+(`OPENAI_API_KEY` lives at `/vc` prod; the audio is never modified.) Paste the
+printed 30fps boundaries into `timing.ts` `BEATS`. **Never eyeball boundaries** —
+proportional guesses drift up to ~1s/beat.
+
+## Step 3 — Author the scenes
+
+Author each scene against its real boundary and the script's `visual` note:
+
+- **Legibility floor:** no functional text below ~24px at 1080p; stagger labels
+  in time rather than shrink. Verify by scaling a still to 360px wide.
+- Use the shared `ENTRANCE` easing; springs settle (no bouncing UI).
+- **Cool → warm:** structure is `accent` while explaining, shifts to `gold` for
+  the payoff; the gold `DataPulse` is the one hero motion.
+- Beats sharing a diagram render the settled `StaticDiagram` for seamless cuts.
+- One narration track only — no overlapping audio.
+
+## Step 4 — Draft render & check sync
+
+```bash
+npm run render -- src/index.ts <slug> videos/<slug>/out/draft.mp4 --gl=angle --scale=0.5
+```
+
+Scrub in `npm run studio` (or sample frames) and confirm each beat's content lands
+on its narration line. Fix timing/scene issues; re-draft until clean.
+
+## Step 5 — Final render
+
+```bash
+remotion render src/index.ts <slug> videos/<slug>/out/explainer.mp4 --gl=angle --crf 16
+```
+
+## Verification
+
+- `npx remotion compositions src/index.ts` lists `<slug>` and bundles with no
+  import errors.
+- Rendered duration ≈ `AUDIO_SEC + (HEAD+TAIL)/30`.
+- Legibility: a 360px-wide still — every functional label readable.
+- Every color/font traces to `src/theme.ts`; the approved mp3 is untouched.
+
+## Notes
+
+- Hand off to `/video-package` once the final render passes taste review.
+- VO generation is blocked on `ELEVENLABS_API_KEY` (not in vault) — this skill
+  assumes the take already exists and is approved.

--- a/.claude/commands/video-package.md
+++ b/.claude/commands/video-package.md
@@ -1,0 +1,76 @@
+# /video-package - Caption, Chapter & Package an Explainer
+
+Turns a final render into the publish bundle: SRT captions, YouTube chapters, a
+filled-in `youtube.md` (title / description / tags), and thumbnail candidates.
+Deterministic — the exact bundle `/video-publish` consumes.
+
+## Usage
+
+```
+/video-package <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop:
+"Usage: `/video-package <slug>`."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. Load the house style: `crane_doc('vc', 'video-production.md')`
+   (§"Captions & chapters" and §"Packaging").
+2. Verify `videos/<slug>/out/explainer.mp4` and `public/<slug>/vo/roger.align.json`
+   exist. If the final render is missing, stop — run `/video-build` first.
+
+## Step 1 — Captions
+
+```bash
+node scripts/captions.mjs <slug>
+```
+
+Writes `videos/<slug>/out/explainer.srt` (Whisper segments, offset by HEAD_FRAMES,
+≤9 words/cue). Spot-check the first and last cue line up with the audio.
+
+## Step 2 — Chapters
+
+From `videos/<slug>/timing.ts` `BEATS`, convert each `start` frame to `mm:ss`
+(`floor(start/30)`), label each beat, and ensure the first chapter is `0:00`
+(YouTube requires it). Produce lines like `0:00 The cold-start problem`.
+
+## Step 3 — `youtube.md`
+
+Write `videos/<slug>/youtube.md` with:
+
+- **Title** — a hook, not a label (the curiosity gap or the payoff).
+- **Description** — 2–3 lines of context, then the chapter list, then the article
+  link as a **bare `https://venturecrane.com/articles/<slug>/` URL on its own
+  line**, then the channel tagline.
+- **Tags** — topical keywords.
+
+## Step 4 — Thumbnail candidates
+
+Render 2–3 stills at strong frames (the **warm payoff frame** is the proven
+primary; a clean architecture frame is a good alternate):
+
+```bash
+remotion still src/index.ts <slug> videos/<slug>/out/thumb-<label>.png --frame=<F>
+```
+
+## Output
+
+List the bundle for `/video-publish`:
+
+```
+videos/<slug>/out/explainer.mp4   — video
+videos/<slug>/out/explainer.srt   — captions
+videos/<slug>/youtube.md          — title / description / chapters / tags
+videos/<slug>/out/thumb-*.png     — thumbnail candidates (primary: warm)
+```
+
+## Notes
+
+- The description article link must be bare `https://` on its own line — YouTube
+  only linkifies https, and only once the channel is verified (see publish
+  gotchas in the house-style doc).
+- Captions and chapters are reproducible; never hand-edit the SRT — fix the
+  alignment and re-run.

--- a/.claude/commands/video-publish.md
+++ b/.claude/commands/video-publish.md
@@ -1,0 +1,71 @@
+# /video-publish - Upload to YouTube & Cross-Promote
+
+Publishes a packaged explainer to the Venture Crane channel via Playwright and
+wires the bidirectional cross-promotion with venturecrane.com. The human performs
+the Google login/2FA; the agent drives Studio and opens the vc-web PR.
+
+## Usage
+
+```
+/video-publish <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')` (§"Publishing").
+2. Verify the bundle exists: `videos/<slug>/out/explainer.mp4`,
+   `explainer.srt`, `videos/<slug>/youtube.md`, and at least one
+   `videos/<slug>/out/thumb-*.png`. If missing, stop — run `/video-package`.
+3. **Confirm before publishing.** Uploading is an outward, public action. Unless
+   the Captain has clearly authorized it this turn, ask which **visibility**
+   (public / unlisted / private) and confirm go/no-go before any upload.
+
+## Channel facts (don't rediscover)
+
+- Channel **Venture Crane**, handle **@venturecrane**, id `UCGL5cJSNWxPKQ-XHaUE_vPg`.
+- On the `smdurgan@smdurgan.com` Workspace account (not a Brand Account).
+  `@venturecrane.com` is a domain alias — the human signs in with `@smdurgan.com`.
+
+## Step 1 — Upload (Playwright MCP)
+
+- **The human enters all credentials, 2FA, and phone codes — never the agent.**
+- Stage any file to upload under `crane-console/.playwright-mcp/upload/` (Playwright
+  sandboxes uploads to the repo tree); remove the copy afterward.
+- In YouTube Studio: upload `explainer.mp4`; set title + description from
+  `youtube.md` (chapters live in the description); set the thumbnail (primary =
+  warm); upload `explainer.srt` as captions; set visibility.
+- Re-snapshot before each click — refs go stale after DOM re-renders.
+
+## Step 2 — Capture the result
+
+Record the video id and `https://youtu.be/<id>` URL.
+
+## Step 3 — Cross-promote (both directions)
+
+- **Video → article:** already present as the bare article URL in the description.
+- **Article → video:** branch `vc-web`, add a callout near the top of
+  `src/content/articles/<slug>.md` linking the video (and bump `updatedDate`),
+  then `gh pr create` + merge. Never push to `main`.
+
+## Step 4 — Note the feature gotchas
+
+- **Custom thumbnail** needs phone verification (Intermediate features) — already
+  satisfied for this channel.
+- **Clickable description links** need one-time channel verification **plus a 4–6h
+  propagation delay**; links must be `https://`. A freshly verified channel shows
+  the link as plain text until the window elapses — this is expected, not a bug.
+
+## Step 5 — Record
+
+Update the project memory (`project_vc_video_explainer`) with the new video's
+slug, id, and URL so future sessions have the channel inventory.
+
+## Notes
+
+- Use the `gh` CLI for the vc-web PR (not MCP github\_\*).
+- If the upload is interrupted, the draft persists in Studio — resume rather than
+  re-upload.

--- a/.claude/commands/video-script.md
+++ b/.claude/commands/video-script.md
@@ -1,0 +1,81 @@
+# /video-script - Explainer Script Drafting
+
+Turns a topic or an existing vc-web article into a house-format **6-beat narration
+script** with per-beat visual notes and alignment anchors — the input to
+`/video-build`. Drafting only; it does not generate audio or render anything.
+
+## Usage
+
+```
+/video-script <topic>                       # from a topic phrase
+/video-script articles/<slug>.md            # from a vc-web article
+/video-script https://venturecrane.com/...  # from a published article URL
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- A path under `articles/` or a `venturecrane.com/articles/...` URL → **article source**.
+- Any other non-empty string → **topic source** (use verbatim as the seed).
+- Empty → list recent vc-web articles (`~/dev/vc-web/src/content/articles/*.md`, newest 5) and ask the Captain to pick one or supply a topic via AskUserQuestion.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')`. The narrative
+   shape (§"Narrative shape: 6 beats"), brand voice, and pacing rules below come
+   from there — re-read if unsure.
+2. If the source is an article, read the markdown
+   (`~/dev/vc-web/src/content/articles/<slug>.md`) — body and frontmatter.
+
+## Step 1 — Find the spine
+
+State, in one sentence each: the **problem**, the **system** that solves it, and
+the **payoff**. If you can't, the topic isn't ready — say so and stop. For an
+article, extract the decision/surprise it documents; that's usually the spine.
+
+## Step 2 — Draft the 6 beats
+
+Follow the arc: (1) cold-open problem, (2) reveal "so we built X", (3) mechanism A,
+(4) mechanism B, (5) the non-obvious benefit, (6) payoff + brand end card.
+
+- **One idea per beat.** No beat does two jobs.
+- **Pacing:** ~12–22 spoken words/beat. Total target **60–120s** at ~2.5 words/sec.
+- **TTS spelling:** spell numerals and acronyms as spoken — "M C P", "D one",
+  "A.P.I.", "C.L.I." Keep a clean prose version for captions.
+- **Voice:** confident, technical, transparent. No hype, no apology. Agent work
+  shown as agent work (matches the venturecrane.com article voice).
+
+## Step 3 — Per beat, produce three things
+
+| Field       | What                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `narration` | the spoken line (TTS-spelled)                                                            |
+| `visual`    | what's on screen + the motion (blueprint boxes, the gold pulse, terminal, etc.)          |
+| `anchor`    | the first 1–2 words, lowercased — used by `/video-build` to locate the beat in the audio |
+
+Anchors must be **unique in order** (no two beats starting with the same word in
+a way the sequential matcher can't resolve).
+
+## Step 4 — Sanity-check duration
+
+Sum the word counts ÷ 2.5 → estimated seconds. If outside 60–120s, tighten or
+expand and say what you changed.
+
+## Step 5 — Present, then write on approval
+
+Output the script as a markdown table (beat | narration | visual | anchor) plus a
+proposed **slug** (kebab-case, matches the article slug when sourced from one).
+Ask the Captain to approve or adjust.
+
+On approval, write `~/dev/vc-video/videos/<slug>/script.md` containing the beats,
+anchors, the clean caption text, and the source link. That file is the contract
+`/video-build` consumes.
+
+## Notes
+
+- **Voice selection is separate and manual.** This skill does not pick or generate
+  a voice take — see the VO gap in the house-style doc. Hand the approved script
+  to voice production, then to `/video-build` once the take is approved.
+- This is a creative drafting skill: it reads the source and the house style, and
+  writes prose. It does not call render or alignment tooling.

--- a/.gemini/commands/video-build.toml
+++ b/.gemini/commands/video-build.toml
@@ -1,0 +1,102 @@
+description = "Scaffold, Align & Render an Explainer"
+
+prompt = """
+
+Takes an approved script + an approved voice take and produces a rendered
+explainer: scaffolds `videos/<slug>/`, locks beat timing with Whisper forced
+alignment, guides scene authoring against the house style, and renders. The
+highest-leverage video skill.
+
+## Usage
+
+```
+/video-build <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required; matches `videos/<slug>/script.md`).
+If empty, stop: "Usage: `/video-build <slug>` — run `/video-script` first."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. If not a git repo / wrong dir, stop.
+2. Load the house style: `crane_doc('vc', 'video-production.md')` — Composition
+   spec, Motion & legibility rules, and Narration & sync govern this skill.
+3. Verify inputs:
+   - `videos/<slug>/script.md` exists (from `/video-script`).
+   - The **approved voice take** is at `public/<slug>/vo/narration_*.mp3` and is
+     read-only (`chmod 444`). If absent, stop — VO is the fixed input (see VO gap).
+4. If `videos/<slug>/` already has scenes, treat as a re-run: align + author, do
+   not re-scaffold over authored work.
+
+## Step 1 — Scaffold from the template
+
+Use `videos/agent-context/` as the structural template. Create for `<slug>`:
+
+- `timing.ts` — `FPS=30`, `HEAD_FRAMES=12`, `TAIL_FRAMES=26`, `AUDIO_SEC` (from
+  the mp3), `TOTAL_FRAMES = ceil(AUDIO_SEC*30)+HEAD+TAIL`, and a `BEATS` array
+  with one entry per script beat (`start` filled in Step 2).
+- `Explainer.tsx` — one `<Audio src={staticFile("<slug>/vo/...")}/>` inside
+  `<Sequence from={HEAD_FRAMES}>`, then a `<Sequence>` per beat mapping to scenes.
+- `layout.ts` + `Diagram.tsx` — diagram coordinates for this video (adapt or
+  replace the agent-context diagram to fit the new content).
+- `scenes/<Beat>.tsx` — one stub per beat.
+
+Register the composition in `src/Root.tsx` with **id === `<slug>`** (and add it to
+the per-video section). Use **relative imports** (`../../src/...`, `../../../src/...`).
+
+## Step 2 — Lock beat timing (forced alignment)
+
+Set the beat anchors (from `script.md`) in `scripts/whisper-align.mjs`'s `ANCHORS`,
+then run:
+
+```bash
+infisical run --env prod --path /vc -- node scripts/whisper-align.mjs <slug>
+```
+
+(`OPENAI_API_KEY` lives at `/vc` prod; the audio is never modified.) Paste the
+printed 30fps boundaries into `timing.ts` `BEATS`. **Never eyeball boundaries** —
+proportional guesses drift up to ~1s/beat.
+
+## Step 3 — Author the scenes
+
+Author each scene against its real boundary and the script's `visual` note:
+
+- **Legibility floor:** no functional text below ~24px at 1080p; stagger labels
+  in time rather than shrink. Verify by scaling a still to 360px wide.
+- Use the shared `ENTRANCE` easing; springs settle (no bouncing UI).
+- **Cool → warm:** structure is `accent` while explaining, shifts to `gold` for
+  the payoff; the gold `DataPulse` is the one hero motion.
+- Beats sharing a diagram render the settled `StaticDiagram` for seamless cuts.
+- One narration track only — no overlapping audio.
+
+## Step 4 — Draft render & check sync
+
+```bash
+npm run render -- src/index.ts <slug> videos/<slug>/out/draft.mp4 --gl=angle --scale=0.5
+```
+
+Scrub in `npm run studio` (or sample frames) and confirm each beat's content lands
+on its narration line. Fix timing/scene issues; re-draft until clean.
+
+## Step 5 — Final render
+
+```bash
+remotion render src/index.ts <slug> videos/<slug>/out/explainer.mp4 --gl=angle --crf 16
+```
+
+## Verification
+
+- `npx remotion compositions src/index.ts` lists `<slug>` and bundles with no
+  import errors.
+- Rendered duration ≈ `AUDIO_SEC + (HEAD+TAIL)/30`.
+- Legibility: a 360px-wide still — every functional label readable.
+- Every color/font traces to `src/theme.ts`; the approved mp3 is untouched.
+
+## Notes
+
+- Hand off to `/video-package` once the final render passes taste review.
+- VO generation is blocked on `ELEVENLABS_API_KEY` (not in vault) — this skill
+  assumes the take already exists and is approved.
+"""

--- a/.gemini/commands/video-package.toml
+++ b/.gemini/commands/video-package.toml
@@ -1,0 +1,79 @@
+description = "Caption, Chapter & Package an Explainer"
+
+prompt = """
+
+Turns a final render into the publish bundle: SRT captions, YouTube chapters, a
+filled-in `youtube.md` (title / description / tags), and thumbnail candidates.
+Deterministic — the exact bundle `/video-publish` consumes.
+
+## Usage
+
+```
+/video-package <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop:
+"Usage: `/video-package <slug>`."
+
+## Pre-flight
+
+1. `cd ~/dev/vc-video`. Load the house style: `crane_doc('vc', 'video-production.md')`
+   (§"Captions & chapters" and §"Packaging").
+2. Verify `videos/<slug>/out/explainer.mp4` and `public/<slug>/vo/roger.align.json`
+   exist. If the final render is missing, stop — run `/video-build` first.
+
+## Step 1 — Captions
+
+```bash
+node scripts/captions.mjs <slug>
+```
+
+Writes `videos/<slug>/out/explainer.srt` (Whisper segments, offset by HEAD_FRAMES,
+≤9 words/cue). Spot-check the first and last cue line up with the audio.
+
+## Step 2 — Chapters
+
+From `videos/<slug>/timing.ts` `BEATS`, convert each `start` frame to `mm:ss`
+(`floor(start/30)`), label each beat, and ensure the first chapter is `0:00`
+(YouTube requires it). Produce lines like `0:00 The cold-start problem`.
+
+## Step 3 — `youtube.md`
+
+Write `videos/<slug>/youtube.md` with:
+
+- **Title** — a hook, not a label (the curiosity gap or the payoff).
+- **Description** — 2–3 lines of context, then the chapter list, then the article
+  link as a **bare `https://venturecrane.com/articles/<slug>/` URL on its own
+  line**, then the channel tagline.
+- **Tags** — topical keywords.
+
+## Step 4 — Thumbnail candidates
+
+Render 2–3 stills at strong frames (the **warm payoff frame** is the proven
+primary; a clean architecture frame is a good alternate):
+
+```bash
+remotion still src/index.ts <slug> videos/<slug>/out/thumb-<label>.png --frame=<F>
+```
+
+## Output
+
+List the bundle for `/video-publish`:
+
+```
+videos/<slug>/out/explainer.mp4   — video
+videos/<slug>/out/explainer.srt   — captions
+videos/<slug>/youtube.md          — title / description / chapters / tags
+videos/<slug>/out/thumb-*.png     — thumbnail candidates (primary: warm)
+```
+
+## Notes
+
+- The description article link must be bare `https://` on its own line — YouTube
+  only linkifies https, and only once the channel is verified (see publish
+  gotchas in the house-style doc).
+- Captions and chapters are reproducible; never hand-edit the SRT — fix the
+  alignment and re-run.
+"""

--- a/.gemini/commands/video-publish.toml
+++ b/.gemini/commands/video-publish.toml
@@ -1,0 +1,74 @@
+description = "Upload to YouTube & Cross-Promote"
+
+prompt = """
+
+Publishes a packaged explainer to the Venture Crane channel via Playwright and
+wires the bidirectional cross-promotion with venturecrane.com. The human performs
+the Google login/2FA; the agent drives Studio and opens the vc-web PR.
+
+## Usage
+
+```
+/video-publish <slug>
+```
+
+## Arguments
+
+`$ARGUMENTS` = the video **slug** (required). If empty, stop.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')` (§"Publishing").
+2. Verify the bundle exists: `videos/<slug>/out/explainer.mp4`,
+   `explainer.srt`, `videos/<slug>/youtube.md`, and at least one
+   `videos/<slug>/out/thumb-*.png`. If missing, stop — run `/video-package`.
+3. **Confirm before publishing.** Uploading is an outward, public action. Unless
+   the Captain has clearly authorized it this turn, ask which **visibility**
+   (public / unlisted / private) and confirm go/no-go before any upload.
+
+## Channel facts (don't rediscover)
+
+- Channel **Venture Crane**, handle **@venturecrane**, id `UCGL5cJSNWxPKQ-XHaUE_vPg`.
+- On the `smdurgan@smdurgan.com` Workspace account (not a Brand Account).
+  `@venturecrane.com` is a domain alias — the human signs in with `@smdurgan.com`.
+
+## Step 1 — Upload (Playwright MCP)
+
+- **The human enters all credentials, 2FA, and phone codes — never the agent.**
+- Stage any file to upload under `crane-console/.playwright-mcp/upload/` (Playwright
+  sandboxes uploads to the repo tree); remove the copy afterward.
+- In YouTube Studio: upload `explainer.mp4`; set title + description from
+  `youtube.md` (chapters live in the description); set the thumbnail (primary =
+  warm); upload `explainer.srt` as captions; set visibility.
+- Re-snapshot before each click — refs go stale after DOM re-renders.
+
+## Step 2 — Capture the result
+
+Record the video id and `https://youtu.be/<id>` URL.
+
+## Step 3 — Cross-promote (both directions)
+
+- **Video → article:** already present as the bare article URL in the description.
+- **Article → video:** branch `vc-web`, add a callout near the top of
+  `src/content/articles/<slug>.md` linking the video (and bump `updatedDate`),
+  then `gh pr create` + merge. Never push to `main`.
+
+## Step 4 — Note the feature gotchas
+
+- **Custom thumbnail** needs phone verification (Intermediate features) — already
+  satisfied for this channel.
+- **Clickable description links** need one-time channel verification **plus a 4–6h
+  propagation delay**; links must be `https://`. A freshly verified channel shows
+  the link as plain text until the window elapses — this is expected, not a bug.
+
+## Step 5 — Record
+
+Update the project memory (`project_vc_video_explainer`) with the new video's
+slug, id, and URL so future sessions have the channel inventory.
+
+## Notes
+
+- Use the `gh` CLI for the vc-web PR (not MCP github\_\*).
+- If the upload is interrupted, the draft persists in Studio — resume rather than
+  re-upload.
+"""

--- a/.gemini/commands/video-script.toml
+++ b/.gemini/commands/video-script.toml
@@ -1,0 +1,84 @@
+description = "Explainer Script Drafting"
+
+prompt = """
+
+Turns a topic or an existing vc-web article into a house-format **6-beat narration
+script** with per-beat visual notes and alignment anchors — the input to
+`/video-build`. Drafting only; it does not generate audio or render anything.
+
+## Usage
+
+```
+/video-script <topic>                       # from a topic phrase
+/video-script articles/<slug>.md            # from a vc-web article
+/video-script https://venturecrane.com/...  # from a published article URL
+```
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- A path under `articles/` or a `venturecrane.com/articles/...` URL → **article source**.
+- Any other non-empty string → **topic source** (use verbatim as the seed).
+- Empty → list recent vc-web articles (`~/dev/vc-web/src/content/articles/*.md`, newest 5) and ask the Captain to pick one or supply a topic via AskUserQuestion.
+
+## Pre-flight
+
+1. Load the house style: `crane_doc('vc', 'video-production.md')`. The narrative
+   shape (§"Narrative shape: 6 beats"), brand voice, and pacing rules below come
+   from there — re-read if unsure.
+2. If the source is an article, read the markdown
+   (`~/dev/vc-web/src/content/articles/<slug>.md`) — body and frontmatter.
+
+## Step 1 — Find the spine
+
+State, in one sentence each: the **problem**, the **system** that solves it, and
+the **payoff**. If you can't, the topic isn't ready — say so and stop. For an
+article, extract the decision/surprise it documents; that's usually the spine.
+
+## Step 2 — Draft the 6 beats
+
+Follow the arc: (1) cold-open problem, (2) reveal "so we built X", (3) mechanism A,
+(4) mechanism B, (5) the non-obvious benefit, (6) payoff + brand end card.
+
+- **One idea per beat.** No beat does two jobs.
+- **Pacing:** ~12–22 spoken words/beat. Total target **60–120s** at ~2.5 words/sec.
+- **TTS spelling:** spell numerals and acronyms as spoken — "M C P", "D one",
+  "A.P.I.", "C.L.I." Keep a clean prose version for captions.
+- **Voice:** confident, technical, transparent. No hype, no apology. Agent work
+  shown as agent work (matches the venturecrane.com article voice).
+
+## Step 3 — Per beat, produce three things
+
+| Field       | What                                                                                     |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `narration` | the spoken line (TTS-spelled)                                                            |
+| `visual`    | what's on screen + the motion (blueprint boxes, the gold pulse, terminal, etc.)          |
+| `anchor`    | the first 1–2 words, lowercased — used by `/video-build` to locate the beat in the audio |
+
+Anchors must be **unique in order** (no two beats starting with the same word in
+a way the sequential matcher can't resolve).
+
+## Step 4 — Sanity-check duration
+
+Sum the word counts ÷ 2.5 → estimated seconds. If outside 60–120s, tighten or
+expand and say what you changed.
+
+## Step 5 — Present, then write on approval
+
+Output the script as a markdown table (beat | narration | visual | anchor) plus a
+proposed **slug** (kebab-case, matches the article slug when sourced from one).
+Ask the Captain to approve or adjust.
+
+On approval, write `~/dev/vc-video/videos/<slug>/script.md` containing the beats,
+anchors, the clean caption text, and the source link. That file is the contract
+`/video-build` consumes.
+
+## Notes
+
+- **Voice selection is separate and manual.** This skill does not pick or generate
+  a voice take — see the VO gap in the house-style doc. Hand the approved script
+  to voice production, then to `/video-build` once the take is approved.
+- This is a creative drafting skill: it reads the source and the house style, and
+  writes prose. It does not call render or alignment tooling.
+"""

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -42,6 +42,10 @@
     "ui-drift-audit",
     "analytics",
     "auth-setup",
-    "docs-refresh"
+    "docs-refresh",
+    "video-script",
+    "video-build",
+    "video-package",
+    "video-publish"
   ]
 }

--- a/docs/ventures/vc/video-production.md
+++ b/docs/ventures/vc/video-production.md
@@ -1,0 +1,196 @@
+# Venture Crane Video Production — House Style
+
+> Canonical conventions for producing motion-graphics explainers for the Venture
+> Crane YouTube channel. The skills (`/video-script`, `/video-build`,
+> `/video-package`, `/video-publish`) and any agent doing video work read from
+> this doc. The repo `~/dev/vc-video` (private `venturecrane/vc-video`) is the
+> implementation; this is the source of truth for _how_ and _why_.
+> Last updated: 2026-06-01
+
+## What this is
+
+Short (~60–120s) narrated **engineering explainers** — the same voice as
+venturecrane.com articles, rendered as motion graphics. Confident, technical,
+transparent; agent-authored work shown as agent work. The visual language is the
+"blueprint" system: chrome background, line-drawn boxes, a gold data pulse
+tracing a spine. Not stock footage, not talking heads, not corporate.
+
+First video (reference exemplar): the **Context Management System** explainer,
+`videos/agent-context/`, live at https://youtu.be/2D3PhQdEINs.
+
+## The pipeline (5 stages → 4 skills)
+
+| Stage   | Owner                | In → Out                                                                             |
+| ------- | -------------------- | ------------------------------------------------------------------------------------ |
+| Script  | `/video-script`      | topic or vc-web article → 6-beat house-format script + per-beat visual notes         |
+| Voice   | (manual; see VO gap) | script → narration mp3 (approved take, read-only)                                    |
+| Build   | `/video-build`       | script + VO → scaffolded `videos/<slug>/`, Whisper-aligned `timing.ts`, draft render |
+| Package | `/video-package`     | final mp4 → SRT + chapters + `youtube.md` + thumbnail candidates                     |
+| Publish | `/video-publish`     | bundle → YouTube upload + bidirectional cross-promo PR in vc-web                     |
+
+## Repo layout & conventions
+
+```
+src/                       # shared across all videos
+  Root.tsx                 # registry: shared comps + one entry per video
+  theme.ts                 # brand tokens — single source of color/type
+  components/blueprint.tsx # BlueprintBox · Connector · DataPulse · ENTRANCE
+  components/geometry.ts   # Pt · polyPath · pointAt
+  Avatar.tsx Banner.tsx    # channel art (per channel, not per video)
+videos/<slug>/             # one per video
+  Explainer.tsx timing.ts layout.ts Diagram.tsx scenes/*.tsx youtube.md
+public/<slug>/vo/          # narration mp3 + roger.align.json
+scripts/*.mjs              # shared, slug-parameterized pipeline tooling
+```
+
+- **Composition id === directory slug** (`agent-context`, plus `<slug>-hero` for
+  any reference cut). Channel art (`Avatar`/`Banner`) and `SmokeTest` are the
+  only non-slug ids.
+- **Relative imports only** — Remotion
+  [recommends against](https://www.remotion.dev/docs/typescript-aliases) tsconfig
+  path aliases (they can shadow the `remotion` import). Video files reach shared
+  code via `../../src/...` (video root) or `../../../src/...` (scenes/).
+- **Assets** via `staticFile("<slug>/vo/…")`.
+- **Scripts take the slug as argv:** `node scripts/whisper-align.mjs <slug>`
+  (default `agent-context`). Renders → `videos/<slug>/out/` (gitignored).
+
+## Brand tokens (mirror of the web design system)
+
+All color/type traces to `src/theme.ts`, which mirrors the site
+(`crane_doc('vc', 'design-spec.md')`). Never introduce a color outside this set.
+
+| Token      | Hex       | Role on screen                                  |
+| ---------- | --------- | ----------------------------------------------- |
+| chrome     | `#1a1a2e` | background (every scene)                        |
+| code-bg    | `#14142a` | inset panels (Workers/D1 container)             |
+| surface    | `#242438` | raised cards                                    |
+| border     | `#2e2e4a` | inactive box strokes                            |
+| text       | `#e8e8f0` | primary labels, captions                        |
+| text-muted | `#a0a0b8` | sublabels, eyebrows, secondary                  |
+| accent     | `#818cf8` | active connectors/structure (cool state)        |
+| gold       | `#dbb05c` | the data pulse, "warm"/payoff state, brand mark |
+| gold-muted | `#a08040` | warm structure strokes                          |
+
+**Type:** `fontBody` (system sans) for captions/taglines; `fontMono`
+(ui-monospace stack) for labels, eyebrows, terminal, code. No external fonts.
+
+## Composition spec
+
+- **1920×1080, 30fps.** (SVG tweens look identical to 60fps on YouTube; 30fps
+  halves render + tuning cost. Do not author at 60.)
+- **HEAD_FRAMES = 12** — a pre-VO breath; the `<Audio>` is delayed by this via a
+  `<Sequence from={HEAD_FRAMES}>`, and captions add the same offset.
+- **TAIL_FRAMES = 26** — end-card hold after the last word.
+- **TOTAL** = `ceil(audioSeconds × 30) + HEAD + TAIL`. (agent-context: 2415.)
+- One `<Audio>` (the approved take) spans the whole piece; each beat is a
+  `<Sequence>` that fades its content in from the shared chrome background.
+
+## Narrative shape: 6 beats
+
+Explainers follow a problem→system→payoff arc. The reference script's beats —
+reuse the _shape_, not the words:
+
+1. **Cold open / problem** — the pain, stated plainly.
+2. **Reveal** — "so we built X"; the architecture assembles.
+3. **Mechanism A** — the entry point / one command.
+4. **Mechanism B** — the lifecycle / what happens under the hood.
+5. **Mechanism C** — the non-obvious benefit (e.g. coordination).
+6. **Payoff** — the one-line result + brand end card.
+
+Keep beats to one idea each. Spoken numerals/acronyms get spelled for TTS
+("M C P", "D one", "A.P.I."). Beats are located in the audio by their first
+1–2 words (anchors) during alignment.
+
+## Motion & legibility rules
+
+- **Legibility floor: no functional text below ~24px at 1080p.** Terminal,
+  checklist, and chip labels especially. If labels won't fit at 24px, stagger
+  them in time — don't shrink. Verify by scaling a still to 360px wide; every
+  label must still read.
+- **Easing:** use the shared `ENTRANCE` curve for appears; springs settle, no
+  bouncing UI.
+- **Continuity:** beats that show the same diagram render the shared
+  `StaticDiagram` (settled, `PAST` frames) so hard cuts between them don't jump.
+- **No overlapping audio.** One narration track, full stop. Music/SFX only after
+  VO sync is approved, and ducked under VO.
+- **Cool → warm.** Structure is `accent` while explaining, shifts to `gold` for
+  the payoff. The gold pulse is the one "hero" motion.
+
+## Narration & sync
+
+- **Voice take is the fixed asset.** Once approved, the mp3 is read-only; the
+  pipeline never regenerates or trims it. Keep audition takes under
+  `public/<slug>/vo/audition/`.
+- **Forced alignment, not estimates.** Beat boundaries come from real word
+  timings — proportional guesses drift up to ~1s/beat. Primary path is OpenAI
+  Whisper:
+  ```bash
+  infisical run --env prod --path /vc -- node scripts/whisper-align.mjs <slug>
+  ```
+  (`whisper-1`, `response_format=verbose_json`, word+segment granularities;
+  `OPENAI_API_KEY` lives at `/vc` prod). Writes `public/<slug>/vo/roger.align.json`
+  and prints 30fps beat boundaries to paste into `timing.ts`.
+- **⚠️ VO generation gap.** `ELEVENLABS_API_KEY` is **not in the vault**
+  (`/vc`, `/`, `/ss`, `/shared` all checked). `scripts/tts.mjs` /
+  `scripts/audition.mjs` / `scripts/align.mjs` need it. Until a key is dropped in
+  via `crane_secret_set` (or we standardize on another TTS provider), VO
+  generation is a manual/blocked step — don't assume `/video-script` can hand
+  straight to an unattended voice render. Alignment (Whisper) is unaffected.
+
+## Captions & chapters
+
+- **SRT:** `node scripts/captions.mjs <slug>` → `videos/<slug>/out/explainer.srt`.
+  Built from the Whisper segments, offset by HEAD_FRAMES. Prefer punctuated
+  segments; ≤9 words/cue; break on >0.7s pause.
+- **Chapters:** derived from beat start times (mm:ss), first chapter at 0:00,
+  written into `youtube.md`.
+
+## Packaging — `videos/<slug>/youtube.md`
+
+Holds: **title** (hook, not a label), **description** (2–3 lines + chapters +
+article link + channel tagline), **chapters** (one `0:00 Label` per line),
+**tags**. The description's article link must be a bare `https://…` URL on its
+own line (YouTube only linkifies https and only once the channel is verified —
+see publish gotchas).
+
+## Publishing
+
+**Channel facts**
+
+- Name **Venture Crane**, handle **@venturecrane**, channel id
+  `UCGL5cJSNWxPKQ-XHaUE_vPg`.
+- Lives on the **`smdurgan@smdurgan.com`** Google Workspace account — _not_ a
+  Brand Account.
+- **Workspace alias gotcha:** `@venturecrane.com` is a domain alias, not a login
+  identity. Sign in with the primary `@smdurgan.com`. Channel name/handle are
+  independent of the login email.
+
+**Upload (Playwright MCP, human does Google login/2FA)**
+
+- The human enters all credentials/2FA/phone codes — never the agent.
+- Playwright file uploads are **sandboxed to the crane-console tree**: stage a
+  copy under `crane-console/.playwright-mcp/upload/` and clean it up after.
+- Set: title, description, thumbnail, chapters (in description), captions (.srt),
+  visibility. Refs go stale after DOM re-renders — re-snapshot before clicking.
+
+**Feature gates**
+
+- **Custom thumbnails** require **phone verification** (Intermediate features) —
+  already done for this channel.
+- **Clickable description links** require one-time channel verification **plus a
+  4–6 hour propagation delay**, and the link must start with `https://`. A
+  freshly verified channel shows links as plain text until the window elapses.
+
+**Cross-promotion (both directions)**
+
+- Article → video: a callout near the top of the vc-web article linking the
+  video (a PR to `vc-web`).
+- Video → article: the bare `https://venturecrane.com/articles/<slug>/` URL in
+  the description.
+
+## Asset protection
+
+- Approved VO mp3 and any kill-gate reference render are kept read-only
+  (`chmod 444`); render to a distinct name so they can't be clobbered.
+- Renders are reproducible and **gitignored** — never commit `out/` artifacts.
+- The narration audio is never modified by any pipeline step.


### PR DESCRIPTION
Codifies the explainer-video pipeline so the **@venturecrane** channel can scale past the first video. Four stable skills + the canonical house-style doc they read from.

## Skills
| Skill | Does |
| --- | --- |
| `/video-script` | topic or vc-web article → 6-beat house-format script + visual notes + anchors |
| `/video-build` | script + approved VO → scaffold `videos/<slug>/`, Whisper-align `timing.ts`, render |
| `/video-package` | final mp4 → SRT captions + YouTube chapters + `youtube.md` + thumbnail candidates |
| `/video-publish` | Playwright upload to the channel + bidirectional cross-promo PR in vc-web |

Each: `.agents/skills/<name>/SKILL.md` (stable, v1.0.0, agent-team) + `.claude/commands/<name>.md` dispatcher + `.gemini` mirror.

## Doc
`docs/ventures/vc/video-production.md` (→ `crane_doc('vc', 'video-production.md')`): brand tokens, 30fps + legibility floor, the 6-beat shape, the Whisper forced-alignment pattern, the **ElevenLabs VO-key gap**, the publish checklist, and channel facts (id, handle, Workspace-alias gotcha, clickable-link verification).

## Companion
Built on `venturecrane/vc-video#1` (factory restructure: shared `src/` + per-video `videos/<slug>/`, slug-parameterized scripts).

## Verification
- `skill-review --all` → **0 errors** (4 warn / 5 info, all pre-existing).
- `sync-commands.sh --check` → no drift (Gemini TOML + Codex SKILL.md match).
- Prettier clean; pre-push `verify` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)