### PR TITLE
fix(secret-leak-detector): handle MCP array-shaped tool_response

### DIFF
--- a/scripts/secret-leak-detector.sh
+++ b/scripts/secret-leak-detector.sh
@@ -37,16 +37,30 @@ SESSION_ID=$(jq -r '.session_id // empty' <<<"$INPUT" 2>/dev/null)
 
 # Tool output can be at several JSON paths depending on tool. Concat candidates
 # and scan once.
+#
+# tool_response shapes seen in the wild:
+#   - string                          (some legacy tools)
+#   - { stdout, stderr, output, ... } (Bash and friends)
+#   - { content: [ {text}, ... ] }    (object-wrapped content)
+#   - [ {type,text}, ... ]            (MCP tools — the bare content array)
+# The MCP array shape was previously unhandled: the else-branch indexed an
+# array with "stdout", jq errored (exit 5), and under `set -e` the failing
+# command substitution killed the hook before it scanned anything. The
+# `?` optional-index operators plus the `|| OUTPUT=""` fallback make any
+# future unexpected shape degrade to "no output" instead of aborting.
 OUTPUT=$(jq -r '
-  ((.tool_response // {}) | if type == "string" then . else
-    [
-      (.stdout // ""),
-      (.stderr // ""),
-      (.output // ""),
-      (.content // [] | if type == "array" then map(.text // "") | join("\n") else . end)
-    ] | join("\n")
-  end)
-' <<<"$INPUT" 2>/dev/null)
+  ((.tool_response // {}) |
+    if type == "string" then .
+    elif type == "array" then (map(.text? // "") | join("\n"))
+    else
+      [
+        (.stdout? // ""),
+        (.stderr? // ""),
+        (.output? // ""),
+        (.content // [] | if type == "array" then map(.text? // "") | join("\n") else . end)
+      ] | join("\n")
+    end)
+' <<<"$INPUT" 2>/dev/null) || OUTPUT=""
 
 if [ -z "$OUTPUT" ]; then
   exit 0

--- a/scripts/secret-leak-detector.test.sh
+++ b/scripts/secret-leak-detector.test.sh
@@ -55,6 +55,23 @@ mkpayload() {
   }'
 }
 
+# MCP-shaped payload: tool_response is a bare array of content blocks
+# ([ {type,text}, ... ]), which is what every mcp__*__* tool returns. This is
+# the shape that previously errored the jq extractor (exit 5) and, under the
+# hook's `set -e`, aborted the hook before any scan ran — silently disabling
+# secret detection for ALL MCP tool output. The assert helpers below pick the
+# builder via $PAYLOAD_FN (default mkpayload), so the same alert/no-alert
+# cases can be replayed against this shape.
+mkpayload_mcp() {
+  jq -n --arg out "$1" '{
+    session_id: "test-session",
+    tool_name: "mcp__crane__crane_sos",
+    tool_input: {},
+    tool_response: [ { type: "text", text: $out } ],
+    hook_event_name: "PostToolUse"
+  }'
+}
+
 expect_alert() {
   local label="$1"
   local output_str="$2"
@@ -63,7 +80,7 @@ expect_alert() {
 
   rm -f "$TMPDIR_TEST/.claude/secret-leak-alerts.jsonl"
   local payload
-  payload=$(mkpayload "$output_str")
+  payload=$("${PAYLOAD_FN:-mkpayload}" "$output_str")
 
   HOME_BAK="$HOME"
   export HOME="$TMPDIR_TEST"
@@ -109,7 +126,7 @@ expect_no_alert() {
 
   rm -f "$TMPDIR_TEST/.claude/secret-leak-alerts.jsonl"
   local payload
-  payload=$(mkpayload "$output_str")
+  payload=$("${PAYLOAD_FN:-mkpayload}" "$output_str")
 
   HOME_BAK="$HOME"
   export HOME="$TMPDIR_TEST"
@@ -172,6 +189,37 @@ expect_no_alert "git status" "On branch main\nnothing to commit"
 expect_no_alert "uuid (not a secret)" "5b9d5e8a-1f2d-4e6c-9a3b-7c8d9e0f1a2b"
 expect_no_alert "git sha (not a secret)" "aff50dc fix(crane-context): use json_each"
 expect_no_alert "short token-like string" "sk-abc"
+
+# ---------------------------------------------------------------------------
+# MCP array-shaped tool_response (regression: bare [{type,text}] arrays)
+# ---------------------------------------------------------------------------
+#
+# Before the array branch was added, this shape made the jq extractor exit 5
+# and `set -e` aborted the hook (exit 5, no stdout/stderr) on every MCP tool
+# call. Assert (a) the hook now exits 0, (b) secrets in MCP output are still
+# detected, and (c) clean MCP output produces no false positive.
+
+echo
+echo "== MCP array shape =="
+
+# (a) Regression: the original symptom was a non-zero hook exit on this shape.
+mcp_clean_payload=$(mkpayload_mcp "All checks passed. Nothing to see here.")
+HOME_BAK="$HOME"; export HOME="$TMPDIR_TEST"; mkdir -p "$HOME/.claude"
+printf '%s' "$mcp_clean_payload" | bash "$HOOK" >/dev/null 2>&1
+mcp_exit=$?
+export HOME="$HOME_BAK"
+if [ "$mcp_exit" -eq 0 ]; then
+  PASS=$((PASS + 1)); printf "  \033[32mPASS\033[0m MCP array shape exits 0\n"
+else
+  FAIL=$((FAIL + 1)); FAILED_CASES+=("MCP array shape exit (got $mcp_exit, expected 0)")
+  printf "  \033[31mFAIL\033[0m MCP array shape exits 0 (got %s)\n" "$mcp_exit"
+fi
+
+# (b) + (c) Replay alert / no-alert coverage against the MCP shape.
+PAYLOAD_FN=mkpayload_mcp
+expect_alert "GitHub PAT (MCP shape)" "crane output: ${P_GHP}${SUF_BASE} end" "github-pat" "${P_GHP}"
+expect_no_alert "clean MCP output" "Session ready. 4/4 checks passed."
+unset PAYLOAD_FN
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Problem

Every session was logging on every crane / MCP tool call:

```
PostToolUse:mcp__crane__crane_sos hook error
Failed with non-blocking status code: No stderr output
```

**Root cause.** The `PostToolUse` secret-leak detector (`scripts/secret-leak-detector.sh`, deployed to `~/.claude/hooks/`) extracts tool output with a jq filter that only handled `string` and object (`{stdout,...}`) shapes. MCP tools (`mcp__*__*`) return a **bare array of content blocks** (`[{type,text}]`). The `else` branch indexed that array with `"stdout"` → `jq: error: Cannot index array with string "stdout"` → jq exits 5. Because the script runs `set -e` and the line is `OUTPUT=$(jq … 2>/dev/null)`, the failing command substitution aborted the hook (exit 5); the `2>/dev/null` is why the harness reported "No stderr output."

**Two consequences:**
1. **Noise** — a hook-failure line on every MCP tool call, every session.
2. **Security gap** — secret-leak scanning was *silently disabled for all MCP tool output*, because the hook errored out before it scanned anything.

## Fix

- Add an `array` branch to the jq extractor that joins `.text` across content blocks (the MCP shape).
- Use `?` optional indexing + `|| OUTPUT=""` so any future unexpected `tool_response` shape degrades to "no output" instead of aborting under `set -e`.
- Test harness: add `mkpayload_mcp` + a pluggable `$PAYLOAD_FN` so the existing alert/no-alert cases replay against the MCP shape, plus an explicit exit-0 regression assertion.

## Verification

- New MCP-shape cases **fail against the old hook** (`exit 5`, secret undetected — the exact symptom) and **pass against the fix**.
- Full suite: **16/16 pass** with the fix.
- Live `~/.claude/hooks/` copy hotfixed in-session; the recurring errors stop immediately. This PR keeps the source of truth in sync so the fix survives the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)