### PR TITLE
feat(skills): sos/eos/critique hygiene — dispatcher parity, telemetry, eos v2.2

### DIFF
--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: critique
 description: Plan Critique & Auto-Revision
-version: 1.0.0
+version: 1.1.0
 scope: enterprise
 owner: captain
 status: stable
@@ -77,9 +77,9 @@ Select perspectives based on `AGENT_COUNT`. Always assign from the top of this l
 
 ### Step 3: Spawn Critic Agents
 
-Launch `AGENT_COUNT` agents **in a single message** using the Task tool (`subagent_type: general-purpose`).
+Launch `AGENT_COUNT` agents **in a single message** using the Agent tool (`subagent_type: general-purpose`). In a harness without subagent support, run each perspective sequentially yourself and label each critique section.
 
-**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+**CRITICAL**: All Agent tool calls MUST be in a single message to run in true parallel.
 
 Each agent receives:
 
@@ -194,6 +194,6 @@ Do NOT automatically start implementing. Wait for the user.
 - **No files written**: Critique and revision happen in conversation, not on disk. The plan isn't a file - it's the working approach.
 - **Context-dependent**: The quality of critique depends on how much context is in the conversation. A vague "I'll fix the bug" produces vague critique. A detailed technical plan produces detailed critique.
 - **Fast by default**: 1 agent, no confirmation step, auto-revise. The whole flow should complete in one shot.
-- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Task tool.
+- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Agent tool.
 - **Parallelism**: All agents launch in a single message for true parallel execution.
 - **No rounds**: Unlike `/prd-review` and `/design-brief`, critique is single-pass by design. If the user wants another round, they run `/critique` again - the revised plan is now the conversation context.

--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eos
 description: End of Session Handoff
-version: 2.1.0
+version: 2.2.0
 scope: enterprise
 owner: captain
 status: stable
@@ -53,7 +53,7 @@ Before synthesizing the handoff, run the mechanical audit below. This is the onl
 Checks A-F are objective. Do NOT substitute judgment.
 
 **A. Uncommitted session-originated changes.**
-Run `git status --porcelain`. For each output line, classify as session-originated by consulting the session transcript's `Edit` and `Write` tool calls. A file is **high-confidence session-originated** iff its path appears in at least one `Edit` or `Write` call this session. Files dirty but NOT in the tool-call history are **low-confidence** (could be pre-existing working tree state or a parallel-agent edit - see `feedback_commit_early_when_parallel_agents.md`).
+Run `git status --porcelain`. For each output line, classify as session-originated by consulting the session transcript's `Edit` and `Write` tool calls. A file is **high-confidence session-originated** iff its path appears in at least one `Edit` or `Write` call this session. Files dirty but NOT in the tool-call history are **low-confidence** (could be pre-existing working tree state or a parallel-agent edit).
 
 - **High-confidence files** surface in the close-out prompt automatically.
 - **Low-confidence files** surface under a separate "verify ownership" line and require per-file confirmation before any completion action runs.
@@ -76,16 +76,19 @@ For every branch named in the session transcript's `git checkout`, `git switch`,
 ```bash
 gh pr list --author @me --state open \
   --json number,title,mergeStateStatus,statusCheckRollup,reviewDecision,isDraft \
-  --jq '.[] | select(.isDraft == false and .mergeStateStatus != "BLOCKED" and .mergeStateStatus != "DIRTY" and .mergeStateStatus != "BEHIND")'
+  --jq '.[] | select(.isDraft == false)'
 ```
 
-Classify each PR by the `(required-checks, reviewDecision)` pair:
+Do NOT filter out `BEHIND`/`DIRTY`/`BLOCKED` merge states in the query — a session PR that fell behind main is still session work; dropping it from the audit lets it rot silently.
 
+Classify each PR by `mergeStateStatus` first, then the `(required-checks, reviewDecision)` pair:
+
+- **Needs-update** — `mergeStateStatus == "BEHIND"`: run `gh pr update-branch <N>`, wait for checks to re-run, then reclassify. `mergeStateStatus == "DIRTY"`: merge conflicts — surface in the close-out prompt; never auto-resolve conflicts.
 - **Merge-ready** — all required checks `SUCCESS`, `reviewDecision == "APPROVED"` (or no approval required on this repo), no unresolved review threads.
 - **Review-ready** — all required checks `SUCCESS`, awaiting review.
 - **CI-failing** — at least one required check `conclusion == "FAILURE"`. Surfaced via Check E.
 
-**Ship Gate policy.** Session-authored PRs represent work the session was responsible for finishing. `feedback_incomplete_work` is explicit: sessions must end with PRs merged or explicitly blocked. The Ship Gate enforces that:
+**Ship Gate policy.** Session-authored PRs represent work the session was responsible for finishing. Sessions must end with PRs merged or explicitly blocked — incomplete work does not slide. The Ship Gate enforces that:
 
 - Merge-ready → /eos runs `gh pr merge <N> --squash --delete-branch` as the completion action.
 - Review-ready → /eos pauses and prompts the Captain (see Completion Actions) for merge, named reviewer, or external blocker. No silent deferral.
@@ -182,41 +185,43 @@ If **≤4 items pass the gate**, present them in ONE consolidated prompt using `
 
 #### Completion Actions (per check)
 
-| Check                         | Action                                                                                                                                  | Notes                                                                                                                                                                                          |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A (high-confidence)           | `git add <specific file>` + commit with a message derived from file path + session context                                              | Stage ONLY the specific files from the tool-call history. **Never** `git add -A` or `git add .` — this would sweep parallel-agent state (see `feedback_commit_early_when_parallel_agents.md`). |
-| A (low-confidence, confirmed) | Same as above, per confirmed file                                                                                                       | Confirmation is per-file; partial confirmations are allowed.                                                                                                                                   |
-| A (`/code-review` report)     | Prompt: `(a) commit with prior-report convention`, `(b) rm the file`. No third option.                                                  | Prior reports in `docs/reviews/` are committed. Match convention or discard. Deferral disallowed — the report cannot sit untracked across session boundaries.                                  |
-| B                             | `git push` (or `git push -u origin <branch>` if no upstream)                                                                            | Do not force-push. If push is rejected (non-fast-forward), roll back to the prompt — do not attempt to resolve.                                                                                |
-| C                             | `git switch <branch> && git push && git switch -`                                                                                       | Restore original branch on completion.                                                                                                                                                         |
-| D (merge-ready)               | Run `gh pr merge <N> --squash --delete-branch`. On success, note the merge in the handoff "Accomplished" section.                       | This is the only merge `/eos` performs. Gated on: green required checks, approved (or no approval required), no unresolved review threads. Any gate missing → fall to D (review-ready).        |
-| D (review-ready)              | Pause `/eos` and prompt Captain: `(a) approve+merge now`, `(b) name the reviewer and block`, `(c) declare external blocker`.            | No "leave for next session" option. If Captain absent (auto mode), /eos blocks with machine reason `"blocked: pending Captain merge authorization for #<N>"` so the deferral is explicit.      |
-| E                             | Surface the failing check names + URL                                                                                                   | Do NOT attempt to fix. Ask whether to investigate now (breaks out of `/eos` into interactive debug) or block with the failure noted as the external-blocker reason.                            |
-| F                             | Update the file to reflect actual state (e.g., "merged in PR #N" → "proposed in open PR #N")                                            | Use `Edit` with precise `old_string`/`new_string`; do not rewrite the file.                                                                                                                    |
-| G                             | `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."`                                            | Deferral disallowed. In-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.                                                 |
-| H                             | Rewrite the handoff diagnostic section to cite the matching memory filename, or add "no matching memory found (candidate for new one)". | Forces the check to run. "Root cause unknown" with no memory check is rejected.                                                                                                                |
+| Check                         | Action                                                                                                                                  | Notes                                                                                                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A (high-confidence)           | `git add <specific file>` + commit with a message derived from file path + session context                                              | Stage ONLY the specific files from the tool-call history. **Never** `git add -A` or `git add .` — this would sweep parallel-agent state.                                                  |
+| A (low-confidence, confirmed) | Same as above, per confirmed file                                                                                                       | Confirmation is per-file; partial confirmations are allowed.                                                                                                                              |
+| A (`/code-review` report)     | Prompt: `(a) commit with prior-report convention`, `(b) rm the file`. No third option.                                                  | Prior reports in `docs/reviews/` are committed. Match convention or discard. Deferral disallowed — the report cannot sit untracked across session boundaries.                             |
+| B                             | `git push` (or `git push -u origin <branch>` if no upstream)                                                                            | Do not force-push. If push is rejected (non-fast-forward), roll back to the prompt — do not attempt to resolve.                                                                           |
+| C                             | `git switch <branch> && git push && git switch -`                                                                                       | Restore original branch on completion.                                                                                                                                                    |
+| D (needs-update, BEHIND)      | `gh pr update-branch <N>`, wait for checks to re-run, then re-run Check D and reclassify.                                               | If update-branch fails on conflicts, treat as DIRTY.                                                                                                                                      |
+| D (needs-update, DIRTY)       | Surface the conflicting files; prompt Captain: `(a) resolve now (breaks into interactive)`, `(b) declare external blocker`.             | Never auto-resolve merge conflicts at `/eos`.                                                                                                                                             |
+| D (merge-ready)               | Run `gh pr merge <N> --squash --delete-branch`. On success, note the merge in the handoff "Accomplished" section.                       | This is the only merge `/eos` performs. Gated on: green required checks, approved (or no approval required), no unresolved review threads. Any gate missing → fall to D (review-ready).   |
+| D (review-ready)              | Pause `/eos` and prompt Captain: `(a) approve+merge now`, `(b) name the reviewer and block`, `(c) declare external blocker`.            | No "leave for next session" option. If Captain absent (auto mode), /eos blocks with machine reason `"blocked: pending Captain merge authorization for #<N>"` so the deferral is explicit. |
+| E                             | Surface the failing check names + URL                                                                                                   | Do NOT attempt to fix. Ask whether to investigate now (breaks out of `/eos` into interactive debug) or block with the failure noted as the external-blocker reason.                       |
+| F                             | Update the file to reflect actual state (e.g., "merged in PR #N" → "proposed in open PR #N")                                            | Use `Edit` with precise `old_string`/`new_string`; do not rewrite the file.                                                                                                               |
+| G                             | `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."`                                            | Deferral disallowed. In-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.                                            |
+| H                             | Rewrite the handoff diagnostic section to cite the matching memory filename, or add "no matching memory found (candidate for new one)". | Forces the check to run. "Root cause unknown" with no memory check is rejected.                                                                                                           |
 
 #### Post-Action Verification
 
 After completion actions run, re-run Checks A–H. Any check that still returns items means the action failed or was partial — surface those items in a second prompt with the completion result attached. Do not mark items as resolved in the handoff if the check still flags them.
 
-#### Deferral Age Tracking
+#### Blocked-Item Age Tracking
 
