### PR TITLE
feat(crane-mcp): add venture-sidebar-parity check to docs drift audit

### DIFF
--- a/packages/crane-mcp/src/tools/docs-drift-audit.ts
+++ b/packages/crane-mcp/src/tools/docs-drift-audit.ts
@@ -31,6 +31,7 @@ import {
   checkStaleByGit,
   checkSidebarDrift,
   checkCaptainReviewCandidates,
+  checkVentureSidebarParity,
 } from './drift-checks.js'
 
 // ---------------------------------------------------------------------------
@@ -51,6 +52,7 @@ export {
   checkStaleByGit,
   checkSidebarDrift,
   checkCaptainReviewCandidates,
+  checkVentureSidebarParity,
 } from './drift-checks.js'
 
 // ---------------------------------------------------------------------------
@@ -177,6 +179,7 @@ export function runDocsDriftAudit(input: DocsDriftAuditInput): DocsDriftAuditRes
     ...checkStaleByGit(sitePublishedFiles, repoRoot, mtimeMap, input.stale_threshold_days)
   )
   findings.push(...checkSidebarDrift(repoRoot, sidebar))
+  findings.push(...checkVentureSidebarParity(repoRoot))
   findings.push(
     ...checkCaptainReviewCandidates(
       sitePublishedFiles,

--- a/packages/crane-mcp/src/tools/docs-drift-checks.ts
+++ b/packages/crane-mcp/src/tools/docs-drift-checks.ts
@@ -12,5 +12,6 @@ export {
   checkStaleByGit,
   checkSidebarDrift,
   checkCaptainReviewCandidates,
+  checkVentureSidebarParity,
 } from './drift-checks.js'
 export type { Finding, Severity } from './drift-checks.js'

--- a/packages/crane-mcp/src/tools/drift-checks.test.ts
+++ b/packages/crane-mcp/src/tools/drift-checks.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for drift-checks.ts
  *
- * Covers all six drift check functions with synthetic filesystem fixtures.
+ * Covers all drift check functions with synthetic filesystem fixtures.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
@@ -16,6 +16,7 @@ import {
   checkStaleByGit,
   checkSidebarDrift,
   checkCaptainReviewCandidates,
+  checkVentureSidebarParity,
 } from './drift-checks.js'
 import type { SidebarExtraction } from './drift-astro-sidebar.js'
 import type { DeprecatedSkill } from './drift-fs-helpers.js'
@@ -356,5 +357,67 @@ describe('checkCaptainReviewCandidates', () => {
     const mtimeMap = new Map<string, number>([['docs/auto.md', oldTs]])
     const findings = checkCaptainReviewCandidates([file], repoRoot, mtimeMap, 180, now)
     expect(findings).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkVentureSidebarParity — venture registry vs astro sidebar
+// ---------------------------------------------------------------------------
+
+function makeVentureFixture(repoRoot: string, ventures: string[], sidebarEntries: string[]): void {
+  // config/ventures.json
+  mkdirSync(join(repoRoot, 'config'), { recursive: true })
+  writeFileSync(
+    join(repoRoot, 'config', 'ventures.json'),
+    JSON.stringify({ ventures: ventures.map((code) => ({ code })) }),
+    'utf8'
+  )
+  // site/astro.config.mjs with sidebar entries for each code
+  mkdirSync(join(repoRoot, 'site'), { recursive: true })
+  const sidebarLines = sidebarEntries
+    .map((code) => `      { label: '${code}', autogenerate: { directory: 'ventures/${code}' } },`)
+    .join('\n')
+  const astroConfig = `export default { sidebar: [\n${sidebarLines}\n] }`
+  writeFileSync(join(repoRoot, 'site', 'astro.config.mjs'), astroConfig, 'utf8')
+}
+
+describe('checkVentureSidebarParity', () => {
+  let repoRoot: string
+
+  beforeEach(() => {
+    repoRoot = makeTmpRepo()
+  })
+
+  afterEach(() => {
+    rmSync(repoRoot, { recursive: true, force: true })
+  })
+
+  it('pass case: all ventures with docs have a sidebar entry', () => {
+    makeVentureFixture(repoRoot, ['vc', 'ss'], ['vc', 'ss'])
+    writeDoc(repoRoot, 'docs/ventures/vc/overview.md', '# vc')
+    writeDoc(repoRoot, 'docs/ventures/ss/overview.md', '# ss')
+    const findings = checkVentureSidebarParity(repoRoot)
+    expect(findings.filter((f) => f.type === 'venture-has-docs-no-sidebar-entry')).toHaveLength(0)
+  })
+
+  it('fail case: venture has docs but is missing from sidebar → one ERROR', () => {
+    makeVentureFixture(repoRoot, ['vc', 'ss'], ['vc'])
+    writeDoc(repoRoot, 'docs/ventures/vc/overview.md', '# vc')
+    writeDoc(repoRoot, 'docs/ventures/ss/overview.md', '# ss')
+    const findings = checkVentureSidebarParity(repoRoot)
+    const errors = findings.filter((f) => f.type === 'venture-has-docs-no-sidebar-entry')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].severity).toBe('error')
+    expect(errors[0].file).toBe('docs/ventures/ss')
+  })
+
+  it('emits INFO for ventures in config with no docs directory', () => {
+    makeVentureFixture(repoRoot, ['vc', 'future'], ['vc'])
+    writeDoc(repoRoot, 'docs/ventures/vc/overview.md', '# vc')
+    const findings = checkVentureSidebarParity(repoRoot)
+    const infos = findings.filter((f) => f.type === 'venture-in-config-no-docs')
+    expect(infos).toHaveLength(1)
+    expect(infos[0].severity).toBe('info')
+    expect(infos[0].file).toBe('docs/ventures/future')
   })
 })

--- a/packages/crane-mcp/src/tools/drift-checks.ts
+++ b/packages/crane-mcp/src/tools/drift-checks.ts
@@ -244,8 +244,7 @@ export function checkVentureSidebarParity(repoRoot: string): Finding[] {
   for (const code of ventureCodes) {
     const ventureDocsDir = join(docsVenturesRoot, code)
     const hasDocs =
-      existsSync(ventureDocsDir) &&
-      readdirSync(ventureDocsDir).some((n) => n.endsWith('.md'))
+      existsSync(ventureDocsDir) && readdirSync(ventureDocsDir).some((n) => n.endsWith('.md'))
 
     const inSidebar =
       astroSource.includes(`directory: 'ventures/${code}'`) ||

--- a/packages/crane-mcp/src/tools/drift-checks.ts
+++ b/packages/crane-mcp/src/tools/drift-checks.ts
@@ -1,5 +1,5 @@
 /**
- * Docs drift audit — six drift check functions
+ * Docs drift audit — drift check functions
  *
  * Each function receives the pre-built data (file list, mtime map,
  * deprecated-skill list, sidebar extraction) and returns Finding[].
@@ -199,6 +199,73 @@ export function checkSidebarDrift(repoRoot: string, sidebar: SidebarExtraction):
         type: 'sidebar-drift',
         file: `docs/${dir}`,
         detail: 'sidebar references this directory but it has no markdown files',
+      })
+    }
+  }
+
+  return findings
+}
+
+export function checkVentureSidebarParity(repoRoot: string): Finding[] {
+  const findings: Finding[] = []
+
+  const venturesConfigPath = join(repoRoot, 'config', 'ventures.json')
+  let ventureCodes: string[]
+  try {
+    const raw = readFileSync(venturesConfigPath, 'utf8')
+    const parsed = JSON.parse(raw) as { ventures?: Array<{ code?: string }> }
+    ventureCodes = (parsed.ventures ?? []).map((v) => v.code ?? '').filter(Boolean)
+  } catch {
+    findings.push({
+      severity: 'error',
+      type: 'audit-tool-broken',
+      file: 'config/ventures.json',
+      detail: 'could not read or parse config/ventures.json',
+    })
+    return findings
+  }
+
+  const astroConfigPath = join(repoRoot, 'site', 'astro.config.mjs')
+  let astroSource: string
+  try {
+    astroSource = readFileSync(astroConfigPath, 'utf8')
+  } catch {
+    findings.push({
+      severity: 'error',
+      type: 'audit-tool-broken',
+      file: 'site/astro.config.mjs',
+      detail: 'could not read site/astro.config.mjs',
+    })
+    return findings
+  }
+
+  const docsVenturesRoot = join(repoRoot, 'docs', 'ventures')
+
+  for (const code of ventureCodes) {
+    const ventureDocsDir = join(docsVenturesRoot, code)
+    const hasDocs =
+      existsSync(ventureDocsDir) &&
+      readdirSync(ventureDocsDir).some((n) => n.endsWith('.md'))
+
+    const inSidebar =
+      astroSource.includes(`directory: 'ventures/${code}'`) ||
+      astroSource.includes(`directory: "ventures/${code}"`) ||
+      astroSource.includes(`'ventures/${code}/`) ||
+      astroSource.includes(`"ventures/${code}/`)
+
+    if (hasDocs && !inSidebar) {
+      findings.push({
+        severity: 'error',
+        type: 'venture-has-docs-no-sidebar-entry',
+        file: `docs/ventures/${code}`,
+        detail: `venture "${code}" has docs but no sidebar entry in site/astro.config.mjs`,
+      })
+    } else if (!existsSync(ventureDocsDir)) {
+      findings.push({
+        severity: 'info',
+        type: 'venture-in-config-no-docs',
+        file: `docs/ventures/${code}`,
+        detail: `venture "${code}" is in config/ventures.json but has no docs/ventures/${code}/ directory`,
       })
     }
   }


### PR DESCRIPTION
## Summary

- Adds `checkVentureSidebarParity()` to `drift-checks.ts` - the 7th drift check
- Reads `config/ventures.json` and compares each venture against `site/astro.config.mjs` sidebar entries
- Emits ERROR (`venture-has-docs-no-sidebar-entry`) when a venture has docs but no sidebar entry
- Emits INFO (`venture-in-config-no-docs`) when a venture is in config but has no docs directory yet
- Registers the check in `docs-drift-audit.ts` (import, re-export, execution loop)
- Exports via `docs-drift-checks.ts` barrel for backward compat
- 3 new unit tests covering pass case, fail case (ERROR), and INFO case

Closes the audit gap that let the SS/SMD sidebar drift go unnoticed.

## Test plan

- [x] `npm test -w @venturecrane/crane-mcp` - all drift-checks.test.ts pass (26 tests)
- [x] Pass case: all ventures with docs have sidebar entries → no findings
- [x] Fail case: venture has docs but missing from sidebar → one ERROR
- [x] Info case: venture in config with no docs dir → one INFO

🤖 Generated with [Claude Code](https://claude.com/claude-code)