### PR TITLE
feat(eos-gate): make "done" mean wired - relevance+aliveness verify gate

### DIFF
--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -252,6 +252,7 @@ Using conversation history and gathered context, the agent generates a summary c
 - Questions for PM
 - Decisions needed
 - External dependencies
+- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam and use `status:blocked` rather than implying completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
 
 **Next Session:** Recommended focus - write as an ordered action plan
 

--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -106,6 +106,7 @@ Using conversation history and gathered context, the agent generates a summary c
 - Questions for PM
 - Decisions needed
 - External dependencies
+- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam here and use `status:blocked`, rather than letting the handoff imply completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
 
 **Next Session:** Recommended focus — write as an ordered action plan
 

--- a/.gemini/commands/eos.toml
+++ b/.gemini/commands/eos.toml
@@ -108,6 +108,7 @@ Using conversation history and gathered context, the agent generates a summary c
 - Questions for PM
 - Decisions needed
 - External dependencies
+- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam here and use `status:blocked`, rather than letting the handoff imply completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
 
 **Next Session:** Recommended focus — write as an ordered action plan
 

--- a/.github/workflows/pr-verify-gate.yml
+++ b/.github/workflows/pr-verify-gate.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       verify_required: ${{ steps.classify.outputs.verify_required }}
+      surface_files: ${{ steps.classify.outputs.surface_files }}
       override_active: ${{ steps.check-override.outputs.override }}
     steps:
       - name: Check override label
@@ -70,13 +71,22 @@ jobs:
             --files /tmp/changed-files.txt \
             > /tmp/classification.json
           cat /tmp/classification.json
-          # verify_required is true iff the diff touches mcp-tool, boot-config,
-          # fleet-artifact, or config-canon. skill is exempt (covered by
-          # pr-eos-gate.yml's triplet check).
+          # verify_required is true iff the diff touches a verify-required
+          # surface class. skill is exempt (covered by pr-eos-gate.yml's
+          # triplet check). app-data-seam is included so the SS-style
+          # "renders honest-empty" failure is gated by verify evidence.
           REQ=$(node -e "const c=require('/tmp/classification.json').surfaces_touched; \
-            console.log(['mcp-tool','boot-config','fleet-artifact','config-canon'] \
+            console.log(['mcp-tool','boot-config','fleet-artifact','config-canon','app-data-seam'] \
               .some((k)=>!!c[k]) ? 'true' : 'false')")
           echo "verify_required=$REQ" >> "$GITHUB_OUTPUT"
+          # Union of changed files in the verify-required classes — passed to
+          # pr-verify-check so it can confirm a listed verification actually
+          # NAMES one of these seams (relevance), not just exists.
+          FILES=$(node -e "const c=require('/tmp/classification.json').surfaces_touched; \
+            const k=['mcp-tool','boot-config','fleet-artifact','config-canon','app-data-seam']; \
+            const s=new Set(); for(const key of k){(c[key]||[]).forEach((f)=>s.add(f))} \
+            console.log([...s].join(','))")
+          echo "surface_files=$FILES" >> "$GITHUB_OUTPUT"
 
   verify-gate:
     name: Verify ledger evidence in PR body
@@ -101,4 +111,8 @@ jobs:
           # launcher env var, not the worker var). The verify_ledger lives in prod
           # — that's where crane_verify writes by default — so PR-CI hits prod.
           CRANE_RELAY_KEY: ${{ secrets.CRANE_CONTEXT_KEY }}
+          # Comma-separated changed surface files; pr-verify-check requires at
+          # least one listed verification to NAME one of these (relevance) and
+          # be a live/fresh observation with non-empty output (aliveness).
+          SURFACE_FILES: ${{ needs.classify.outputs.surface_files }}
         run: node scripts/pr-verify-check.mjs

--- a/config/eos-gate-surfaces.json
+++ b/config/eos-gate-surfaces.json
@@ -49,6 +49,19 @@
       "probe_mode": "session-boot",
       "requires_fleet_probe": true,
       "exclude_paths": ["packages/crane-mcp/src/cli/**/*.test.ts"]
+    },
+    "app-data-seam": {
+      "description": "Producer->consumer data seams: read paths whose failure mode is rendering honest-empty because the producer is dead (the SS UI-renders-empty class). Worker endpoints reading D1, Astro pages/loaders, route handlers. NOT a CI-probeable deployment artifact — covered by the relevance+aliveness verify gate (Layer 4c + pr-verify-gate), which requires a live_state/fresh_process crane_verify naming the seam with non-empty output. Per-venture adoption: add the venture's read-path globs here.",
+      "paths": [
+        "workers/*/src/endpoints/**/*.ts",
+        "src/pages/**/*.astro",
+        "src/**/*.loader.ts",
+        "src/**/loaders/**/*.ts",
+        "app/**/route.ts"
+      ],
+      "probe_mode": "verify-evidence",
+      "requires_fleet_probe": false,
+      "exclude_paths": ["**/*.test.ts", "**/*.spec.ts"]
     }
   },
   "exempt_classes": {
@@ -90,6 +103,10 @@
     "session-boot": {
       "description": "On the probe machine, build crane-mcp from PR branch, start a fresh crane vc session, run /sos, verify session reaches ready state.",
       "timeout_seconds": 240
+    },
+    "verify-evidence": {
+      "description": "No CI/fleet probe. The seam is proven by a live_state/fresh_process crane_verify record that names a changed file and whose output shows data (not []/empty). Enforced by the verify-coverage gate (Layer 4c, EOS-time) and pr-verify-gate.yml (PR-time).",
+      "timeout_seconds": 0
     }
   }
 }

--- a/docs/instructions/eos-gate.md
+++ b/docs/instructions/eos-gate.md
@@ -72,24 +72,27 @@ Best-effort by design: if `gh` CLI isn't available or the API call fails, the ga
 
 Implemented in: `packages/crane-mcp/src/lib/pr-merge-gate.ts` and `packages/crane-mcp/src/tools/handoff.ts`.
 
-### Layer 4c — EOS-time verify-coverage gate
+### Layer 4c — EOS-time verify-coverage gate (relevance + aliveness)
 
-When `crane_handoff` is called with `status=done` AND Layer 4b passes, the verify-coverage gate runs. It asks: did this session record any `crane_verify` rows for the runtime claims its diff implies?
+When `crane_handoff` is called with `status=done` AND Layer 4b passes, the verify-coverage gate runs. It asks the **wiring** question, not the existence question: did this session record a `crane_verify` row that actually **proves the seam it changed carried data**?
+
+This is the teeth behind the "Done means wired" Definition of Done (`docs/process/team-workflow.md`). The earlier version only checked that _some_ verify row existed this session — an agent could satisfy it with an unrelated `vendor_docs` "I read the docs" record while the shipped seam went untested. The gate now requires **relevance + aliveness**.
 
 Decision tree (any "yes" short-circuits to non-blocking):
 
 1. `gh` or `git` unavailable, or not in a git repo → skip
 2. `git diff --quiet origin/main...HEAD` exits 0 AND `git status --porcelain` is empty → skip (this session changed nothing relative to main; no surface to verify). **No branch-name heuristic** — direct-on-main hotfixes are intentionally NOT bypassed
-3. Diff classifier (`scripts/eos-gate-classify.mjs`) finds zero touched surfaces in `{mcp-tool, boot-config, fleet-artifact, config-canon}` → skip. The `skill` class is intentionally excluded; Layer 2's triplet check covers the dominant skill failure mode and a verify gate would mostly nag on prose changes
-4. `GET /verify/session-count` returns ≥1 → skip
-5. Otherwise → block with reason naming the touched surfaces and the override hint
+3. Diff classifier (`scripts/eos-gate-classify.mjs`) finds zero touched surfaces in `{mcp-tool, boot-config, fleet-artifact, config-canon, app-data-seam}` → skip. The `skill` class is intentionally excluded; Layer 2's triplet check covers the dominant skill failure mode. **`app-data-seam`** (worker endpoints, `.astro` pages, loaders — read paths whose failure is "renders honest-empty") was added so the SS-style "wasn't wired" failure is in scope, not just deployment artifacts
+   3b. The diff on the surface files is **behaviorally inert** (comments / imports / formatting only) → skip. A pure refactor has no seam to prove; this prevents false-positives that train reflex-override. Only provably-inert diffs skip — never real code
+4. `GET /verify/session-verifications` returns ≥1 row that **qualifies**: method is `live_state` or `fresh_process` (proof methods — `vendor_docs` never proves a runtime seam), its server-computed `output_nonempty` is true (the captured output showed data, not `[]`/empty), AND its `files_touched` names one of the changed surface files → skip
+5. Otherwise → block with a reason naming the unproven surface files and the override hint
 
 Override paths:
 
 - Pass `status=blocked` if the runtime claim genuinely cannot be verified this session
 - Pass `override_verify_coverage_gate=true` for false-positive cases. The override is logged in the handoff record (mirror Layer 4b) and visible in the next session's SOS
 