-Each deferred item is recorded in the handoff's "Loose ends captured at /eos" section with:
+"Leave for next session" is never an option (see Close-Out Prompt) — the only way an item carries forward is as a declared external blocker. Each blocked item is recorded in the handoff's "Loose ends captured at /eos" section with:
 
 - Item description (path, branch, PR number)
 - `first_seen: YYYY-MM-DD` (today if new; copied from prior handoff if this item already appeared)
 - `age: N` sessions (1 if new; incremented if matched to a prior handoff's item via path/branch/PR number)
-- `reason:` the one-line justification the Captain provided
+- `reason:` the externally-verifiable blocker the Captain declared
 
 On the next `/eos`, match by identifier (path/branch/PR number) against the prior session's "Loose ends captured at /eos" list (fetched via `crane_context` or the prior handoff record). Increment `age` for matches.
 
-**When `age >= 3`, the skill refuses "Leave for next session" for that item.** The Captain must choose:
+**When `age >= 3`, the blocker must re-justify itself.** The Captain must choose:
 
-- Promote to `Blocked:` with a real external blocker name (vendor response, secret unavailable, etc.), OR
-- Kill the item (remove from the handoff entirely - per `feedback_kill_dont_file.md`, speculative work gets killed, not re-filed).
+- Re-affirm the blocker with current evidence that it is still external and still live (a stale reason cannot roll forward), OR
+- Kill the item (remove from the handoff entirely — speculative work gets killed, not re-filed).
 
-This converts filing pressure into closure pressure without removing the deferral option for legitimately deferrable items.
+This converts filing pressure into closure pressure: blocked items age visibly and must re-earn their place every session past the third.
 
 **Critical:** the audit produces at most ONE close-out prompt (plus a post-action verification prompt if some completions failed, plus an age≥3 escalation prompt if that case hits). Do not follow up with "anything else?" - that phrasing is the exact invitation to fabricate that this audit exists to prevent.
 
@@ -268,7 +273,7 @@ Display the generated handoff, then **immediately save it to D1 without asking f
 
 ### 5. End Work Day
 
-Call `POST /work-day` with `action: "end"` via the `upsertWorkDay` API method.
+Handled automatically: `crane_handoff` closes the work day server-side when the final handoff is saved (any call without `final: false`). No separate call — there is no agent-exposed work-day tool.
 
 ### 6. Save Handoff via MCP
 
@@ -318,6 +323,4 @@ The agent has full session context - every command run, every file edited, every
 ## Related
 
 - `/own-it` rule 4 — mid-session closure checklist; `/eos` inherits the same discipline at session end.
-- `feedback_no_manufactured_loose_ends.md` — pad is worse than done.
-- `feedback_kill_dont_file.md` — speculative work gets killed, not filed.
-- `feedback_commit_early_when_parallel_agents.md` — never `git add -A` under parallel agents.
+- Principles enforced here: pad is worse than done (no manufactured loose ends); speculative work gets killed, not filed; never `git add -A` under parallel agents.

--- a/.agents/skills/sos/SKILL.md
+++ b/.agents/skills/sos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sos
 description: Start of Session
-version: 1.0.0
+version: 1.1.0
 scope: enterprise
 owner: captain
 status: stable

--- a/.claude/commands/critique.md
+++ b/.claude/commands/critique.md
@@ -1,5 +1,7 @@
 # /critique - Plan Critique & Auto-Revision
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "critique")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command spawns critic subagents to challenge the current plan or approach in conversation, then auto-revises based on the critique.
 
 No files required - works against whatever plan, proposal, or approach is in the current conversation context.
@@ -66,9 +68,9 @@ Select perspectives based on `AGENT_COUNT`. Always assign from the top of this l
 
 ### Step 3: Spawn Critic Agents
 
-Launch `AGENT_COUNT` agents **in a single message** using the Task tool (`subagent_type: general-purpose`).
+Launch `AGENT_COUNT` agents **in a single message** using the Agent tool (`subagent_type: general-purpose`). In a harness without subagent support, run each perspective sequentially yourself and label each critique section.
 
-**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+**CRITICAL**: All Agent tool calls MUST be in a single message to run in true parallel.
 
 Each agent receives:
 
@@ -183,6 +185,6 @@ Do NOT automatically start implementing. Wait for the user.
 - **No files written**: Critique and revision happen in conversation, not on disk. The plan isn't a file - it's the working approach.
 - **Context-dependent**: The quality of critique depends on how much context is in the conversation. A vague "I'll fix the bug" produces vague critique. A detailed technical plan produces detailed critique.
 - **Fast by default**: 1 agent, no confirmation step, auto-revise. The whole flow should complete in one shot.
-- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Task tool.
+- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Agent tool.
 - **Parallelism**: All agents launch in a single message for true parallel execution.
 - **No rounds**: Unlike `/prd-review` and `/design-brief`, critique is single-pass by design. If the user wants another round, they run `/critique` again - the revised plan is now the conversation context.

--- a/.claude/commands/eos.md
+++ b/.claude/commands/eos.md
@@ -1,6 +1,8 @@
 # /eos - End of Session Handoff
 
-Auto-generate handoff from session context. The agent summarizes - never ask the user.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "eos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+The agent closes or blocks, then summarizes and saves. The default is not "defer" — the default is "complete." /eos halts until every session-originated loose end is either completed or blocked with an externally-verifiable reason. Only then does it synthesize and save the handoff. The Session Close-Out Audit (Step 2) is the gate.
 
 ## Usage
 
@@ -28,62 +30,196 @@ gh pr list --author @me --state all --json number,title,state,updatedAt --jq '.[
 gh issue list --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
 ```
 
-### 1.5 Inspect Worktree State (Read-Only)
+### 2. Session Close-Out Audit
 
-Determine whether this session is running inside a `.claude/worktrees/<id>/` worktree, and pre-compute the cleanup decision so Step 2 can write an accurate handoff. **No destructive actions in this step.**
+Before synthesizing the handoff, run the mechanical audit below. This is the only way to avoid both (a) leaving unmerged in-session work to rot, and (b) fabricating loose ends that weren't actually part of this session's goals.
+
+#### Detection checklist
+
+Checks A-F are objective. Do NOT substitute judgment.
+
+**A. Uncommitted session-originated changes.**
+Run `git status --porcelain`. For each output line, classify as session-originated by consulting the session transcript's `Edit` and `Write` tool calls. A file is **high-confidence session-originated** iff its path appears in at least one `Edit` or `Write` call this session. Files dirty but NOT in the tool-call history are **low-confidence** (could be pre-existing working tree state or a parallel-agent edit).
+
+- **High-confidence files** surface in the close-out prompt automatically.
+- **Low-confidence files** surface under a separate "verify ownership" line and require per-file confirmation before any completion action runs.
+
+If the tool-call history is unavailable (long session, compaction), downgrade ALL dirty files to low-confidence and require per-file confirmation.
+
+**B. Unpushed commits on the current branch.**
 
 ```bash
