### PR TITLE
docs: catch up content for Clerk auth swap on crane-command

### DIFF
--- a/docs/company/disaster-recovery.md
+++ b/docs/company/disaster-recovery.md
@@ -246,17 +246,18 @@ Only run this if crane-context D1 was lost or corrupted, not for standard machin
 
 ## Access Control
 
-This site contains confidential operational detail and is gated by Cloudflare Access.
+This site contains confidential operational detail and is gated by Clerk.
 
 **Current setup:**
 
-- **Site URL:** `crane-command.pages.dev`
-- **Auth domain:** `venturecrane.cloudflareaccess.com`
-- **Auth method:** Email OTP (one-time PIN sent to Captain's email)
-- **Session duration:** 24 hours
-- **Configuration:** Cloudflare Dashboard > Zero Trust > Access > Applications > crane-command
+- **Site URL:** `crane-command.automation-ab6.workers.dev`
+- **Hosting:** Cloudflare Worker (Astro SSR, `@astrojs/cloudflare` v13)
+- **Auth provider:** Clerk (dev instance, `@clerk/astro` v3)
+- **Middleware:** `site/src/middleware.ts` — `clerkMiddleware()` + email-allowlist gate
+- **Allowlist:** Worker secret `CRANE_COMMAND_ALLOWED_EMAILS` (comma-separated)
+- **Sign-in surface:** `/auth/sign-in` on the app's own domain (no Account Portal redirect)
 
-To add a new authorized user, edit the Access policy to include their email address. The Cloudflare Access free tier supports up to 50 users.
+To add a new authorized user, append their email to the `CRANE_COMMAND_ALLOWED_EMAILS` Worker secret (and add them in the Clerk dashboard so they can complete the sign-in flow). Secret update pattern: `infisical secrets get CRANE_COMMAND_ALLOWED_EMAILS --path /vc --plain | tr -d '\n' | wrangler secret put CRANE_COMMAND_ALLOWED_EMAILS --name crane-command` — never echo the value.
 
 ---
 

--- a/docs/infra/token-registry.md
+++ b/docs/infra/token-registry.md
@@ -81,9 +81,9 @@ Use one of these instead:
 
 ## Dormant and Delete Candidates
 
-| Credential             | Status at 2026-05-20 review                       | Why it is safe to remove                                                                                                             | Action                                                                 |
-| ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `crane-command-center` | Expired 2026-04-14, last used around January 2026 | No source references in `crane-console` or `ss-console`. `crane-command.pages.dev` deploys use `CLOUDFLARE_API_TOKEN`, not this PAT. | Delete in GitHub UI after the replacement `GH_TOKEN` path is verified. |
+| Credential             | Status at 2026-05-20 review                       | Why it is safe to remove                                                                                                          | Action                                                                 |
+| ---------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `crane-command-center` | Expired 2026-04-14, last used around January 2026 | No source references in `crane-console` or `ss-console`. `crane-command` Worker deploys use `CLOUDFLARE_API_TOKEN`, not this PAT. | Delete in GitHub UI after the replacement `GH_TOKEN` path is verified. |
 
 Legacy `GITHUB_MCP_PAT` references were removed from the canonical docs in this repo. The remote GitHub surface uses the OAuth app above, not a standalone PAT.
 

--- a/docs/process/doc-sync-pipeline.md
+++ b/docs/process/doc-sync-pipeline.md
@@ -24,7 +24,7 @@ docs/**/*.md committed to main ───┤       ▼
                                        sync-docs.mjs (prebuild)
                                           │
                                           ▼
-                                       Cloudflare Pages (crane-command.pages.dev)
+                                       Cloudflare Worker (crane-command.automation-ab6.workers.dev)
 ```
 
 ### Path 1: Git Push to Agent-Readable D1
@@ -33,7 +33,7 @@ Agents read documentation via the `crane_doc` MCP tool, which fetches from crane
 
 ### Path 2: Git Push to Starlight Documentation Site
 
-The Starlight site (hosted on Cloudflare Pages at `crane-command.pages.dev`) is built and deployed by the `deploy-site.yml` GitHub Actions workflow. The build runs `sync-docs.mjs` to copy markdown files from the repo into the site's content directory with frontmatter injection and template variable replacement.
+The Starlight site (hosted as a Cloudflare Worker at `crane-command.automation-ab6.workers.dev`, Astro SSR via `@astrojs/cloudflare` v13, gated by Clerk via `@clerk/astro` middleware) is built and deployed by the `deploy-site.yml` GitHub Actions workflow. The build runs `sync-docs.mjs` to copy markdown files from the repo into the site's content directory with frontmatter injection and template variable replacement.
 
 ## Path 1: GitHub Action to D1
 

--- a/site/deprecated-patterns.json
+++ b/site/deprecated-patterns.json
@@ -13,9 +13,21 @@
   },
   {
     "pattern": "crane-console\\.vercel\\.app",
-    "replacement": "crane-command.pages.dev",
+    "replacement": "crane-command.automation-ab6.workers.dev",
     "added": "2026-04-12",
-    "reason": "Site migrated from Vercel to Cloudflare Pages"
+    "reason": "Site migrated from Vercel to Cloudflare Pages, then to Cloudflare Workers (SSR via @astrojs/cloudflare v13)"
+  },
+  {
+    "pattern": "crane-command\\.pages\\.dev",
+    "replacement": "crane-command.automation-ab6.workers.dev",
+    "added": "2026-06-02",
+    "reason": "Pages project deleted; site is now a Cloudflare Worker (Astro SSR + Clerk via @clerk/astro). PR #975."
+  },
+  {
+    "pattern": "cloudflareaccess\\.com",
+    "replacement": "Clerk auth via @clerk/astro middleware (see docs/company/disaster-recovery.md)",
+    "added": "2026-06-02",
+    "reason": "Cloudflare Access gate replaced by Clerk on crane-command. PR #975."
   },
   {
     "pattern": "crane_token_report",


### PR DESCRIPTION
## Summary

PR #975 swapped crane-command's auth from Cloudflare Access to Clerk and moved hosting from Pages to a Cloudflare Worker, but several docs were not caught up. This catches them up and tightens the build-time deprecated-pattern scanner so future drift is flagged.

- `docs/company/disaster-recovery.md` — "Access Control" section now describes Clerk + `@clerk/astro` middleware + Worker URL + allowlist Worker secret pattern (replacing CF Access / Email OTP / `pages.dev`)
- `docs/process/doc-sync-pipeline.md` — Path 2 diagram and prose now reference the Cloudflare Worker URL and SSR shape
- `docs/infra/token-registry.md` — `crane-command-center` dormant-PAT row now references "crane-command Worker deploys" instead of `crane-command.pages.dev` deploys
- `site/deprecated-patterns.json` — existing `crane-console.vercel.app` row's replacement now points at the Worker URL; added rows for `crane-command.pages.dev` and `cloudflareaccess.com` so future docs that try to describe the old setup get a build-time WARN from `site/scripts/sync-docs.mjs`

Note: this only addresses the auth-swap drift. The existing docs-drift-audit MCP tool covers dead links, broken `crane_doc()` refs, and sidebar drift — it does not know about infrastructure-fact changes. The `deprecated-patterns.json` scanner is currently the closest thing to that, and remains build-warning-only.

## Test plan

- [x] `npm run verify` passes
- [ ] Post-merge: `crane_docs_drift_audit` re-run is clean for these files
- [ ] Post-merge: deploy-site build log shows the new patterns in the DEPRECATED PATTERN REPORT only against files we haven't fixed (expected: none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)