### PR TITLE
docs(golden-path): register SS on the compliance dashboard

### DIFF
--- a/docs/standards/golden-path.md
+++ b/docs/standards/golden-path.md
@@ -277,6 +277,7 @@ Track where each product stands:
 | DFG     | Growth     | 2    | Partial | Yes   | Partial    | No  | Yes   | PWA + Sentry frontend     |
 | KE      | Validation | 1    | No      | Basic | No         | No  | Basic | PWA, then validation      |
 | SC      | Validation | 1    | No      | TBD   | No         | No  | TBD   | PWA + continue validation |
+| SS      | Pre-Launch | 2    | Yes     | Yes   | Partial    | No  | Yes   | PWA                       |
 | VC      | N/A        | -    | N/A     | Yes   | Yes        | No  | Yes   | PWA (marketing site)      |
 
 **Review cadence:** Update quarterly or at stage transitions


### PR DESCRIPTION
SS (SMD Services) operates at effective **Tier 2** but was missing from the Golden Path compliance dashboard — an administrative gap flagged by the 2026-06-08 ss-console code review (Golden Path dimension graded A, with this as the lone non-repo gap).

Adds the SS row:

| Venture | Stage | Tier | Sentry | CI/CD | Monitoring | PWA | Docs | Next Action |
| ------- | ----- | ---- | ------ | ----- | ---------- | --- | ---- | ----------- |
| SS | Pre-Launch | 2 | Yes | Yes | Partial | No | Yes | PWA |

**Basis (from the review):**
- **Sentry** — wired via `src/lib/observability/sentry.ts`, wraps every request; no-ops without DSN.
- **CI/CD** — 11 workflows incl. full `verify` + `security.yml` (daily audit + gitleaks + dependency review).
- **Branch protection** — active (required check, strict up-to-date).
- **Monitoring (Partial)** — `api/health.ts` + `api/webhooks/healthchecks.ts` integration; not claiming fully-active external uptime config.
- **Docs** — best-in-fleet CLAUDE.md, 39 ADRs, documented migrations.
- **PWA (No)** — the open Tier-1+ compliance gap → Next Action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)