-Best-effort by design: classifier missing, ledger lookup failing, or any infra error returns `should_block: false`. Never fail closed on gate-infrastructure problems.
+**Fail-open but LOUD.** classifier missing or gate-infra error → `should_block: false` (never fail closed). But a _ledger lookup failure_ returns `degraded: true` — the handoff records "EOS verify-coverage gate: DEGRADED (failed open)" so the unverified pass is visible and auditable, never a silent bypass.
 
 Implemented in: `packages/crane-mcp/src/lib/verify-coverage-gate.ts` and `packages/crane-mcp/src/tools/handoff.ts`.
 

--- a/docs/process/team-workflow.md
+++ b/docs/process/team-workflow.md
@@ -534,6 +534,22 @@ A story is DONE when:
 - [ ] No open P0/P1 bugs linked to story
 - [ ] Issue closed with `status:done` label
 - [ ] Deployed to production
+- [ ] **Wired (not just deployed)** — see below
+
+### Done means wired
+
+> Every producer→consumer seam your change introduces or depends on is observed
+> working on the real runtime, evidenced by a `crane_verify` record whose
+> `files_touched` names the seam **and whose captured output shows the seam
+> carried data** (not `[]`/empty). "Merged" and "deployed" are not "wired" — a
+> deployed read path that returns nothing because its producer is dead is not
+> done. A seam you cannot verify this session is declared `status:blocked` with
+> the seam named — never shipped as a silent stub.
+
+This is the canonical statement of the wiring bar. It is documentation of a
+control, not the control itself: the teeth are the relevance+aliveness verify
+gate (Layer 4c at EOS, `pr-verify-gate.yml` at PR time). See
+`docs/instructions/eos-gate.md` and `docs/global/verify.md`.
 
 ---
 

--- a/packages/crane-mcp/src/lib/crane-api-extended-types.ts
+++ b/packages/crane-mcp/src/lib/crane-api-extended-types.ts
@@ -297,8 +297,23 @@ export interface GetVerifySessionCountResponse {
   correlation_id?: string
 }
 
+/** One verify-ledger row's gate-relevant facts (relevance + aliveness gates). */
+export interface VerificationDetailEntry {
+  id: string
+  method: string
+  files_touched: string[]
+  output_nonempty: boolean
+}
+
+export interface GetSessionVerificationsResponse {
+  session_id: string
+  verifications: VerificationDetailEntry[]
+  correlation_id?: string
+}
+
 export interface VerifyLookupResponse {
   exists: Record<string, boolean>
+  records?: Record<string, Omit<VerificationDetailEntry, 'id'>>
   correlation_id?: string
 }
 

