### PR TITLE
refactor(operator): crane-console rename catch-up post ADR 0034

### DIFF
--- a/.agents/skills/operator-onboard/SKILL.md
+++ b/.agents/skills/operator-onboard/SKILL.md
@@ -1,39 +1,43 @@
 ---
-name: aie-onboard
-description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
-version: 0.1.0
+name: operator-onboard
+description: Authors a validated Operator customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+version: 0.2.0
 scope: enterprise
 owner: captain
 status: draft
 ---
 
-# /aie-onboard - Author an AI-Employee config from a client interview
+# /operator-onboard - Author an Operator config from a client interview
 
-> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "aie-onboard")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "operator-onboard")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 Turns an initial client-interview transcript or notes into two artifacts under the
-venture repo's `ai-employee/customers/<slug>/`:
+venture repo's `operator/customers/<slug>/`:
 
-1. `customer.yaml` — the validated AI-Employee configuration
+1. `customer.yaml` — the validated Operator configuration
 2. `onboarding-plan.md` — the specific per-engagement onboarding steps
 
 It then validates the YAML and **stops for Captain review**. It does not provision a
-Machine and it does not commit. This is the operator-side authoring step that precedes
-`ai-employee/bin/provision-customer.sh` in the onboarding runbook
-(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+Machine and it does not commit. This is the authoring step that precedes
+`operator/bin/provision-customer.sh`; it does not run it.
+
+> **Naming note (2026-06-03):** Product renamed from "AI Employee" to **Operator** on
+> 2026-06-01 (ADR 0034 in venturecrane/ss-console; PRs #1188/#1189 landed the rename and
+> the deferred boot-substrate cutover). The dual usage of "operator" — the product vs.
+> the human RBAC role / "Designated Operator" persona — is deliberate per ADR 0034 §2.
 
 ## Canonical sources (read these; do not re-encode them here)
 
 This skill is a thin extractive procedure over docs that already own their content. Load
 them rather than duplicating their rules:
 
-- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
-- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
-- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
-  (per-vertical task taxonomy + cross-vertical patterns)
+- **Field rules + closed enums:** `docs/specs/operator/customer-yaml-schema.md`
+- **Scaffold to render from:** `operator/customers/_template/customer.yaml`
+- **Product thesis + what the Operator does:** `docs/adr/0037-operator-thesis.md`
+  (compete-with-a-hire framing, configurable substrate, packs as the entry, the
+  harness+guide+memory moat)
 - **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
-- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
-  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **Onboarding phases:** the inline 3-phase description in Step 8 below.
 - **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
 
 ## Deltas this skill owns (not covered by the docs above)
@@ -45,8 +49,8 @@ them rather than duplicating their rules:
    carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
    promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
    the skill's `SKILL.md` — never a hardcoded name list.
-2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
-   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+2. **Two-layer catalog (ADR 0022).** Base skills live in `operator/skills/`; vertical
+   addon skills (e.g. PI) live in `operator/verticals/<vertical>/addons/<addon>/skills/`
    and are in scope **only** when the customer's `vertical`/addons select that pack. For a
    `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
    appear.
@@ -59,7 +63,7 @@ them rather than duplicating their rules:
 ### Step 1 — Gather inputs
 
 Take the transcript/notes and a target customer slug. Confirm the slug with the user
-(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `operator/customers/<slug>/customer.yaml` already
 exists, stop and ask whether to overwrite-with-review — never silently clobber.
 
 ### Step 2 — Load the contract
@@ -77,11 +81,10 @@ conversation; write an `INTENT.md` only if the Captain wants the audit trail.
 
 ### Step 4 — Map pains → skills
 
-Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
-candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
-selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
-`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
-enabled skill.
+Using the **two-layer catalog** rule above: read each candidate skill's `SKILL.md`
+frontmatter live; restrict to base skills unless the vertical selects an addon pack; set
+`trust_ceiling = min(authored, requested)`; force any `trust_ceiling_locked: true` skill
+to `draft_for_review`. Surface the justifying quote per enabled skill.
 
 ### Step 5 — Decide connectors
 
@@ -91,7 +94,7 @@ an onboarding open-item to confirm and swap. Never emit `composio:`.
 
 ### Step 6 — Render customer.yaml
 
-Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+Render from `operator/customers/_template/customer.yaml`. Fill bracketed values; drop
 PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
 (`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
 `vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
@@ -107,7 +110,7 @@ Ask the Captain to approve, revise, or cancel. Write nothing until approved.
 ### Step 8 — Write the artifacts
 
 On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
-`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+`operator/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
 connectors and skills** — a short three-phase list, not a parameterized template:
 
 - **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
@@ -126,7 +129,7 @@ connectors and skills** — a short three-phase list, not a parameterized templa
 Run the canonical validator and require a clean exit:
 
 ```bash
-npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+npx tsx scripts/validate-customer-yaml.ts operator/customers/<slug>/customer.yaml
 ```
 
 On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
@@ -156,4 +159,4 @@ the next steps (a separate branch + PR, then provisioning) are theirs to trigger
 - `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
 - `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
 - `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
-- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)
+- `operator/customers/_template/customer.yaml` — the render scaffold (in the venture repo)

--- a/.agents/skills/operator-onboard/references/extraction-contract.md
+++ b/.agents/skills/operator-onboard/references/extraction-contract.md
@@ -1,4 +1,4 @@
-# Extraction contract — `aie-onboard`
+# Extraction contract — `operator-onboard`
 
 This is the **P0 no-fabrication contract** for the onboarding skill. It governs how
 facts are pulled from a client-interview transcript/notes into a `customer.yaml` and
@@ -18,7 +18,7 @@ actually said or supplied. If it is not in the transcript/notes, it is not a fac
 have.
 
 **Do not infer management style, communication preference, personality, likely objections, or private business conditions.**
-You are configuring an AI Employee, not profiling a person. Tone descriptors come from
+You are configuring an Operator, not profiling a person. Tone descriptors come from
 how the principal describes the voice they want or from supplied writing — never from
 your read of their character.
 
@@ -45,7 +45,7 @@ missing field is a `TBD`, a `synthetic:` connector, or an explicit onboarding op
 ## Evidence binding
 
 For every non-trivial decision, carry the verbatim quote that justifies it (the
-`proposal-drafter` pattern — `ai-employee/skills/proposal-drafter/SKILL.md`). The
+`proposal-drafter` pattern — `operator/skills/proposal-drafter/SKILL.md`). The
 reviewer must be able to see that the config reflects what was said, not what was
 imagined. If you cannot quote a source line for a value, you cannot write that value.
 

--- a/.agents/skills/operator-onboard/references/test-cases.md
+++ b/.agents/skills/operator-onboard/references/test-cases.md
@@ -1,4 +1,4 @@
-# Test cases — `aie-onboard`
+# Test cases — `operator-onboard`
 
 Synthetic **narrative** intakes used to exercise the skill (and to drive the SMD
 customer-zero dogfood). These are written as kickoff-conversation prose on purpose:

--- a/.agents/skills/operator-onboard/test_contract.py
+++ b/.agents/skills/operator-onboard/test_contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prompt-contract guard for the aie-onboard skill.
+"""Prompt-contract guard for the operator-onboard skill.
 
 The skill turns a client-interview transcript into a customer.yaml + onboarding
 plan — all client-facing engagement config — so it must stay strictly extractive
@@ -11,7 +11,7 @@ Mirrors the ss-console enrichment-prompt-contract tests: source-level assertions
 the skill text, not runtime behavior. Stdlib unittest (matches the estimate skill's
 test convention; no pytest dependency).
 
-Run: python3 .agents/skills/aie-onboard/test_contract.py
+Run: python3 .agents/skills/operator-onboard/test_contract.py
 """
 
 from __future__ import annotations

--- a/.claude/commands/operator-onboard.md
+++ b/.claude/commands/operator-onboard.md
@@ -1,33 +1,37 @@
 ---
-name: aie-onboard
-description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+name: operator-onboard
+description: Authors a validated Operator customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
 ---
 
-# /aie-onboard - Author an AI-Employee config from a client interview
+# /operator-onboard - Author an Operator config from a client interview
 
 Turns an initial client-interview transcript or notes into two artifacts under the
-venture repo's `ai-employee/customers/<slug>/`:
+venture repo's `operator/customers/<slug>/`:
 
-1. `customer.yaml` — the validated AI-Employee configuration
+1. `customer.yaml` — the validated Operator configuration
 2. `onboarding-plan.md` — the specific per-engagement onboarding steps
 
 It then validates the YAML and **stops for Captain review**. It does not provision a
-Machine and it does not commit. This is the operator-side authoring step that precedes
-`ai-employee/bin/provision-customer.sh` in the onboarding runbook
-(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+Machine and it does not commit. This is the authoring step that precedes
+`operator/bin/provision-customer.sh`; it does not run it.
+
+> **Naming note (2026-06-03):** Product renamed from "AI Employee" to **Operator** on
+> 2026-06-01 (ADR 0034 in venturecrane/ss-console; PRs #1188/#1189 landed the rename and
+> the deferred boot-substrate cutover). The dual usage of "operator" — the product vs.
+> the human RBAC role / "Designated Operator" persona — is deliberate per ADR 0034 §2.
 
 ## Canonical sources (read these; do not re-encode them here)
 
 This skill is a thin extractive procedure over docs that already own their content. Load
 them rather than duplicating their rules:
 
-- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
-- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
-- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
-  (per-vertical task taxonomy + cross-vertical patterns)
+- **Field rules + closed enums:** `docs/specs/operator/customer-yaml-schema.md`
+- **Scaffold to render from:** `operator/customers/_template/customer.yaml`
+- **Product thesis + what the Operator does:** `docs/adr/0037-operator-thesis.md`
+  (compete-with-a-hire framing, configurable substrate, packs as the entry, the
+  harness+guide+memory moat)
 - **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
-- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
-  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **Onboarding phases:** the inline 3-phase description in Step 8 below.
 - **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
 
 ## Deltas this skill owns (not covered by the docs above)
@@ -39,8 +43,8 @@ them rather than duplicating their rules:
    carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
    promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
    the skill's `SKILL.md` — never a hardcoded name list.
-2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
-   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+2. **Two-layer catalog (ADR 0022).** Base skills live in `operator/skills/`; vertical
+   addon skills (e.g. PI) live in `operator/verticals/<vertical>/addons/<addon>/skills/`
    and are in scope **only** when the customer's `vertical`/addons select that pack. For a
    `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
    appear.
@@ -53,7 +57,7 @@ them rather than duplicating their rules:
 ### Step 1 — Gather inputs
 
 Take the transcript/notes and a target customer slug. Confirm the slug with the user
-(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `operator/customers/<slug>/customer.yaml` already
 exists, stop and ask whether to overwrite-with-review — never silently clobber.
 
 ### Step 2 — Load the contract
@@ -71,11 +75,10 @@ conversation; write an `INTENT.md` only if the Captain wants the audit trail.
 
 ### Step 4 — Map pains → skills
 
-Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
-candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
-selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
-`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
-enabled skill.
+Using the **two-layer catalog** rule above: read each candidate skill's `SKILL.md`
+frontmatter live; restrict to base skills unless the vertical selects an addon pack; set
+`trust_ceiling = min(authored, requested)`; force any `trust_ceiling_locked: true` skill
+to `draft_for_review`. Surface the justifying quote per enabled skill.
 
 ### Step 5 — Decide connectors
 
@@ -85,7 +88,7 @@ an onboarding open-item to confirm and swap. Never emit `composio:`.
 
 ### Step 6 — Render customer.yaml
 
-Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+Render from `operator/customers/_template/customer.yaml`. Fill bracketed values; drop
 PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
 (`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
 `vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
@@ -101,7 +104,7 @@ Ask the Captain to approve, revise, or cancel. Write nothing until approved.
 ### Step 8 — Write the artifacts
 
 On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
-`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+`operator/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
 connectors and skills** — a short three-phase list, not a parameterized template:
 
 - **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
@@ -120,7 +123,7 @@ connectors and skills** — a short three-phase list, not a parameterized templa
 Run the canonical validator and require a clean exit:
 
 ```bash
-npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+npx tsx scripts/validate-customer-yaml.ts operator/customers/<slug>/customer.yaml
 ```
 
 On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
@@ -150,4 +153,4 @@ the next steps (a separate branch + PR, then provisioning) are theirs to trigger
 - `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
 - `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
 - `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
-- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)
+- `operator/customers/_template/customer.yaml` — the render scaffold (in the venture repo)

--- a/.gemini/commands/operator-onboard.toml
+++ b/.gemini/commands/operator-onboard.toml
@@ -1,35 +1,39 @@
 description = "---"
 
 prompt = """
-name: aie-onboard
-description: Authors a validated AI-Employee customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
+name: operator-onboard
+description: Authors a validated Operator customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
 ---
 
-# /aie-onboard - Author an AI-Employee config from a client interview
+# /operator-onboard - Author an Operator config from a client interview
 
 Turns an initial client-interview transcript or notes into two artifacts under the
-venture repo's `ai-employee/customers/<slug>/`:
+venture repo's `operator/customers/<slug>/`:
 
-1. `customer.yaml` — the validated AI-Employee configuration
+1. `customer.yaml` — the validated Operator configuration
 2. `onboarding-plan.md` — the specific per-engagement onboarding steps
 
 It then validates the YAML and **stops for Captain review**. It does not provision a
-Machine and it does not commit. This is the operator-side authoring step that precedes
-`ai-employee/bin/provision-customer.sh` in the onboarding runbook
-(`docs/runbooks/pi-firm-demo-prep.md`); it does not run it.
+Machine and it does not commit. This is the authoring step that precedes
+`operator/bin/provision-customer.sh`; it does not run it.
+
+> **Naming note (2026-06-03):** Product renamed from "AI Employee" to **Operator** on
+> 2026-06-01 (ADR 0034 in venturecrane/ss-console; PRs #1188/#1189 landed the rename and
+> the deferred boot-substrate cutover). The dual usage of "operator" — the product vs.
+> the human RBAC role / "Designated Operator" persona — is deliberate per ADR 0034 §2.
 
 ## Canonical sources (read these; do not re-encode them here)
 
 This skill is a thin extractive procedure over docs that already own their content. Load
 them rather than duplicating their rules:
 
-- **Field rules + closed enums:** `docs/specs/ai-employee/customer-yaml-schema.md`
-- **Scaffold to render from:** `ai-employee/customers/_template/customer.yaml`
-- **Pain → skill mapping:** `docs/strategy/ai-employee-functional-shape-2026-05-13.md`
-  (per-vertical task taxonomy + cross-vertical patterns)
+- **Field rules + closed enums:** `docs/specs/operator/customer-yaml-schema.md`
+- **Scaffold to render from:** `operator/customers/_template/customer.yaml`
+- **Product thesis + what the Operator does:** `docs/adr/0037-operator-thesis.md`
+  (compete-with-a-hire framing, configurable substrate, packs as the entry, the
+  harness+guide+memory moat)
 - **Connector backend choice:** `docs/adr/0020-connector-strategy.md` (MCP-first)
-- **Onboarding stages:** `docs/strategy/ai-employee-service-contract-2026-05-13.md`
-  (3 phases) and `docs/specs/ai-employee/day-1-onboarding.md` (dashboard sequence)
+- **Onboarding phases:** the inline 3-phase description in Step 8 below.
 - **The non-fabrication contract:** `references/extraction-contract.md` (load every run)
 
 ## Deltas this skill owns (not covered by the docs above)
@@ -41,8 +45,8 @@ them rather than duplicating their rules:
    carries `trust_ceiling_locked: true` is forced to `draft_for_review` and can never be
    promoted. Detect lock via the `trust_ceiling_locked` frontmatter flag, read live from
    the skill's `SKILL.md` — never a hardcoded name list.
-2. **Two-layer catalog (ADR 0022).** Base skills live in `ai-employee/skills/`; vertical
-   addon skills (e.g. PI) live in `ai-employee/verticals/<vertical>/addons/<addon>/skills/`
+2. **Two-layer catalog (ADR 0022).** Base skills live in `operator/skills/`; vertical
+   addon skills (e.g. PI) live in `operator/verticals/<vertical>/addons/<addon>/skills/`
    and are in scope **only** when the customer's `vertical`/addons select that pack. For a
    `mixed` (or any non-`law-firm`) customer, map only base skills; addon skills must not
    appear.
@@ -55,7 +59,7 @@ them rather than duplicating their rules:
 ### Step 1 — Gather inputs
 
 Take the transcript/notes and a target customer slug. Confirm the slug with the user
-(`^[a-z0-9][a-z0-9-]{0,31}$`). If `ai-employee/customers/<slug>/customer.yaml` already
+(`^[a-z0-9][a-z0-9-]{0,31}$`). If `operator/customers/<slug>/customer.yaml` already
 exists, stop and ask whether to overwrite-with-review — never silently clobber.
 
 ### Step 2 — Load the contract
@@ -73,11 +77,10 @@ conversation; write an `INTENT.md` only if the Captain wants the audit trail.
 
 ### Step 4 — Map pains → skills
 
-Using the functional-shape taxonomy and the **two-layer catalog** rule above: read each
-candidate skill's `SKILL.md` frontmatter live; restrict to base skills unless the vertical
-selects an addon pack; set `trust_ceiling = min(authored, requested)`; force any
-`trust_ceiling_locked: true` skill to `draft_for_review`. Surface the justifying quote per
-enabled skill.
+Using the **two-layer catalog** rule above: read each candidate skill's `SKILL.md`
+frontmatter live; restrict to base skills unless the vertical selects an addon pack; set
+`trust_ceiling = min(authored, requested)`; force any `trust_ceiling_locked: true` skill
+to `draft_for_review`. Surface the justifying quote per enabled skill.
 
 ### Step 5 — Decide connectors
 
@@ -87,7 +90,7 @@ an onboarding open-item to confirm and swap. Never emit `composio:`.
 
 ### Step 6 — Render customer.yaml
 
-Render from `ai-employee/customers/_template/customer.yaml`. Fill bracketed values; drop
+Render from `operator/customers/_template/customer.yaml`. Fill bracketed values; drop
 PI-only blocks when `vertical != law-firm`; set the memory invariants to the slug
 (`d1_namespace == <slug>`, `r2_vault_path == vaults/<slug>/`,
 `vectorize_index == hermes-<slug>-vault`); set `hermes_ref` to the operator-supplied /
@@ -103,7 +106,7 @@ Ask the Captain to approve, revise, or cancel. Write nothing until approved.
 ### Step 8 — Write the artifacts
 
 On approval, write `customer.yaml` and `onboarding-plan.md` (+ optional `INTENT.md`) to
-`ai-employee/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
+`operator/customers/<slug>/`. Emit the onboarding plan **inline from the actual enabled
 connectors and skills** — a short three-phase list, not a parameterized template:
 
 - **Phase 1 — Discovery + Access + Data audit (Day 1–5):** one OAuth/access row per
@@ -122,7 +125,7 @@ connectors and skills** — a short three-phase list, not a parameterized templa
 Run the canonical validator and require a clean exit:
 
 ```bash
-npx tsx scripts/validate-customer-yaml.ts ai-employee/customers/<slug>/customer.yaml
+npx tsx scripts/validate-customer-yaml.ts operator/customers/<slug>/customer.yaml
 ```
 
 On any error, surface every `[code] path: message`, fix, and re-run until it exits 0.
@@ -152,5 +155,5 @@ the next steps (a separate branch + PR, then provisioning) are theirs to trigger
 - `references/extraction-contract.md` — the P0 no-fabrication contract (load every run)
 - `references/test-cases.md` — synthetic narrative intakes (SMD + adversarial)
 - `scripts/validate-customer-yaml.ts` — the validation gate (in the venture repo)
-- `ai-employee/customers/_template/customer.yaml` — the render scaffold (in the venture repo)
+- `operator/customers/_template/customer.yaml` — the render scaffold (in the venture repo)
 """

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -23,7 +23,7 @@
     "status",
     "update",
     "heartbeat",
-    "aie-onboard"
+    "operator-onboard"
   ],
   "agent-team": [
     "build-log",

--- a/docs/runbooks/claude-ai-project-setup.md
+++ b/docs/runbooks/claude-ai-project-setup.md
@@ -1,14 +1,14 @@
 # Claude.ai Project Setup (venture-bound MCP)
 
 **Audience:** Captain.
-**Outcome:** Each of the 5 claude.ai venture projects (web + iOS) reliably loads venture context and GitHub access on every conversation — no manual scoping, no confabulation about "no such product" or "token dead."
+**Outcome:** Each of the 5 claude.ai venture projects (web + iOS) reliably loads venture context and GitHub access on every conversation — no manual scoping, no confabulation about "no such product" or "token dead," no corporate-employee posture failures.
 **Time to apply:** ~10 minutes per project after Phase 0 routing is confirmed.
 
 ## Why this exists
 
-`crane-mcp-remote` exposes 23 tools (14 `github_*`, 9 `crane_*` + `crane_context` + `crane_health`) over OAuth-secured MCP. Before the venture-binding work, all tools were venture-agnostic — every claude.ai project was indistinguishable to the worker, and agents had to guess venture/repo per call. They guessed wrong constantly. This runbook configures each project so the worker auto-scopes everything.
+`crane-mcp-remote` exposes 23 tools (14 `github_*`, 9 `crane_*` + `crane_context` + `crane_health`) over OAuth-secured MCP. Before the venture-binding work, all tools were venture-agnostic — every claude.ai project was indistinguishable to the worker, and agents had to guess venture/repo per call. They guessed wrong constantly. This runbook configures each project so the worker auto-scopes everything **and** the agent's posture matches a thought-partner, not a corporate-employee gatekeeper (per 2026-06-03 transcript audit).
 
-See `plans/nested-wobbling-matsumoto.md` (kept) for the full architecture. PR: feat(crane-mcp-remote): venture binding via per-venture MCP endpoints.
+See `plans/nested-wobbling-matsumoto.md` (kept) for the full architecture. PRs: feat(crane-mcp-remote): venture binding via per-venture MCP endpoints (#959); fix(crane-mcp-remote): auto-refresh GitHub user token (#968).
 
 ---
 
@@ -66,10 +66,12 @@ After 0a/0b/0c pass, retire the `_test` connector and proceed with the 5 real ve
 1. **Create the project** on claude.ai (web). One per venture.
 2. **Add the MCP connector**: Settings → Connectors → "Add custom connector" → use the venture-specific URL above. Save.
 3. **Connect (OAuth flow)**: Open the project, ask any question that uses a tool. Claude.ai will prompt for OAuth. Click through. GitHub redirects to the worker's `/callback`, then back to claude.ai. Done.
-4. **Set project custom instructions** (Settings → Project → Custom instructions) — paste the block below, substituting `{VENTURE_CODE}` and `{VENTURE_NAME}` for the right venture:
+4. **Set project custom instructions** (Settings → Project → Custom instructions) — paste the block below, substituting `{VENTURE_CODE}` and `{VENTURE_NAME}` for the right venture. The block has two halves: **tool mechanics** (how to use the MCP server) and **posture** (how to engage with the Captain). Both halves are required.
 
    ```text
    You represent the {VENTURE_NAME} venture (code: {VENTURE_CODE}).
+
+   ## Tool mechanics
 
    The crane-mcp-remote MCP server auto-scopes your `crane_*` and `github_*`
    tools to this venture — you do not need to specify `venture` on crane
@@ -91,17 +93,84 @@ After 0a/0b/0c pass, retire the `_test` connector and proceed with the 5 real ve
    the top of the response when crane-context is unreachable). When a
    tool fails, run `crane_health` and surface the failure mode in your
    answer rather than guessing.
+
+   ## Posture
+
+   You are a thought partner to the Captain, not a corporate-employee
+   gatekeeper. The Captain runs this venture; you support it.
+
+   - Engage with the actual question first. When asked for help with X,
+     help with X. Do not open with pushback before being asked. Do not
+     lead with "Decision: Don't do this yet." If you genuinely see a
+     problem, raise it in one short paragraph after delivering on the
+     ask, not before.
+
+   - No corporate decision templates on every turn. Reserve
+     Decision / Rationale / Risks / "What would change my mind" for
+     moments when the Captain explicitly asks for a structured decision.
+     In every other turn, write plain prose.
+
+   - Ground before pushing back. Before objecting to a plan, call
+     crane_notes for the venture's exec-summary and relevant ADRs. If
+     you object based on a document, name the document and quote the
+     line. If the document does not say what you are claiming, you are
+     inventing authority.
+
+   - Engineering snapshots are not go-to-market gates. VCMS notes tagged
+     `audit` or `build-state` are internal engineering self-assessments.
+     They inform Captain decisions; they do not gate them. Read the
+     banner at the top of any audit note before quoting from it.
+
+   - Ask for inputs before doing economics. If the Captain wants help
+     with a pricing, comp, ad, or cost question, ask for the missing
+     inputs (price, volume, comp structure, channel) before calculating.
+     Do not invent placeholders and then build analysis on the invented
+     numbers.
+
+   ## Sourcing and citations
+
+   Before any factual claim about the venture or product, cite the
+   source: a VCMS note ID, a file:line, a doc path, a PR number, or a
+   command output. If you cannot cite, say "checking" and verify first.
+   Do not assert.
+
+   Do not assert that something "doesn't exist" until you have searched
+   VCMS by both its current and historical names. Negative claims need a
+   positive search.
+
+   ## Format
+
+   - Plain prose. Bullets only when listing genuinely parallel items.
+   - Avoid em-dashes; use hyphens or commas.
+   - Short paragraphs. State the conclusion first, then the reasoning.
+   - The Captain reads diffs; do not summarize what you just did at the
+     end of every response unless the work spanned multiple tools.
+
+   ## Captain profile
+
+   The Captain is the founder of SMDurgan, LLC and operates the venture
+   portfolio. Experienced operator with deep AI-native operations
+   background. Treat him as a peer, not as someone you need to protect
+   from his own decisions. He runs the venture; you support it.
    ```
 
-5. **Smoke test (Phase 5 from the plan)** — run all 6 checks in both web and iOS for this project:
+5. **SS-specific addendum (paste only into the SS project):** the Operator product was renamed from "AI Employee" on 2026-06-01 (ADR 0034 in venturecrane/ss-console; thesis locked in ADR 0037). Forward conversations should use **Operator**; "AI Employee" appears only in historical artifacts. The lowercase word "operator" is also a deliberate human-role term (RBAC role, "Designated Operator" persona, "backup operator," "SMD Operator" = Captain). For the full SS-tailored block, see VCMS `note_01KT75CXNC77QS1QHNSSXF6EC6` (title: "SS claude.ai Project — Tightened Custom Instructions").
+
+6. **Smoke test (Phase 5 from the plan)** — run all 6 checks in both web and iOS for this project:
    1. "What venture is this?" → `crane_context` returns the bound venture name + repo.
    2. "What's the latest work?" → `crane_handoffs` (no args) auto-targets this venture's handoffs.
    3. "What's our top P0 issue?" → `github_list_issues` (no args) auto-targets the venture's repo.
-   4. (ss only) "What is the ai-employee product?" → surfaces the refreshed exec-summary note + recent commits.
+   4. (ss only) "What is the Operator product?" → surfaces the refreshed exec-summary note + recent commits. Agent should use **Operator** (not "AI Employee") and reference ADR 0034/0037.
    5. "What are the top P0s across all 5 ventures?" → `github_list_issues` called 5x with explicit `owner`+`repo`. Verifies override mechanic.
    6. `crane_health` → all three sections healthy, venture bound.
 
    Record results in this file under "Verification log" below. A project is declared "reliable" only after all 6 pass in both web and iOS.
+
+7. **Posture smoke test (ss only, re-runs the 2026-06-03 transcript scenario):** ask "I'm thinking of placing an ad to hire salespeople to sell the Operator." Pass criteria:
+   - Agent does NOT open with "Decision: Don't do this yet."
+   - Agent asks for missing inputs (price, comp structure, channel) before calculating economics.
+   - Agent names the **Operator** correctly without confabulating "no such product."
+   - Agent does NOT cite the 2026-05-29 build-state audit as a launch gate.
 
 ---
 
@@ -145,6 +214,10 @@ The OAuth token in the session has expired or been revoked. In claude.ai: Settin
 
 iOS aggressively caches connector configs. Force a reconnect on the device: Settings → Connectors → the connector → Disconnect → Connect.
 
+### Posture failures (Decision-template on every turn, manufactured authority, invented economics)
+
+The Posture section of the custom-instructions block was not pasted, or was pasted in a project that ignores Markdown headers. Verify the block in Settings → Project → Custom instructions. If posture failures persist after the block is confirmed pasted, the model's training defaults are overriding the project instructions — re-run the posture smoke test (step 7) and flag the specific failure mode to the Captain.
+
 ---
 
 ## See also
@@ -153,3 +226,6 @@ iOS aggressively caches connector configs. Force a reconnect on the device: Sett
 - Token registry: `docs/infra/token-registry.md` (callback URL, OAuth App ID)
 - MCP surfaces overview: `docs/infra/mcp-surfaces.md`
 - Worker README: `workers/crane-mcp-remote/CLAUDE.md`
+- SS-specific custom-instructions addendum: VCMS `note_01KT75CXNC77QS1QHNSSXF6EC6`
+- ADR 0034 (Operator product naming): `docs/adr/0034-operator-product-naming.md` in venturecrane/ss-console
+- ADR 0037 (Operator thesis): `docs/adr/0037-operator-thesis.md` in venturecrane/ss-console

--- a/workers/crane-context/migrations/0054_operator_rename_in_cadence_description.sql
+++ b/workers/crane-context/migrations/0054_operator_rename_in_cadence_description.sql
@@ -1,0 +1,21 @@
+-- Migration 0054: Reflect Operator product rename in exec-summary refresh cadence
+--
+-- ADR 0034 (venturecrane/ss-console, 2026-06-01) renamed the active SS product
+-- line from "AI Employee" to "Operator". Migration 0053 seeded the monthly
+-- exec-summary refresh cadence with the phrase "Must explicitly cover the
+-- ai-employee product line" on the ss row (sched_seed_015). That phrasing now
+-- contradicts the canonical product name and would re-introduce stale framing
+-- if the next cadence run cited the description verbatim.
+--
+-- This migration updates only the description text for sched_seed_015. All
+-- other rows (014, 016, 017, 018) and all other columns (cadence_days, scope,
+-- enabled, last_completed_at, ...) are left untouched. The row's last_completed_at
+-- still points at 2026-05-27T17:00:00Z because the data-layer refresh that this
+-- migration accompanies was applied directly to VCMS (note_01KN2ZFMZ8PSXYYR9QAPV4MTNV)
+-- in the same change window; the next scheduled refresh remains 30 days from that mark.
+
+UPDATE schedule_items
+SET
+  description = 'Refresh the SMD Services exec-summary VCMS note. Pass criteria: cite recent commits/PRs, reference top 3 focus areas verifiable against gh issue list for venturecrane/ss-console, dated within 7 days. Must explicitly cover the Operator product line (renamed from AI Employee on 2026-06-01 per ADR 0034 in venturecrane/ss-console; thesis locked in ADR 0037).',
+  updated_at = datetime('now')
+WHERE id = 'sched_seed_015';


### PR DESCRIPTION
## Summary

The Operator rename (ADR 0034 in venturecrane/ss-console, 2026-06-01) was scoped to ss-console + hermes-smd-overlay; crane-console wasn't in the workflow's scope. This catches up the three artifacts that referenced the old "AI Employee" name and were either stale, broken, or missing posture guardrails.

- Renames the `aie-onboard` skill triplet → `operator-onboard` across `.agents/skills/`, `.claude/commands/`, `.gemini/commands/` (plus the `config/skill-owners.json` registry). Body rewritten to point at post-rename ss-console paths (`operator/`, `docs/specs/operator/`) and to ADR 0037 for the strategic framing; the old skill was effectively broken because every doc-path reference in it pointed at files that no longer exist post-rename.
- Adds migration `0054_operator_rename_in_cadence_description.sql` to UPDATE the SS exec-summary refresh cadence row (`sched_seed_015`) so the description cites Operator + ADR 0034/0037 instead of "ai-employee product line."
- Extends the claude.ai project-setup runbook's Step-4 custom-instructions block with Posture, Sourcing, Format, and Captain-profile sections (universal across the 5 ventures) addressing the failure modes surfaced in the 2026-06-03 sales-rep transcript audit. Adds an SS-specific addendum pointer to VCMS `note_01KT75CXNC77QS1QHNSSXF6EC6`, updates smoke test step 4 to ask about the **Operator** product, adds step 7 as a posture smoke test rerunning the transcript scenario, and adds a "Posture failures" entry to common failure modes.

`packages/crane-mcp/src/tools/secret-check.test.ts` was deliberately left alone: the `/ss/ai-employee/customer-zero/telegram` Infisical path is infrastructure naming, explicitly out of scope per ADR 0034 §4.

## Context

The 2026-06-03 SS claude.ai conversation about hiring sales reps for the Operator was unusable for posture reasons more than context reasons. Even after the SS exec summary in VCMS was refreshed today to lead with Operator (`note_01KN2ZFMZ8PSXYYR9QAPV4MTNV`), the underlying skill in crane-console was still calling the product "AI-Employee" and pointing at removed paths, the cadence row would have re-introduced stale framing on the next monthly run, and the runbook's custom-instructions block only covered tool mechanics, not the posture failures that destroyed the transcript. This PR closes those three gaps.

Companion VCMS edits (already applied, not in this diff):
- SS exec summary rewritten to lead with Operator (`note_01KN2ZFMZ8PSXYYR9QAPV4MTNV`).
- Build-state audit annotated with an "engineering snapshot, NOT a go-to-market gate" banner (`note_01KSTYSNC9CYPKYFJZ3TJ7F6RM`).
- Harness-is-the-product strategy note pointed at ADR 0037 as the canonical successor (`note_01KSS3TCTKWYVF6EZ04482X389`).
- Overlay-enforcement methodology lesson re-slugged with `also_known_as` (`note_01KSRWTZQPGGG2942JASVVKDK3`).
- ADR 0023 Wave 1 handoff banner-annotated as pre-rename historical record (`note_01KSN3MQ2XEA7GNM1HG5H2AQMH`).
- New tightened SS claude.ai custom-instructions draft as a ready-to-paste VCMS note (`note_01KT75CXNC77QS1QHNSSXF6EC6`).

## Verification

- `npm run verify` clean locally (typecheck + format + lint + tests + builds).
- `python3 .agents/skills/operator-onboard/test_contract.py` → 5/5 pass after the rename + content rewrite.
- Final grep for `aie-onboard` in the worktree returns zero matches.
- Remaining `AI Employee` / `ai-employee` references are intentional retentions (rename history banners; infra paths covered by ADR 0034 §4).
- Migration 0054 is a single `UPDATE` on an existing row (`sched_seed_015`), idempotent under the `INSERT OR REPLACE` semantics 0053 used. Schema-DDL untouched.

## Test plan

- [ ] CI green on this PR (parity check + tests + builds + format/lint).
- [ ] After merge, deploy crane-context migration `0054` to staging then production (`workers/crane-context && npm run db:migrate` then `npm run db:migrate:prod`).
- [ ] Captain (or agent) re-pastes the extended Step-4 block into the SS claude.ai project (web + iOS), plus the SS-specific addendum from VCMS `note_01KT75CXNC77QS1QHNSSXF6EC6`.
- [ ] Captain runs the posture smoke test (Step 7 in the runbook) and records pass/fail against the four pass criteria.
- [ ] (Optional) Repeat for the four non-SS venture projects with just the universal block (no SS addendum).

QA grade: **B+** — unit-covered (npm verify + python contract guard); the end-to-end loop (migration applied + posture smoke test passes in claude.ai) lands in deployment, not CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)