### PR TITLE
fix(launcher): self-heal stale crane-console tree so new skills reach agents

### DIFF
--- a/packages/crane-mcp/src/cli/launch-lib/agent-launch.ts
+++ b/packages/crane-mcp/src/cli/launch-lib/agent-launch.ts
@@ -314,6 +314,11 @@ export function launchAgent(
   }
 
   validateAgentBinary(agent)
+  // Sync the checkout BEFORE mirroring skills: checkMcpSetup() copies skills
+  // from this tree, so a skill merged upstream must be pulled first or it lands
+  // a launch late. git fetch uses the launcher's ambient credentials, so this
+  // is independent of the SSH auth prepared for the spawned agent.
+  syncVentureRepo(venture.localPath!)
   checkMcpSetup(venture.localPath!, agent)
 
   const result = fetchSecrets(venture.localPath!, infisicalPath, sshAuth.env)
@@ -335,7 +340,6 @@ export function launchAgent(
   console.log(`-> Launching ${agent} with ${infisicalPath} secrets (direct inject)...\n`)
 
   process.chdir(venture.localPath!)
-  syncVentureRepo(venture.localPath!)
 
   const binary = KNOWN_AGENTS[agent]
   const repoName = basename(venture.localPath!)

--- a/packages/crane-mcp/src/cli/launch-lib/build-utils.ts
+++ b/packages/crane-mcp/src/cli/launch-lib/build-utils.ts
@@ -89,6 +89,33 @@ function makeGitOut(repoPath: string): (args: string[], timeout: number) => stri
   }
 }
 