--- a/packages/crane-mcp/src/lib/crane-api.ts
+++ b/packages/crane-mcp/src/lib/crane-api.ts
@@ -40,6 +40,8 @@ import type {
   GetClaimOriginParams,
   GetClaimOriginResponse,
   GetVerifySessionCountResponse,
+  GetSessionVerificationsResponse,
+  VerificationDetailEntry,
   VerifyLookupResponse,
   GetVerifyAuditParams,
   VerifyAuditResponse,
@@ -369,6 +371,29 @@ export class CraneApi extends CraneApiSchedule {
 
     const data = (await response.json()) as GetVerifySessionCountResponse
     return data.count
+  }
+
+  /**
+   * Per-row session verifications with method, files_touched, and the
+   * server-computed aliveness boolean. Used by the Layer 4c relevance+aliveness
+   * gate. Throws on non-OK so the gate's catch can fail-open-but-loud (a silent
+   * 0 here would let the gate skip without recording the degradation).
+   */
+  async getSessionVerifications(sessionId: string): Promise<VerificationDetailEntry[]> {
+    const response = await fetch(
+      `${this.apiBase}/verify/session-verifications?session_id=${encodeURIComponent(sessionId)}`,
+      {
+        headers: { 'X-Relay-Key': this.apiKey },
+      }
+    )
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Get session verifications failed (${response.status}): ${text}`)
+    }
+
+    const data = (await response.json()) as GetSessionVerificationsResponse
+    return data.verifications
   }
 
   async lookupVerifyIds(ids: string[]): Promise<Record<string, boolean>> {

--- a/packages/crane-mcp/src/lib/verify-coverage-gate.test.ts
+++ b/packages/crane-mcp/src/lib/verify-coverage-gate.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for evaluateVerifyCoverageGate (Layer 4c).
  *
  * The gate is best-effort and depends on git + a classifier script. Tests
- * exercise the decision tree using a fake repo root (so git commands fail
- * predictably) and an injected getSessionCount, isolating the policy logic
- * from the surrounding infrastructure.
+ * exercise the decision tree using a real throwaway git repo and an injected
+ * getSessionVerifications, isolating the relevance + aliveness + seam-trigger
+ * policy from the surrounding infrastructure.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -12,7 +12,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { evaluateVerifyCoverageGate } from './verify-coverage-gate.js'
+import { evaluateVerifyCoverageGate, type VerificationDetail } from './verify-coverage-gate.js'
 
 // Manifest matching the production shape just enough to drive classification.
 const MANIFEST_JSON = {
@@ -23,6 +23,7 @@ const MANIFEST_JSON = {
     },
     'fleet-artifact': { paths: ['scripts/sync-commands.sh'] },
     'config-canon': { paths: ['config/*.json'] },
+    'app-data-seam': { paths: ['src/pages/**/*.astro'] },
     skill: { paths: ['.claude/commands/*.md'] },
   },
   exempt_classes: {
@@ -30,17 +31,10 @@ const MANIFEST_JSON = {
   },
 }
 
-// Build a minimal repo with a real git history so the gate can run its
-// `git diff origin/main...HEAD` and `git status` checks against actual git
-// state. This is the smallest reproduction that exercises both empty-diff
-// and non-empty-diff branches without mocking execSync.
-// When running inside a git hook (pre-push, pre-commit) — and apparently
-// also inside vitest's harness, which inherits any GIT_* env from its
-// parent — git child processes see GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE
-// pointing at the parent worktree's .git. Even with `cwd: dir` set, git
-// prefers the env override and writes the test's "initial" commit into
-// the parent repo, corrupting it. Strip every GIT_* env var from the
-// child env to fully isolate.
+const TOOL_FILE = 'packages/crane-mcp/src/tools/fake.ts'
+
+// Strip every GIT_* env var so child git processes don't target the parent
+// worktree (vitest inherits GIT_* when run from a hook). See original note.
 function makeChildEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env }
   for (const key of Object.keys(env)) {
@@ -49,76 +43,96 @@ function makeChildEnv(): NodeJS.ProcessEnv {
   return env
 }
 
+const ISOLATED = [
+  '-c',
+  'init.defaultBranch=main',
+  '-c',
+  'core.hooksPath=/dev/null',
+  '-c',
+  'commit.gpgsign=false',
+  '-c',
+  'tag.gpgsign=false',
+  '-c',
+  'core.autocrlf=false',
+  '-c',
+  'commit.template=',
+].join(' ')
+
+function gitIn(dir: string, subcmd: string): string {
+  try {
+    return execSync(`git ${ISOLATED} ${subcmd}`, {
+      cwd: dir,
+      env: makeChildEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString()
+  } catch (err) {
+    const e = err as { stderr?: Buffer; stdout?: Buffer; message: string }
+    throw new Error(`${e.message}\n${e.stderr?.toString() ?? ''}\n${e.stdout?.toString() ?? ''}`)
+  }
+}
+
 function makeRepo(): { dir: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'verify-cov-repo-'))
-  // Run git commands in the test repo with isolated config (no user-level
-  // hooks, no signing, no commit template) so this test stays portable
-  // across dev machines. Each command gets `-c` overrides explicitly.
-  const ISOLATED = [
-    '-c',
-    'init.defaultBranch=main',
-    '-c',
-    'core.hooksPath=/dev/null',
-    '-c',
-    'commit.gpgsign=false',
-    '-c',
-    'tag.gpgsign=false',
-    '-c',
-    'core.autocrlf=false',
-    '-c',
-    'commit.template=',
-  ].join(' ')
-  const childEnv = makeChildEnv()
-  const run = (subcmd: string) => {
-    try {
-      return execSync(`git ${ISOLATED} ${subcmd}`, {
-        cwd: dir,
-        env: childEnv,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }).toString()
-    } catch (err) {
-      // execSync's default Error swallows git stderr. Surface it so test
-      // failures inside CI hooks aren't opaque.
-      const e = err as { stderr?: Buffer; stdout?: Buffer; message: string }
-      const stderr = e.stderr?.toString() ?? ''
-      const stdout = e.stdout?.toString() ?? ''
-      throw new Error(`${e.message}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`)
-    }
-  }
-
-  run('init -q')
-  run('config user.email test@example.com')
-  run('config user.name test')
-  // -B is idempotent: switches to main if it exists, creates it if not.
-  run('checkout -q -B main')
+  gitIn(dir, 'init -q')
+  gitIn(dir, 'config user.email test@example.com')
+  gitIn(dir, 'config user.name test')
+  gitIn(dir, 'checkout -q -B main')
   writeFileSync(join(dir, 'README.md'), '# repo\n')
-  run('add README.md')
-  run('commit -q -m initial')
-  // Establish a fake `origin/main` ref pointing at the same commit so
-  // `origin/main...HEAD` resolves cleanly.
-  run('update-ref refs/remotes/origin/main HEAD')
-
-  const cleanup = () => {
-    try {
-      rmSync(dir, { recursive: true, force: true })
-    } catch {
-      /* ignore */
-    }
+  gitIn(dir, 'add README.md')
+  gitIn(dir, 'commit -q -m initial')
+  gitIn(dir, 'update-ref refs/remotes/origin/main HEAD')
+  return {
+    dir,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {
+        /* ignore */
+      }
+    },
   }
-  return { dir, cleanup }
 }
 
 function writeManifest(): string {
-  // Write outside the repo so it doesn't show up in `git status --porcelain`
-  // and accidentally make the working tree look dirty.
   const dir = mkdtempSync(join(tmpdir(), 'verify-cov-manifest-'))
   const path = join(dir, 'eos-gate-surfaces.json')
   writeFileSync(path, JSON.stringify(MANIFEST_JSON, null, 2))
   return path
 }
 
-// Path to the real classifier — it's a pure node script with no repo deps.
+/** Drop an uncommitted mcp-tool change so the gate sees a surface seam. */
+function addToolSeam(dir: string, body = 'export const x = 1\n'): void {
+  const toolPath = join(dir, 'packages/crane-mcp/src/tools')
+  mkdirSync(toolPath, { recursive: true })
+  writeFileSync(join(toolPath, 'fake.ts'), body)
+}
+
+function verif(overrides: Partial<VerificationDetail> = {}): VerificationDetail {
+  return {
+    id: 'vfy_test',
+    method: 'live_state',
+    files_touched: [TOOL_FILE],
+    output_nonempty: true,
+    ...overrides,
+  }
+}
+
 const CLASSIFY_SCRIPT = join(__dirname, '..', '..', '..', '..', 'scripts', 'eos-gate-classify.mjs')
+
+function run(
+  repoDir: string,
+  manifestPath: string,
+  getSessionVerifications: () => Promise<VerificationDetail[]>,
+  classifyScript = CLASSIFY_SCRIPT
+) {
+  return evaluateVerifyCoverageGate({
+    repoRoot: repoDir,
+    classifyScript,
+    manifestPath,
+    sessionId: 'sess_test',
+    getSessionVerifications,
+  })
+}
 
 describe('evaluateVerifyCoverageGate', () => {
   let repo: ReturnType<typeof makeRepo>
@@ -129,54 +143,77 @@ describe('evaluateVerifyCoverageGate', () => {
     manifestPath = writeManifest()
   })
 
-  it('returns should_block:false when working tree is clean and no commits ahead', async () => {
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 0,
-    })
+  it('does not block when working tree is clean and no commits ahead', async () => {
+    const gate = await run(repo.dir, manifestPath, async () => [])
     expect(gate.should_block).toBe(false)
     expect(gate.reason).toMatch(/no diff vs origin\/main/)
     repo.cleanup()
   })
 
-  it('blocks when surface class is touched and no verifications recorded', async () => {
-    // Add an mcp-tool change (uncommitted is fine; gate sees it via git diff HEAD).
-    const toolPath = join(repo.dir, 'packages/crane-mcp/src/tools')
-    mkdirSync(toolPath, { recursive: true })
-    writeFileSync(join(toolPath, 'fake.ts'), 'export const x = 1\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 0,
-    })
+  it('blocks when a surface seam is touched and no verification qualifies', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [])
     expect(gate.should_block).toBe(true)
     expect(gate.surfaces_touched).toContain('mcp-tool')
-    expect(gate.reason).toMatch(/No crane_verify records/)
-    expect(gate.verify_count).toBe(0)
+    expect(gate.reason).toMatch(/no crane_verify record this session PROVES/i)
+    expect(gate.qualifying_count).toBe(0)
     repo.cleanup()
   })
 
-  it('passes when surface class is touched but verifications were recorded', async () => {
-    const toolPath = join(repo.dir, 'packages/crane-mcp/src/tools')
-    mkdirSync(toolPath, { recursive: true })
-    writeFileSync(join(toolPath, 'fake.ts'), 'export const x = 1\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 3,
-    })
+  it('passes when a live, relevant verification proves the changed seam', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [verif()])
     expect(gate.should_block).toBe(false)
-    expect(gate.reason).toMatch(/3 verification\(s\) recorded/)
-    expect(gate.verify_count).toBe(3)
+    expect(gate.qualifying_count).toBe(1)
+    expect(gate.reason).toMatch(/prove the changed seam/)
+    repo.cleanup()
+  })
+
+  it('blocks a relevant verification whose output was a stub (aliveness)', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [verif({ output_nonempty: false })])
+    expect(gate.should_block).toBe(true)
+    expect(gate.qualifying_count).toBe(0)
+    repo.cleanup()
+  })
+
+  it('blocks a live verification whose files do not name the seam (relevance)', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [
+      verif({ files_touched: ['some/other/file.ts'] }),
+    ])
+    expect(gate.should_block).toBe(true)
+    repo.cleanup()
+  })
+
+  it('blocks a relevant alive verification that used vendor_docs (proof method)', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [verif({ method: 'vendor_docs' })])
+    expect(gate.should_block).toBe(true)
+    repo.cleanup()
+  })
+
+  it('covers app-data-seam paths (SS UI-renders-empty class)', async () => {
+    const pagePath = join(repo.dir, 'src/pages/dashboard')
+    mkdirSync(pagePath, { recursive: true })
+    writeFileSync(join(pagePath, 'index.astro'), 'const rows = await db.all()\n')
+    const gate = await run(repo.dir, manifestPath, async () => [])
+    expect(gate.should_block).toBe(true)
+    expect(gate.surfaces_touched).toContain('app-data-seam')
+    repo.cleanup()
+  })
+
+  it('does not block a behaviorally-inert diff on a surface file (seam-trigger)', async () => {
+    // Commit a tool file into origin/main, then make a comment-only edit.
+    addToolSeam(repo.dir, 'export const x = 1\n')
+    gitIn(repo.dir, 'add -A')
+    gitIn(repo.dir, 'commit -q -m "add tool"')
+    gitIn(repo.dir, 'update-ref refs/remotes/origin/main HEAD')
+    writeFileSync(join(repo.dir, TOOL_FILE), 'export const x = 1\n// a clarifying comment\n')
+
+    const gate = await run(repo.dir, manifestPath, async () => [])
+    expect(gate.should_block).toBe(false)
+    expect(gate.reason).toMatch(/behaviorally inert/)
     repo.cleanup()
   })
 
@@ -184,69 +221,38 @@ describe('evaluateVerifyCoverageGate', () => {
     const docsPath = join(repo.dir, 'docs')
     mkdirSync(docsPath, { recursive: true })
     writeFileSync(join(docsPath, 'note.md'), '# note\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 0,
-    })
+    const gate = await run(repo.dir, manifestPath, async () => [])
     expect(gate.should_block).toBe(false)
     expect(gate.reason).toMatch(/no verify-required surface classes touched/)
     repo.cleanup()
   })
 
-  it('passes when only skill files are touched (Layer 2 already covers them)', async () => {
+  it('passes when only skill files are touched (Layer 2 covers them)', async () => {
     const cmdsPath = join(repo.dir, '.claude/commands')
     mkdirSync(cmdsPath, { recursive: true })
     writeFileSync(join(cmdsPath, 'newskill.md'), '# new skill\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 0,
-    })
+    const gate = await run(repo.dir, manifestPath, async () => [])
     expect(gate.should_block).toBe(false)
     expect(gate.reason).toMatch(/no verify-required surface classes touched/)
     repo.cleanup()
   })
 
-  it('skips with should_block:false when classifier is missing', async () => {
-    const toolPath = join(repo.dir, 'packages/crane-mcp/src/tools')
-    mkdirSync(toolPath, { recursive: true })
-    writeFileSync(join(toolPath, 'fake.ts'), 'export const x = 1\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: '/nonexistent/classify.mjs',
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => 0,
-    })
+  it('skips (no block) when the classifier is missing', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => [], '/nonexistent/classify.mjs')
     expect(gate.should_block).toBe(false)
     expect(gate.reason).toMatch(/classifier unavailable/)
     repo.cleanup()
   })
 
-  it('skips with should_block:false when getSessionCount throws', async () => {
-    const toolPath = join(repo.dir, 'packages/crane-mcp/src/tools')
-    mkdirSync(toolPath, { recursive: true })
-    writeFileSync(join(toolPath, 'fake.ts'), 'export const x = 1\n')
-
-    const gate = await evaluateVerifyCoverageGate({
-      repoRoot: repo.dir,
-      classifyScript: CLASSIFY_SCRIPT,
-      manifestPath,
-      sessionId: 'sess_test',
-      getSessionCount: async () => {
-        throw new Error('api unreachable')
-      },
+  it('fails open but LOUD (degraded) when the ledger lookup throws', async () => {
+    addToolSeam(repo.dir)
+    const gate = await run(repo.dir, manifestPath, async () => {
+      throw new Error('api unreachable')
     })
     expect(gate.should_block).toBe(false)
-    expect(gate.reason).toMatch(/verify-ledger lookup failed/)
+    expect(gate.degraded).toBe(true)
+    expect(gate.reason).toMatch(/degraded/i)
     repo.cleanup()
   })
 })

--- a/packages/crane-mcp/src/lib/verify-coverage-gate.ts
+++ b/packages/crane-mcp/src/lib/verify-coverage-gate.ts
@@ -15,8 +15,15 @@
  *      agents reviewing without writing — without depending on branch names)
  *   3. Did the diff touch only skill / docs / tests / build-info? → skip
  *      (skill triplet drift is caught by Layer 2; the rest are exempt)
- *   4. Was the verify_ledger written to in this session at least once?
- *      Yes → skip. No → block.
+ *   3b. Is the diff on the surface files behaviorally inert (comments,
+ *      imports, formatting only)? → skip (no seam to verify; avoids
+ *      false-positives that train reflex-override)
+ *   4. Does the session have ≥1 verification that PROVES a changed seam —
+ *      a live_state/fresh_process record whose files_touched names a changed
+ *      surface file AND whose captured output was alive (not []/empty)?
+ *      Yes → skip. No → block. (Relevance + aliveness: "verified the thing
+ *      you shipped", not "verified something".) Lookup failure → fail-open
+ *      but mark the result `degraded` so the pass is recorded, not silent.
  *
  * Best-effort by design: any infra failure (gh missing, classifier exit ≠ 0,
  * fetch failure, etc.) returns should_block: false. Never fail closed on
@@ -45,7 +52,28 @@ const SURFACE_CLASSES_REQUIRING_VERIFY = new Set<string>([
   'boot-config',
   'fleet-artifact',
   'config-canon',
+  // app-data-seam: read paths (worker endpoints, .astro pages, loaders) whose
+  // failure mode is "renders honest-empty because the producer is dead". Added
+  // so the SS-style "wasn't wired" failure is mechanically in scope, not just
+  // deployment artifacts. Classification is by path glob in the manifest.
+  'app-data-seam',
 ])
+
+/**
+ * Methods that count as PROOF a seam carried data. `vendor_docs` reads can be
+ * relevant but never prove a runtime seam is alive — only a live_state or
+ * fresh_process observation does. The policy lives here (gate), while the
+ * content fact (`output_nonempty`) is computed server-side.
+ */
+const PROOF_METHODS = new Set<string>(['live_state', 'fresh_process'])
+
+/** One verify-ledger row's gate-relevant facts (mirror of the worker shape). */
+export interface VerificationDetail {
+  id: string
+  method: string
+  files_touched: string[]
+  output_nonempty: boolean
+}
 
 export interface VerifyCoverageGateInput {
   /** Path to the repo root (where config/eos-gate-surfaces.json lives) */
@@ -57,19 +85,24 @@ export interface VerifyCoverageGateInput {
   /** Session ID for ledger lookup (passed in from session context) */
   sessionId: string
   /**
-   * Function that returns the verify-ledger record count for the session.
-   * Wrapped so the gate can be tested without network. The caller
-   * (`handoff.ts`) wires this to `api.getVerifySessionCount(sessionId)`.
+   * Returns this session's verify-ledger rows with the facts the gate needs:
+   * method, files_touched, and the server-computed aliveness boolean. Wrapped
+   * so the gate is testable without network. `handoff.ts` wires this to
+   * `api.getSessionVerifications(sessionId)`.
    */
-  getSessionCount: (sessionId: string) => Promise<number>
+  getSessionVerifications: (sessionId: string) => Promise<VerificationDetail[]>
 }
 
 export interface VerifyCoverageGateResult {
   branch: string | null
   /** Names of surface classes the diff touches (post-classification) */
   surfaces_touched: string[]
-  /** Verify-ledger row count for this session at gate-evaluation time */
+  /** Total session verify-ledger rows seen at gate-evaluation time */
   verify_count: number
+  /** Rows that PROVE a changed seam: proof-method + alive + names a surface file */
+  qualifying_count: number
+  /** True when an infra failure forced a fail-open pass (recorded, not silent) */
+  degraded: boolean
   should_block: boolean
   reason: string
 }
@@ -205,19 +238,82 @@ const SKIP_OK = (
   branch: string | null,
   reason: string,
   surfaces: string[] = [],
-  count = 0
+  opts: { verify_count?: number; qualifying_count?: number; degraded?: boolean } = {}
 ): VerifyCoverageGateResult => ({
   branch,
   surfaces_touched: surfaces,
-  verify_count: count,
+  verify_count: opts.verify_count ?? 0,
+  qualifying_count: opts.qualifying_count ?? 0,
+  degraded: opts.degraded ?? false,
   should_block: false,
   reason,
 })
 
+/**
+ * A verification PROVES a changed seam iff it (a) used a proof method
+ * (live_state / fresh_process — not vendor_docs), (b) its captured output was
+ * alive (server-computed `output_nonempty`), and (c) its files_touched names
+ * at least one of the changed surface files. This is the relevance+aliveness
+ * test that turns "verified something" into "verified the thing you shipped".
+ */
+function isQualifyingProof(v: VerificationDetail, surfaceFiles: Set<string>): boolean {
+  if (!PROOF_METHODS.has(v.method)) return false
+  if (!v.output_nonempty) return false
+  return v.files_touched.some((f) => surfaceFiles.has(f))
+}
+
+/**
+ * Lines that change no runtime behavior: blank, comment-only, or
+ * import/export-from statements. Used to detect a behaviorally-inert diff so
+ * pure formatting / comment / import-sort changes to a surface file don't trip
+ * the gate (the false-positive class that trains reflex-override). We only ever
+ * SKIP on provably-inert diffs — never skip real code — so this narrows
+ * false-positives without opening a false-negative hole.
+ */
+function isInertLine(line: string): boolean {
+  const t = line.trim()
+  if (t.length === 0) return true
+  if (/^(\/\/|\/\*|\*\/|\*|#)/.test(t)) return true
+  if (/^import\b/.test(t)) return true
+  if (/^export\s+(\*|\{)[^=]*\bfrom\b/.test(t)) return true
+  if (/^\}\s+from\b/.test(t)) return true
+  return false
+}
+
+/**
+ * True if the diff on the given surface files is behaviorally inert. Any
+ * untracked (brand-new) surface file is never inert. Otherwise we scan the
+ * added/removed content lines and ask whether anything substantive remains.
+ */
+function surfaceDiffIsInert(repoRoot: string, surfaceFiles: string[]): boolean {
+  const untracked = new Set(
+    (safeExec('git ls-files --others --exclude-standard 2>/dev/null', { cwd: repoRoot }) ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+  )
+  if (surfaceFiles.some((f) => untracked.has(f))) return false
+
+  const quoted = surfaceFiles.map((f) => JSON.stringify(f)).join(' ')
+  const committed = safeExec(`git diff origin/main...HEAD -- ${quoted} 2>/dev/null`, {
+    cwd: repoRoot,
+  })
+  const uncommitted = safeExec(`git diff HEAD -- ${quoted} 2>/dev/null`, { cwd: repoRoot })
+  const diff = `${committed ?? ''}\n${uncommitted ?? ''}`
+
+  for (const raw of diff.split('\n')) {
+    if (raw.startsWith('+++') || raw.startsWith('---')) continue
+    if (raw.startsWith('+') || raw.startsWith('-')) {
+      if (!isInertLine(raw.slice(1))) return false
+    }
+  }
+  return true
+}
+
 export async function evaluateVerifyCoverageGate(
   input: VerifyCoverageGateInput
 ): Promise<VerifyCoverageGateResult> {
-  const { repoRoot, classifyScript, manifestPath, sessionId, getSessionCount } = input
+  const { repoRoot, classifyScript, manifestPath, sessionId, getSessionVerifications } = input
 
   // Step 1: gh/git availability
   const ghAvailable = safeExec('gh --version') !== null
@@ -257,37 +353,77 @@ export async function evaluateVerifyCoverageGate(
     )
   }
 
-  // Step 4: ledger lookup
-  let count: number
-  try {
-    count = await getSessionCount(sessionId)
-  } catch {
-    // Best-effort: fail open on count-fetch failure.
+  const surfaceFiles = new Set<string>(
+    touchedSurfaces.flatMap((c) => classified.surfaces_touched[c] ?? [])
+  )
+
+  // Step 3b: seam-triggered firing. A behaviorally-inert diff (comments,
+  // imports, formatting) on the surface files has no runtime claim to prove.
+  if (surfaceDiffIsInert(repoRoot, Array.from(surfaceFiles))) {
     return SKIP_OK(
       branch,
-      '[skip] verify-ledger lookup failed; gate cannot evaluate',
+      `[ok] surface(s) ${touchedSurfaces.join(', ')} touched but the diff is behaviorally inert (comments/imports/formatting) — no seam to verify`,
       touchedSurfaces
     )
   }
 
-  if (count > 0) {
+  // Step 4: ledger lookup — relevance + aliveness.
+  let verifications: VerificationDetail[]
+  try {
+    verifications = await getSessionVerifications(sessionId)
+  } catch {
+    // Fail-open-but-LOUD: pass so infra trouble never blocks legit work, but
+    // mark the pass degraded so it's recorded on the handoff and audited —
+    // never a silent bypass.
+    return SKIP_OK(
+      branch,
+      `[degraded] verify-ledger lookup failed; could not confirm seam coverage for ${touchedSurfaces.join(', ')} — passing OPEN (recorded as degraded)`,
+      touchedSurfaces,
+      { degraded: true }
+    )
+  }
+
+  return decideFromVerifications(branch, touchedSurfaces, surfaceFiles, verifications)
+}
+
+/**
+ * Final verdict from this session's verifications: pass iff ≥1 qualifies
+ * (proof method + alive + names a changed surface file), else block with a
+ * reason naming the unproven seams. Extracted to keep the orchestrator under
+ * the per-function line cap.
+ */
+function decideFromVerifications(
+  branch: string | null,
+  touchedSurfaces: string[],
+  surfaceFiles: Set<string>,
+  verifications: VerificationDetail[]
+): VerifyCoverageGateResult {
+  const qualifying = verifications.filter((v) => isQualifyingProof(v, surfaceFiles))
+
+  if (qualifying.length > 0) {
     return {
       branch,
       surfaces_touched: touchedSurfaces,
-      verify_count: count,
+      verify_count: verifications.length,
+      qualifying_count: qualifying.length,
+      degraded: false,
       should_block: false,
-      reason: `[ok] ${count} verification(s) recorded this session covering ${touchedSurfaces.join(', ')}`,
+      reason: `[ok] ${qualifying.length} live verification(s) name and prove the changed seam(s) in ${touchedSurfaces.join(', ')}`,
     }
   }
 
   return {
     branch,
     surfaces_touched: touchedSurfaces,
-    verify_count: 0,
+    verify_count: verifications.length,
+    qualifying_count: 0,
+    degraded: false,
     should_block: true,
     reason:
-      `[gate] No crane_verify records this session, but the diff touches ` +
-      `${touchedSurfaces.join(', ')}. Record at least one verification of the runtime ` +
-      `claim — fresh process, live state, or vendor docs. See docs/global/verify.md.`,
+      `[gate] The diff changes seam(s) in ${touchedSurfaces.join(', ')} but no crane_verify ` +
+      `record this session PROVES them. A qualifying record must be a live_state or fresh_process ` +
+      `observation whose files_touched names one of: ${Array.from(surfaceFiles).join(', ')}, and ` +
+      `whose captured output shows the seam carried data (not []/empty). ` +
+      `${verifications.length} record(s) exist but none qualify. See docs/global/verify.md.`,
   }
 }

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -198,7 +198,18 @@ interface VerifyGateState {
   reason: string | null
   surfaces: string[]
   count: number
+  /** True when the gate failed open due to infra trouble (recorded, not silent). */
+  degraded?: boolean
   blocked?: HandoffResult
+}
+
+/** Render the EOS verify-coverage line for the handoff summary. */
+function renderVerifyCoverageBlock(g: VerifyGateState): string {
+  const tag = g.surfaces.length ? ` [${g.surfaces.join(', ')}]` : ''
+  if (g.overrideUsed) return `EOS verify-coverage gate: OVERRIDDEN\n`
+  if (g.degraded) return `EOS verify-coverage gate: DEGRADED (failed open)${tag} — ${g.reason}\n`
+  if (g.reason) return `Verification coverage: ${g.count} recorded${tag} — ${g.reason}\n`
+  return ''
 }
 
 /** Evaluate the verify-coverage gate (Layer 4c). Returns gate state and optional blocking result. */
@@ -228,7 +239,7 @@ async function evaluateVerifyGate(
       classifyScript,
       manifestPath,
       sessionId,
-      getSessionCount: (sid) => api.getVerifySessionCount(sid),
+      getSessionVerifications: (sid) => api.getSessionVerifications(sid),
     })
 
     if (verifyGate.should_block) {
@@ -256,6 +267,7 @@ async function evaluateVerifyGate(
       reason: verifyGate.reason,
       surfaces: verifyGate.surfaces_touched,
       count: verifyGate.verify_count,
+      degraded: verifyGate.degraded,
     }
   } catch (err) {
     console.warn('crane_handoff: verify-coverage gate evaluation failed (non-fatal)', {
@@ -381,13 +393,7 @@ async function buildAndSubmitHandoff(p: HandoffSubmitParams): Promise<HandoffRes
     return { success: false, message: `Failed to create handoff.\n${detail}` }
   }
 
-  let verifyCoverageBlock = ''
-  if (p.verifyGate.overrideUsed) {
-    verifyCoverageBlock = `EOS verify-coverage gate: OVERRIDDEN\n`
-  } else if (p.verifyGate.reason) {
-    const tag = p.verifyGate.surfaces.length ? ` [${p.verifyGate.surfaces.join(', ')}]` : ''
-    verifyCoverageBlock = `Verification coverage: ${p.verifyGate.count} recorded${tag} — ${p.verifyGate.reason}\n`
-  }
+  const verifyCoverageBlock = renderVerifyCoverageBlock(p.verifyGate)
 
   return {
     success: true,

--- a/packages/crane-mcp/src/tools/sos.test.ts
+++ b/packages/crane-mcp/src/tools/sos.test.ts
@@ -810,6 +810,7 @@ describe('sos tool', () => {
     expect(result.message).toContain('venturecrane/crane-console')
     expect(result.message).toContain('Never remove, deprecate, or disable')
     expect(result.message).toContain('npm run verify')
+    expect(result.message).toContain('Done means wired')
     expect(result.message).toContain('Scope discipline')
   })
 

--- a/packages/crane-mcp/src/tools/sos/message-sections.ts
+++ b/packages/crane-mcp/src/tools/sos/message-sections.ts
@@ -57,6 +57,7 @@ export function renderDirectivesBlock(fullRepo: string): string {
   out += `- All GitHub issues this session target **${fullRepo}**. Targeting a different repo? STOP.\n`
   out += `- Never remove, deprecate, or disable features without Captain directive.\n`
   out += `- Run \`npm run verify\` before pushing. Fix root causes, not symptoms.\n`
+  out += `- **Done means wired**, not merged or deployed: every seam your change introduces or relies on must be observed working on the real runtime, with a \`crane_verify\` record naming the seam and output showing it carried data. Unverifiable seams → \`status:blocked\`, never a silent stub. Definition of Done: \`crane_doc('global', 'team-workflow.md')\`.\n`
   out += `- Scope discipline: finish current task, file new issues for discovered work.\n`
   out += `- Never switch repos or ventures without explicit Captain approval. Announce all context switches.\n`
   out += `- Before editing against any third-party API/SDK/CLI (GitHub, Vercel, Cloudflare, npm, etc.), consult Context7 (\`mcp__plugin_context7_context7__*\`) — training data is frozen; don't guess at vendor syntax. Full tooling catalog: \`crane_doc('global', 'tooling.md')\`.\n`

--- a/scripts/pr-verify-check.mjs
+++ b/scripts/pr-verify-check.mjs
@@ -2,8 +2,12 @@
 //
 // pr-verify-check.mjs — PR-CI verify gate (Layer of Prong 2).
 //
-// Reads the PR body, extracts vfy_<ULID> IDs, and confirms each one exists
-// in the verify_ledger. Used by .github/workflows/pr-verify-gate.yml.
+// Reads the PR body, extracts vfy_<ULID> IDs, and confirms each one (a) exists
+// in the verify_ledger, and (b) actually PROVES a changed seam: at least one
+// listed verification must be a live_state/fresh_process observation whose
+// files_touched names one of the PR's changed surface files AND whose captured
+// output showed data (server-computed aliveness). This turns "verified
+// something" into "verified the thing you shipped". Used by pr-verify-gate.yml.
 //
 // Required env:
 //   GITHUB_TOKEN       — gh CLI auth (provided automatically in workflows)
@@ -14,10 +18,14 @@
 // Optional env:
 //   CRANE_API_BASE     — defaults to production worker
 //   GRACE_MINUTES      — opened-but-zero-IDs grace window (default 5)
+//   SURFACE_FILES      — comma-separated changed surface files (relevance set).
+//                        Empty / worker without `records` → degrade to
+//                        existence-only with a loud warning (never silent).
 //
 // Exit codes:
-//   0  — pass (or grace window: warn-only)
-//   1  — fail (zero IDs past grace, or any listed ID missing from ledger)
+//   0  — pass (or grace window: warn-only, or degraded existence-only)
+//   1  — fail (zero IDs past grace, any ID missing, or no listed verification
+//        proves a changed seam)
 //   2  — script error (invalid args, network, etc.) — workflow treats as failure
 
 import { execSync } from 'node:child_process'
@@ -50,6 +58,16 @@ const REPO = getEnv('GITHUB_REPOSITORY')
 const RELAY_KEY = getEnv('CRANE_RELAY_KEY')
 const API_BASE = getEnv('CRANE_API_BASE', DEFAULT_API_BASE)
 const GRACE_MINUTES = parseInt(getEnv('GRACE_MINUTES', '5'), 10)
+// Changed surface files the PR must PROVE. Empty when the workflow didn't pass
+// them (older workflow) — then we degrade to existence-only.
+const SURFACE_FILES = new Set(
+  getEnv('SURFACE_FILES', '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+)
+// Only live observations prove a seam carried data — reading docs does not.
+const PROOF_METHODS = new Set(['live_state', 'fresh_process'])
 
 // Step 1: pull PR body + createdAt via gh CLI.
 let prJson
@@ -128,5 +146,47 @@ if (missing.length > 0) {
   )
 }
 
-notice(`All ${ids.length} vfy_ ID(s) verified against the ledger.`)
+notice(`All ${ids.length} vfy_ ID(s) exist in the ledger.`)
+
+// Step 4: relevance + aliveness. At least one listed verification must PROVE a
+// changed seam. Degrade loudly (warn + pass) when we lack the inputs to judge
+// relevance — never silently, and never fail-closed on a worker version skew.
+const records = lookup.records
+if (!records) {
+  warn(
+    `verify gate running in EXISTENCE-ONLY mode: the crane-context worker did not return ` +
+      `per-record detail (it predates the relevance+aliveness check). IDs exist but the gate ` +
+      `could not confirm any one names a changed seam. Deploy the updated worker to enforce.`
+  )
+  process.exit(0)
+}
+if (SURFACE_FILES.size === 0) {
+  warn(
+    `verify gate running in EXISTENCE-ONLY mode: no SURFACE_FILES were provided by the workflow, ` +
+      `so relevance cannot be judged. IDs exist; passing. Update pr-verify-gate.yml to pass surface_files.`
+  )
+  process.exit(0)
+}
+
+const qualifying = ids.filter((id) => {
+  const r = records[id]
+  if (!r) return false
+  if (!PROOF_METHODS.has(r.method)) return false
+  if (r.output_nonempty !== true) return false
+  return (r.files_touched ?? []).some((f) => SURFACE_FILES.has(f))
+})
+
+if (qualifying.length === 0) {
+  fail(
+    `No listed verification PROVES a changed seam. A qualifying record must be a ` +
+      `live_state or fresh_process observation whose files_touched names one of the changed ` +
+      `surface files and whose captured output showed data (not []/empty).\n\n` +
+      `Changed surface files:\n  ${[...SURFACE_FILES].join('\n  ')}\n\n` +
+      `${ids.length} ID(s) exist but none qualify. Run crane_verify against the actual seam ` +
+      `(pass files_touched naming the changed file), then add its vfy_ ID to the PR body. ` +
+      `See docs/global/verify.md, or apply skip-verify-gate with rationale to bypass.`
+  )
+}
+
+notice(`${qualifying.length} verification(s) prove the changed seam(s): ${qualifying.join(', ')}`)
 process.exit(0)

--- a/workers/crane-context/src/endpoints/verify-ledger.ts
+++ b/workers/crane-context/src/endpoints/verify-ledger.ts
@@ -50,6 +50,21 @@ interface ClaimRecord {
   files_touched: string[]
 }
 
+/**
+ * Detailed verification record used by the relevance+aliveness gates
+ * (Layer 4c and PR-CI). `output_nonempty` is the server-computed aliveness
+ * fact — whether the captured output actually demonstrates the seam carried
+ * data (vs. a stub `[]`/`{}`/`null`/empty). The gate owns the *policy*
+ * (which methods count, intersection with changed surface files); the worker
+ * owns this single content fact so all callers agree on "alive".
+ */
+interface VerificationDetail {
+  id: string
+  method: VerifyMethod
+  files_touched: string[]
+  output_nonempty: boolean
+}
+
 // ============================================================================
 // POST /verify — Record a Verification
 // ============================================================================
@@ -263,14 +278,70 @@ export async function handleVerifyLookup(request: Request, env: Env): Promise<Re
   }
 
   try {
-    const exists = await lookupIds(env, idsResult)
+    const details = await lookupIdsDetailed(env, idsResult)
+    // `exists` retained for back-compat with older pr-verify-check.mjs builds.
+    const exists: Record<string, boolean> = {}
+    const records: Record<string, Omit<VerificationDetail, 'id'>> = {}
+    for (const id of idsResult) {
+      const d = details.get(id)
+      exists[id] = d !== undefined
+      if (d) {
+        records[id] = {
+          method: d.method,
+          files_touched: d.files_touched,
+          output_nonempty: d.output_nonempty,
+        }
+      }
+    }
     return jsonResponse(
-      { exists, correlation_id: context.correlationId },
+      { exists, records, correlation_id: context.correlationId },
       HTTP_STATUS.OK,
       context.correlationId
     )
   } catch (error) {
     console.error('GET /verify/lookup error:', error)
+    return errorResponse(
+      error instanceof Error ? error.message : 'Internal server error',
+      HTTP_STATUS.INTERNAL_ERROR,
+      context.correlationId
+    )
+  }
+}
+
+// ============================================================================
+// GET /verify/session-verifications?session_id=... — relevance+aliveness gate
+// ============================================================================
+//
+// Returns one record per verify_ledger row for the session, each carrying the
+// method, the files it touched, and the server-computed `output_nonempty`
+// aliveness fact. The EOS-time Layer 4c gate (verify-coverage-gate.ts) uses
+// this to decide whether a session has at least one verification that both
+// names a changed surface seam AND proves it carried data. Successor to
+// /verify/session-count (which only answered "any rows at all?").
+
+export async function handleGetSessionVerifications(request: Request, env: Env): Promise<Response> {
+  const context = await buildRequestContext(request, env)
+  if (isResponse(context)) return context
+
+  const url = new URL(request.url)
+  const sessionId = url.searchParams.get('session_id')
+
+  if (!sessionId) {
+    return validationErrorResponse(
+      [{ field: 'session_id', message: 'Required query parameter' }],
+      context.correlationId
+    )
+  }
+
+  try {
+    const verifications = await querySessionVerifications(env, sessionId)
+    return jsonResponse(
+      { session_id: sessionId, verifications, correlation_id: context.correlationId },
+      HTTP_STATUS.OK,
+      context.correlationId
+    )
+  } catch (error) {
+    console.error('GET /verify/session-verifications error:', error)
     return errorResponse(
       error instanceof Error ? error.message : 'Internal server error',
       HTTP_STATUS.INTERNAL_ERROR,
@@ -381,16 +452,96 @@ async function queryOriginClaims(
   }))
 }
 
-async function lookupIds(env: Env, ids: string[]): Promise<Record<string, boolean>> {
-  const placeholders = ids.map(() => '?').join(',')
-  const result = await env.DB.prepare(`SELECT id FROM verify_ledger WHERE id IN (${placeholders})`)
-    .bind(...ids)
-    .all<{ id: string }>()
+/**
+ * Trimmed-output values that mean "the seam produced nothing" — a stub or
+ * empty result, not proof of wiring. Kept conservative: exact-match on the
+ * whole trimmed output so we never reject a large body that merely *mentions*
+ * an empty token. Structural emptiness (parses to [], {}, null) is handled
+ * separately via JSON.parse.
+ */
+const STUB_OUTPUT_LITERALS = new Set(['', '[]', '{}', 'null', 'undefined', '()', '[ ]', '{ }'])
+const STUB_OUTPUT_PHRASE = /^(0 rows?|no rows?|none|empty|no results?|n\/a)$/i
 
-  const found = new Set((result.results ?? []).map((r) => r.id))
-  const exists: Record<string, boolean> = {}
-  for (const id of ids) {
-    exists[id] = found.has(id)
+/**
+ * Server-computed aliveness fact: does this captured output demonstrate the
+ * seam carried data? This is the single source of truth shared by Layer 4c
+ * and the PR-CI gate — both read the boolean rather than re-implementing the
+ * stub-detection. Content-only: the *policy* of which methods count toward
+ * proof lives in the gate, not here.
+ */
+function isOutputAlive(output: string): boolean {
+  const trimmed = output.trim()
+  if (STUB_OUTPUT_LITERALS.has(trimmed)) return false
+  if (STUB_OUTPUT_PHRASE.test(trimmed)) return false
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (parsed === null) return false
+    if (Array.isArray(parsed)) return parsed.length > 0
+    if (typeof parsed === 'object') return Object.keys(parsed).length > 0
+  } catch {
+    // Not JSON — non-empty prose / command output counts as alive.
   }
-  return exists
+  return true
+}
+
+interface DetailRow {
+  id: string
+  method: VerifyMethod
+  output_scrubbed: string
+  files_concat: string | null
+}
+
+function mapDetailRow(row: DetailRow): VerificationDetail {
+  return {
+    id: row.id,
+    method: row.method,
+    files_touched: row.files_concat ? row.files_concat.split(',').filter(Boolean) : [],
+    output_nonempty: isOutputAlive(row.output_scrubbed),
+  }
+}
+
+async function lookupIdsDetailed(
+  env: Env,
+  ids: string[]
+): Promise<Map<string, VerificationDetail>> {
+  const placeholders = ids.map(() => '?').join(',')
+  const result = await env.DB.prepare(
+    `SELECT vl.id              AS id,
+            vl.method          AS method,
+            vl.output_scrubbed AS output_scrubbed,
+            GROUP_CONCAT(DISTINCT vf.file_path) AS files_concat
+     FROM verify_ledger vl
+     LEFT JOIN verify_files vf ON vf.verify_id = vl.id
+     WHERE vl.id IN (${placeholders})
+     GROUP BY vl.id`
+  )
+    .bind(...ids)
+    .all<DetailRow>()
+
+  const map = new Map<string, VerificationDetail>()
+  for (const row of result.results ?? []) {
+    map.set(row.id, mapDetailRow(row))
+  }
+  return map
+}
+
+async function querySessionVerifications(
+  env: Env,
+  sessionId: string
+): Promise<VerificationDetail[]> {
+  const result = await env.DB.prepare(
+    `SELECT vl.id              AS id,
+            vl.method          AS method,
+            vl.output_scrubbed AS output_scrubbed,
+            GROUP_CONCAT(DISTINCT vf.file_path) AS files_concat
+     FROM verify_ledger vl
+     LEFT JOIN verify_files vf ON vf.verify_id = vl.id
+     WHERE vl.session_id = ?
+     GROUP BY vl.id
+     ORDER BY vl.created_at DESC`
+  )
+    .bind(sessionId)
+    .all<DetailRow>()
+
+  return (result.results ?? []).map(mapDetailRow)
 }

--- a/workers/crane-context/src/router.ts
+++ b/workers/crane-context/src/router.ts
@@ -113,6 +113,7 @@ import {
   handleRecordVerification,
   handleGetVerificationOrigin,
   handleGetVerificationSessionCount,
+  handleGetSessionVerifications,
   handleVerifyLookup,
 } from './endpoints/verify-ledger'
 import { handleVerifyAudit } from './endpoints/verify-audit'
@@ -420,6 +421,7 @@ const INFRA_EXACT: ExactTable = {
   'POST /verify': (req, env) => handleRecordVerification(req, env),
   'GET /verify/origin': (req, env) => handleGetVerificationOrigin(req, env),
   'GET /verify/session-count': (req, env) => handleGetVerificationSessionCount(req, env),
+  'GET /verify/session-verifications': (req, env) => handleGetSessionVerifications(req, env),
   'GET /verify/lookup': (req, env) => handleVerifyLookup(req, env),
   'GET /verify/audit': (req, env) => handleVerifyAudit(req, env),
 }

--- a/workers/crane-context/test/harness/verify-lookup.test.ts
+++ b/workers/crane-context/test/harness/verify-lookup.test.ts
@@ -27,9 +27,65 @@ beforeAll(() => {
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const migrationsDir = join(__dirname, '..', '..', 'migrations')
 
+interface VerificationDetail {
+  method: string
+  files_touched: string[]
+  output_nonempty: boolean
+}
+
 interface VerifyLookupResponse {
   exists: Record<string, boolean>
+  records: Record<string, VerificationDetail>
   correlation_id: string
+}
+
+interface SessionVerificationsResponse {
+  session_id: string
+  verifications: Array<{ id: string } & VerificationDetail>
+  correlation_id: string
+}
+
+/**
+ * Insert a verify_ledger row (+ verify_files rows) with control over the
+ * fields the relevance+aliveness gates read: session_id, method, output,
+ * and files. Used by the records/aliveness and session-verifications tests.
+ */
+async function insertVerifyRowFull(
+  db: D1Database,
+  opts: {
+    id: string
+    sessionId?: string | null
+    method?: string
+    output?: string
+    files?: string[]
+  }
+): Promise<void> {
+  const {
+    id,
+    sessionId = null,
+    method = 'live_state',
+    output = 'scrubbed output',
+    files = [],
+  } = opts
+  await db
+    .prepare(
+      `INSERT INTO verify_ledger
+         (id, session_id, venture, repo, method, source, claim,
+          output_scrubbed, output_hash, output_redacted, output_truncation,
+          tool_used, command, command_hash, fresh_runtime,
+          fresh_runtime_justification, actor_key_id)
+       VALUES (?, ?, NULL, NULL, ?, 'tool', 'test claim',
+               ?, 'deadbeef', 0, 'none',
+               'Bash', 'echo hi', 'feedface', NULL, NULL, 'test-actor')`
+    )
+    .bind(id, sessionId, method, output)
+    .run()
+  for (const path of files) {
+    await db
+      .prepare(`INSERT OR IGNORE INTO verify_files (verify_id, file_path) VALUES (?, ?)`)
+      .bind(id, path)
+      .run()
+  }
 }
 
 describe('GET /verify/lookup', () => {
@@ -166,5 +222,113 @@ describe('GET /verify/lookup', () => {
       env,
     })
     expect(res.status).toBe(401)
+  })
+
+  it('records carry files_touched, method, and the aliveness boolean', async () => {
+    const aliveId = 'vfy_01HQXV3NK8YXM3G5ZXQXQXQXQX'
+    const stubId = 'vfy_01HQXV3NK8YXM3G5ZXQXBBBBBB'
+    await insertVerifyRowFull(db, {
+      id: aliveId,
+      method: 'live_state',
+      output: '[{"id":1},{"id":2}]',
+      files: ['workers/crane-context/src/endpoints/verify-ledger.ts'],
+    })
+    await insertVerifyRowFull(db, {
+      id: stubId,
+      method: 'live_state',
+      output: '[]',
+      files: ['workers/crane-context/src/router.ts'],
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: `/verify/lookup?ids=${aliveId},${stubId}`,
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as VerifyLookupResponse
+    expect(json.records[aliveId]).toEqual({
+      method: 'live_state',
+      files_touched: ['workers/crane-context/src/endpoints/verify-ledger.ts'],
+      output_nonempty: true,
+    })
+    // Stub output ([]) is recorded but flagged not-alive — the gate rejects it.
+    expect(json.records[stubId].output_nonempty).toBe(false)
+  })
+})
+
+describe('GET /verify/session-verifications', () => {
+  let db: D1Database
+  let env: Env
+  const headers = { 'X-Relay-Key': 'test-relay-key' }
+
+  beforeEach(async () => {
+    db = createTestD1()
+    await runMigrations(db, { files: discoverNumericMigrations(migrationsDir) })
+    env = {
+      DB: db,
+      CONTEXT_RELAY_KEY: 'test-relay-key',
+      CONTEXT_ADMIN_KEY: 'test-admin-key',
+      CONTEXT_SESSION_STALE_MINUTES: '45',
+      IDEMPOTENCY_TTL_SECONDS: '3600',
+      HEARTBEAT_INTERVAL_SECONDS: '600',
+      HEARTBEAT_JITTER_SECONDS: '120',
+    }
+  })
+
+  it('returns per-row detail (method, files, aliveness) for the session', async () => {
+    const sid = 'sess_01HQXV3NK8YXM3G5ZXQXQXQXQX'
+    await insertVerifyRowFull(db, {
+      id: 'vfy_01HQXV3NK8YXM3G5ZXQXQXQXQX',
+      sessionId: sid,
+      method: 'fresh_process',
+      output: 'crane_verify  Record a verification artifact',
+      files: ['packages/crane-mcp/src/index.ts'],
+    })
+    await insertVerifyRowFull(db, {
+      id: 'vfy_01HQXV3NK8YXM3G5ZXQXCCCCCC',
+      sessionId: sid,
+      method: 'vendor_docs',
+      output: 'From context7: streamText accepts provider/model strings...',
+      files: ['packages/crane-mcp/src/lib/llm.ts'],
+    })
+
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: `/verify/session-verifications?session_id=${sid}`,
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as SessionVerificationsResponse
+    expect(json.verifications).toHaveLength(2)
+    const byId = Object.fromEntries(json.verifications.map((v) => [v.id, v]))
+    expect(byId['vfy_01HQXV3NK8YXM3G5ZXQXQXQXQX'].files_touched).toEqual([
+      'packages/crane-mcp/src/index.ts',
+    ])
+    expect(byId['vfy_01HQXV3NK8YXM3G5ZXQXQXQXQX'].output_nonempty).toBe(true)
+  })
+
+  it('returns an empty list for a session with no rows', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: `/verify/session-verifications?session_id=sess_none`,
+      headers,
+      env,
+    })
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as SessionVerificationsResponse
+    expect(json.verifications).toEqual([])
+  })
+
+  it('rejects missing session_id with 400', async () => {
+    const res = await invoke(worker, {
+      method: 'GET',
+      path: `/verify/session-verifications`,
+      headers,
+      env,
+    })
+    expect(res.status).toBe(400)
   })
 })


### PR DESCRIPTION
## Problem

The Captain keeps catching the same failure: an agent declares work **done** at CI-green / merged / deployed, but the feature isn't **wired** — a UI renders honest-empty, a stub returns `[]`, a cron never fires. The sharp version (raised in an SS session today): *if an agent can tell later it wasn't wired, why not at build time?*

Confirmed in code: the enforcement machinery already existed and was mechanical — it just didn't check that the evidence covers what you shipped.

1. The DoD (`docs/process/team-workflow.md`) ended at "Deployed." Deployed ≠ the data path carries data.
2. Both gates were **existence-only**: Layer 4c (`verify-coverage-gate.ts`) blocked only on *zero* verify rows; PR-CI (`pr-verify-check.mjs`) only confirmed `vfy_` IDs *exist*. One unrelated "I read the docs" record satisfied either gate.
3. The canonical app-data-seam failure (UI renders empty, dead producer) wasn't in any surface class, so neither gate fired on it.

This was scoped with the Captain and hardened through a `/critique` pass (the first draft only relocated the gaming target; the loud-unwired manifest was circular theater — both fixed here).

## What changed

**Lever 1 — Definition of Done ("Done means wired").** One canonical clause in `team-workflow.md`, referenced (not copied) from the SOS directives, `eos-gate.md`, and the EOS skill. Merged/deployed ≠ wired. Framed as documentation of the control; the teeth are Lever 2.

**Lever 2 — one unified gate (Layer 4c at EOS + `pr-verify-gate.yml` at PR time):**
- **Relevance** — a verify row counts only if its `files_touched` intersects the changed surface files.
- **Aliveness** — for `live_state`/`fresh_process`, the captured output must show data (not `[]`/`{}`/`null`/empty). `vendor_docs` never proves a runtime seam. The **worker** computes the `output_nonempty` fact (single source of truth) and returns it via extended `/verify/lookup` (`records`) and a new `GET /verify/session-verifications`.
- **Seam-triggered** — a behaviorally-inert diff (comments/imports/formatting) on a surface file skips, so refactors don't train reflex-override. Only provably-inert diffs skip — never real code.
- **Fail-open but LOUD** — a ledger-lookup failure passes (house philosophy: never fail closed on infra) but marks the handoff `DEGRADED (failed open)`, recorded and auditable — never a silent bypass.
- **`app-data-seam` surface class** — worker endpoints, `.astro` pages, loaders. The SS-style failure is now mechanically in scope. Per-venture adoption is a one-line glob in `config/eos-gate-surfaces.json`.

**Cut from the draft:** the separate seam-manifest + seam-smoke runner. A voluntary manifest depends on the diligence we said isn't a control (the agent who silently stubs a seam won't register it), and aliveness already covers the diffed case. The only non-redundant role — a *pre-existing* seam dying with no diff — is a separate scheduled gate, not raised here.