-PWD_OUT=$(pwd)
-if [[ "$PWD_OUT" != *"/.claude/worktrees/"* ]]; then
-  WORKTREE_DECISION=n/a
-else
-  WORKTREE_PATH="$PWD_OUT"
-  WORKTREE_ID="${WORKTREE_PATH##*/}"
-  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  STATUS=$(git status --porcelain)
-
-  # Refresh main; ignore failure (offline OK — fall through to PR check)
-  git fetch origin main --quiet 2>/dev/null
-
-  # Squash-merge-aware ahead check (canonical post-squash idiom; offline-safe).
-  # `git cherry` outputs `+` for commits NOT on main, `-` for patch-equivalent on main.
-  CHERRY=$(git cherry origin/main "$BRANCH" 2>/dev/null)
-  MERGED_VIA_CHERRY=false
-  if [ -z "$CHERRY" ] || ! echo "$CHERRY" | grep -q '^+'; then
-    MERGED_VIA_CHERRY=true
-  fi
-
-  # Direct-ancestor check (fast-forward / rebase merges)
-  AHEAD=$(git log "$BRANCH" --not origin/main --oneline 2>/dev/null)
-  MERGED_VIA_LOG=false
-  [ -z "$AHEAD" ] && MERGED_VIA_LOG=true
-
-  # PR-merged tertiary check (network-dependent)
-  PR_NUM=$(gh pr list --head "$BRANCH" --state merged --json number --jq '.[0].number // empty' 2>/dev/null)
-  PR_MERGED=false
-  [ -n "$PR_NUM" ] && PR_MERGED=true
-
-  if [ -z "$STATUS" ]; then
-    if [ "$MERGED_VIA_CHERRY" = true ] || [ "$MERGED_VIA_LOG" = true ] || [ "$PR_MERGED" = true ]; then
-      WORKTREE_DECISION=remove
-    else
-      WORKTREE_DECISION=keep_unpushed
-    fi
-  else
-    WORKTREE_DECISION=keep_dirty
-    DIRTY_FILE_COUNT=$(echo "$STATUS" | wc -l | tr -d ' ')
-  fi
-fi
+git log @{u}..HEAD --oneline 2>/dev/null || git log --oneline -10
 ```
 
-Stash `WORKTREE_DECISION`, `WORKTREE_PATH`, `BRANCH`, and `DIRTY_FILE_COUNT` for use in Steps 2 and 5.5. Decision values:
+If the current branch has an upstream with commits above it, OR the branch has no upstream and carries commits from this session, flag it.
 
-- `n/a` — not in a worktree (skip cleanup)
-- `remove` — clean tree AND merged via cherry, log, or PR
-- `keep_unpushed` — clean tree, commits ahead of main, no merged PR (work needs follow-up)
-- `keep_dirty` — uncommitted changes present
+**C. Unpushed commits on other branches touched this session.**
+For every branch named in the session transcript's `git checkout`, `git switch`, or `git branch` calls, run the Check B query. Report each that has unpushed commits.
 
-### 2. Synthesize Handoff (Agent Task)
+**D. Session-authored PRs — Ship Gate.**
+
+```bash
+gh pr list --author @me --state open \
+  --json number,title,mergeStateStatus,statusCheckRollup,reviewDecision,isDraft \
+  --jq '.[] | select(.isDraft == false)'
+```
+
+Do NOT filter out `BEHIND`/`DIRTY`/`BLOCKED` merge states in the query — a session PR that fell behind main is still session work; dropping it from the audit lets it rot silently.
+
+Classify each PR by `mergeStateStatus` first, then the `(required-checks, reviewDecision)` pair:
+
+- **Needs-update** — `mergeStateStatus == "BEHIND"`: run `gh pr update-branch <N>`, wait for checks to re-run, then reclassify. `mergeStateStatus == "DIRTY"`: merge conflicts — surface in the close-out prompt; never auto-resolve conflicts.
+- **Merge-ready** — all required checks `SUCCESS`, `reviewDecision == "APPROVED"` (or no approval required on this repo), no unresolved review threads.
+- **Review-ready** — all required checks `SUCCESS`, awaiting review.
+- **CI-failing** — at least one required check `conclusion == "FAILURE"`. Surfaced via Check E.
+
+**Ship Gate policy.** Session-authored PRs represent work the session was responsible for finishing. Sessions must end with PRs merged or explicitly blocked — incomplete work does not slide. The Ship Gate enforces that:
+
+- Merge-ready → /eos runs `gh pr merge <N> --squash --delete-branch` as the completion action.
+- Review-ready → /eos pauses and prompts the Captain (see Completion Actions) for merge, named reviewer, or external blocker. No silent deferral.
+- Explicitly blocked → allowed only with an externally-verifiable reason. "Captain to review," "next session will merge," and "will decide later" are rejected — those are deferrals, not blockers.
+
+This is the one place /eos merges. /ship still forbids auto-merge on direct invocation; /eos earns its narrow merge path by gating on green+approved and by being the last gate before handoff.
+
+**E. Session-authored PRs with explicit FAILURE on required checks.**
+Filter Check D's query to PRs with `statusCheckRollup` containing at least one `conclusion == "FAILURE"` on a required check. PENDING/STALE/NEUTRAL/SKIPPED states do NOT count as failures for this check - surface them separately as "CI unresolved" in the handoff without marking them as loose ends requiring action.
+
+**F. Memory/doc edits that reference unshipped PRs.**
+For each memory or doc file edited this session (identify via the transcript's `Edit`/`Write` tool calls), extract PR references with:
+
+```bash
+grep -oE '\b(PR |pull/|#)([0-9]+)\b' <file>
+```
+
+For each match, verify with `gh pr view <N> --json state` - if the command returns an issue (not a PR) it errors out harmlessly and the match is discarded. For each PR number where `state != MERGED`, inspect the file's surrounding text. If the text claims post-merge state (phrases like "merged", "landed", "in production", "resolved by"), flag the file.
+
+**G. Open issues asserted as resolved during this session.**
+
+Scan the session transcript for phrases matching any of:
+
+- `verified( as)? resolved`
+- `confirmed (remediated|fixed|closed|gone)`
+- `(all|both) .* (violations|findings) confirmed (gone|remediated)`
+- `fix in code AND tested`
+
+For each match, extract any `#\d+` issue numbers within ±200 characters. For each extracted number, run `gh issue view <N> --json state`. If `state == OPEN`, surface the issue.
+
+**Completion action:** `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."` Deferral disallowed — an in-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.
+
+**H. Session diagnostic notes must cite matching memory.**
+
+If the session transcript contains failure-narrative keywords ("silent failure", "root cause unknown", "mysterious", "didn't work as expected", "recovered via", "bug-hunt", "investigate next"), extract the surrounding context. For each match, grep `MEMORY.md` for matching memory filenames (by topic keywords: "worktree" → `feedback_parallel_agents_worktrees.md`, "MCP" → `feedback_mcp_debugging.md`, etc.).
+
+For each match, the handoff's diagnostic/retro section MUST cite the memory by filename. A bare "investigate next session" or "root cause unknown" without citing a matching memory entry is rejected — re-synthesize the section with the citation. If no memory matches after an honest check, add the assertion "no matching memory found (candidate for new feedback memory)" so the gate is explicit.
+
+**Defensive note on `gh` JSON schema.** Fields like `mergeStateStatus` and `statusCheckRollup` have stable names but nested shape changes across `gh` minor versions. Wrap each jq call at the shell level: unexpected output formats should log a warning like `[eos:check-X] gh output unexpected, skipping this check` and proceed to the next check. Do NOT crash the skill on schema drift.
+
+#### Anti-Fabrication Gate
+
+Every item you are about to list as a loose end must pass this gate.
+
+**Gate:** Is this item one of:
+
+1. A high-confidence uncommitted file from Check A (in the session's tool-call history), OR
+2. A low-confidence uncommitted file from Check A that the Captain confirmed as session-originated, OR
+3. Unpushed commits from Check B or C, OR
+4. An open session-authored PR from Check D (Ship Gate: merge-ready, review-ready, or explicitly blocked), OR
+5. An open session-authored PR from Check E (failing required checks), OR
+6. A memory/doc file from Check F that references an unshipped PR with post-merge prose, OR
+7. An open issue from Check G that the session asserted as resolved, OR
+8. A diagnostic note from Check H that needs memory citation, OR
+9. A specific item the Captain requested **via an explicit chat message with a verb and subject** that has not been completed. (NOT an aside summarized from context. NOT an inference. A literal user message.)
+
+If NO to all nine → do not list it. Do not hedge. Do not qualify. Kill it.
+
+**Specifically forbidden items** (these are fabrications, never list them):
+
+- Refactors, test additions, or cleanups "noticed in passing"
+- Documentation/comment/naming improvements the Captain did not request
+- Adjacent bugs unrelated to this session's goals
+- "Nice-to-have" improvements to code that shipped this session
+- Work explicitly deferred earlier in the session (the decision already happened)
+- Anything prefixed with "we should also…" or "it would be nice to…"
+- Fleet-wide or time-distant concerns surfaced for completeness
+- Reassurances dressed up as open items ("the CI gate is still alive" is a result, not a loose end)
+
+If the audit finds nothing that passes the gate, skip directly to Step 3. Do not fabricate a list. Saying "we're done" is the correct output.
+
+#### Deduplication with /own-it
+
+If `/own-it` was invoked earlier in this session and resolved items via its rule-4 closure checklist, those items do NOT re-surface here. Consult the transcript; items already marked as resolved earlier are excluded.
+
+#### Close-Out Prompt (only if items exist)
+
+If **>4 items pass the gate**, do NOT auto-split. Surface the count and halt with:
+
+> Session close-out audit found N items - this session wasn't actually closable in one flow. Invoke `/own-it` and address them individually, or pick the highest-priority items to resolve now.
+
+Do not proceed to a bulk prompt that hides items behind a scroll.
+
+If **≤4 items pass the gate**, present them in ONE consolidated prompt using `AskUserQuestion`:
+
+- Question: "Session close-out: N items to resolve before handoff. Complete now?"
+- Header: `Close-out` (≤12 chars)
+- Options:
+  - **"Complete all"** — execute the obvious completion for each item per the Completion Actions table below. After actions, re-run Checks A–H; items that are still in scope roll back to a second prompt.
+  - **"Complete selected"** — present per-item options in a second `AskUserQuestion`.
+  - **"Declare external blocker"** — each item left requires a one-line reason naming an external party or system that prevents completion (vendor response pending, Captain directive required, approver identified by name, etc.). Reasons matching `(?i)(Captain to review|next session|later|will decide|I'll review)` are rejected with: "That's not an external blocker — it's a deferral. Name the actual blocker, or complete the item." Reprompt once; if the second reason also fails, default to "Complete selected."
+
+"Leave for next session" is **not** an available option. Session-originated loose ends complete or block with a named blocker — they do not slide.
+
+#### Completion Actions (per check)
+
+| Check                         | Action                                                                                                                                  | Notes                                                                                                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A (high-confidence)           | `git add <specific file>` + commit with a message derived from file path + session context                                              | Stage ONLY the specific files from the tool-call history. **Never** `git add -A` or `git add .` — this would sweep parallel-agent state.                                                  |
+| A (low-confidence, confirmed) | Same as above, per confirmed file                                                                                                       | Confirmation is per-file; partial confirmations are allowed.                                                                                                                              |
+| A (`/code-review` report)     | Prompt: `(a) commit with prior-report convention`, `(b) rm the file`. No third option.                                                  | Prior reports in `docs/reviews/` are committed. Match convention or discard. Deferral disallowed — the report cannot sit untracked across session boundaries.                             |
+| B                             | `git push` (or `git push -u origin <branch>` if no upstream)                                                                            | Do not force-push. If push is rejected (non-fast-forward), roll back to the prompt — do not attempt to resolve.                                                                           |
+| C                             | `git switch <branch> && git push && git switch -`                                                                                       | Restore original branch on completion.                                                                                                                                                    |
+| D (needs-update, BEHIND)      | `gh pr update-branch <N>`, wait for checks to re-run, then re-run Check D and reclassify.                                               | If update-branch fails on conflicts, treat as DIRTY.                                                                                                                                      |
+| D (needs-update, DIRTY)       | Surface the conflicting files; prompt Captain: `(a) resolve now (breaks into interactive)`, `(b) declare external blocker`.             | Never auto-resolve merge conflicts at `/eos`.                                                                                                                                             |
+| D (merge-ready)               | Run `gh pr merge <N> --squash --delete-branch`. On success, note the merge in the handoff "Accomplished" section.                       | This is the only merge `/eos` performs. Gated on: green required checks, approved (or no approval required), no unresolved review threads. Any gate missing → fall to D (review-ready).   |
+| D (review-ready)              | Pause `/eos` and prompt Captain: `(a) approve+merge now`, `(b) name the reviewer and block`, `(c) declare external blocker`.            | No "leave for next session" option. If Captain absent (auto mode), /eos blocks with machine reason `"blocked: pending Captain merge authorization for #<N>"` so the deferral is explicit. |
+| E                             | Surface the failing check names + URL                                                                                                   | Do NOT attempt to fix. Ask whether to investigate now (breaks out of `/eos` into interactive debug) or block with the failure noted as the external-blocker reason.                       |
+| F                             | Update the file to reflect actual state (e.g., "merged in PR #N" → "proposed in open PR #N")                                            | Use `Edit` with precise `old_string`/`new_string`; do not rewrite the file.                                                                                                               |
+| G                             | `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."`                                            | Deferral disallowed. In-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.                                            |
+| H                             | Rewrite the handoff diagnostic section to cite the matching memory filename, or add "no matching memory found (candidate for new one)". | Forces the check to run. "Root cause unknown" with no memory check is rejected.                                                                                                           |
+
+#### Post-Action Verification
+
+After completion actions run, re-run Checks A–H. Any check that still returns items means the action failed or was partial — surface those items in a second prompt with the completion result attached. Do not mark items as resolved in the handoff if the check still flags them.
+
+#### Blocked-Item Age Tracking
+
+"Leave for next session" is never an option (see Close-Out Prompt) — the only way an item carries forward is as a declared external blocker. Each blocked item is recorded in the handoff's "Loose ends captured at /eos" section with:
+
+- Item description (path, branch, PR number)
+- `first_seen: YYYY-MM-DD` (today if new; copied from prior handoff if this item already appeared)
+- `age: N` sessions (1 if new; incremented if matched to a prior handoff's item via path/branch/PR number)
+- `reason:` the externally-verifiable blocker the Captain declared
+
+On the next `/eos`, match by identifier (path/branch/PR number) against the prior session's "Loose ends captured at /eos" list (fetched via `crane_context` or the prior handoff record). Increment `age` for matches.
+
+**When `age >= 3`, the blocker must re-justify itself.** The Captain must choose:
+
+- Re-affirm the blocker with current evidence that it is still external and still live (a stale reason cannot roll forward), OR
+- Kill the item (remove from the handoff entirely — speculative work gets killed, not re-filed).
+
+This converts filing pressure into closure pressure: blocked items age visibly and must re-earn their place every session past the third.
+
+**Critical:** the audit produces at most ONE close-out prompt (plus a post-action verification prompt if some completions failed, plus an age≥3 escalation prompt if that case hits). Do not follow up with "anything else?" - that phrasing is the exact invitation to fabricate that this audit exists to prevent.
+
+### 3. Synthesize Handoff (Agent Task)
+
+#### 3a. Self-Review Bias Caveat
+
+If `/code-review` was invoked in this session (check transcript for the skill invocation) AND the review graded code that Claude wrote in a prior or current session, any grade-change claim in "Accomplished" carries the caveat:
+
+> (self-review — subject to bias; treat as signal, not measurement)
+
+This is a one-line boilerplate. Do not omit. Do not reword. Do not soften to "may be biased." The caveat exists because we run review and authorship on the same model; a neutral framing misrepresents the evidence.
 
 Using conversation history and gathered context, the agent generates a summary covering:
 
@@ -94,11 +230,12 @@ Using conversation history and gathered context, the agent generates a summary c
 - Problems solved
 - Code changes made
 
-**In Progress:** Unfinished work — write as pickup instructions for an agent with NO conversation history
+**In Progress:** Unfinished work - write as pickup instructions for an agent with NO conversation history
 
 - Include specific file paths, function names, and branch names
 - State exactly where you stopped: "Function X is partially implemented in file Y"
 - List what remains as numbered steps
+- Include any items from Step 2's audit that the Captain declared blocked by an external party or system, under a subheading **"Loose ends captured at /eos"** with exact file paths, branch names, PR numbers, `first_seen`, `age`, and `reason` (the externally-verifiable blocker name). Do not paraphrase or compress. The next session's `/eos` reads this to increment age. Items that completed via action do NOT appear here.
 
 **Blocked:** Items needing attention
 
@@ -106,28 +243,25 @@ Using conversation history and gathered context, the agent generates a summary c
 - Questions for PM
 - Decisions needed
 - External dependencies
-- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam here and use `status:blocked`, rather than letting the handoff imply completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
+- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam and use `status:blocked` rather than implying completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
 
-**Next Session:** Recommended focus — write as an ordered action plan
+**Next Session:** Recommended focus - write as an ordered action plan
 
 - "1. Open src/foo.ts and complete the retryWithBackoff() function"
-- "2. Run npm test — expect 2 new tests to pass"
+- "2. Run npm test - expect 2 new tests to pass"
 - "3. Create PR for issue #123"
 
-**Worktree-aware resume guidance:**
+**Anti-Fabrication rule (also applies to this section).** The same gate from Step 2 governs what goes into "In Progress," "Blocked," and "Next Session." If an item does not pass the Step 2 gate, it does not belong in the synthesized handoff. Write "(none)" for empty sections. Do not pad.
 
-- If `WORKTREE_DECISION` from Step 1.5 is `keep_unpushed` or `keep_dirty`, the **In Progress** and **Next Session** sections MUST start with `cd $WORKTREE_PATH && git checkout $BRANCH` so an agent with no context resumes in the right place. For `keep_dirty`, also list the modified files.
-- If `WORKTREE_DECISION` is `remove` or `n/a`, do NOT reference the worktree path or branch in the handoff — the worktree will be gone after Step 5.5 and the reference would mislead the next session.
-
-### 3. Display and Save (Auto-Save)
+### 4. Display and Save (Auto-Save)
 
 Display the generated handoff, then **immediately save it to D1 without asking for confirmation.** Do not prompt the user with "Save to D1?" or any yes/no question. Just show the summary and save.
 
-### 4. End Work Day
+### 5. End Work Day
 
-Call `POST /work-day` with `action: "end"` via the `upsertWorkDay` API method.
+Handled automatically: `crane_handoff` closes the work day server-side when the final handoff is saved (any call without `final: false`). No separate call — there is no agent-exposed work-day tool.
 
-### 5. Save Handoff via MCP
+### 6. Save Handoff via MCP
 
 Call the `crane_handoff` MCP tool with:
 
@@ -139,77 +273,40 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 
 **Important:** When status is `in_progress`, the full summary is shown to the next session's SOD briefing. Write "In Progress" and "Next Session" as if giving instructions to another developer who has zero context from this conversation.
 
+**Status invariants (enforced before save):**
+
+- `done` — Step 2 found nothing. No unmerged session PRs, no uncommitted session files, no open-but-verified-resolved issues, no uncited failure diagnostics. If any of those exist, `done` is rejected.
+- `in_progress` — work genuinely carries into the next session (in-flight branch, research thread, design spike). Not a synonym for "PRs opened but not merged" — that is a Ship Gate violation, not in-progress work.
+- `blocked` — at least one Check item carries into the next session with an externally-verifiable blocker reason. The reason must name the blocker.
+
 #### Cross-venture sessions
 
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
-3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
-4. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
+3. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
 
-Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
-
-### 5.5 Execute Worktree Decision
-
-Acts on `WORKTREE_DECISION` from Step 1.5. For cross-venture sessions, this runs **once**, after the FINAL `crane_handoff` call (the one without `final: false`). Earlier per-venture handoffs do NOT trigger cleanup — the session is still active.
-
-1. **`WORKTREE_DECISION=n/a`** — skip; jump to Step 6.
-
-2. **`WORKTREE_DECISION=remove`** — call:
-
-   ```
-   ExitWorktree(action: "remove", discard_changes: true)
-   ```
-
-   `discard_changes: true` is required when local commits exist (post-squash case): the substance is already on main as a squash commit, but the original branch commits are not ancestors of `origin/main` and the harness needs explicit consent to discard them.
-
-3. **`WORKTREE_DECISION=keep_unpushed`** or **`keep_dirty`** — call:
-
-   ```
-   ExitWorktree(action: "keep")
-   ```
-
-   Worktree stays, branch stays, next session resumes via the handoff text written in Step 2.
-
-4. **Fallback on `ExitWorktree` failure** (rare — running outside the harness, session-state mismatch, etc.):
-   - For `remove`: attempt raw cleanup. Identify canonical repo path (`git rev-parse --git-common-dir` then resolve up two levels from `.git`, or use the path before `/.claude/worktrees/` in `WORKTREE_PATH`). Then:
-     ```bash
-     CANONICAL="${WORKTREE_PATH%/.claude/worktrees/*}"
-     cd "$CANONICAL"
-     git worktree remove --force "$WORKTREE_PATH" \
-       && git branch -D "$BRANCH"
-     ```
-     If raw cleanup also fails, capture both error messages for Step 6 — do NOT crash `/eos`.
-   - For `keep_unpushed` or `keep_dirty`: ExitWorktree failure is non-fatal; the worktree was going to stay anyway.
-
-### 6. Report Completion
-
-Build the closing line based on `WORKTREE_DECISION` and the actual outcome of Step 5.5:
+### 7. Report Completion
 
 ```
-Handoff saved to D1. Worktree: {removed | kept (unpushed: <branch>) | kept (dirty: <N> file(s)) | n/a | remove failed (see above)}. Next session will see this via crane_sos.
+Handoff saved to D1. Next session will see this via crane_sos.
 ```
-
-Examples:
-
-- `Handoff saved to D1. Worktree: removed. Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: kept (unpushed: feat/some-thing). Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: kept (dirty: 3 file(s)). Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: n/a. Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: remove failed (ExitWorktree: <err>; raw cleanup: <err>). Next session will see this via crane_sos.`
 
 ## Key Principle
 
-**The agent summarizes. The agent saves. No confirmation needed.**
+**The agent summarizes. The agent saves. No confirmation needed — with one targeted exception: if Step 2's audit surfaces genuine unshipped work, the skill asks ONE consolidated close-out question before proceeding. Otherwise, auto-save proceeds silently.**
 
-The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything.
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything. The Session Close-Out Audit is the only place `/eos` produces a prompt, and only when objective detection checks find loose ends that pass the anti-fabrication gate.
 
-Auto-save directly to D1. Never ask "Save to D1?" or any confirmation question.
+## Related
+
+- `/own-it` rule 4 — mid-session closure checklist; `/eos` inherits the same discipline at session end.
+- Principles enforced here: pad is worse than done (no manufactured loose ends); speculative work gets killed, not filed; never `git add -A` under parallel agents.

--- a/.claude/commands/sos.md
+++ b/.claude/commands/sos.md
@@ -1,5 +1,7 @@
 # /sos - Start of Session
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "sos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
 3. **Orphan worktree backstop** — see below. Auto-remove provably-safe orphans from sessions that ended unnaturally; surface the rest. Compute a one-line worktree status line for the briefing.

--- a/.gemini/commands/critique.toml
+++ b/.gemini/commands/critique.toml
@@ -2,6 +2,8 @@ description = "Plan Critique & Auto-Revision"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "critique")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command spawns critic subagents to challenge the current plan or approach in conversation, then auto-revises based on the critique.
 
 No files required - works against whatever plan, proposal, or approach is in the current conversation context.
@@ -68,9 +70,9 @@ Select perspectives based on `AGENT_COUNT`. Always assign from the top of this l
 
 ### Step 3: Spawn Critic Agents
 
-Launch `AGENT_COUNT` agents **in a single message** using the Task tool (`subagent_type: general-purpose`).
+Launch `AGENT_COUNT` agents **in a single message** using the Agent tool (`subagent_type: general-purpose`). In a harness without subagent support, run each perspective sequentially yourself and label each critique section.
 
-**CRITICAL**: All Task tool calls MUST be in a single message to run in true parallel.
+**CRITICAL**: All Agent tool calls MUST be in a single message to run in true parallel.
 
 Each agent receives:
 
@@ -185,7 +187,7 @@ Do NOT automatically start implementing. Wait for the user.
 - **No files written**: Critique and revision happen in conversation, not on disk. The plan isn't a file - it's the working approach.
 - **Context-dependent**: The quality of critique depends on how much context is in the conversation. A vague "I'll fix the bug" produces vague critique. A detailed technical plan produces detailed critique.
 - **Fast by default**: 1 agent, no confirmation step, auto-revise. The whole flow should complete in one shot.
-- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Task tool.
+- **Agent type**: All critic agents use `subagent_type: general-purpose` via the Agent tool.
 - **Parallelism**: All agents launch in a single message for true parallel execution.
 - **No rounds**: Unlike `/prd-review` and `/design-brief`, critique is single-pass by design. If the user wants another round, they run `/critique` again - the revised plan is now the conversation context.
 """

--- a/.gemini/commands/eos.toml
+++ b/.gemini/commands/eos.toml
@@ -2,7 +2,9 @@ description = "End of Session Handoff"
 
 prompt = """
 
-Auto-generate handoff from session context. The agent summarizes - never ask the user.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "eos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+The agent closes or blocks, then summarizes and saves. The default is not "defer" — the default is "complete." /eos halts until every session-originated loose end is either completed or blocked with an externally-verifiable reason. Only then does it synthesize and save the handoff. The Session Close-Out Audit (Step 2) is the gate.
 
 ## Usage
 
@@ -30,62 +32,196 @@ gh pr list --author @me --state all --json number,title,state,updatedAt --jq '.[
 gh issue list --state all --json number,title,state,updatedAt --jq '.[] | select(.updatedAt | startswith("'$(date +%Y-%m-%d)'"))'
 ```
 
-### 1.5 Inspect Worktree State (Read-Only)
+### 2. Session Close-Out Audit
 
-Determine whether this session is running inside a `.claude/worktrees/<id>/` worktree, and pre-compute the cleanup decision so Step 2 can write an accurate handoff. **No destructive actions in this step.**
+Before synthesizing the handoff, run the mechanical audit below. This is the only way to avoid both (a) leaving unmerged in-session work to rot, and (b) fabricating loose ends that weren't actually part of this session's goals.
+
+#### Detection checklist
+
+Checks A-F are objective. Do NOT substitute judgment.
+
+**A. Uncommitted session-originated changes.**
+Run `git status --porcelain`. For each output line, classify as session-originated by consulting the session transcript's `Edit` and `Write` tool calls. A file is **high-confidence session-originated** iff its path appears in at least one `Edit` or `Write` call this session. Files dirty but NOT in the tool-call history are **low-confidence** (could be pre-existing working tree state or a parallel-agent edit).
+
+- **High-confidence files** surface in the close-out prompt automatically.
+- **Low-confidence files** surface under a separate "verify ownership" line and require per-file confirmation before any completion action runs.
+
+If the tool-call history is unavailable (long session, compaction), downgrade ALL dirty files to low-confidence and require per-file confirmation.
+
+**B. Unpushed commits on the current branch.**
 
 ```bash
-PWD_OUT=$(pwd)
-if [[ "$PWD_OUT" != *"/.claude/worktrees/"* ]]; then
-  WORKTREE_DECISION=n/a
-else
-  WORKTREE_PATH="$PWD_OUT"
-  WORKTREE_ID="${WORKTREE_PATH##*/}"
-  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  STATUS=$(git status --porcelain)
-
-  # Refresh main; ignore failure (offline OK — fall through to PR check)
-  git fetch origin main --quiet 2>/dev/null
-
-  # Squash-merge-aware ahead check (canonical post-squash idiom; offline-safe).
-  # `git cherry` outputs `+` for commits NOT on main, `-` for patch-equivalent on main.
-  CHERRY=$(git cherry origin/main "$BRANCH" 2>/dev/null)
-  MERGED_VIA_CHERRY=false
-  if [ -z "$CHERRY" ] || ! echo "$CHERRY" | grep -q '^+'; then
-    MERGED_VIA_CHERRY=true
-  fi
-
-  # Direct-ancestor check (fast-forward / rebase merges)
-  AHEAD=$(git log "$BRANCH" --not origin/main --oneline 2>/dev/null)
-  MERGED_VIA_LOG=false
-  [ -z "$AHEAD" ] && MERGED_VIA_LOG=true
-
-  # PR-merged tertiary check (network-dependent)
-  PR_NUM=$(gh pr list --head "$BRANCH" --state merged --json number --jq '.[0].number // empty' 2>/dev/null)
-  PR_MERGED=false
-  [ -n "$PR_NUM" ] && PR_MERGED=true
-
-  if [ -z "$STATUS" ]; then
-    if [ "$MERGED_VIA_CHERRY" = true ] || [ "$MERGED_VIA_LOG" = true ] || [ "$PR_MERGED" = true ]; then
-      WORKTREE_DECISION=remove
-    else
-      WORKTREE_DECISION=keep_unpushed
-    fi
-  else
-    WORKTREE_DECISION=keep_dirty
-    DIRTY_FILE_COUNT=$(echo "$STATUS" | wc -l | tr -d ' ')
-  fi
-fi
+git log @{u}..HEAD --oneline 2>/dev/null || git log --oneline -10
 ```
 
-Stash `WORKTREE_DECISION`, `WORKTREE_PATH`, `BRANCH`, and `DIRTY_FILE_COUNT` for use in Steps 2 and 5.5. Decision values:
+If the current branch has an upstream with commits above it, OR the branch has no upstream and carries commits from this session, flag it.
 
-- `n/a` — not in a worktree (skip cleanup)
-- `remove` — clean tree AND merged via cherry, log, or PR
-- `keep_unpushed` — clean tree, commits ahead of main, no merged PR (work needs follow-up)
-- `keep_dirty` — uncommitted changes present
+**C. Unpushed commits on other branches touched this session.**
+For every branch named in the session transcript's `git checkout`, `git switch`, or `git branch` calls, run the Check B query. Report each that has unpushed commits.
 
-### 2. Synthesize Handoff (Agent Task)
+**D. Session-authored PRs — Ship Gate.**
+
+```bash
+gh pr list --author @me --state open \
+  --json number,title,mergeStateStatus,statusCheckRollup,reviewDecision,isDraft \
+  --jq '.[] | select(.isDraft == false)'
+```
+
+Do NOT filter out `BEHIND`/`DIRTY`/`BLOCKED` merge states in the query — a session PR that fell behind main is still session work; dropping it from the audit lets it rot silently.
+
+Classify each PR by `mergeStateStatus` first, then the `(required-checks, reviewDecision)` pair:
+
+- **Needs-update** — `mergeStateStatus == "BEHIND"`: run `gh pr update-branch <N>`, wait for checks to re-run, then reclassify. `mergeStateStatus == "DIRTY"`: merge conflicts — surface in the close-out prompt; never auto-resolve conflicts.
+- **Merge-ready** — all required checks `SUCCESS`, `reviewDecision == "APPROVED"` (or no approval required on this repo), no unresolved review threads.
+- **Review-ready** — all required checks `SUCCESS`, awaiting review.
+- **CI-failing** — at least one required check `conclusion == "FAILURE"`. Surfaced via Check E.
+
+**Ship Gate policy.** Session-authored PRs represent work the session was responsible for finishing. Sessions must end with PRs merged or explicitly blocked — incomplete work does not slide. The Ship Gate enforces that:
+
+- Merge-ready → /eos runs `gh pr merge <N> --squash --delete-branch` as the completion action.
+- Review-ready → /eos pauses and prompts the Captain (see Completion Actions) for merge, named reviewer, or external blocker. No silent deferral.
+- Explicitly blocked → allowed only with an externally-verifiable reason. "Captain to review," "next session will merge," and "will decide later" are rejected — those are deferrals, not blockers.
+
+This is the one place /eos merges. /ship still forbids auto-merge on direct invocation; /eos earns its narrow merge path by gating on green+approved and by being the last gate before handoff.
+
+**E. Session-authored PRs with explicit FAILURE on required checks.**
+Filter Check D's query to PRs with `statusCheckRollup` containing at least one `conclusion == "FAILURE"` on a required check. PENDING/STALE/NEUTRAL/SKIPPED states do NOT count as failures for this check - surface them separately as "CI unresolved" in the handoff without marking them as loose ends requiring action.
+
+**F. Memory/doc edits that reference unshipped PRs.**
+For each memory or doc file edited this session (identify via the transcript's `Edit`/`Write` tool calls), extract PR references with:
+
+```bash
+grep -oE '\b(PR |pull/|#)([0-9]+)\b' <file>
+```
+
+For each match, verify with `gh pr view <N> --json state` - if the command returns an issue (not a PR) it errors out harmlessly and the match is discarded. For each PR number where `state != MERGED`, inspect the file's surrounding text. If the text claims post-merge state (phrases like "merged", "landed", "in production", "resolved by"), flag the file.
+
+**G. Open issues asserted as resolved during this session.**
+
+Scan the session transcript for phrases matching any of:
+
+- `verified( as)? resolved`
+- `confirmed (remediated|fixed|closed|gone)`
+- `(all|both) .* (violations|findings) confirmed (gone|remediated)`
+- `fix in code AND tested`
+
+For each match, extract any `#\d+` issue numbers within ±200 characters. For each extracted number, run `gh issue view <N> --json state`. If `state == OPEN`, surface the issue.
+
+**Completion action:** `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."` Deferral disallowed — an in-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.
+
+**H. Session diagnostic notes must cite matching memory.**
+
+If the session transcript contains failure-narrative keywords ("silent failure", "root cause unknown", "mysterious", "didn't work as expected", "recovered via", "bug-hunt", "investigate next"), extract the surrounding context. For each match, grep `MEMORY.md` for matching memory filenames (by topic keywords: "worktree" → `feedback_parallel_agents_worktrees.md`, "MCP" → `feedback_mcp_debugging.md`, etc.).
+
+For each match, the handoff's diagnostic/retro section MUST cite the memory by filename. A bare "investigate next session" or "root cause unknown" without citing a matching memory entry is rejected — re-synthesize the section with the citation. If no memory matches after an honest check, add the assertion "no matching memory found (candidate for new feedback memory)" so the gate is explicit.
+
+**Defensive note on `gh` JSON schema.** Fields like `mergeStateStatus` and `statusCheckRollup` have stable names but nested shape changes across `gh` minor versions. Wrap each jq call at the shell level: unexpected output formats should log a warning like `[eos:check-X] gh output unexpected, skipping this check` and proceed to the next check. Do NOT crash the skill on schema drift.
+
+#### Anti-Fabrication Gate
+
+Every item you are about to list as a loose end must pass this gate.
+
+**Gate:** Is this item one of:
+
+1. A high-confidence uncommitted file from Check A (in the session's tool-call history), OR
+2. A low-confidence uncommitted file from Check A that the Captain confirmed as session-originated, OR
+3. Unpushed commits from Check B or C, OR
+4. An open session-authored PR from Check D (Ship Gate: merge-ready, review-ready, or explicitly blocked), OR
+5. An open session-authored PR from Check E (failing required checks), OR
+6. A memory/doc file from Check F that references an unshipped PR with post-merge prose, OR
+7. An open issue from Check G that the session asserted as resolved, OR
+8. A diagnostic note from Check H that needs memory citation, OR
+9. A specific item the Captain requested **via an explicit chat message with a verb and subject** that has not been completed. (NOT an aside summarized from context. NOT an inference. A literal user message.)
+
+If NO to all nine → do not list it. Do not hedge. Do not qualify. Kill it.
+
+**Specifically forbidden items** (these are fabrications, never list them):
+
+- Refactors, test additions, or cleanups "noticed in passing"
+- Documentation/comment/naming improvements the Captain did not request
+- Adjacent bugs unrelated to this session's goals
+- "Nice-to-have" improvements to code that shipped this session
+- Work explicitly deferred earlier in the session (the decision already happened)
+- Anything prefixed with "we should also…" or "it would be nice to…"
+- Fleet-wide or time-distant concerns surfaced for completeness
+- Reassurances dressed up as open items ("the CI gate is still alive" is a result, not a loose end)
+
+If the audit finds nothing that passes the gate, skip directly to Step 3. Do not fabricate a list. Saying "we're done" is the correct output.
+
+#### Deduplication with /own-it
+
+If `/own-it` was invoked earlier in this session and resolved items via its rule-4 closure checklist, those items do NOT re-surface here. Consult the transcript; items already marked as resolved earlier are excluded.
+
+#### Close-Out Prompt (only if items exist)
+
+If **>4 items pass the gate**, do NOT auto-split. Surface the count and halt with:
+
+> Session close-out audit found N items - this session wasn't actually closable in one flow. Invoke `/own-it` and address them individually, or pick the highest-priority items to resolve now.
+
+Do not proceed to a bulk prompt that hides items behind a scroll.
+
+If **≤4 items pass the gate**, present them in ONE consolidated prompt using `AskUserQuestion`:
+
+- Question: "Session close-out: N items to resolve before handoff. Complete now?"
+- Header: `Close-out` (≤12 chars)
+- Options:
+  - **"Complete all"** — execute the obvious completion for each item per the Completion Actions table below. After actions, re-run Checks A–H; items that are still in scope roll back to a second prompt.
+  - **"Complete selected"** — present per-item options in a second `AskUserQuestion`.
+  - **"Declare external blocker"** — each item left requires a one-line reason naming an external party or system that prevents completion (vendor response pending, Captain directive required, approver identified by name, etc.). Reasons matching `(?i)(Captain to review|next session|later|will decide|I'll review)` are rejected with: "That's not an external blocker — it's a deferral. Name the actual blocker, or complete the item." Reprompt once; if the second reason also fails, default to "Complete selected."
+
+"Leave for next session" is **not** an available option. Session-originated loose ends complete or block with a named blocker — they do not slide.
+
+#### Completion Actions (per check)
+
+| Check                         | Action                                                                                                                                  | Notes                                                                                                                                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A (high-confidence)           | `git add <specific file>` + commit with a message derived from file path + session context                                              | Stage ONLY the specific files from the tool-call history. **Never** `git add -A` or `git add .` — this would sweep parallel-agent state.                                                  |
+| A (low-confidence, confirmed) | Same as above, per confirmed file                                                                                                       | Confirmation is per-file; partial confirmations are allowed.                                                                                                                              |
+| A (`/code-review` report)     | Prompt: `(a) commit with prior-report convention`, `(b) rm the file`. No third option.                                                  | Prior reports in `docs/reviews/` are committed. Match convention or discard. Deferral disallowed — the report cannot sit untracked across session boundaries.                             |
+| B                             | `git push` (or `git push -u origin <branch>` if no upstream)                                                                            | Do not force-push. If push is rejected (non-fast-forward), roll back to the prompt — do not attempt to resolve.                                                                           |
+| C                             | `git switch <branch> && git push && git switch -`                                                                                       | Restore original branch on completion.                                                                                                                                                    |
+| D (needs-update, BEHIND)      | `gh pr update-branch <N>`, wait for checks to re-run, then re-run Check D and reclassify.                                               | If update-branch fails on conflicts, treat as DIRTY.                                                                                                                                      |
+| D (needs-update, DIRTY)       | Surface the conflicting files; prompt Captain: `(a) resolve now (breaks into interactive)`, `(b) declare external blocker`.             | Never auto-resolve merge conflicts at `/eos`.                                                                                                                                             |
+| D (merge-ready)               | Run `gh pr merge <N> --squash --delete-branch`. On success, note the merge in the handoff "Accomplished" section.                       | This is the only merge `/eos` performs. Gated on: green required checks, approved (or no approval required), no unresolved review threads. Any gate missing → fall to D (review-ready).   |
+| D (review-ready)              | Pause `/eos` and prompt Captain: `(a) approve+merge now`, `(b) name the reviewer and block`, `(c) declare external blocker`.            | No "leave for next session" option. If Captain absent (auto mode), /eos blocks with machine reason `"blocked: pending Captain merge authorization for #<N>"` so the deferral is explicit. |
+| E                             | Surface the failing check names + URL                                                                                                   | Do NOT attempt to fix. Ask whether to investigate now (breaks out of `/eos` into interactive debug) or block with the failure noted as the external-blocker reason.                       |
+| F                             | Update the file to reflect actual state (e.g., "merged in PR #N" → "proposed in open PR #N")                                            | Use `Edit` with precise `old_string`/`new_string`; do not rewrite the file.                                                                                                               |
+| G                             | `gh issue close <N> --comment "Verified resolved during session {session_id}. See handoff."`                                            | Deferral disallowed. In-session verification that isn't carried through to closure is the same incomplete-work pattern Check D catches on PRs.                                            |
+| H                             | Rewrite the handoff diagnostic section to cite the matching memory filename, or add "no matching memory found (candidate for new one)". | Forces the check to run. "Root cause unknown" with no memory check is rejected.                                                                                                           |
+
+#### Post-Action Verification
+
+After completion actions run, re-run Checks A–H. Any check that still returns items means the action failed or was partial — surface those items in a second prompt with the completion result attached. Do not mark items as resolved in the handoff if the check still flags them.
+
+#### Blocked-Item Age Tracking
+
+"Leave for next session" is never an option (see Close-Out Prompt) — the only way an item carries forward is as a declared external blocker. Each blocked item is recorded in the handoff's "Loose ends captured at /eos" section with:
+
+- Item description (path, branch, PR number)
+- `first_seen: YYYY-MM-DD` (today if new; copied from prior handoff if this item already appeared)
+- `age: N` sessions (1 if new; incremented if matched to a prior handoff's item via path/branch/PR number)
+- `reason:` the externally-verifiable blocker the Captain declared
+
+On the next `/eos`, match by identifier (path/branch/PR number) against the prior session's "Loose ends captured at /eos" list (fetched via `crane_context` or the prior handoff record). Increment `age` for matches.
+
+**When `age >= 3`, the blocker must re-justify itself.** The Captain must choose:
+
+- Re-affirm the blocker with current evidence that it is still external and still live (a stale reason cannot roll forward), OR
+- Kill the item (remove from the handoff entirely — speculative work gets killed, not re-filed).
+
+This converts filing pressure into closure pressure: blocked items age visibly and must re-earn their place every session past the third.
+
+**Critical:** the audit produces at most ONE close-out prompt (plus a post-action verification prompt if some completions failed, plus an age≥3 escalation prompt if that case hits). Do not follow up with "anything else?" - that phrasing is the exact invitation to fabricate that this audit exists to prevent.
+
+### 3. Synthesize Handoff (Agent Task)
+
+#### 3a. Self-Review Bias Caveat
+
+If `/code-review` was invoked in this session (check transcript for the skill invocation) AND the review graded code that Claude wrote in a prior or current session, any grade-change claim in "Accomplished" carries the caveat:
+
+> (self-review — subject to bias; treat as signal, not measurement)
+
+This is a one-line boilerplate. Do not omit. Do not reword. Do not soften to "may be biased." The caveat exists because we run review and authorship on the same model; a neutral framing misrepresents the evidence.
 
 Using conversation history and gathered context, the agent generates a summary covering:
 
@@ -96,11 +232,12 @@ Using conversation history and gathered context, the agent generates a summary c
 - Problems solved
 - Code changes made
 
-**In Progress:** Unfinished work — write as pickup instructions for an agent with NO conversation history
+**In Progress:** Unfinished work - write as pickup instructions for an agent with NO conversation history
 
 - Include specific file paths, function names, and branch names
 - State exactly where you stopped: "Function X is partially implemented in file Y"
 - List what remains as numbered steps
+- Include any items from Step 2's audit that the Captain declared blocked by an external party or system, under a subheading **"Loose ends captured at /eos"** with exact file paths, branch names, PR numbers, `first_seen`, `age`, and `reason` (the externally-verifiable blocker name). Do not paraphrase or compress. The next session's `/eos` reads this to increment age. Items that completed via action do NOT appear here.
 
 **Blocked:** Items needing attention
 
@@ -108,28 +245,25 @@ Using conversation history and gathered context, the agent generates a summary c
 - Questions for PM
 - Decisions needed
 - External dependencies
-- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam here and use `status:blocked`, rather than letting the handoff imply completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
+- **Unwired seams:** any producer→consumer seam this session touched but did not observe working on the real runtime. Per the Definition of Done ("Done means wired", `crane_doc('global', 'team-workflow.md')`), these are NOT done — name the seam and use `status:blocked` rather than implying completion. The EOS verify-coverage gate (Layer 4c) enforces this mechanically when `status=done`; see `docs/instructions/eos-gate.md`.
 
-**Next Session:** Recommended focus — write as an ordered action plan
+**Next Session:** Recommended focus - write as an ordered action plan
 
 - "1. Open src/foo.ts and complete the retryWithBackoff() function"
-- "2. Run npm test — expect 2 new tests to pass"
+- "2. Run npm test - expect 2 new tests to pass"
 - "3. Create PR for issue #123"
 
-**Worktree-aware resume guidance:**
+**Anti-Fabrication rule (also applies to this section).** The same gate from Step 2 governs what goes into "In Progress," "Blocked," and "Next Session." If an item does not pass the Step 2 gate, it does not belong in the synthesized handoff. Write "(none)" for empty sections. Do not pad.
 
-- If `WORKTREE_DECISION` from Step 1.5 is `keep_unpushed` or `keep_dirty`, the **In Progress** and **Next Session** sections MUST start with `cd $WORKTREE_PATH && git checkout $BRANCH` so an agent with no context resumes in the right place. For `keep_dirty`, also list the modified files.
-- If `WORKTREE_DECISION` is `remove` or `n/a`, do NOT reference the worktree path or branch in the handoff — the worktree will be gone after Step 5.5 and the reference would mislead the next session.
-
-### 3. Display and Save (Auto-Save)
+### 4. Display and Save (Auto-Save)
 
 Display the generated handoff, then **immediately save it to D1 without asking for confirmation.** Do not prompt the user with "Save to D1?" or any yes/no question. Just show the summary and save.
 
-### 4. End Work Day
+### 5. End Work Day
 
-Call `POST /work-day` with `action: "end"` via the `upsertWorkDay` API method.
+Handled automatically: `crane_handoff` closes the work day server-side when the final handoff is saved (any call without `final: false`). No separate call — there is no agent-exposed work-day tool.
 
-### 5. Save Handoff via MCP
+### 6. Save Handoff via MCP
 
 Call the `crane_handoff` MCP tool with:
 
@@ -141,78 +275,41 @@ This writes to D1 via the Crane Context API. The next session's SOD will read it
 
 **Important:** When status is `in_progress`, the full summary is shown to the next session's SOD briefing. Write "In Progress" and "Next Session" as if giving instructions to another developer who has zero context from this conversation.
 
+**Status invariants (enforced before save):**
+
+- `done` — Step 2 found nothing. No unmerged session PRs, no uncommitted session files, no open-but-verified-resolved issues, no uncited failure diagnostics. If any of those exist, `done` is rejected.
+- `in_progress` — work genuinely carries into the next session (in-flight branch, research thread, design spike). Not a synonym for "PRs opened but not merged" — that is a Ship Gate violation, not in-progress work.
+- `blocked` — at least one Check item carries into the next session with an externally-verifiable blocker reason. The reason must name the blocker.
+
 #### Cross-venture sessions
 
 If work was done across multiple ventures this session (e.g., started in dc-console then switched to crane-console), write a separate handoff for each venture:
 
 1. Identify all ventures that had meaningful work this session (commits, PRs, code changes, issue progress).
-2. For each venture EXCEPT THE LAST, call `crane_handoff` with `venture: "<code>"` AND `final: false`. The `final: false` flag tells the API to create the handoff record but keep the session active so the next call doesn't 409 with "Session is not active".
-3. For the FINAL venture, call `crane_handoff` without `final` (or with `final: true`). This call ends the session.
-4. Each handoff summary should cover only the work relevant to that venture.
+2. For each venture, call `crane_handoff` with a `venture` parameter set to the venture code. This overrides auto-detection so you can write handoffs for ventures other than the current repo.
+3. Each handoff summary should cover only the work relevant to that venture.
 
 Example for a session that touched both `dc` and `vc`:
 
 ```
-crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc", final: false)
+crane_handoff(summary: "Rebuilt AI assist panels...", status: "done", venture: "dc")
 crane_handoff(summary: "Added /ship skill, command sync...", status: "done", venture: "vc")
 ```
 
-Order doesn't strictly matter, but the LAST call must omit `final: false` (or pass `final: true`) so the session terminates cleanly.
-
-### 5.5 Execute Worktree Decision
-
-Acts on `WORKTREE_DECISION` from Step 1.5. For cross-venture sessions, this runs **once**, after the FINAL `crane_handoff` call (the one without `final: false`). Earlier per-venture handoffs do NOT trigger cleanup — the session is still active.
-
-1. **`WORKTREE_DECISION=n/a`** — skip; jump to Step 6.
-
-2. **`WORKTREE_DECISION=remove`** — call:
-
-   ```
-   ExitWorktree(action: "remove", discard_changes: true)
-   ```
-
-   `discard_changes: true` is required when local commits exist (post-squash case): the substance is already on main as a squash commit, but the original branch commits are not ancestors of `origin/main` and the harness needs explicit consent to discard them.
-
-3. **`WORKTREE_DECISION=keep_unpushed`** or **`keep_dirty`** — call:
-
-   ```
-   ExitWorktree(action: "keep")
-   ```
-
-   Worktree stays, branch stays, next session resumes via the handoff text written in Step 2.
-
-4. **Fallback on `ExitWorktree` failure** (rare — running outside the harness, session-state mismatch, etc.):
-   - For `remove`: attempt raw cleanup. Identify canonical repo path (`git rev-parse --git-common-dir` then resolve up two levels from `.git`, or use the path before `/.claude/worktrees/` in `WORKTREE_PATH`). Then:
-     ```bash
-     CANONICAL="${WORKTREE_PATH%/.claude/worktrees/*}"
-     cd "$CANONICAL"
-     git worktree remove --force "$WORKTREE_PATH" \
-       && git branch -D "$BRANCH"
-     ```
-     If raw cleanup also fails, capture both error messages for Step 6 — do NOT crash `/eos`.
-   - For `keep_unpushed` or `keep_dirty`: ExitWorktree failure is non-fatal; the worktree was going to stay anyway.
-
-### 6. Report Completion
-
-Build the closing line based on `WORKTREE_DECISION` and the actual outcome of Step 5.5:
+### 7. Report Completion
 
 ```
-Handoff saved to D1. Worktree: {removed | kept (unpushed: <branch>) | kept (dirty: <N> file(s)) | n/a | remove failed (see above)}. Next session will see this via crane_sos.
+Handoff saved to D1. Next session will see this via crane_sos.
 ```
-
-Examples:
-
-- `Handoff saved to D1. Worktree: removed. Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: kept (unpushed: feat/some-thing). Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: kept (dirty: 3 file(s)). Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: n/a. Next session will see this via crane_sos.`
-- `Handoff saved to D1. Worktree: remove failed (ExitWorktree: <err>; raw cleanup: <err>). Next session will see this via crane_sos.`
 
 ## Key Principle
 
-**The agent summarizes. The agent saves. No confirmation needed.**
+**The agent summarizes. The agent saves. No confirmation needed — with one targeted exception: if Step 2's audit surfaces genuine unshipped work, the skill asks ONE consolidated close-out question before proceeding. Otherwise, auto-save proceeds silently.**
 
-The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything.
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything. The Session Close-Out Audit is the only place `/eos` produces a prompt, and only when objective detection checks find loose ends that pass the anti-fabrication gate.
 
-Auto-save directly to D1. Never ask "Save to D1?" or any confirmation question.
+## Related
+
+- `/own-it` rule 4 — mid-session closure checklist; `/eos` inherits the same discipline at session end.
+- Principles enforced here: pad is worse than done (no manufactured loose ends); speculative work gets killed, not filed; never `git add -A` under parallel agents.
 """

--- a/.gemini/commands/sos.toml
+++ b/.gemini/commands/sos.toml
@@ -2,6 +2,8 @@ description = "Start of Session"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "sos")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 1. Call `crane_sos` MCP tool (returns formatted briefing).
 2. Call `crane_schedule(action: "planned-events", from: "{today}", to: "{today}", type: "planned")`.
 3. **Orphan worktree backstop** — see below. Auto-remove provably-safe orphans from sessions that ended unnaturally; surface the rest. Compute a one-line worktree status line for the briefing.

--- a/docs/skills/governance.md
+++ b/docs/skills/governance.md
@@ -88,7 +88,7 @@ npm run skill-review -- --all --strict
 Checks:
 
 1. **Frontmatter conformance** — required fields present, enums valid, semver parseable.
-2. **Dispatcher parity** — matching `.claude/commands/<name>.md` exists (unless `backend_only: true`).
+2. **Dispatcher parity** — matching `.claude/commands/<name>.md` exists (unless `backend_only: true`); its body matches the SKILL.md body (`dispatcher.body-drift`, warning — comparison ignores blank lines, trailing whitespace, and the invocation directive); and it carries the `crane_skill_invoked` invocation directive (`dispatcher.missing-invocation-directive`, warning — without it, Claude Code invocations are not recorded in telemetry). The dispatcher is what Claude Code executes: body drift means the SKILL.md and the running skill are different programs.
 3. **Reference validity**:
    - `depends_on.mcp_tools` — every name exists in `config/mcp-tool-manifest.json` (CI-generated).
    - `depends_on.files` — scope-prefixed; validator checks the correct location per scope.

--- a/packages/crane-mcp/src/cli/skill-review.test.ts
+++ b/packages/crane-mcp/src/cli/skill-review.test.ts
@@ -201,19 +201,34 @@ describe('checkFrontmatterConformance', () => {
 // ---------------------------------------------------------------------------
 
 describe('checkDispatcherParity', () => {
+  const DIRECTIVE =
+    '> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "foo")`. This is non-blocking.'
+  const BODY = `# /foo - Does Something\n\n${DIRECTIVE}\n\n## Behavior\n\nStep one.\nStep two.\n`
+
   beforeEach(() => {
     vi.mocked(existsSync).mockReset()
+    vi.mocked(readFileSync).mockReset()
   })
 
-  it('passes when command file exists', () => {
+  it('passes when dispatcher matches the SKILL.md body', () => {
     vi.mocked(existsSync).mockReturnValue(true)
-    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT)
+    vi.mocked(readFileSync).mockReturnValue(BODY)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
     expect(violations).toHaveLength(0)
+  })
+
+  it('ignores blank lines, trailing whitespace, and the directive line when comparing', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    // Dispatcher: no directive, extra blank lines, trailing spaces — still parity.
+    const dispatcherWithDirective = `# /foo - Does Something\n\n\n${DIRECTIVE}\n## Behavior  \n\n\nStep one.\nStep two.\n\n`
+    vi.mocked(readFileSync).mockReturnValue(dispatcherWithDirective)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
+    expect(violations.find((x) => x.rule === 'dispatcher.body-drift')).toBeUndefined()
   })
 
   it('errors when command file is missing', () => {
     vi.mocked(existsSync).mockReturnValue(false)
-    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
     const v = violations.find((x) => x.rule === 'dispatcher.missing-command-file')
     expect(v).toBeDefined()
     expect(v!.severity).toBe('error')
@@ -223,8 +238,30 @@ describe('checkDispatcherParity', () => {
   it('skips check when backend_only is true', () => {
     vi.mocked(existsSync).mockReturnValue(false)
     const fm = { ...goodFrontmatter(), backend_only: true }
-    const violations = checkDispatcherParity(SKILL_PATH, fm, REPO_ROOT)
+    const violations = checkDispatcherParity(SKILL_PATH, fm, REPO_ROOT, BODY)
     expect(violations).toHaveLength(0)
+  })
+
+  it('warns on body drift between dispatcher and SKILL.md', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const staleDispatcher = `# /foo - Does Something\n\n${DIRECTIVE}\n\n## Behavior\n\nOld step that was replaced.\n`
+    vi.mocked(readFileSync).mockReturnValue(staleDispatcher)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
+    const v = violations.find((x) => x.rule === 'dispatcher.body-drift')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('warning')
+    expect(v!.message).toContain('first divergence')
+  })
+
+  it('warns when dispatcher is missing the invocation directive', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const noDirective = `# /foo - Does Something\n\n## Behavior\n\nStep one.\nStep two.\n`
+    vi.mocked(readFileSync).mockReturnValue(noDirective)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
+    const v = violations.find((x) => x.rule === 'dispatcher.missing-invocation-directive')
+    expect(v).toBeDefined()
+    expect(v!.severity).toBe('warning')
+    expect(v!.message).toContain('telemetry')
   })
 })
 

--- a/packages/crane-mcp/src/cli/skill-review.ts
+++ b/packages/crane-mcp/src/cli/skill-review.ts
@@ -109,7 +109,7 @@ export function reviewSkill(
 
   return [
     ...checkFrontmatterConformance(relPath, relPath, fm, dirName, knownOwners),
-    ...checkDispatcherParity(relPath, fm, repoRoot),
+    ...checkDispatcherParity(relPath, fm, repoRoot, content),
     ...checkReferenceValidity(relPath, fm, repoRoot, manifestTools),
     ...checkStructuralLint(relPath, fm, content),
     ...checkInvocationDirective(relPath, fm, content),

--- a/packages/crane-mcp/src/cli/skill-review/checks.ts
+++ b/packages/crane-mcp/src/cli/skill-review/checks.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { spawnSync } from 'node:child_process'
@@ -108,10 +108,25 @@ export function checkFrontmatterConformance(
   ]
 }
 
+/**
+ * Normalize a markdown body for parity comparison: drop the telemetry
+ * directive line (injected independently on each side), blank lines, and
+ * trailing whitespace. The remaining lines must match exactly — the
+ * dispatcher is what Claude Code executes, so silent body drift means the
+ * SKILL.md and the running skill are different programs.
+ */
+function normalizeBody(text: string): string[] {
+  return text
+    .split('\n')
+    .map((l) => l.replace(/\s+$/, ''))
+    .filter((l) => l !== '' && !l.includes('crane_skill_invoked'))
+}
+
 export function checkDispatcherParity(
   skillPath: string,
   fm: Frontmatter,
-  repoRoot: string
+  repoRoot: string,
+  skillBody: string
 ): Violation[] {
   if (fm.backend_only === true) return []
   const name = String(fm.name ?? '')
@@ -129,7 +144,50 @@ export function checkDispatcherParity(
       },
     ]
   }
-  return []
+
+  const violations: Violation[] = []
+  const dispatcherRaw = readFileSync(commandFile, 'utf-8')
+
+  const skillLines = normalizeBody(skillBody)
+  const dispatcherLines = normalizeBody(dispatcherRaw)
+
+  if (skillLines.join('\n') !== dispatcherLines.join('\n')) {
+    let firstDiff = 0
+    const max = Math.max(skillLines.length, dispatcherLines.length)
+    while (firstDiff < max && skillLines[firstDiff] === dispatcherLines[firstDiff]) firstDiff++
+    violations.push({
+      rule: 'dispatcher.body-drift',
+      severity: 'warning',
+      path: skillPath,
+      message:
+        `Dispatcher body differs from SKILL.md body ` +
+        `(${skillLines.length} vs ${dispatcherLines.length} normalized lines; ` +
+        `first divergence at normalized line ${firstDiff + 1})`,
+      fix: `Sync the bodies: the dispatcher at .claude/commands/${name}.md is what Claude Code executes. Regenerate it from the SKILL.md body (strip frontmatter), or port dispatcher-only edits back into SKILL.md.`,
+    })
+  }
+
+  const dispatcherHead = dispatcherRaw
+    .split('\n')
+    .filter((l) => l.trim() !== '')
+    .slice(0, 20)
+  const hasDirective = dispatcherHead.some((l) => {
+    const invokedIdx = l.indexOf('crane_skill_invoked')
+    if (invokedIdx === -1) return false
+    const rest = l.slice(invokedIdx)
+    return rest.includes('skill_name') && (rest.includes(`"${name}"`) || rest.includes(`'${name}'`))
+  })
+  if (!hasDirective) {
+    violations.push({
+      rule: 'dispatcher.missing-invocation-directive',
+      severity: 'warning',
+      path: skillPath,
+      message: `Dispatcher .claude/commands/${name}.md is missing the invocation directive — Claude Code invocations of /${name} will not be recorded in skill telemetry`,
+      fix: `Add \`> **Invocation:** As your first action, call \\\`crane_skill_invoked(skill_name: "${name}")\\\`.\` as a blockquote immediately after the \`# /${name}\` heading in the dispatcher.`,
+    })
+  }
+
+  return violations
 }
 
 function checkFileRef(skillPath: string, fileRef: string, repoRoot: string): Violation | null {

--- a/packages/crane-mcp/src/tools/handoff.test.ts
+++ b/packages/crane-mcp/src/tools/handoff.test.ts
@@ -95,6 +95,84 @@ describe('handoff tool', () => {
     expect(result.message).toContain('sess_test123')
   })
 
+  it('ends the work day after a final handoff is saved', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_workday',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ work_day: { ended: true } }) })
+
+    const result = await executeHandoff({ summary: 'Test', status: 'done' })
+
+    expect(result.success).toBe(true)
+    const workDayCall = mockFetch.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('/work-day')
+    )
+    expect(workDayCall).toBeDefined()
+    expect(JSON.parse(workDayCall![1].body).action).toBe('end')
+  })
+
+  it('does not end the work day when final=false keeps the session open', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_workday2',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+
+    const result = await executeHandoff({ summary: 'Test', status: 'done', final: false })
+
+    expect(result.success).toBe(true)
+    const workDayCall = mockFetch.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('/work-day')
+    )
+    expect(workDayCall).toBeUndefined()
+  })
+
+  it('handoff still succeeds when the work-day call fails', async () => {
+    const { executeHandoff } = await getModule()
+    const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
+    const { getSessionContext } = await import('../lib/session-state.js')
+
+    vi.mocked(getSessionContext).mockReturnValue({
+      sessionId: 'sess_workday3',
+      venture: 'vc',
+      repo: 'venturecrane/crane-console',
+    })
+    vi.mocked(getCurrentRepoInfo).mockReturnValue(mockRepoInfo)
+    vi.mocked(findVentureByRepo).mockReturnValue(mockVentures[0])
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'boom' })
+
+    const result = await executeHandoff({ summary: 'Test', status: 'done' })
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Handoff created')
+  })
+
   it('passes session_id in API request body', async () => {
     const { executeHandoff } = await getModule()
     const { getCurrentRepoInfo, findVentureByRepo } = await import('../lib/repo-scanner.js')
@@ -291,15 +369,16 @@ describe('handoff tool', () => {
       '2026-04-29T15:30:00.000Z',
     ])
 
-    // 1: /ventures, 2: /sessions/sess_abc/activity, 3: /eos
+    // 1: /ventures, 2: /sessions/sess_abc/activity, 3: /eos, 4: /work-day
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ recorded: 2, skipped: 0 }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ work_day: { ended: true } }) })
 
     await executeHandoff({ summary: 'Test', status: 'done' })
 
-    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(mockFetch).toHaveBeenCalledTimes(4)
     const activityCall = mockFetch.mock.calls[1]
     expect(activityCall[0]).toMatch(/\/sessions\/sess_abc\/activity$/)
     const activityBody = JSON.parse(activityCall[1].body)
@@ -331,12 +410,14 @@ describe('handoff tool', () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ ventures: mockVentures }) })
       .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ work_day: { ended: true } }) })
 
     await executeHandoff({ summary: 'Test', status: 'done' })
 
-    // No activity call — fetch invoked exactly twice (/ventures, /eos)
-    expect(mockFetch).toHaveBeenCalledTimes(2)
+    // No activity call — /ventures, /eos, then /work-day (no /sessions/:id/activity)
+    expect(mockFetch).toHaveBeenCalledTimes(3)
     expect(mockFetch.mock.calls[1][0]).toMatch(/\/eos$/)
+    expect(mockFetch.mock.calls[2][0]).toMatch(/\/work-day$/)
   })
 
   it('does not abort /eos when activity post fails (best-effort)', async () => {
@@ -363,11 +444,12 @@ describe('handoff tool', () => {
       .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
       // /eos still proceeds and succeeds
       .mockResolvedValueOnce({ ok: true, json: async () => ({ success: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ work_day: { ended: true } }) })
 
     const result = await executeHandoff({ summary: 'Test', status: 'done' })
 
     expect(result.success).toBe(true)
-    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(mockFetch).toHaveBeenCalledTimes(4)
   })
 
   it('returns [client] error when session null and CRANE_VENTURE_CODE missing', async () => {

--- a/packages/crane-mcp/src/tools/handoff.ts
+++ b/packages/crane-mcp/src/tools/handoff.ts
@@ -314,6 +314,17 @@ async function resolveVenture(
   return { venture }
 }
 
+/** End the work day when the final handoff is saved. Best-effort. */
+async function endWorkDay(api: CraneApi): Promise<void> {
+  try {
+    await api.upsertWorkDay('end')
+  } catch (err) {
+    console.warn('crane_handoff: work-day end failed (non-fatal)', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
 /** Post current-session activity to the server before closing. Best-effort. */
 async function postSessionActivityEvents(api: CraneApi, craneSessionId: string): Promise<void> {
   try {
@@ -391,6 +402,10 @@ async function buildAndSubmitHandoff(p: HandoffSubmitParams): Promise<HandoffRes
           ? `Network error: ${error.message}`
           : `Unknown error: ${String(error)}`
     return { success: false, message: `Failed to create handoff.\n${detail}` }
+  }
+
+  if (!keepSessionOpen) {
+    await endWorkDay(new CraneApi(process.env.CRANE_CONTEXT_KEY!, getApiBase()))
   }
 
   const verifyCoverageBlock = renderVerifyCoverageBlock(p.verifyGate)


### PR DESCRIPTION
## Summary

Periodic optimization review of the three every-session skills (/sos, /eos, /critique) found the Claude Code dispatcher for /eos was a major version stale — 240 normalized lines of drift, missing the entire Session Close-Out Audit (#650) and eos-gate "done means wired" content (#1053). CC dispatches from `.claude/commands/`, so the v2.x machinery never ran in CC sessions. Root cause: PR #762's dual-canon design requires body changes "by hand on both files," and that step was missed twice. The parity linter couldn't catch it because it only checked file existence.

## Changes

**Skills**
- `eos` 2.1.0 → 2.2.0:
  - Ship Gate query no longer drops `BEHIND`/`DIRTY`/`BLOCKED` PRs from the audit; new **needs-update** classification with completion actions (`gh pr update-branch`, conflict surfacing)
  - Step 5 (End Work Day) now documented as automatic via `crane_handoff` — the previous instruction cited `upsertWorkDay`, which no exposed tool could call
  - Machine-local memory-file citations replaced with inline principle statements (fleet-portable — fleet agents don't have the Captain's memory dir)
  - "Deferral Age Tracking" reconciled with the close-out prompt's no-deferral rule → "Blocked-Item Age Tracking"
- `sos` 1.0.0 → 1.1.0, `critique` 1.0.0 → 1.1.0 (version catch-up for #824/#826/#828); critique renames Task tool → Agent tool and gains a no-subagent fallback
- All three `.claude/commands/*.md` dispatchers regenerated **byte-identical** to their SKILL.md bodies, including the `crane_skill_invoked` directive — CC invocations now record telemetry (90-day counts were eos 58 / sos 22 / critique 4 because the directive only existed on the Codex side)

**Runtime (crane-mcp)**
- `crane_handoff` calls `upsertWorkDay('end')` best-effort when the final handoff saves (`final !== false`) — first caller of the previously dead lib method; failures log and never block the handoff

**Linter (skill-review)**
- `checkDispatcherParity` now compares normalized bodies (`dispatcher.body-drift`, warning) and requires the telemetry directive in dispatchers (`dispatcher.missing-invocation-directive`, warning)
- Repo-wide run: 0 errors, 54 warnings — existing drift debt on ~14 other skills is now visible instead of silent (follow-up issue to be filed)

## Verification

- `npm run verify` green: typecheck, format, lint (0 errors), 827 crane-mcp tests incl. 3 new work-day tests and 6 rewritten parity tests
- `./scripts/sync-commands.sh --check`: all generated files match
- `skill-review` on sos/eos/critique: 0 violations each under the hardened checks
- Byte-parity confirmed: dispatcher == SKILL.md body for all three skills

QA grade: self-reviewed, mechanical verification above; runtime work-day seam to be observed live at this session's /eos after merge + rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRtD3ArkPK913zuK6vJF2a