+/**
+ * Detect and correct a mis-set `core.bare` flag on the launcher's checkout.
+ *
+ * A stray `core.bare=true` on a normal repo makes git refuse every working-tree
+ * operation (`pull`, `merge`, `checkout`) with "fatal: this operation must be
+ * run in a work tree", silently freezing the tree the launcher mirrors skills
+ * from. This froze m16's crane-console for a month — a skill added upstream
+ * (skunkworks) never reached ~/.agents/skills/ on any venture. There is no valid
+ * reason for the launcher's checkout to be bare, so correct it in place and warn
+ * loudly rather than fail silent. Returns true if a correction was applied.
+ */
+function ensureNotBare(
+  repoPath: string,
+  gitOut: (args: string[], timeout: number) => string | null
+): boolean {
+  if (gitOut(['config', '--get', 'core.bare'], 5_000) !== 'true') return false
+  console.warn(
+    `-> ⚠ ${repoPath}: core.bare=true on a normal checkout — correcting (this silently freezes tree updates)`
+  )
+  spawnSync('git', ['config', 'core.bare', 'false'], {
+    cwd: repoPath,
+    stdio: 'ignore',
+    timeout: 5_000,
+  })
+  return true
+}
+
 interface RepoSyncState {
   branch: string
   upstream: string
@@ -165,6 +192,10 @@ export function syncVentureRepo(repoPath: string): void {
     if (!existsSync(join(repoPath, '.git'))) return
 
     const gitOut = makeGitOut(repoPath)
+
+    // A mis-set core.bare=true freezes every working-tree op; correct it before
+    // attempting fetch/pull so the tree can actually advance.
+    ensureNotBare(repoPath, gitOut)
 
     const fetchResult = spawnSync('git', ['fetch', 'origin', '--quiet'], {
       cwd: repoPath,

--- a/packages/crane-mcp/src/cli/launch-lib/engagement-launch.ts
+++ b/packages/crane-mcp/src/cli/launch-lib/engagement-launch.ts
@@ -113,6 +113,10 @@ export async function launchEngagement(
   }
 
   validateAgentBinary(agent)
+  // Sync the checkout BEFORE mirroring skills: checkMcpSetup() copies skills
+  // from this tree, so a skill merged upstream must be pulled first or it lands
+  // a launch late. git fetch uses the launcher's ambient credentials.
+  syncVentureRepo(localPath)
   checkMcpSetup(localPath, agent)
 
   const sshAuth = prepareSSHAuth(debug)
@@ -140,7 +144,6 @@ export async function launchEngagement(
   console.log(`-> Launching ${agent} with ${ctx.infisicalPath} secrets (via crane-context)...\n`)
 
   process.chdir(localPath)
-  syncVentureRepo(localPath)
 
   const binary = KNOWN_AGENTS[agent]
 

--- a/packages/crane-mcp/src/cli/launch-lib/mcp-setup.ts
+++ b/packages/crane-mcp/src/cli/launch-lib/mcp-setup.ts
@@ -30,10 +30,16 @@ export function checkMcpBinary(): void {
     console.log('-> crane-mcp not found on PATH, rebuilding...')
     const mcpDir = join(CRANE_CONSOLE_ROOT, 'packages', 'crane-mcp')
     if (existsSync(mcpDir)) {
-      execSync('npm install && npm run build && npm link', {
-        cwd: mcpDir,
-        stdio: 'inherit',
-      })
+      // `npm ci` (not `npm install`) so the install never rewrites the tracked
+      // lockfile. Under a newer npm, `npm install` rewrites package-lock.json
+      // with cosmetic churn (e.g. `peer:true` markers), leaving the tree
+      // permanently dirty — which silently flips syncVentureRepo() into
+      // skip-the-auto-pull mode and freezes the checkout the fleet syncs from.
+      // npm ci installs strictly from the lockfile and fails loud on real drift.
+      // Run at repo root: workspaces share the root lockfile, and npm ci needs
+      // one in its working directory.
+      execSync('npm ci', { cwd: CRANE_CONSOLE_ROOT, stdio: 'inherit' })
+      execSync('npm run build && npm link', { cwd: mcpDir, stdio: 'inherit' })
       console.log('-> crane-mcp rebuilt and linked\n')
     } else {
       console.error('Cannot find packages/crane-mcp - is this crane-console?')

--- a/packages/crane-mcp/src/cli/launch.test.ts
+++ b/packages/crane-mcp/src/cli/launch.test.ts
@@ -63,6 +63,7 @@ import {
   INFISICAL_PATHS,
   KNOWN_AGENTS,
   syncVentureRepo,
+  checkMcpBinary,
 } from './launch-lib.js'
 import { spawn, execSync } from 'node:child_process'
 import { existsSync, readdirSync, statSync } from 'node:fs'
@@ -766,10 +767,13 @@ describe('syncVentureRepo', () => {
 
   it('returns silently when `git fetch` fails (offline)', () => {
     vi.mocked(existsSync).mockReturnValue(true)
-    // First spawnSync is the fetch; make it fail
-    vi.mocked(spawnSync).mockImplementationOnce(
-      () => ({ status: 128, stdout: '', stderr: 'fatal: not connected', error: undefined }) as any
-    )
+    // Sequence: core.bare check (not bare), then fetch fails
+    const results = [
+      { status: 0, stdout: 'false', stderr: '', error: undefined }, // config --get core.bare
+      { status: 128, stdout: '', stderr: 'fatal: not connected', error: undefined }, // fetch
+    ]
+    let i = 0
+    vi.mocked(spawnSync).mockImplementation(() => results[i++] as any)
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     syncVentureRepo('/fake/repo')
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('git fetch failed'))
@@ -778,8 +782,9 @@ describe('syncVentureRepo', () => {
 
   it('warns and does NOT pull when the tree is dirty and behind upstream', () => {
     vi.mocked(existsSync).mockReturnValue(true)
-    // Sequence: fetch ok, branch=main, upstream=origin/main, behind=3, ahead=0, dirty=2 files
+    // Sequence: core.bare=false, fetch ok, branch=main, upstream=origin/main, behind=3, ahead=0, dirty=2 files
     const results = [
+      { status: 0, stdout: 'false', stderr: '', error: undefined },
       { status: 0, stdout: '', stderr: '', error: undefined },
       { status: 0, stdout: 'main', stderr: '', error: undefined },
       { status: 0, stdout: 'origin/main', stderr: '', error: undefined },
@@ -804,8 +809,9 @@ describe('syncVentureRepo', () => {
 
   it('fast-forwards when the tree is clean and behind upstream', () => {
     vi.mocked(existsSync).mockReturnValue(true)
-    // Sequence: fetch ok, branch=main, upstream=origin/main, behind=2, ahead=0, dirty=empty, pull ok
+    // Sequence: core.bare=false, fetch ok, branch=main, upstream=origin/main, behind=2, ahead=0, dirty=empty, pull ok
     const results = [
+      { status: 0, stdout: 'false', stderr: '', error: undefined },
       { status: 0, stdout: '', stderr: '', error: undefined },
       { status: 0, stdout: 'main', stderr: '', error: undefined },
       { status: 0, stdout: 'origin/main', stderr: '', error: undefined },
@@ -828,5 +834,97 @@ describe('syncVentureRepo', () => {
     expect(pullCalls[0][1]).toEqual(['pull', '--ff-only', '--quiet'])
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('synced main +2'))
     logSpy.mockRestore()
+  })
+
+  it('corrects a mis-set core.bare=true before syncing', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    // Sequence: core.bare=true, correction write, fetch ok, branch, upstream, behind=0, ahead=0, dirty=empty (current)
+    const results = [
+      { status: 0, stdout: 'true', stderr: '', error: undefined }, // config --get core.bare
+      { status: 0, stdout: '', stderr: '', error: undefined }, // config core.bare false (correction)
+      { status: 0, stdout: '', stderr: '', error: undefined }, // fetch
+      { status: 0, stdout: 'main', stderr: '', error: undefined },
+      { status: 0, stdout: 'origin/main', stderr: '', error: undefined },
+      { status: 0, stdout: '0', stderr: '', error: undefined },
+      { status: 0, stdout: '0', stderr: '', error: undefined },
+      { status: 0, stdout: '', stderr: '', error: undefined },
+    ]
+    let i = 0
+    vi.mocked(spawnSync).mockImplementation(() => results[i++] as any)
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    syncVentureRepo('/fake/repo')
+
+    // The in-place correction `git config core.bare false` was issued
+    const fixCalls = vi
+      .mocked(spawnSync)
+      .mock.calls.filter(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).join(' ') === 'config core.bare false'
+      )
+    expect(fixCalls.length).toBe(1)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('core.bare=true'))
+    warnSpy.mockRestore()
+  })
+
+  it('does not touch core.bare when it is already false', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    // Sequence: core.bare=false, fetch ok, branch, upstream, behind=0, ahead=0, dirty=empty (current)
+    const results = [
+      { status: 0, stdout: 'false', stderr: '', error: undefined },
+      { status: 0, stdout: '', stderr: '', error: undefined },
+      { status: 0, stdout: 'main', stderr: '', error: undefined },
+      { status: 0, stdout: 'origin/main', stderr: '', error: undefined },
+      { status: 0, stdout: '0', stderr: '', error: undefined },
+      { status: 0, stdout: '0', stderr: '', error: undefined },
+      { status: 0, stdout: '', stderr: '', error: undefined },
+    ]
+    let i = 0
+    vi.mocked(spawnSync).mockImplementation(() => results[i++] as any)
+
+    syncVentureRepo('/fake/repo')
+
+    const fixCalls = vi
+      .mocked(spawnSync)
+      .mock.calls.filter(
+        (c) => Array.isArray(c[1]) && (c[1] as string[]).join(' ') === 'config core.bare false'
+      )
+    expect(fixCalls.length).toBe(0)
+  })
+})
+
+// ============================================================================
+// checkMcpBinary
+// ============================================================================
+
+describe('checkMcpBinary', () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockReset()
+    vi.mocked(existsSync).mockReturnValue(true)
+  })
+
+  it('rebuilds with `npm ci` (never `npm install`) so the tracked lockfile is not rewritten', () => {
+    // `which crane-mcp` fails -> enters rebuild path; later calls succeed.
+    let call = 0
+    vi.mocked(execSync).mockImplementation(() => {
+      if (call++ === 0) throw new Error('not found')
+      return Buffer.from('')
+    })
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    checkMcpBinary()
+
+    const cmds = vi.mocked(execSync).mock.calls.map((c) => String(c[0]))
+    expect(cmds).toContain('npm ci')
+    expect(cmds).toContain('npm run build && npm link')
+    // The lockfile-dirtying form must never be used.
+    expect(cmds.some((c) => c.includes('npm install'))).toBe(false)
+    logSpy.mockRestore()
+  })
+
+  it('is a no-op when crane-mcp is already on PATH', () => {
+    vi.mocked(execSync).mockReturnValue(Buffer.from('')) // `which` succeeds
+    checkMcpBinary()
+    const cmds = vi.mocked(execSync).mock.calls.map((c) => String(c[0]))
+    expect(cmds).toEqual(['which crane-mcp'])
   })
 })


### PR DESCRIPTION
## Problem

\`/skunkworks\` (added in #969) was unavailable to every agent in every venture. Root cause: the launcher mirrors skills **from the crane-console working tree** (\`syncGlobalSkills\` / \`syncClaudeAssets\` / \`syncVentureSkills\`) but never guaranteed that tree was current. A skill merged upstream stays invisible on any machine whose tree is stale. Two independent silent staleness modes were found in the field:

1. **\`core.bare=true\` on a normal checkout** (m16) — froze every working-tree git op (\`fatal: this operation must be run in a work tree\`). The tree sat a month stale; the new skill never reached \`~/.agents/skills/\`.
2. **Lockfile churn** (mbp27 / mini / think) — \`npm install\` in \`checkMcpBinary\` rewrote the tracked \`package-lock.json\` with cosmetic \`peer:true\` markers under a newer npm, leaving the tree permanently dirty. That silently flipped the **existing** \`syncVentureRepo()\` auto-pull into skip-mode (\`dirty + behind → skip\`), freezing all three at one SHA for ~10 days.

The auto-pull infrastructure already existed — it was just being silently defeated.

## Fixes

- **\`syncVentureRepo\` (build-utils.ts):** detect a mis-set \`core.bare\` and correct it in place (\`git config core.bare false\`) with a loud warning, before fetch/pull — so the tree can actually advance instead of failing silent.
- **\`checkMcpBinary\` (mcp-setup.ts):** rebuild with \`npm ci\` (at repo root) instead of \`npm install\`. \`npm ci\` installs strictly from the lockfile, never rewrites it, and fails loud on real drift — so the launcher stops dirtying the tree and re-freezing the fleet.
- **agent-launch / engagement-launch:** sync the checkout **before** mirroring skills, so a skill pulled this launch is available this launch, not one launch late.

## Tests

- \`syncVentureRepo\`: corrects \`core.bare=true\`; no-op when already false (plus existing offline / dirty+behind / clean+behind cases updated for the new leading check).
- \`checkMcpBinary\`: rebuild uses \`npm ci\` and **never** \`npm install\`; no-op when already on PATH.
- Full suite green locally: 816 crane-mcp + 39 crane-mcp-remote, typecheck clean, lint 0 errors.

## Field remediation already applied (this session)

All five fleet machines restored to \`skunkworks PRESENT\`: m16 (\`core.bare\` corrected), mbp27/mini/think (lockfile churn discarded + ff-pulled \`2d102b4 → c957dc4\`), mac23 (already current). This PR prevents recurrence.

## QA grade

**B+** — targeted fix for both confirmed freeze modes with regression tests; the \`npm install → npm ci\` change is scoped to the rare rebuild-recovery path (low steady-state blast radius). Not A because the worker-lockfile churn vector (\`workers/*\` dirtied by a root install lifecycle step) is out of scope and noted for separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)