## Corpus replay (required by `eos-gate.md`)

- `feedback_verify_fix_end_to_end.md` — now requires a `fresh_process` record naming the boot-config file with alive output; an unrelated record no longer passes. ✓ (strengthened)
- `feedback_finish_means_merged.md` — Layer 4b (red-CI on open PRs) unchanged, still caught. ✓
- **SS "wasn't wired" (today)** — read path now classified `app-data-seam`; a dead seam can't produce non-empty output, so the gate blocks rather than letting it ship. ✓ (the headline fix)
- Critic's gaming vector (relevant record, `[]` output) → `output_nonempty:false` → blocked. ✓

Each is backed by a unit test (aliveness rejects stub, relevance rejects wrong-file, method rejects vendor_docs, inert skips, degraded fails-open, app-data-seam classified).

## Verification

`npm run verify` green (typecheck + format + lint + all suites + builds). New tests: worker `verify-lookup`/`session-verifications` (11), gate `verify-coverage-gate` (12), `sos` directive assertion.

This PR dogfoods its own gate: it touches `mcp-tool` (`handoff.ts`) and `app-data-seam` (`verify-ledger.ts`), and carries alive, seam-naming verify records below. (PR-CI runs in graceful existence-only mode until this PR's worker deploys — no chicken-and-egg.)

## Verifications

- vfy_01KVM5BW0HDFZQWYX3FZ1WSB1Q · fresh_process · worker /verify/lookup records + /verify/session-verifications exercised against real D1 rows; aliveness rejects [] (files: verify-ledger.ts, router.ts)
- vfy_01KVM5C4Q1T6Z911Q31DE1FB2M · fresh_process · Layer 4c gate + handoff wiring; full crane-mcp suite + 12 gate tests green (files: verify-coverage-gate.ts, handoff.ts)

QA grade: **A** (mechanical change, unit-tested across all branches, corpus-replayed, dogfooded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)