### PR TITLE
fix(ci): make venture-template Semgrep gate diff-aware

### DIFF
--- a/templates/venture/.github/workflows/security.yml
+++ b/templates/venture/.github/workflows/security.yml
@@ -102,26 +102,79 @@ jobs:
       image: returntocorp/semgrep:1.157.0
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Diff-aware scanning (--baseline-commit) resolves a merge-base, so
+          # it needs full history. The default shallow clone can't reach it.
+          fetch-depth: 0
+      - name: Determine baseline commit
+        id: baseline
+        # Diff-aware gating: only findings NEW since the baseline block a
+        # merge. On PRs the baseline is the merge-base with the target
+        # branch; on pushes it is the commit the branch pointed at before the
+        # push. Scheduled and manual runs get NO baseline and remain a full
+        # audit (unchanged) — the daily cron still surfaces pre-existing debt.
+        # Motivation: the p/* rule packs are fetched live from the registry
+        # (the container tag is pinned, the packs are NOT), so a pack update
+        # can reclassify long-standing code as blocking and freeze all merges
+        # on unrelated PRs. Baselining scopes the merge gate to what each
+        # change actually introduces.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          # The container runs git as root over a workspace owned by the
+          # runner UID; without this, git refuses with "dubious ownership".
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          baseline=""
+          case "$EVENT_NAME" in
+            pull_request)
+              baseline=$(git merge-base HEAD "$PR_BASE_SHA" 2>/dev/null || true)
+              ;;
+            push)
+              # Skip the all-zero SHA GitHub sends for a branch's first push.
+              case "$PUSH_BEFORE" in
+                '' | 0000000000000000000000000000000000000000) ;;
+                *) baseline=$(git merge-base HEAD "$PUSH_BEFORE" 2>/dev/null || true) ;;
+              esac
+              ;;
+          esac
+          echo "commit=$baseline" >> "$GITHUB_OUTPUT"
+          if [ -n "$baseline" ]; then
+            echo "Diff-aware baseline: $baseline (only findings new since this commit block)."
+          else
+            echo "No baseline — full audit (schedule/dispatch or first push)."
+          fi
       - name: Run Semgrep
         # POSIX-compatible shell script — the returntocorp/semgrep container
         # uses Alpine ash, not bash, so ${PIPESTATUS[n]} is unavailable.
         # We redirect to a file, capture $? directly, then cat for both the
         # CI log and (on failure) $GITHUB_STEP_SUMMARY.
+        env:
+          BASELINE_COMMIT: ${{ steps.baseline.outputs.commit }}
         run: |
           echo "## Static Analysis (Semgrep)" >> "$GITHUB_STEP_SUMMARY"
-          # `--error` fails on findings. Pinned packs prevent silent rule
-          # drift; if a derivative venture needs different packs, override
-          # locally rather than editing the template.
+          # `--error` fails on findings. `--baseline-commit` (when set) reports
+          # only findings introduced since the baseline, so pre-existing debt
+          # and live rule-pack drift don't block merges. If a derivative
+          # venture needs different packs, override locally rather than
+          # editing the template.
+          run_semgrep() {
+            semgrep scan "$@" \
+              --metrics=off \
+              --config=p/typescript \
+              --config=p/javascript \
+              --config=p/security-audit \
+              --config=p/owasp-top-ten \
+              --exclude=node_modules --exclude=dist --exclude='**/*.test.ts' \
+              > semgrep-output.txt 2>&1
+          }
           set +e
-          semgrep scan \
-            --error \
-            --metrics=off \
-            --config=p/typescript \
-            --config=p/javascript \
-            --config=p/security-audit \
-            --config=p/owasp-top-ten \
-            --exclude=node_modules --exclude=dist --exclude='**/*.test.ts' \
-            > semgrep-output.txt 2>&1
+          if [ -n "$BASELINE_COMMIT" ]; then
+            run_semgrep --error --baseline-commit "$BASELINE_COMMIT"
+          else
+            run_semgrep --error
+          fi
           rc=$?
           set -e
           cat semgrep-output.txt


### PR DESCRIPTION
Ports the #1070 fix to `templates/venture/.github/workflows/security.yml` so newly provisioned venture repos (and any template re-sync) inherit the **diff-aware** Semgrep gate rather than the non-reproducible one.

Root cause (see #1071): the template pins the semgrep *container* but fetches the `p/*` rule packs **live from the registry**, so a pack update reclassifies long-standing config as blocking and freezes merges. This was the fleet-wide freeze.

- Adds `--baseline-commit` on the merge-gating paths (PR: merge-base with target; push: state before push); `schedule`/`dispatch` keep the full audit.
- `fetch-depth: 0` + git `safe.directory` guard for the merge-base resolution in-container.
- Corrects the misleading "pinned packs prevent silent rule drift" comment — the packs are **not** pinned.

Live venture repos (ke / sc / dfg / dc / ss / smd-console) are patched via their own PRs in parallel. Follow-up hardening (pin the packs, pin Actions to SHAs) tracked in #1071.

**QA grade: A-** — YAML validated (3 steps; `fetch-depth: 0`, `--baseline-commit`, `run_semgrep()` present); template file (not itself executed), mirrors the already-verified #1070 change.