### PR TITLE
fix(skills): eliminate dispatcher drift debt across 37 skills (#1110)

### DIFF
--- a/.agents/skills/analytics/SKILL.md
+++ b/.agents/skills/analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: analytics
 description: Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: agent-team
 status: draft

--- a/.agents/skills/auth-setup/SKILL.md
+++ b/.agents/skills/auth-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-setup
 description: Wires up @clerk/testing/playwright so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes without manual login.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: agent-team
 status: draft

--- a/.agents/skills/auto-build/SKILL.md
+++ b/.agents/skills/auto-build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto-build
 description: Captain-invoked rigor pass for an implementation task. Enter plan mode, build the plan, run /critique to revise, gate on user approval via ExitPlanMode, then execute autonomously under Auto Mode. Captain types `/auto-build [agents]` when they want the full plan-and-vet cycle before going autonomous; harness should not auto-suggest this skill (the trigger is a Captain judgment, not a pattern).
-version: 1.1.0
+version: 1.1.1
 scope: global
 owner: captain
 status: stable

--- a/.agents/skills/calendar-sync/SKILL.md
+++ b/.agents/skills/calendar-sync/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: calendar-sync
 description: Calendar Sync
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-review
 description: Codebase Review
-version: 1.1.0
+version: 1.2.0
 scope: enterprise
 owner: captain
 status: stable
@@ -20,17 +20,21 @@ depends_on:
 
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "code-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-Deep codebase review by a single Claude Task agent across 7 dimensions. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
+Deep codebase review with multi-model perspectives. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
 
 ## Arguments
 
 ```
-/code-review [focus]
+/code-review [focus] [--quick]
 ```
 
 - `focus` - Optional path to scope the review (e.g., `workers/ke-api`, `app/src/components`). If omitted, reviews the entire codebase.
+- `--quick` - Claude-only review. Skips Codex and Gemini. Faster and cheaper for routine reviews.
 
-Parse `$ARGUMENTS`: trimmed contents are `FOCUS_PATH`. Empty string means full codebase.
+Parse `$ARGUMENTS`:
+
+- If it contains `--quick`, set `QUICK_MODE = true` and strip the flag.
+- Whatever remains (trimmed) is `FOCUS_PATH`. Empty string means full codebase.
 
 ## Execution
 
@@ -52,6 +56,7 @@ Display:
 Codebase Review: {VENTURE_NAME} ({VENTURE_CODE})
 Repo: {ORG}/{repo-name}
 Focus: {FOCUS_PATH or "Full codebase"}
+Mode: {QUICK_MODE ? "Quick (Claude-only)" : "Full (multi-model)"}
 ```
 
 ### Step 2: Build File Manifest
@@ -67,7 +72,15 @@ Write the manifest to `/tmp/crane-file-manifest-{VENTURE_CODE}.md` for agent del
 
 ### Step 3: Claude Review
 
-Launch a single Claude Task agent (`subagent_type: general-purpose`, `model: "sonnet"`) with this prompt to work through all 7 review dimensions sequentially:
+**Phase 1 (current):** A single Claude Task agent (`subagent_type: general-purpose`, `model: "sonnet"`) works through all 7 review dimensions sequentially.
+
+**Phase 2 (future):** Split into 3 parallel agents:
+
+- **Architect** - Architecture + Code Quality
+- **Security Analyst** - Security + Testing
+- **Standards Auditor** - Dependencies + Documentation + Golden Path
+
+For Phase 1, launch one Task agent (`model: "sonnet"`) with this prompt:
 
 ```
 You are performing a deep codebase review for {VENTURE_NAME} ({VENTURE_CODE}).
@@ -164,15 +177,29 @@ After all 7 dimensions, output:
 
 Wait for the agent to complete. Store its output as `CLAUDE_REVIEW`.
 
-### Step 4: Synthesize
+### Steps 4-5: Codex and Gemini Reviews (Phase 2 - not yet implemented)
 
-The orchestrator (you, not the review agent) owns final grading. This ensures single-point consistency.
+Skip these steps. Display: "Codex review: skipped (Phase 1 - Claude-only)" and "Gemini review: skipped (Phase 1 - Claude-only)"
 
-**4a. Apply grading rubric:**
+Phase 2 will add parallel Codex and Gemini reviews with `--quick` flag to opt out. See git history for the full Phase 2 implementation spec.
+
+### Step 6: Synthesize
+
+The orchestrator (you, not the review agents) owns final grading. This ensures single-point consistency.
+
+**6a. Deduplicate findings across models:**
+
+If multiple model outputs exist, merge findings:
+
+- Group by file and description similarity.
+- If 2+ models flagged the same issue, note convergence: "Flagged by 2/3 models" or "Flagged by 3/3 models". Convergence increases confidence.
+- Preserve unique findings from each model.
+
+**6b. Apply grading rubric:**
 
 Grade each of the 7 dimensions using the rubric below. The grade is based on the worst finding in that dimension, adjusted by count.
 
-**4b. Compare against previous review:**
+**6c. Compare against previous review:**
 
 Search VCMS for the most recent `code-review` scorecard for this venture:
 
@@ -190,13 +217,13 @@ If a previous scorecard exists:
   ```
   Report: "{N} of {M} previous findings resolved."
 
-**4c. Assign overall grade:**
+**6d. Assign overall grade:**
 
 The overall grade is the mode of dimension grades, pulled toward the worst grade if any dimension is D or F.
 
-### Step 5: Store Artifacts
+### Step 7: Store Artifacts
 
-**5a. VCMS Scorecard**
+**7a. VCMS Scorecard**
 
 Store a concise scorecard (under 500 words) in VCMS using `crane_note`:
 
@@ -213,6 +240,8 @@ Content format:
 **Date:** {YYYY-MM-DD}
 **Venture:** {VENTURE_NAME} ({VENTURE_CODE})
 **Scope:** {FOCUS_PATH or "Full codebase"}
+**Mode:** {Quick/Full}
+**Models:** {Claude / Claude+Codex+Gemini}
 
 ### Grades
 
@@ -253,6 +282,8 @@ Full report format:
 **Date:** {YYYY-MM-DD}
 **Reviewer:** Claude Code (automated)
 **Scope:** {FOCUS_PATH or "Full codebase"}
+**Mode:** {Quick/Full}
+**Models Used:** {list}
 **Golden Path Tier:** {TIER}
 
 ## Summary
@@ -296,6 +327,10 @@ Rationale: {Why this grade per the rubric}
 
 {...}
 
+## Model Convergence
+
+{If multi-model: which findings were flagged by multiple models}
+
 ## Trend Analysis
 
 {Comparison with previous review, if available}
@@ -304,12 +339,22 @@ Rationale: {Why this grade per the rubric}
 
 {Summary: file count, line count, languages}
 
-## Raw Review Output
+## Raw Model Outputs
+
+### Claude Review
 
 {CLAUDE_REVIEW}
+
+### Codex Review
+
+{CODEX_REVIEW or "Skipped"}
+
+### Gemini Review
+
+{GEMINI_REVIEW or "Skipped"}
 ```
 
-### Step 6: Create GitHub Issues (Optional)
+### Step 8: Create GitHub Issues (Optional)
 
 If there are any critical or high severity findings, ask the Captain:
 
@@ -337,9 +382,9 @@ gh issue list --repo {ORG}/{REPO_NAME} --label "source:code-review" --state open
 
 If an existing open issue covers the same finding, skip creation and note it in the report.
 
-### Step 7: Record Completion and Display Summary
+### Step 9: Record Completion and Display Summary
 
-**7a. Record completion in the Cadence Engine — this MUST happen before the summary.** Past runs have skipped this when it was framed as a tail action; if you skip it now, the briefing will say "Code Review (X) — UNTRACKED" even though the review ran.
+**9a. Record completion in the Cadence Engine — this MUST happen before the summary.** Past runs have skipped this when it was framed as a tail action; if you skip it now, the briefing will say "Code Review (X) — UNTRACKED" even though the review ran.
 
 ```
 crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "success", summary: "Grade: {GRADE}, {N} issues created", completed_by: "crane-mcp")
@@ -347,7 +392,7 @@ crane_schedule(action: "complete", name: "code-review-{VENTURE_CODE}", result: "
 
 If `crane_schedule` returns an error, surface it in the summary so the gap is visible — do NOT silently move on.
 
-**7b. Display the summary:**
+**9b. Display the summary:**
 
 ```
 Review complete.
@@ -365,8 +410,6 @@ Top action items:
 ```
 
 Do NOT automatically commit the full report. The user may want to review it first.
-
-> At session end, `/eos` enforces commit-or-discard on this file. It cannot be left untracked across session boundaries.
 
 ---
 
@@ -434,12 +477,13 @@ Concrete thresholds per dimension. The grade is determined by the most severe fi
 
 ## Error Handling
 
-Graceful degradation: every external call (VCMS, GitHub CLI) has a skip-on-failure path. If VCMS is unavailable, write report to disk only. If `gh` is unavailable, skip issue creation. A review always produces output.
+Graceful degradation: every external call (VCMS, GitHub CLI, future Codex/Gemini) has a skip-on-failure path. If VCMS is unavailable, write report to disk only. If `gh` is unavailable, skip issue creation. A review always produces output.
 
 ---
 
 ## Notes
 
+- **Phase 1**: Single Claude agent, Claude-only. Phase 2 will add Codex/Gemini via `--quick` opt-out flag.
 - **VCMS tag:** `code-review` (venture-scoped). **Report:** `docs/reviews/code-review-{YYYY-MM-DD}.md`.
 - **Issue labels:** `source:code-review`, `type:tech-debt`, `severity:{level}`.
 - Distributed to venture repos via `sync-commands.sh`. `/enterprise-review` stays in crane-console only.

--- a/.agents/skills/content-scan/SKILL.md
+++ b/.agents/skills/content-scan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: content-scan
 description: Content Candidate Triage
-version: 1.1.0
+version: 1.1.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/context-refresh/SKILL.md
+++ b/.agents/skills/context-refresh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: context-refresh
 description: Enterprise Context Refresh
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/docs-audit/SKILL.md
+++ b/.agents/skills/docs-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-audit
 description: Monthly docs site drift report. Walks site-published docs/ directories for broken references, deprecated entity mentions, structural drift, and git staleness.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/docs-refresh/SKILL.md
+++ b/.agents/skills/docs-refresh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: docs-refresh
 description: Update managed-block content on crane-command venture pages from canonical sources (gh PRs and issues). Deterministic, no LLM in the loop. Audit, refresh, init-markers modes.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/edit-article/SKILL.md
+++ b/.agents/skills/edit-article/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: edit-article
 description: Editorial Review Agent
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/edit-log/SKILL.md
+++ b/.agents/skills/edit-log/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: edit-log
 description: Build Log Editorial Review
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/enterprise-review/SKILL.md
+++ b/.agents/skills/enterprise-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: enterprise-review
 description: Cross-Venture Codebase Audit
-version: 1.1.0
+version: 1.1.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/go-live/SKILL.md
+++ b/.agents/skills/go-live/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: go-live
 description: Launch a venture to production with mandatory secret rotation and readiness checks.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: captain
 status: draft

--- a/.agents/skills/heartbeat/SKILL.md
+++ b/.agents/skills/heartbeat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: heartbeat
 description: Send a heartbeat to prevent your session from timing out.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: captain
 status: draft

--- a/.agents/skills/nav-spec/SKILL.md
+++ b/.agents/skills/nav-spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nav-spec
 description: "Authors and enforces `.design/NAVIGATION.md` — the per-venture three-layer navigation specification (IA + patterns + chrome). Anchors to NN/g, Material Design 3, Apple HIG, and Dan Brown's 8 IA principles. v3 ships as a **challenger, not a chooser**: citation-anchored disqualifier conditions (R25) refuse patterns that contradict the task model, and an authoring-direction lint (R26) prevents Sections 1–4 from ratifying shipped chrome."
-version: 3.0.1
+version: 3.0.2
 scope: global
 owner: agent-team
 status: stable
@@ -24,6 +24,8 @@ depends_on:
   commands: [python3]
 ---
 
+# /nav-spec - Nav Spec Authority (v3)
+
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 > **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
@@ -32,8 +34,6 @@ depends_on:
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
-
-# /nav-spec - Nav Spec Authority (v3)
 
 You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.
 

--- a/.agents/skills/new-client/SKILL.md
+++ b/.agents/skills/new-client/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-client
 description: Adds a client entity under the SS venture. A client is the billing entity; engagements (the unit of work) live underneath.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: agent-team
 status: draft

--- a/.agents/skills/new-engagement/SKILL.md
+++ b/.agents/skills/new-engagement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-engagement
 description: Creates a new engagement repo under an existing client and wires it into the launcher. An engagement is the unit of billable work for a client.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: agent-team
 status: draft

--- a/.agents/skills/new-venture/SKILL.md
+++ b/.agents/skills/new-venture/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-venture
 description: Set Up a New Venture
-version: 1.0.0
+version: 1.1.0
 scope: enterprise
 owner: agent-team
 status: stable
@@ -61,7 +61,9 @@ DRY_RUN=true ./scripts/setup-new-venture.sh {venture-code} {github-org} {install
 The script handles:
 
 - GitHub repo creation and structure
-- Standard labels and project board
+- Standard labels and project board (incl. `force-close`, `closed-with-unmet-ac`, `scope-deferred` for AC enforcement)
+- AC-tick workflow callers (`tick-acs-on-merge.yml`, `unmet-ac-on-close.yml`) pointing at `crane-console@tick-acs-v1`
+- Canonical PR template with `## Acceptance criteria status` section (parsed by the AC-tick workflow on merge)
 - Venture registry (`config/ventures.json`) - single source of truth
 - crane-context venture registry
 - crane-watch installation ID

--- a/.agents/skills/operator-onboard/SKILL.md
+++ b/.agents/skills/operator-onboard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: operator-onboard
 description: Authors a validated Operator customer.yaml + onboarding plan from a client-interview transcript. Captain-side; extractive, non-provisioning, non-committing.
-version: 0.2.0
+version: 0.2.1
 scope: enterprise
 owner: captain
 status: draft

--- a/.agents/skills/own-it/SKILL.md
+++ b/.agents/skills/own-it/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: own-it
 description: Forces professional decision-making. Claude decides instead of punting to the Captain, partners with a peer agent when genuinely stuck (never escalates), holds professional rigor for venture + enterprise health, finishes in-session with no loose ends, avoids theater. Invoke when about to ask the Captain a judgment call Claude can make itself, file a follow-up for work that could be finished now, defer substance to "Captain input," or engage in ceremony that doesn't move the venture forward. Also triggers when the Captain invokes with "what's the professional thing to do here" or similar.
-version: 1.0.0
+version: 1.0.1
 scope: global
 owner: captain
 status: stable
 ---
 
-> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "own-it")`. Non-blocking - if it fails, log and continue.
-
 # /own-it - Own the decision, own the finish
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "own-it")`. Non-blocking - if it fails, log and continue.
 
 You are running this skill because you were about to punt - or because the Captain just called you on it.
 

--- a/.agents/skills/platform-audit/SKILL.md
+++ b/.agents/skills/platform-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: platform-audit
 description: Platform Audit
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/portfolio-review/SKILL.md
+++ b/.agents/skills/portfolio-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: portfolio-review
 description: Portfolio Status Review
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/prd-review/SKILL.md
+++ b/.agents/skills/prd-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prd-review
 description: Multi-Agent PRD Review
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/product-design/SKILL.md
+++ b/.agents/skills/product-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: product-design
 description: Produces production-ready Astro/React components in a venture's own repo from the harness inputs (nav-spec, design system, UX brief). Runs a simple loop — assemble prompt from specs and existing component source → generate component → build (npm/pnpm/yarn auto-detected from lockfile) → validate.py → land. On greenfield surfaces (no file at target component path, no `--revise`), first invokes the `frontend-design` plugin to produce a per-surface composition reference within the venture's locked design language; the reference is appended to prompt-assembly as block 7-bis. Components drop into src/components/..., pages stay hand-wired. Invoke when the Captain asks to design, generate, revise, or build product UI for any venture.
-version: 1.1.0
+version: 1.1.1
 scope: global
 owner: agent-team
 status: stable
@@ -23,6 +23,8 @@ depends_on:
   commands: [python3]
 ---
 
+# /product-design — Product UI realization
+
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
 
 > **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
@@ -31,8 +33,6 @@ depends_on:
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
-
-# /product-design — Product UI realization
 
 You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.
 

--- a/.agents/skills/save-lesson/SKILL.md
+++ b/.agents/skills/save-lesson/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: save-lesson
 description: Capture a memoryable lesson or anti-pattern from the current session into the enterprise memory system (VCMS). Agent drafts frontmatter from session context; Captain confirms before save.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable
@@ -116,7 +116,7 @@ venture: { the venture code, e.g. "ss" — REQUIRED when scope is venture:<code>
 owner: captain
 status: draft
 captain_approved: false
-version: 1.0.0
+version: 1.0.1
 severity: { if anti-pattern }
 applies_when: { inferred }
 supersedes_source: { if applicable }

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship
 description: Ship to Production
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/skill-audit/SKILL.md
+++ b/.agents/skills/skill-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-audit
 description: Monthly skill health report. Audits all SKILL.md files for schema gaps, staleness, and deprecation queue status.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/skill-review/SKILL.md
+++ b/.agents/skills/skill-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-review
 description: Lint a skill or the entire repo against the governance schema. Reports frontmatter conformance, dispatcher parity, reference validity, structural lint, and deprecation sanity violations.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/skunkworks/SKILL.md
+++ b/.agents/skills/skunkworks/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skunkworks
 description: Loads the operating stance for a live, high-stakes operation - understand the mission before acting, take a stand and commit, move with caution-then-speed without guessing or cutting corners, and own the outcome end to end. Invoke when the Captain says "skunkworks," when you're entering or resetting your stance for a fast-moving multi-step operation, or when you catch yourself drifting into passive task-taking under real stakes. Distinct from /own-it, which is for a single decision; /skunkworks sets your stance for a whole operation.
-version: 1.0.0
+version: 1.0.1
 scope: global
 owner: captain
 status: stable

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: status
 description: Display current session state, tasks, and git status for situational awareness.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: captain
 status: draft

--- a/.agents/skills/ui-drift-audit/SKILL.md
+++ b/.agents/skills/ui-drift-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-drift-audit
 description: Source-level UI drift audit. Counts visual-design anti-patterns (pills, typography, spacing, headings, primary CTAs, redundancy, token-compliance) across .astro/.tsx/.jsx files and emits a markdown matrix or JSON.
-version: 2.2.1
+version: 2.2.2
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/update/SKILL.md
+++ b/.agents/skills/update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update
 description: Update your session with current branch, commit, and work metadata.
-version: 0.1.0
+version: 0.1.1
 scope: enterprise
 owner: captain
 status: draft

--- a/.agents/skills/verify-audit/SKILL.md
+++ b/.agents/skills/verify-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verify-audit
 description: Weekly audit over the verify_ledger. Surfaces coverage gaps, override frequency, integrity samples, truncation drift, source distribution, and recurring-command memory candidates. Read-only by default; --apply drafts memory lessons.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: captain
 status: stable

--- a/.agents/skills/video-build/SKILL.md
+++ b/.agents/skills/video-build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: video-build
 description: Scaffolds a videos/<slug> Remotion composition, locks beat timing via Whisper forced alignment, and renders the explainer.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/video-package/SKILL.md
+++ b/.agents/skills/video-package/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: video-package
 description: Packages a final render for publishing — SRT captions, YouTube chapters, youtube.md, and thumbnail candidates.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/video-publish/SKILL.md
+++ b/.agents/skills/video-publish/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: video-publish
 description: Uploads a packaged explainer to the @venturecrane YouTube channel via Playwright and wires bidirectional cross-promotion with venturecrane.com.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.agents/skills/video-script/SKILL.md
+++ b/.agents/skills/video-script/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: video-script
 description: Drafts a house-format 6-beat narration script with visual notes and alignment anchors, from a topic or a vc-web article. Input to /video-build.
-version: 1.0.0
+version: 1.0.1
 scope: enterprise
 owner: agent-team
 status: stable

--- a/.claude/commands/analytics.md
+++ b/.claude/commands/analytics.md
@@ -1,5 +1,7 @@
 # /analytics - Site Traffic Report
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "analytics")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
 
 ## Usage

--- a/.claude/commands/auth-setup.md
+++ b/.claude/commands/auth-setup.md
@@ -1,5 +1,7 @@
 # /auth-setup - Set up Clerk + Playwright auth bootstrap for a venture
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auth-setup")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Wires up `@clerk/testing/playwright` so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes **without manual login**.
 
 Solves the recurring pain: "agent gets hung up needing manual login to test."

--- a/.claude/commands/auto-build.md
+++ b/.claude/commands/auto-build.md
@@ -1,5 +1,7 @@
 # /auto-build - Vetted plan-and-execute workflow
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auto-build")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
 
 The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.

--- a/.claude/commands/calendar-sync.md
+++ b/.claude/commands/calendar-sync.md
@@ -1,5 +1,7 @@
 # /calendar-sync - Calendar Sync
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "calendar-sync")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 
 ## Usage

--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,5 +1,7 @@
 # /code-review - Codebase Review
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "code-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Deep codebase review with multi-model perspectives. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
 
 ## Arguments

--- a/.claude/commands/content-scan.md
+++ b/.claude/commands/content-scan.md
@@ -1,5 +1,7 @@
 # /content-scan - Content Candidate Triage
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "content-scan")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Read-only triage tool that scans all ventures for publishable content candidates. Produces a ranked list of article candidates, promotion candidates, and build log gaps. Does NOT draft anything — drafting is done directly by an agent against the terminology doc, then reviewed via `/edit-log`.
 
 ## Usage

--- a/.claude/commands/context-refresh.md
+++ b/.claude/commands/context-refresh.md
@@ -1,6 +1,10 @@
 # /context-refresh - Enterprise Context Refresh
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "context-refresh")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Audit and update all enterprise context: D1 docs, VCMS executive summaries, and venture metadata. Produces a refresh report and records cadence completion.
+
+> **Note:** Steps 1 and 2 (doc audit + auto-regen) also run automatically as a side effect of `/sos` when invoked from crane-console and the cadence item is due/overdue. Invoke `/context-refresh` explicitly when you want to review executive summaries (Step 3) or ventures.json drift (Step 4), both of which require Captain approval and can't safely auto-run.
 
 ## Arguments
 

--- a/.claude/commands/docs-audit.md
+++ b/.claude/commands/docs-audit.md
@@ -1,46 +1,93 @@
 # /docs-audit - Monthly Docs Site Drift Report
 
-Invoke the `crane_docs_drift_audit` MCP tool and walk through the report.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-audit")`. This is non-blocking — if the call fails, log the warning and continue.
 
-## How to run
+Run a drift audit across the site-published `docs/` directories that ship to the crane-command Starlight site. Surfaces broken internal references, references to deprecated entities, sidebar drift, and stale narrative content. Complements `/docs-refresh` (structural — TBDs, line counts) and `/context-refresh` (D1 sync, exec summaries) by catching semantic decay.
+
+## Usage
 
 ```
 /docs-audit
 ```
 
-This command:
+No arguments required. The audit walks every site-published directory under `docs/`.
 
-1. Calls `crane_docs_drift_audit()` with default parameters (`stale_threshold_days: 180`, `severity_filter: all`, full tree).
-2. Displays the structured report: Inventory → Drift Summary → Errors → Warnings → Info (grouped by type).
-3. Prompts you to review any flagged items.
-4. Records completion via `crane_schedule(action: "complete", name: "docs-audit", ...)`.
+## What it checks
 
-## What to expect
+| Check                         | Severity | What it surfaces                                                                                                 |
+| ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Dead internal links**       | ERROR    | Markdown links `[x](path.md)` whose target doesn't exist (AST-parsed, skips code blocks)                         |
+| **Broken `crane_doc()` refs** | ERROR    | `crane_doc('scope', 'name')` calls in CLAUDE.md, skills, commands, and docs whose target file is missing on disk |
+| **Deprecated skill mentions** | WARN     | Slash-form references like `/old-skill` to skills with `status: deprecated`                                      |
+| **Stale-by-git**              | INFO     | Site-published files untouched in git for > 180 days                                                             |
+| **Sidebar drift**             | INFO     | `astro.config.mjs` `autogenerate` directories that don't exist or are empty on disk                              |
+| **Captain-review candidates** | INFO     | Subset of stale-by-git: narrative content (no TBD/auto-gen markers) the audit can't verify                       |
 
-Six checks across site-published `docs/` directories:
+Self-diagnostic ERROR: if `astro.config.mjs` extraction returns zero `autogenerate` entries, the tool emits an `audit-tool-broken` ERROR rather than silently producing a clean report.
 
-- **Dead internal links** (ERROR) — `[x](path.md)` whose target is missing.
-- **Broken `crane_doc()` references** (ERROR) — calls whose target doc isn't on disk.
-- **Deprecated-skill mentions** (WARN) — slash-form references to retired skills.
-- **Stale-by-git** (INFO) — files untouched > 180 days.
-- **Sidebar drift** (INFO) — `astro.config.mjs` references vs. `docs/` reality.
-- **Captain-review candidates** (INFO) — narrative content the audit can't verify.
+## Workflow
 
-Self-diagnostic: if the sidebar parser returns zero entries, the tool emits an `audit-tool-broken` ERROR rather than silently producing a clean report.
+### Step 1: Run the audit
 
-## Cadence semantics
-
-Completion result is `success` whenever the audit runs cleanly, regardless of drift count. `failure` only on tool error or `audit-tool-broken`. Drift counts go in the summary field. This diverges from `/skill-audit` and `/memory-audit` semantics intentionally — conflating "audit ran" with "drift exists" degrades the cadence-engine signal.
-
-## Options
+Call the MCP tool:
 
 ```
-crane_docs_drift_audit(scope: "runbooks")              # one site-published subdir
-crane_docs_drift_audit(scope: "ventures/vc")           # one venture
-crane_docs_drift_audit(stale_threshold_days: 90)       # tighter staleness window
-crane_docs_drift_audit(severity_filter: "error")       # errors only
+crane_docs_drift_audit()
 ```
 
-## Full workflow
+Default parameters:
 
-See `.agents/skills/docs-audit/SKILL.md` for the complete step-by-step workflow including how to act on each finding category and the `success`/`failure` divergence rationale.
+- `stale_threshold_days`: 180
+- `severity_filter`: all
+- `scope`: undefined (walks every site-published subdir)
+
+Narrow the scope to a single directory if iterating on a specific area:
+
+```
+crane_docs_drift_audit(scope: "runbooks")
+crane_docs_drift_audit(scope: "ventures/vc")
+```
+
+### Step 2: Interpret the report
+
+**Errors** — block site truth. Each entry shows the file, line, and the broken reference. Fix in a PR; do not record completion until cleared (or accepted as known and tracked elsewhere).
+
+**Warnings** — deprecated-skill mentions. Either update the doc to reference the replacement skill, or — if the deprecated skill is being kept around — note the exception. Open a PR with the fixes.
+
+**Info findings** — read for signal, no immediate action required.
+
+- _Stale-by-git_: a file hasn't been touched in 180+ days. May still be accurate; the audit can't tell.
+- _Captain-review candidates_: a Captain-only check. The audit flags narrative content untouched > threshold for human verification of accuracy.
+- _Sidebar drift_: `astro.config.mjs` references a directory that's missing or empty. Either fix the config or restore the directory.
+
+If you see `audit-tool-broken`, treat the report as incomplete. Fix the self-diagnostic before trusting other findings.
+
+### Step 3: Record completion
+
+```
+crane_schedule(
+  action: "complete",
+  name: "docs-audit",
+  result: "<success | failure>",
+  summary: "<N docs audited, X errors / Y warns / Z infos>"
+)
+```
+
+**Result mapping** (diverges from `/skill-audit` and `/memory-audit`):
+
+- `success` — the audit ran cleanly and produced a valid report. **Drift count does not affect the result.**
+- `failure` — only on tool error or `audit-tool-broken` self-diagnostic.
+
+This is intentional: conflating "audit ran" with "drift exists" trains operators to either ignore failures or rush to clear them. Drift counts go in the `summary` field where they belong.
+
+## Cadence
+
+Monthly cadence (`schedule_items` name: `docs-audit`). Surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- **Scope**: `docs/` in this repo only. Venture-repo READMEs and `.design/` files are out of scope (they have different decay modes; cross-repo audit is a separate concern).
+- **No auto-fix in v1**. The tool is report-only. Auto-fixing dead links is brittle (rename vs. delete is non-obvious); deprecated-mention rewriting risks losing context.
+- **Markdown parsing** uses the `remark` AST. Code blocks, inline code spans, and reference-style links are handled correctly.
+- **`astro.config.mjs` parsing** evaluates the config in a Node subprocess (`import()` ESM), not regex. Robust against config refactors.
+- **Git mtime** is collected via a single `git log` pass for the whole `docs/` tree, not per-file subprocesses.

--- a/.claude/commands/docs-refresh.md
+++ b/.claude/commands/docs-refresh.md
@@ -1,48 +1,121 @@
 # /docs-refresh - Enterprise Docs Refresh
 
-Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-refresh")`. This is non-blocking — if the call fails, log the warning and continue.
 
-## Arguments
+Refresh managed-block content on the crane-command site (`docs/ventures/<code>/{product-overview,roadmap}.md`). Companion to `/docs-audit` (which detects drift) — this is the appliance that closes the loop.
+
+The skill is a thin wrapper around `npm run docs-refresh -w @venturecrane/crane-mcp`. The CLI is deterministic Node.js — no LLM in the loop. It's safe to wire to a cron, and a weekly cron is already in `.github/workflows/docs-refresh.yml`.
+
+## Usage
 
 ```
-/docs-refresh [scope]
+/docs-refresh                        # audit mode (no writes)
+/docs-refresh <code>                 # refresh a venture's marked pages
+/docs-refresh <code>/<page>          # refresh a single page
+/docs-refresh <page-type>            # refresh page type across configured ventures
+/docs-refresh --init-markers <code>  # seed markers (first-run, gate-bypassed)
+/docs-refresh --dry-run <code>       # render but don't write
 ```
 
-- No argument: Audit mode - lists stale pages, does NOT modify files
-- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
-- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
-- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+Behind every form, the skill runs:
 
-## Execution
+```
+npm run docs-refresh -w @venturecrane/crane-mcp -- <args>
+```
 
-### Step 1: Audit
+## What it manages
 
-Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+Two page types carry markers in v1; metrics has no managed blocks (placeholder-preserving renderer is a no-op):
 
-**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+| Page type          | Markers                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `product-overview` | `activity-shipped` (last 5 merged feat: PRs)                                                                                                      |
+| `roadmap`          | `activity-current-focus` (status:in-progress issues), `activity-near-term` (status:ready issues), `activity-completed` (last 10 merged feat: PRs) |
+| `metrics`          | (none in v1)                                                                                                                                      |
 
-### Step 2: Gather Data
+Per-venture query strategy lives in `config/docs-refresh.json`. Adding a venture means adding an entry there with `primaryRepo` and `labels`, then running `/docs-refresh --init-markers <code>` to seed the markers.
 
-For pages in scope, pull from:
+## What it does NOT touch
 
-- **Overviews**: `config/ventures.json` + `docs/design/ventures/{code}/design-spec.md` + VCMS exec summaries
-- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
-- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+- **Build-time tokens** (`{{venture:CODE:FIELD}}`, `{{portfolio:table}}`, etc.). Those resolve in `site/scripts/sync-docs.mjs` at site build time and don't need a refresh step.
+- **Captain-curated narrative** (sections that aren't managed blocks). Refresh has a structural diff gate that aborts if anything outside marker pairs changes.
+- **Pages without markers.** Refresh warns-and-skips. Run `--init-markers <code>` first.
+- **Sections whose content is a table or prose** (not a bullet list). The `--init-markers` step refuses to wrap incompatible structure and reports a warning. Captain can normalize the page (e.g., convert a table to a bullet list under `## Near-term`) and re-run init.
 
-### Step 3: Draft
+## Workflow
 
-Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+### Audit a venture's pages
 
-### Step 4: Approve
+```
+/docs-refresh
+```
 
-Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+Prints per-page report: line count, markers present vs. expected, missing markers. No writes. Use this to triage.
 
-### Step 5: PR
+### Seed markers on a new venture
 
-Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+Add the venture to `config/docs-refresh.json`, then:
+
+```
+/docs-refresh --init-markers <code>
+```
+
+Inspect the diff before committing — `--init-markers` bypasses the structural gate (it has to, since markers don't exist yet). Warnings are emitted for any section that can't be safely wrapped (heading missing, content not a bullet list).
+
+### Refresh content from canonical sources
+
+```
+/docs-refresh <code>
+```
+
+Walks the venture's marked pages, fetches gh data per `config/docs-refresh.json`, replaces marker bodies, and runs the structural diff gate (asserts marker set is unchanged and outside-marker content is byte-equal). Aborts with a named violation if the gate fails.
+
+### Closed-loop weekly run
+
+`.github/workflows/docs-refresh.yml` runs the refresh weekly (Monday 13:17 UTC) for every venture in `config/docs-refresh.json` and opens a PR if the diff is non-empty. No manual invocation needed for ongoing maintenance — the loop is closed.
+
+## How the diff gate works
+
+After rendering, the CLI asserts:
+
+1. **Marker set equal across runs.** `parseMarkers(before).names === parseMarkers(after).names`. New marker insertion only happens via `--init-markers`.
+2. **Outside-marker content byte-equal.** The bytes outside any marker pair must be identical. This catches renderer overreach (e.g., accidentally rewriting prose adjacent to a marker).
+
+Gate failure exits 2 and names the violation. Init mode bypasses both checks.
+
+## Configuration
+
+`config/docs-refresh.json`:
+
+```json
+{
+  "ventures": {
+    "<code>": {
+      "primaryRepo": "venturecrane/<repo>",
+      "labels": { "in_progress": "status:in-progress", "ready": "status:ready" },
+      "shippedSearch": "feat: in:title"
+    }
+  },
+  "limits": { "shippedRecent": 5, "completedHistory": 10, "currentFocus": 10, "nearTerm": 10 }
+}
+```
+
+Both vc (in `crane-console`) and dfg (in `dfg-console`) use the same `status:` label vocabulary. If a venture uses different labels, override per-venture.
+
+## Failure modes
+
+| Condition                                    | Behavior                                   | Exit |
+| -------------------------------------------- | ------------------------------------------ | ---- |
+| `config/docs-refresh.json` missing           | Throw                                      | 1    |
+| Venture not in config                        | skip with reason                           | 0    |
+| Page missing all markers                     | skip with reason; suggest `--init-markers` | 0    |
+| Page missing some markers                    | refresh present markers; warn about absent | 0    |
+| Diff gate violation                          | Print named violation; exit 2              | 2    |
+| `gh` CLI failure                             | Throw with `gh` stderr                     | 1    |
+| Malformed marker (unclosed/nested/duplicate) | Throw with line number                     | 1    |
 
 ## Notes
 
-- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
-- After merge, Vercel auto-rebuilds the site
-- Quality bar: 0 unjustified TBDs, 20+ lines, real data
+- **Token vocabulary is unchanged.** `site/scripts/sync-docs.mjs` already supports every fact-zone field — `{{venture:CODE:FIELD}}` resolves both top-level and `portfolio.*` fields. No resolver extension was needed for v1.
+- **Only bullet-list sections are wrapped.** This is intentional. Tables and prose require Captain decisions about structure that the renderer can't safely make.
+- **Source code:** `packages/crane-mcp/src/cli/docs-refresh.ts` (44 unit + integration tests in the sibling `.test.ts`).

--- a/.claude/commands/edit-article.md
+++ b/.claude/commands/edit-article.md
@@ -1,5 +1,7 @@
 # /edit-article - Editorial Review Agent
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-article")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command runs an article through two parallel editor agents, applies blocking fixes directly, and reports what changed. Advisory issues are reported but not auto-fixed.
 
 ## Arguments
@@ -103,6 +105,10 @@ Read the article line by line. Check every line against the rules below. Report 
 
 **Founder-voice fabrication** - any sentence that puts words in the founder's mouth or manufactures a personal anecdote
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (should fix)
 
 - Public venture names per the tag-dependent rules above (suggest genericizing for focus where no matching tag exists)
@@ -111,6 +117,7 @@ Read the article line by line. Check every line against the rules below. Report 
 - Throat-clearing openers ("In this article, we will...", "Today we're going to...")
 - Marketing language (superlatives, hype, "revolutionary", "game-changing", etc.)
 - Register mismatch (article should be analytical/explanatory, not terse build-log voice)
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the article's title or H1 describe a Claude Code capability, workflow, or session? (2) Does the article already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### Output Format
 

--- a/.claude/commands/edit-log.md
+++ b/.claude/commands/edit-log.md
@@ -1,5 +1,7 @@
 # /edit-log - Build Log Editorial Review
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-log")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Single-agent editorial review for build logs. Checks genericization and style, auto-fixes blocking issues, reports advisory issues for human judgment.
 
 ## Arguments
@@ -107,6 +109,10 @@ For each blocking issue, provide:
 - venturecrane org -> Omit or "example-org"
 - Specific counts -> "multiple ventures" or "several projects"
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (report but don't auto-fix)
 
 - Public venture names per the tag-dependent rules above (not auto-fixed; suggest genericizing for focus)
@@ -114,6 +120,7 @@ For each blocking issue, provide:
 - Article-register voice: flag analytical or explanatory tone that reads like an article rather than an operational log. Build logs should feel like a field report, not an essay.
 - Numbers that might go stale: specific counts, percentages, or metrics that will become wrong over time
 - Article overlap: search the article index for keyword overlap with the log's content. If found, surface: "This log discusses [topic]. An article on this topic exists at [slug]. Verify consistency."
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the log's title describe a Claude Code capability, workflow, or session? (2) Does the log already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### NOT checked (explicitly out of scope)
 

--- a/.claude/commands/enterprise-review.md
+++ b/.claude/commands/enterprise-review.md
@@ -1,5 +1,7 @@
 # /enterprise-review - Cross-Venture Codebase Audit
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "enterprise-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Detects configuration drift, structural drift, and practice drift across all venture repos. Produces a consistency report stored in VCMS.
 
 **Must run from crane-console.** This command is not synced to venture repos.
@@ -78,6 +80,39 @@ for CODE in {TARGET_VENTURES}; do
   echo "-- commands --"
   ls "$REPO"/.claude/commands/*.md 2>/dev/null | xargs -I{} basename {} | sort
 
+  # Design-system adoption signals (Stream D1)
+  echo "-- design-system --"
+  TOKENS_DEP=N
+  CSS_IMPORT=N
+  CLAUDE_MD=N
+  AUDIT_YML=N
+
+  # 1. token-package consumed: package.json includes @venturecrane/tokens
+  if [ -n "$PKGJSON" ] && grep -q '"@venturecrane/tokens"' "$PKGJSON" 2>/dev/null; then
+    TOKENS_DEP=Y
+  fi
+
+  # 2. CSS imports the package: any *.css under common src roots imports @venturecrane/tokens/
+  for SRCDIR in "$REPO/src" "$REPO/app/src" "$REPO/web/src" "$REPO/app" "$REPO"; do
+    [ -d "$SRCDIR" ] || continue
+    if grep -rEl "@import\s+['\"]@venturecrane/tokens/" "$SRCDIR" --include='*.css' 2>/dev/null | head -1 | grep -q .; then
+      CSS_IMPORT=Y
+      break
+    fi
+  done
+
+  # 3. CLAUDE.md references design-system/patterns
+  if [ -f "$REPO/CLAUDE.md" ] && grep -q 'design-system/patterns' "$REPO/CLAUDE.md" 2>/dev/null; then
+    CLAUDE_MD=Y
+  fi
+
+  # 4. audit workflow wired
+  if [ -f "$REPO/.github/workflows/ui-drift-audit.yml" ]; then
+    AUDIT_YML=Y
+  fi
+
+  echo "[design-system] tokens-dep=$TOKENS_DEP import=$CSS_IMPORT claude-md=$CLAUDE_MD audit-yml=$AUDIT_YML"
+
   echo ""
 done
 ```
@@ -139,6 +174,36 @@ Cross-cutting issues that affect multiple ventures or represent enterprise-wide 
 - Missing enterprise standards (e.g., "3/5 repos missing security.yml workflow")
 - Practice drift (e.g., "only 2/5 repos have pre-commit hooks configured")
 
+**3e. Design System Compliance**
+
+Parse the `[design-system]` line emitted by Step 2 for each venture and build a 4-point compliance matrix. The four checks correspond to the [adoption runbook](../../../docs/design-system/adoption-runbook.md) "what 'compliant' means" definition:
+
+1. **Tokens-dep** — venture's `package.json` declares `@venturecrane/tokens` as a dependency (any version).
+2. **CSS-import** — at least one `*.css` file in the venture imports `@venturecrane/tokens/{code}.css` (or any path under that scope).
+3. **CLAUDE.md** — the venture's root `CLAUDE.md` references `design-system/patterns` (the canonical snippet block).
+4. **Audit-yml** — `.github/workflows/ui-drift-audit.yml` exists.
+
+Render a per-venture row with the four columns plus a total `N/4` and a tier-aware status:
+
+| Venture | Tokens-dep | CSS-import | CLAUDE.md | Audit-yml | Compliance  |
+| ------- | ---------- | ---------- | --------- | --------- | ----------- |
+| ss      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| dc      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| ke      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| vc      | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| sc      | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| dfg     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| dcm     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| smd     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+
+Status interpretation:
+
+- **4/4 ✓ COMPLIANT** — venture has fully adopted the enterprise design system.
+- **N/4 PARTIAL** — adoption is in progress; the missing column(s) name the next step (e.g., `3/4 PARTIAL — missing CLAUDE.md snippet`).
+- **0/4 PENDING_MIGRATION** — no signals present; venture has not started Stream C migration.
+
+A brownfield venture that has shipped its migration PR but only scores 3/4 is the highest-value drift signal — flag it loudly in 3d (Drift Hotspots) so the gap closes in the next session.
+
 ### Step 4: Store and Report
 
 **4a. VCMS Report**
@@ -150,7 +215,7 @@ Store concise report in VCMS using `crane_note`:
 - Venture: (omit - this is cross-venture)
 - Title: `Enterprise Review - {YYYY-MM-DD}`
 
-Content (under 500 words): date, ventures audited, version alignment summary, top 3-5 drift hotspots, overall consistency assessment.
+Content (under 500 words): date, ventures audited, version alignment summary, top 3-5 drift hotspots, **design-system compliance summary** (count of ventures at 4/4 vs partial vs 0/4, plus the names of any partial ventures and their missing columns), overall consistency assessment.
 
 **4b. Compare with Previous Review**
 
@@ -181,6 +246,9 @@ Present the full report inline (this is the primary output - no separate file si
 ### Commands Sync Status
 {table}
 
+### Design System Compliance
+{4-point matrix from 3e}
+
 ### Drift Hotspots
 {numbered list}
 
@@ -197,6 +265,7 @@ After displaying the report, suggest next steps:
 
 - If commands are out of sync: "Run `sync-commands.sh` to distribute missing commands."
 - If version drift detected: "Consider creating issues to align dependency versions."
+- If any venture is at a partial design-system compliance score (1/4, 2/4, or 3/4): name the venture and the missing column(s) (e.g., "ke is 3/4 — missing CLAUDE.md snippet; copy the canonical block from `docs/design-system/adoption/claude-md-snippet.md`"). For ventures at 0/4, point at the [adoption runbook](../../../docs/design-system/adoption-runbook.md) without flagging — those are pending migration, not drift.
 
 Do NOT automatically take any action. Wait for the Captain.
 
@@ -232,6 +301,17 @@ crane_schedule(action: "complete", name: "enterprise-review", result: "success",
 - Security workflow present
 - Secret scanning configured (.gitleaks.toml)
 - Test framework configured
+
+### Design System Compliance
+
+The 4-point compliance matrix (Step 3e) measures Stream C migration status per venture:
+
+- `@venturecrane/tokens` package consumed (`package.json` dependency)
+- CSS imports the package (`@import '@venturecrane/tokens/{code}.css'`)
+- `CLAUDE.md` references `design-system/patterns` (canonical snippet wired)
+- `.github/workflows/ui-drift-audit.yml` workflow exists
+
+Per [adoption-runbook.md](../../../docs/design-system/adoption-runbook.md), a venture is COMPLIANT at 4/4. Brownfield ventures with shipped migration PRs scoring less than 4/4 are the highest-value drift signal — they shipped a migration but missed a step.
 
 ---
 

--- a/.claude/commands/go-live.md
+++ b/.claude/commands/go-live.md
@@ -1,5 +1,7 @@
 # /go-live - Venture Go-Live Process
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "go-live")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Launch a venture to production with mandatory secret rotation and readiness checks.
 
 ```

--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -1,5 +1,7 @@
 # /heartbeat - Keep Session Alive
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "heartbeat")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Send a heartbeat to prevent your session from timing out.
 
 ## What It Does

--- a/.claude/commands/nav-spec.md
+++ b/.claude/commands/nav-spec.md
@@ -1,3 +1,5 @@
+# /nav-spec - Nav Spec Authority (v3)
+
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 > **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
@@ -6,8 +8,6 @@
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
-
-# /nav-spec - Nav Spec Authority (v3)
 
 You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.
 

--- a/.claude/commands/new-client.md
+++ b/.claude/commands/new-client.md
@@ -1,5 +1,7 @@
 # /new-client - Set Up a New SS Client
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-client")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Adds a client entity under the SS venture. A client is the billing entity; engagements (the unit of work) live underneath.
 
 This is **wiring**, not process — no SOW, kickoff, lifecycle states, or templates. Just the registry and Infisical entries needed for `/new-engagement` to work for that client.

--- a/.claude/commands/new-engagement.md
+++ b/.claude/commands/new-engagement.md
@@ -1,5 +1,7 @@
 # /new-engagement - Set Up a New SS Engagement
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-engagement")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Creates a new engagement repo under an existing client and wires it into the launcher. An engagement is the unit of billable work for a client.
 
 This is **wiring**, not process — no SOW scaffolding, kickoff documents, status reporting cadence, or lifecycle states. The agent inside the engagement repo writes whatever the engagement actually needs.

--- a/.claude/commands/new-venture.md
+++ b/.claude/commands/new-venture.md
@@ -1,5 +1,7 @@
 # /new-venture - Set Up a New Venture
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-venture")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command walks through setting up a new venture with Crane infrastructure.
 
 ## Prerequisites (Manual)
@@ -72,6 +74,7 @@ After the script completes, walk through remaining manual steps from the checkli
 4. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
 5. **Monitoring** (Phase 4.6) - Sentry, uptime checks
 6. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
+7. **Claude Design onboarding** (Phase 3.8) - create a named design system in claude.ai/design, link the recommended subdirectory, seed with the venture's `design-spec.md`. Full steps in `docs/runbooks/claude-design-enterprise-setup.md`; context in `docs/instructions/claude-design.md`.
 
 ### Step 5: Update CLAUDE.md
 

--- a/.claude/commands/operator-onboard.md
+++ b/.claude/commands/operator-onboard.md
@@ -5,6 +5,8 @@ description: Authors a validated Operator customer.yaml + onboarding plan from a
 
 # /operator-onboard - Author an Operator config from a client interview
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "operator-onboard")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns an initial client-interview transcript or notes into two artifacts under the
 venture repo's `operator/customers/<slug>/`:
 

--- a/.claude/commands/own-it.md
+++ b/.claude/commands/own-it.md
@@ -1,5 +1,7 @@
 # /own-it - Own the decision, own the finish
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "own-it")`. Non-blocking - if it fails, log and continue.
+
 You are running this skill because you were about to punt - or because the Captain just called you on it.
 
 The Captain's language, distilled:
@@ -108,3 +110,15 @@ If after running this skill you still believe the question is legitimately Capta
 > **Default if no response:** _<what you will proceed with>_
 
 The "default if no response" line is mandatory. It is the forcing function: if you can name the default, you can just do it.
+
+## Related memory
+
+This skill consolidates recurring feedback captured in auto-memory. Existing entries reinforce specific facets:
+
+- `feedback_kill_dont_file.md` - rule 4 (no follow-up tickets for speculative work).
+- `feedback_critique_deferrals.md` - rule 4 (critique deferrals are not the answer).
+- `feedback_no_human_ergonomics_arguments.md` - rule 3 (agents write the code; valid reasons are determinism/cost/parallelism).
+- `feedback_agents_produce_content.md` - rule 1 (don't defer content to "Captain input").
+- `feedback_verify_root_cause_before_fixing.md` - rule 3 (fix root causes, not symptoms).
+
+When this skill fires, it takes precedence over isolated interpretations of those memories.

--- a/.claude/commands/platform-audit.md
+++ b/.claude/commands/platform-audit.md
@@ -1,5 +1,7 @@
 # /platform-audit - Platform Audit
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "platform-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
 
 ## Scope

--- a/.claude/commands/portfolio-review.md
+++ b/.claude/commands/portfolio-review.md
@@ -1,5 +1,7 @@
 # /portfolio-review - Portfolio Status Review
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "portfolio-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Review and update venture portfolio data. Collects live signals, compares against current records, and presents changes for Captain approval.
 
 ## Status Taxonomy

--- a/.claude/commands/prd-review.md
+++ b/.claude/commands/prd-review.md
@@ -1,5 +1,7 @@
 # /prd-review - Multi-Agent PRD Review
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "prd-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command orchestrates a 6-agent PRD review process with configurable rounds. It reads existing source documents, runs structured critique rounds with parallel agents, and synthesizes the output into a production-ready PRD.
 
 Works in any venture console that has the required source documents.

--- a/.claude/commands/product-design.md
+++ b/.claude/commands/product-design.md
@@ -1,3 +1,5 @@
+# /product-design — Product UI realization
+
 > **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
 
 > **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
@@ -6,8 +8,6 @@
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
-
-# /product-design — Product UI realization
 
 You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.
 
@@ -61,6 +61,9 @@ Five steps. Every generation follows this shape. Do not add steps without Captai
 
 1. **Assemble prompt.** See [references/prompt-assembly.md](references/prompt-assembly.md) for exactly what goes into the prompt and in what order. Inputs: nav-spec surface-class appendix, DESIGN.md or @theme tokens, UX brief section for this surface, five-tag classification (`surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`), adapter template, **raw source of every file under the venture's `src/components/**`\*\*. No registry. No AST. Let Claude read the component source directly.
 2. **Generate code.** Use the Write tool to produce the component file at its target path in the venture repo.
+
+   **Greenfield branch.** If no file exists at the target component path AND `--revise` was not passed, the workflow first invokes `Skill(frontend-design:frontend-design)` to produce a per-surface composition reference within the venture's locked design language (no new fonts, colors, or spacing — just composition exploration). The reference is captured as HTML and appended to the prompt-assembly as block 7-bis ("Aesthetic reference"); the in-loop generator then produces the Astro component as usual. Existing files and `--revise` invocations skip this branch entirely. See [references/frontend-design-handoff.md](references/frontend-design-handoff.md) for the seed prompt and constraints.
+
 3. **Build check.** Run the venture's build command (detected from lockfile — see package-manager note above). If it fails: read the compile errors, append to the prompt, regenerate. Max one retry.
 4. **Structural validate.** If a preview route is wired for this surface, extract the rendered HTML and run `~/.agents/skills/nav-spec/validate.py --file <html> --surface <tag> --archetype <tag> --viewport <tag> --task <tag> --pattern <tag> --spec <path-to-NAVIGATION.md>`. If structural violations: append to prompt, regenerate. Max one retry. If no preview route exists for this surface yet, skip — validator runs after the Captain promotes.
 5. **Land.** The component file is in place. Report to the Captain: file path, how to preview (the venture's dev command → `/design-preview/<surface>`), and anything you iterated on. Done.
@@ -98,6 +101,7 @@ If a preview route for the requested surface doesn't exist yet, the skill create
 - `design-brief` — PRD → design charter (upstream)
 - `nav-spec` — IA + patterns + chrome authority (sibling; structural authority)
 - `ux-brief` — three-reviewer surface-level UX brief (upstream)
+- `frontend-design` (Anthropic plugin) — per-surface composition reference generator on greenfield runs (sibling; aesthetic exploration within locked design language)
 
 ## Known limits (v1)
 

--- a/.claude/commands/save-lesson.md
+++ b/.claude/commands/save-lesson.md
@@ -1,6 +1,10 @@
 # /save-lesson - Capture Session Lesson
 
-Capture a memoryable lesson or anti-pattern from the current session into the enterprise memory system. Agent drafts frontmatter and body from session context; Captain confirms before the note is written.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "save-lesson")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Capture a memoryable lesson or anti-pattern from this session into the enterprise memory system. Agent drafts the memory; Captain confirms before it is written.
+
+After filing runs `/eos`, the recommended capture path for routine session learning is the "Memoryable moments?" step at session close. Use `/save-lesson` when you want to capture something immediately, mid-session, without waiting for `/eos`.
 
 ## Usage
 
@@ -8,22 +12,115 @@ Capture a memoryable lesson or anti-pattern from the current session into the en
 /save-lesson [optional one-line summary]
 ```
 
-If a summary is omitted, the agent drafts one from recent session context.
+## Execution Steps
 
-## What it does
+### Step 1: Telemetry
 
-1. Infers `kind` (lesson vs anti-pattern), `scope`, and `applies_when` from session context.
-2. Drafts a 1-2 sentence body and shows it to you for confirmation.
-3. Applies the 3 memoryability tests (actionable, non-obvious, general enough to recur).
-4. Saves to VCMS with `status: draft, captain_approved: false`.
-5. Reports the saved note ID.
+Call `crane_skill_invoked(skill_name: "save-lesson")`.
 
-Draft memories become injection-eligible only after Captain approval via `/memory-audit` or `crane_memory(update)`. For immediate `captain_approved: true` capture, use the "Memoryable moments?" step in `/eos`.
+### Step 2: Parse arguments
 
-## Examples
+Parse `$ARGUMENTS` as an optional one-line summary.
+
+- If a summary is provided, use it as the seed for the draft body.
+- If empty, scan the last 10 messages of the session transcript for the most operationally significant event — a correction made, an unexpected failure, a gotcha discovered, an anti-pattern avoided. Draft a one-line summary from that context.
+
+### Step 3: Infer frontmatter from session context
+
+Infer the following fields from the session transcript and environment:
+
+**kind** — default `lesson`. Use `anti-pattern` if the summary contains "don't", "never", "avoid", "stop", or "do not".
+
+**scope** — default `enterprise`. Use `venture:<code>` for any rule that only applies inside one venture, including: marketing voice and positioning, business-model rules, page-level copy patterns, and venture-specific code (API contracts, data models). Use `global` if the learning applies outside the Venture Crane enterprise (e.g., a third-party tool gotcha).
+
+**Why scope matters:** the SOS injection path filters by `scope === 'enterprise' || scope === 'global' || scope === 'venture:<active_venture>'` (`packages/crane-mcp/src/tools/memory.ts` recall path). An enterprise-scoped memory surfaces in **every** venture's session. A SMD-positioning rule filed at `enterprise` scope will inject into KE/VC/SC/etc sessions where it does not apply. When in doubt about whether a rule generalizes across ventures, narrow to `venture:<code>` — Captain can promote it to `enterprise` later via `/memory-audit`.
+
+**severity** — required only for `anti-pattern`. Infer:
+
+- `P0` — data loss, security exposure, or production outage risk
+- `P1` — significant wasted time or correctness risk
+- `P2` — workflow friction
+
+**applies_when.skills** — list any skill names mentioned or invoked in the relevant session window (e.g., `["eos", "ship"]`). Omit if no specific skills are relevant.
+
+**applies_when.commands** — list any CLI commands prominent in the relevant context (e.g., `["git", "wrangler"]`). Omit if none.
+
+**applies_when.files** — list abbreviated stems of file paths touched in the relevant session window (e.g., `[".infisical*", "wrangler.toml"]`). Omit if none.
+
+**supersedes_source** — if the lesson was derived from a specific retrospective or incident file, include its path.
+
+### Step 4: Draft body
+
+Write 1-2 sentences:
+
+1. What to do (or not do) — concrete and actionable.
+2. Why — the failure mode or benefit this rule prevents or produces.
+
+Show the full proposed memory to the Captain for confirmation:
 
 ```
-/save-lesson
-/save-lesson "parallel agents writing to the same branch collide — always use worktrees"
-/save-lesson "never run infisical secrets -o json — it dumps plaintext values into the transcript"
+Proposed memory:
+  kind: {kind}
+  scope: {scope}
+  severity: {P0/P1/P2 or omitted}
+  applies_when: {json summary}
+  body: "{draft body}"
+
+Save this memory? (y/n)
 ```
+
+Wait for Captain response before proceeding.
+
+### Step 5: Apply the 3 memoryability tests
+
+Before calling save, verify all three tests hold:
+
+1. **Actionable** — tells a future agent what to do or avoid, not how someone felt.
+2. **Non-obvious** — not derivable from reading the codebase or default Claude reasoning.
+3. **General enough to recur** — applies to a class of situations, not a single accident.
+
+If any test fails, report which one failed and explain why, then suggest a refinement. Do not proceed to save until the draft passes all three or the Captain explicitly overrides.
+
+### Step 5b: Scope/name consistency check
+
+Before calling save, verify both:
+
+1. **If `scope: enterprise` or `global`:** the proposed `name` must NOT encode a single venture's code (current codes: `vc`, `sc`, `dfg`, `ke`, `smd`, `ss`, `dc`) as a prefix or suffix (e.g., `ke-`, `ss-`, `-for-ke`, `-for-ss`). The name should be venture-agnostic. If the rule truly applies cross-venture, the name must read as such.
+2. **If `scope: venture:<code>`:** the `venture` field (passed to `crane_memory(action: 'save')`) must equal `<code>`. Both fields populated, both consistent.
+
+If a venture marker appears in the name despite an enterprise scope, either rename (drop the marker) or rescope (narrow to `venture:<code>`). Mismatched name and scope is the failure mode that surfaces SMD-positioning rules in KE sessions.
+
+### Step 6: Save
+
+Call `crane_memory(action: 'save', ...)` with:
+
+```yaml
+name: { kebab-case from body; strip venture markers if scope is enterprise or global }
+description: { one-sentence purpose, same as body sentence 1 }
+kind: { inferred kind }
+scope: { inferred scope }
+venture: { the venture code, e.g. "ss" — REQUIRED when scope is venture:<code>; omit otherwise }
+owner: captain
+status: draft
+captain_approved: false
+version: 1.0.1
+severity: { if anti-pattern }
+applies_when: { inferred }
+supersedes_source: { if applicable }
+last_validated_on: { today ISO date }
+```
+
+Note: `/save-lesson` always saves `status: draft, captain_approved: false`. The `/eos` path is the only path that creates `captain_approved: true` memories at write time. Captain promotes drafts to injection-eligible via the weekly `/memory-audit` review flow.
+
+### Step 7: Report
+
+```
+Memory saved (draft).
+ID: {note_id}
+Kind: {kind} | Scope: {scope} | Status: draft
+To promote for always-on SOS injection: approve via /memory-audit or crane_memory(update, id, captain_approved: true)
+```
+
+## Key Principle
+
+Zero nagging. If the Captain declines the proposed memory (Step 4 response is "n"), stop immediately. Do not re-propose or suggest alternatives. The session learning was considered and the Captain chose not to file it — that is a valid answer.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,7 @@
 # /ship - Ship to Production
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ship")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Commit, push, PR, CI, merge, and confirm deployment - all in one shot. Follows enterprise rules (branch, PR, CI) but executes the full pipeline without stopping.
 
 ```

--- a/.claude/commands/skill-audit.md
+++ b/.claude/commands/skill-audit.md
@@ -9,42 +9,82 @@ status: stable
 
 # /skill-audit - Monthly Skill Health Report
 
-Invoke the `crane_skill_audit` MCP tool and walk through the report.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-## How to run
+Run a repo-wide audit of every SKILL.md in the enterprise and global skill libraries. The report surfaces schema gaps, stale skills, and zero-usage candidates.
+
+## Usage
 
 ```
 /skill-audit
 ```
 
-This command:
+No arguments required. The audit runs across all scopes by default.
 
-1. Calls `crane_skill_audit()` with default parameters (`scope: all`, `stale_threshold_days: 180`, `include_deprecated: true`).
-2. Displays the structured report with sections for inventory, schema gaps, staleness, and the deprecation queue.
-3. Prompts you to review any flagged items.
-4. Records completion via `crane_schedule(action: "complete", name: "skill-audit", ...)`.
+## What it checks
 
-## What to expect
+| Section         | What it surfaces                                                                                                      |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Inventory**   | Total skill count, broken down by scope, status, and owner                                                            |
+| **Schema gaps** | Skills missing one or more required frontmatter fields (`name`, `description`, `version`, `scope`, `owner`, `status`) |
+| **Staleness**   | Skills whose `SKILL.md` has not been touched in git for more than 180 days                                            |
+| **Zero-usage**  | Skills with zero invocations in the last 90 days — retirement candidates                                              |
 
-The report contains four sections:
+Reference drift (broken `depends_on.mcp_tools`, `depends_on.files`, `depends_on.commands`) is NOT included in this tool - it requires invoking the `skill-review` CLI which cross-checks against live manifests. Run `/skill-review --all` for reference-drift details.
 
-- **Inventory** - Total skills by scope, status, and owner.
-- **Schema gaps** - Skills missing required frontmatter fields. Each entry shows which fields are missing.
-- **Staleness** - Skills not touched in git for more than 180 days, sorted worst-first.
-- **Deprecation queue** - Skills with `status: deprecated`, sorted by days until sunset.
+## Workflow
 
-Reference drift checking (broken MCP tool / file / command references) is not included here. Run `/skill-review --all` separately for that.
+### Step 1: Run the audit
 
-## Options
-
-You can customize the audit:
+Call the MCP tool:
 
 ```
-crane_skill_audit(scope: "enterprise")          # enterprise skills only
-crane_skill_audit(stale_threshold_days: 90)     # tighter staleness window
-crane_skill_audit(include_deprecated: false)    # exclude deprecated from counts
+crane_skill_audit()
 ```
 
-## Full workflow
+Default parameters:
 
-See `.agents/skills/skill-audit/SKILL.md` for the complete step-by-step workflow including how to act on each report section and record completion.
+- `scope`: `all` (enterprise + global)
+- `stale_threshold_days`: 180
+
+You can narrow the scope:
+
+```
+crane_skill_audit(scope: "enterprise", stale_threshold_days: 90)
+```
+
+### Step 2: Interpret the report
+
+**Inventory** - Review the totals. A healthy library has no skills in `unknown` status. Skills in `draft` for more than 30 days should be reviewed.
+
+**Schema gaps** - Each entry names the skill and the missing fields. Schema gaps should be fixed before the skill is marked `stable`. Open a PR to fill them.
+
+**Staleness** - Skills not touched in 180+ days may be outdated. Review each:
+
+- If the skill is still accurate: touch the file (whitespace-only commit) to reset the clock.
+- If the skill is obsolete: get Captain directive, then open a PR that deletes the SKILL.md, dispatcher, `config/skill-owners.json` entry, and any code references.
+
+**Zero-usage candidates** - Skills with zero invocations in 90 days. Either the skill isn't calling `crane_skill_invoked` (fix the SKILL.md), or it's genuinely unused. For genuine orphans, get Captain directive and retire in a single PR.
+
+### Step 3: Record completion
+
+After reviewing the report and taking any required actions, record the audit as complete:
+
+```
+crane_schedule(
+  action: "complete",
+  name: "skill-audit",
+  result: "success",
+  summary: "<one-line summary, e.g. '18 skills audited, 2 stale flagged, 0 schema gaps'>"
+)
+```
+
+## Cadence
+
+This skill is on a monthly cadence (`schedule_items` name: `skill-audit`). It surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- Staleness is derived from `git log -1 --format=%cI -- <path>`. Files never committed show as `last_touched: unknown` and are treated as maximally stale.
+- Skills with `backend_only: true` still appear in the audit - they just have no dispatcher parity requirement.
+- This tool does not modify any SKILL.md. It is read-only.

--- a/.claude/commands/skill-review.md
+++ b/.claude/commands/skill-review.md
@@ -9,39 +9,156 @@ status: stable
 
 # /skill-review
 
-Lint a skill directory or all skills against the schema in `docs/skills/governance.md`.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-## Usage
+Lint a skill directory (or all skills) against the governance schema defined in `docs/skills/governance.md`. Surfaces violations as structured output and exits non-zero in strict mode if any errors are found.
 
-```
-/skill-review [skill-name] [--strict]
-```
+## Behavior
 
-- `/skill-review` - review all skills in advisory mode (always exits 0)
-- `/skill-review sos` - review the `sos` skill only
-- `/skill-review --strict` - review all skills, exit 1 on errors
-- `/skill-review sos --strict` - review `sos`, exit 1 on errors
+The skill delegates to the CLI at `packages/crane-mcp/src/cli/skill-review.ts`. It is the creation/change gate — run it before flipping `status: stable` and opening a PR. CI runs it in advisory mode on every PR that touches `.agents/skills/**`.
 
-## What the Agent Does
-
-When you invoke `/skill-review`, the agent runs:
+### Invocation
 
 ```bash
-# Single skill
+# Review a single skill
 npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
 
-# All skills
-npm run skill-review -w @venturecrane/crane-mcp -- --all [--strict] [--json]
+# Review all skills (advisory — exits 0 regardless of findings)
+npm run skill-review -w @venturecrane/crane-mcp -- --all
+
+# Review all skills, block on errors (CI strict mode)
+npm run skill-review -w @venturecrane/crane-mcp -- --all --strict
+
+# Machine-readable JSON output
+npm run skill-review -w @venturecrane/crane-mcp -- --all --json
+
+# Custom MCP tool manifest path
+npm run skill-review -w @venturecrane/crane-mcp -- --all --manifest config/mcp-tool-manifest.json
 ```
 
-The CLI builds from TypeScript, runs all five checks against each `SKILL.md`, then prints a human-readable report (or JSON with `--json`).
+### Flags
 
-## Output
+| Flag                | Default                         | Description                                                                |
+| ------------------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `--path <dir>`      | -                               | Review a single skill directory. Mutually exclusive with `--all`.          |
+| `--all`             | -                               | Review every skill in `.agents/skills/`. Mutually exclusive with `--path`. |
+| `--strict`          | advisory (exit 0)               | Exit 1 if any `error` violations are found.                                |
+| `--json`            | human-readable                  | Emit machine-readable JSON report.                                         |
+| `--manifest <path>` | `config/mcp-tool-manifest.json` | Path to MCP tool manifest used for `mcp_tools` validation.                 |
 
-Human-readable (default):
+## Rule Categories
+
+Five rule categories are checked. Each violation has a `severity` of `error`, `warning`, or `info`.
+
+### 1. Frontmatter Conformance (`frontmatter.*`)
+
+Validates the YAML frontmatter block at the top of each `SKILL.md`.
+
+Required fields: `name`, `description`, `version`, `scope`, `owner`, `status`.
+
+Violation examples:
 
 ```
-Reviewed 12 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+
+ERROR [frontmatter.name-mismatch] .agents/skills/foo/SKILL.md: name "bar" does not match directory name "foo"
+  Fix: Set `name: foo` in frontmatter to match the skill directory.
+
+ERROR [frontmatter.invalid-semver] .agents/skills/foo/SKILL.md: version "1.0" is not valid semver (expected MAJOR.MINOR.PATCH)
+  Fix: Set version to a semver string, e.g. `version: 1.0.0`.
+
+ERROR [frontmatter.invalid-scope] .agents/skills/foo/SKILL.md: scope "vc" is invalid. Must be enterprise, global, or venture:<code>
+  Fix: Set scope to one of: `enterprise`, `global`, or `venture:<lowercase-code>` (e.g. `venture:ss`).
+
+ERROR [frontmatter.invalid-status] .agents/skills/foo/SKILL.md: status "beta" is invalid. Must be one of: draft, stable, deprecated
+  Fix: Set status to `draft`, `stable`, or `deprecated`.
+
+ERROR [frontmatter.unknown-owner] .agents/skills/foo/SKILL.md: owner "unknown-team" is not a known key in config/skill-owners.json
+  Fix: Add the skill under an existing owner key (captain, agent-team) in config/skill-owners.json, or add a new owner key.
+```
+
+### 2. Dispatcher Parity (`dispatcher.*`)
+
+Unless `backend_only: true` is set, every skill must have a matching `.claude/commands/<name>.md` command dispatcher.
+
+Violation example:
+
+```
+ERROR [dispatcher.missing-command-file] .agents/skills/foo/SKILL.md: No dispatcher found at .claude/commands/foo.md
+  Fix: Create .claude/commands/foo.md, or set `backend_only: true` in frontmatter if this skill has no slash command.
+```
+
+### 3. Reference Validity (`references.*`)
+
+Validates entries in `depends_on.mcp_tools`, `depends_on.files`, and `depends_on.commands`.
+
+- `mcp_tools`: each name must appear in `config/mcp-tool-manifest.json` (errors if manifest exists).
+- `files`: each entry must be scope-prefixed (`crane-console:`, `venture:`, or `global:`). Unprefixed paths are an error. `crane-console:` paths are resolved from repo root. `venture:` paths require `CRANE_VENTURE_SAMPLE_REPO` env var (warning if unset). `global:` paths expand `~/` and check local filesystem; in CI (`CI=true`) they emit a warning instead of an error.
+- `commands`: checked via `which <cmd>`. Missing commands are warnings, not errors.
+
+Violation examples:
+
+```
+ERROR [references.unknown-mcp-tool] .agents/skills/foo/SKILL.md: MCP tool "crane_missing" not found in config/mcp-tool-manifest.json
+  Fix: Remove the tool reference, add it to the manifest, or check for a typo in the tool name.
+
+ERROR [references.file-missing-scope-prefix] .agents/skills/foo/SKILL.md: File path missing scope prefix (expected `crane-console:`, `venture:`, or `global:`): "docs/foo.md"
+  Fix: Prefix the file path with `crane-console:`, `venture:`, or `global:` to indicate where the file lives.
+
+ERROR [references.broken-crane-console-file] .agents/skills/foo/SKILL.md: crane-console file not found: "docs/missing.md"
+  Fix: Create the file at docs/missing.md relative to the repo root, or remove the reference.
+
+WARNING [references.venture-file-unverified] .agents/skills/foo/SKILL.md: venture file reference ".design/DESIGN.md" not verified — CRANE_VENTURE_SAMPLE_REPO is not set
+  Fix: Set CRANE_VENTURE_SAMPLE_REPO to a local venture repo path to enable validation, or verify the path manually.
+
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "missing-cli" not found on PATH
+  Fix: Install "missing-cli" or remove it from depends_on.commands if it is optional.
+```
+
+### 4. Structural Lint (`structure.*`)
+
+The SKILL.md body (text after the closing `---`) must:
+
+1. Have a top-level `#` heading that starts with `/<name>` (e.g. `# /skill-review` or `# /skill-review - Title`).
+2. Contain at least one second-level section named `## Phases`, `## Workflow`, or `## Behavior`.
+
+Violation examples:
+
+```
+ERROR [structure.missing-h1-heading] .agents/skills/foo/SKILL.md: Body has no top-level # heading
+  Fix: Add a `# /foo` heading as the first heading in the SKILL.md body.
+
+ERROR [structure.heading-mismatch] .agents/skills/foo/SKILL.md: First # heading "Foo" does not start with "/foo"
+  Fix: Change the first heading to `# /foo` or `# /foo - Description`.
+
+ERROR [structure.missing-workflow-section] .agents/skills/foo/SKILL.md: Body is missing a workflow section (## Phases, ## Workflow, or ## Behavior)
+  Fix: Add a `## Phases`, `## Workflow`, or `## Behavior` section describing how the skill executes.
+```
+
+### 5. Deprecation Sanity (`deprecation.*`)
+
+If `status: deprecated`, both `deprecation_date` and `sunset_date` must be present, parseable as ISO dates, and `sunset_date` must be strictly after `deprecation_date`.
+
+Violation examples:
+
+```
+ERROR [deprecation.missing-deprecation-date] .agents/skills/foo/SKILL.md: status is deprecated but deprecation_date is missing
+  Fix: Add `deprecation_date: YYYY-MM-DD` to frontmatter.
+
+ERROR [deprecation.missing-sunset-date] .agents/skills/foo/SKILL.md: status is deprecated but sunset_date is missing
+  Fix: Add `sunset_date: YYYY-MM-DD` to frontmatter (typically deprecation_date + 90 days).
+
+ERROR [deprecation.sunset-before-deprecation] .agents/skills/foo/SKILL.md: sunset_date "2025-01-01" must be after deprecation_date "2025-03-01"
+  Fix: Set sunset_date to a date strictly after deprecation_date.
+```
+
+## Output Formats
+
+### Human-readable (default)
+
+```
+Reviewed 3 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
 
 ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
   Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
@@ -49,24 +166,45 @@ WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" n
   Fix: Install "jq" or remove it from depends_on.commands if it is optional.
 ```
 
-JSON (with `--json`):
+### JSON (`--json`)
 
 ```json
 {
-  "skills_reviewed": 12,
+  "skills_reviewed": 3,
   "total_violations": 2,
   "by_severity": { "error": 1, "warning": 1, "info": 0 },
-  "violations": [...]
+  "violations": [
+    {
+      "rule": "frontmatter.missing-field",
+      "severity": "error",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Missing required field: owner",
+      "fix": "Add `owner: <team>` to frontmatter. See docs/skills/governance.md."
+    },
+    {
+      "rule": "references.missing-command",
+      "severity": "warning",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Command \"jq\" not found on PATH",
+      "fix": "Install \"jq\" or remove it from depends_on.commands if it is optional."
+    }
+  ]
 }
 ```
 
-## Exit Codes
+## Adding a New Skill
 
-- Default (advisory): always exits 0
-- `--strict`: exits 1 if any `error`-severity violations are found
+Follow the workflow in `docs/skills/governance.md`:
+
+1. Scaffold the skill directory at `.agents/skills/<name>/SKILL.md`.
+2. Fill in all required frontmatter fields (start with `status: draft`).
+3. Ensure `config/skill-owners.json` has the owning key.
+4. Create `.claude/commands/<name>.md` unless `backend_only: true`.
+5. Run `/skill-review --path .agents/skills/<name>` until zero errors.
+6. Flip to `status: stable` and open a PR.
 
 ## Reference
 
-Full governance spec and rule definitions: `docs/skills/governance.md`
+Full governance spec: `docs/skills/governance.md`
 
 CLI source: `packages/crane-mcp/src/cli/skill-review.ts`

--- a/.claude/commands/skunkworks.md
+++ b/.claude/commands/skunkworks.md
@@ -1,5 +1,7 @@
 # /skunkworks - Operating stance for a live operation
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skunkworks")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 The Captain has put you on a skunkworks operation: a small, trusted, fast-moving effort where the stakes are real and the full path isn't mapped. You are not a task-taker waiting for the next instruction - you own the outcome. Load this stance at the start of the operation and hold it as a filter on every move.
 
 ## Behavior

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,5 +1,7 @@
 # /status - Show Session Status
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "status")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Display current session state, tasks, and git status for situational awareness.
 
 ## What to Show

--- a/.claude/commands/ui-drift-audit.md
+++ b/.claude/commands/ui-drift-audit.md
@@ -9,26 +9,131 @@ status: stable
 
 # /ui-drift-audit - Visual drift audit
 
-Run a source-level audit of the venture's UI code and produce a per-file violation matrix. Use to seed pattern-spec citations, size remediation PRs, or gate token-compliance in CI.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ui-drift-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-See `.agents/skills/ui-drift-audit/SKILL.md` for the full rule mapping, output schemas, and per-venture configuration via `.ui-drift.json`.
+Runs a source-level scan of a venture's UI code and emits a surfaces × rules matrix with violation counts. Use to seed pattern-spec citations, size remediation PRs, and gate token-compliance in CI.
 
-## Quick start
+This is a heuristic, not a verifier. Counts approximate drift scale; inspect hot-spots before writing rule citations. Rendered-DOM checks via Playwright are deliberately out of scope — they earn in only for rules that grep demonstrably can't catch.
+
+## When to run
+
+- **Before authoring or revising a venture's pattern spec** (e.g., `docs/style/UI-PATTERNS.md`) — the matrix tells you which rules bite hardest and on which surfaces.
+- **Before sizing a Rule-class remediation PR** — violation counts set the PR scope; >30 per tier splits by component family.
+- **Monthly as a drift watchdog** — new violations in surfaces previously clean indicate spec erosion or escape-hatch abuse.
+- **In CI on every PR** — token-compliance columns gate merges via `--format json` + threshold checks.
+
+## How to run
 
 ```bash
 # Markdown report (default)
 python3 .agents/skills/ui-drift-audit/audit.py
+# writes .design/audits/ui-drift-{YYYY-MM-DD}.md
 
-# JSON report for CI threshold gates
+# JSON report
 python3 .agents/skills/ui-drift-audit/audit.py --format json --out audit.json
 
-# Custom status words for redundancy detection
+# Override status words for redundancy detection
 python3 .agents/skills/ui-drift-audit/audit.py --status-words "Pending,Approved,Draft"
+
+# Use venture's .ui-drift.json config
+# (auto-loaded from <repo-root>/.ui-drift.json)
 ```
 
-## When to invoke
+Optional flags:
 
-- Before authoring or revising a venture's pattern spec.
-- Before sizing a Rule-class remediation PR (count > 30 → split by component family).
-- Monthly as a drift watchdog.
-- In CI on every PR — see `docs/design-system/adoption/audit-workflow.yml.template`.
+- `--out PATH` — override output path.
+- `--format {markdown,json}` — output format. Default `markdown`.
+- `--status-words "Word1,Word2,..."` — comma-separated list of pill status keywords for the redundancy check. Overrides `.ui-drift.json` and built-in defaults.
+- `--src DIR` — repeatable. Source directories to scan. Defaults to `src/pages` + `src/components`. Override for venture layouts that use different roots.
+- `--config PATH` — explicit `.ui-drift.json` config file. Default: auto-discover at repo root.
+
+No external dependencies — pure Python stdlib. Walks the configured source directories for files ending `.astro`, `.tsx`, `.jsx`.
+
+## Per-venture configuration: `.ui-drift.json`
+
+Each venture may drop a `.ui-drift.json` at repo root to set defaults:
+
+```json
+{
+  "status_words": ["Pending", "Approved", "Draft", "Rejected"],
+  "src_dirs": ["src/pages", "src/components", "app"],
+  "thresholds": {
+    "raw_hex_rgb_in_jsx_max": 0,
+    "raw_hex_rgb_in_inline_style_max": 0,
+    "raw_tailwind_color_classes_max": 5
+  }
+}
+```
+
+Precedence (highest to lowest): CLI flag > `.ui-drift.json` > built-in default.
+
+## What it counts (rule mapping)
+
+The detector covers **7 of 7 patterns** (Rules 1-7 in `docs/style/UI-PATTERNS.md`).
+
+| Column                          | Rule                                          | Signal                                                                                                                                                                  |
+| ------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pills**                       | Rule 1 (status display) + Rule 2 (redundancy) | `rounded-full` + tint bg pattern; avatars excluded (base bg).                                                                                                           |
+| **Typo (arb / token)**          | Rule 5 (typography scale)                     | Arbitrary: `text-[Npx]`. Token: `text-xs/sm/base/lg/xl/...`. Both flag post-Rule-5 tokens.                                                                              |
+| **Spacing (arb / token)**       | Rule 6 (spacing rhythm)                       | Arbitrary: `p-[N]`, `gap-[N]`. Token: raw `p-N`, `gap-N`.                                                                                                               |
+| **H-skips**                     | Rule 4 (heading skip ban)                     | Document-order `h{N}` → `h{N+2+}` jumps within a single file.                                                                                                           |
+| **Primary CTAs**                | Rule 3 (one primary per view)                 | Count of `bg-primary` or `bg-[color:var(--color-primary)]` per file. Violation = count > 1.                                                                             |
+| **Redundancy**                  | Rule 2                                        | Tinted pill whose status-keyword content is echoed in ±10 lines of prose.                                                                                               |
+| **Shared primitives**           | Rule 7 (shared primitives)                    | Hand-rolled `StatusPill`/`MoneyDisplay`/`PortalListItem` shape in files that don't import the primitive. Per-primitive breakdown in JSON `shared_primitives_breakdown`. |
+| **raw_hex_rgb_in_jsx**          | Token compliance                              | Raw `#abc` / `#aabbcc` / `rgba(...)` literals anywhere in `.tsx`/`.jsx` files.                                                                                          |
+| **raw_hex_rgb_in_inline_style** | Token compliance                              | Same regex but only inside `style={{...}}` JSX expressions.                                                                                                             |
+| **raw_tailwind_color_classes**  | Token compliance                              | Tailwind palette colors (`bg-blue-500`, `text-red-300`, ...) — semantic-token replacement candidates.                                                                   |
+
+### Pattern 7 (shared primitives) detection notes
+
+The Pattern 7 detector deliberately trades recall for precision so the
+column is trustworthy in CI:
+
+- **Status pill** matches inline `<span>`/`<div>` combining `rounded-full`
+  with `text-xs` (or arbitrary tiny size) AND `uppercase` or `tracking-`.
+  Avatars (`w-N h-N rounded-full`), progress bars (`h-N rounded-full`),
+  and unstyled `text-xs rounded-full` filter chips are intentionally
+  excluded — they're not the StatusPill shape.
+- **Money display** matches lines containing `tabular-nums` only when a
+  currency-formatter signal (`Intl.NumberFormat(... 'currency')`,
+  `style: 'currency'`, `formatCentsToCurrency`) appears within ±1 line.
+  `tabular-nums` used for dates, phones, or progress numbers is excluded.
+- **List row** is scoped to portal `index.astro` files that iterate via
+  `.map(` and emit `flex` + `justify-between` layout without importing
+  `PortalListItem`. Detail pages (`engagement/index.astro` and
+  `[id].astro`) are excluded.
+- Files that ARE the canonical primitive (`StatusPill.astro`,
+  `MoneyDisplay.astro`, `PortalListItem.astro`) are skipped entirely.
+
+If a violation is real but the file legitimately can't use the primitive,
+the escape hatch is the same as for other rules: see Rule 7 in
+`docs/style/UI-PATTERNS.md` for the `LIST_INDEX_ALLOWLIST` mechanism.
+
+## Known limits (shipped as v2)
+
+- **Source-level only.** Component-rendered headings (e.g., `<PortalHeader>` emits `<h1>` internally) are invisible to the file-local heading-skip scan.
+- **Redundancy uses a curated status-keyword list.** Override per venture via `.ui-drift.json` or `--status-words`. The built-in default covers common SaaS billing / contracting states.
+- **Primary CTA count > 1 is a suggestion, not a verdict.** A page with multi-state branches can legitimately declare multiple primaries as long as only one renders per state.
+- **Tier classification is heuristic.** Defaults to path-prefix mapping; ventures with different IA can customize via `--src` to scope the audit.
+
+## Output formats
+
+### Markdown (default)
+
+Markdown document at `.design/audits/ui-drift-{YYYY-MM-DD}.md`:
+
+1. **Tier totals** — aggregated counts per tier.
+2. **Per-file matrix** — every file's column counts, sorted within tier by total violations.
+3. **Redundancy detail** — pill-line + echoed-word per hit; seeds Rule 2 anti-pattern citations.
+4. **Heading-skip detail** — skip pairs per file; seeds Rule 4 citations.
+5. **Token compliance summary** — per-file counts of the 3 token-compliance columns.
+
+### JSON (`--format json`)
+
+Stable schema documented in `audit.py` module docstring. Designed for CI threshold gating and tooling integration.
+
+## Relationship to other skills
+
+- **Upstream of venture pattern specs.** The audit produces the anti-pattern roster; the venture's spec codifies the rules.
+- **Not overlapping `nav-spec`.** Nav spec governs IA + chrome + navigation patterns. This audit governs visual/component semantics.
+- **Not overlapping `design-brief` or `ux-brief`.** Those are upstream authoring pipelines (PRD → brief → `product-design`). This is a post-hoc audit of what shipped.

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,5 +1,7 @@
 # /update - Update Session Context
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "update")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Update your session with current branch, commit, and work metadata.
 
 ## What It Does

--- a/.claude/commands/video-build.md
+++ b/.claude/commands/video-build.md
@@ -1,5 +1,7 @@
 # /video-build - Scaffold, Align & Render an Explainer
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-build")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Takes an approved script + an approved voice take and produces a rendered
 explainer: scaffolds `videos/<slug>/`, locks beat timing with Whisper forced
 alignment, guides scene authoring against the house style, and renders. The

--- a/.claude/commands/video-package.md
+++ b/.claude/commands/video-package.md
@@ -1,5 +1,7 @@
 # /video-package - Caption, Chapter & Package an Explainer
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-package")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns a final render into the publish bundle: SRT captions, YouTube chapters, a
 filled-in `youtube.md` (title / description / tags), and thumbnail candidates.
 Deterministic — the exact bundle `/video-publish` consumes.

--- a/.claude/commands/video-publish.md
+++ b/.claude/commands/video-publish.md
@@ -1,5 +1,7 @@
 # /video-publish - Upload to YouTube & Cross-Promote
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-publish")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Publishes a packaged explainer to the Venture Crane channel via Playwright and
 wires the bidirectional cross-promotion with venturecrane.com. The human performs
 the Google login/2FA; the agent drives Studio and opens the vc-web PR.

--- a/.claude/commands/video-script.md
+++ b/.claude/commands/video-script.md
@@ -1,5 +1,7 @@
 # /video-script - Explainer Script Drafting
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-script")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns a topic or an existing vc-web article into a house-format **6-beat narration
 script** with per-beat visual notes and alignment anchors — the input to
 `/video-build`. Drafting only; it does not generate audio or render anything.

--- a/.gemini/commands/analytics.toml
+++ b/.gemini/commands/analytics.toml
@@ -2,6 +2,8 @@ description = "Site Traffic Report"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "analytics")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Pull traffic numbers from Cloudflare Web Analytics (RUM) across all Venture Crane sites. No arguments needed for a daily summary. Optional arguments for custom ranges.
 
 ## Usage

--- a/.gemini/commands/auth-setup.toml
+++ b/.gemini/commands/auth-setup.toml
@@ -2,6 +2,8 @@ description = "Set up Clerk + Playwright auth bootstrap for a venture"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auth-setup")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Wires up `@clerk/testing/playwright` so E2E tests (and any agent driving Playwright) authenticate against Clerk-protected routes **without manual login**.
 
 Solves the recurring pain: "agent gets hung up needing manual login to test."

--- a/.gemini/commands/auto-build.toml
+++ b/.gemini/commands/auto-build.toml
@@ -2,6 +2,8 @@ description = "Vetted plan-and-execute workflow"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "auto-build")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This skill orchestrates a fixed six-step workflow the Captain runs by hand for non-trivial implementation tasks: enter plan mode → build a plan → run `/critique` → exit plan mode for approval → execute autonomously under Auto Mode. It is a thin coordination layer over harness primitives and the existing `/critique` skill. It does not reinvent any of those pieces.
 
 The skill is single-shot. There is no internal "revise loop." Re-run `/auto-build` if the approval gate is rejected.

--- a/.gemini/commands/calendar-sync.toml
+++ b/.gemini/commands/calendar-sync.toml
@@ -2,6 +2,8 @@ description = "Calendar Sync"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "calendar-sync")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 
 ## Usage

--- a/.gemini/commands/code-review.toml
+++ b/.gemini/commands/code-review.toml
@@ -2,6 +2,8 @@ description = "Codebase Review"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "code-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Deep codebase review with multi-model perspectives. Produces a graded scorecard stored in VCMS and a full report committed to the repo.
 
 ## Arguments

--- a/.gemini/commands/content-scan.toml
+++ b/.gemini/commands/content-scan.toml
@@ -2,6 +2,8 @@ description = "Content Candidate Triage"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "content-scan")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Read-only triage tool that scans all ventures for publishable content candidates. Produces a ranked list of article candidates, promotion candidates, and build log gaps. Does NOT draft anything — drafting is done directly by an agent against the terminology doc, then reviewed via `/edit-log`.
 
 ## Usage

--- a/.gemini/commands/context-refresh.toml
+++ b/.gemini/commands/context-refresh.toml
@@ -2,7 +2,11 @@ description = "Enterprise Context Refresh"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "context-refresh")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Audit and update all enterprise context: D1 docs, VCMS executive summaries, and venture metadata. Produces a refresh report and records cadence completion.
+
+> **Note:** Steps 1 and 2 (doc audit + auto-regen) also run automatically as a side effect of `/sos` when invoked from crane-console and the cadence item is due/overdue. Invoke `/context-refresh` explicitly when you want to review executive summaries (Step 3) or ventures.json drift (Step 4), both of which require Captain approval and can't safely auto-run.
 
 ## Arguments
 

--- a/.gemini/commands/docs-audit.toml
+++ b/.gemini/commands/docs-audit.toml
@@ -2,48 +2,95 @@ description = "Monthly Docs Site Drift Report"
 
 prompt = """
 
-Invoke the `crane_docs_drift_audit` MCP tool and walk through the report.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-audit")`. This is non-blocking — if the call fails, log the warning and continue.
 
-## How to run
+Run a drift audit across the site-published `docs/` directories that ship to the crane-command Starlight site. Surfaces broken internal references, references to deprecated entities, sidebar drift, and stale narrative content. Complements `/docs-refresh` (structural — TBDs, line counts) and `/context-refresh` (D1 sync, exec summaries) by catching semantic decay.
+
+## Usage
 
 ```
 /docs-audit
 ```
 
-This command:
+No arguments required. The audit walks every site-published directory under `docs/`.
 
-1. Calls `crane_docs_drift_audit()` with default parameters (`stale_threshold_days: 180`, `severity_filter: all`, full tree).
-2. Displays the structured report: Inventory → Drift Summary → Errors → Warnings → Info (grouped by type).
-3. Prompts you to review any flagged items.
-4. Records completion via `crane_schedule(action: "complete", name: "docs-audit", ...)`.
+## What it checks
 
-## What to expect
+| Check                         | Severity | What it surfaces                                                                                                 |
+| ----------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Dead internal links**       | ERROR    | Markdown links `[x](path.md)` whose target doesn't exist (AST-parsed, skips code blocks)                         |
+| **Broken `crane_doc()` refs** | ERROR    | `crane_doc('scope', 'name')` calls in CLAUDE.md, skills, commands, and docs whose target file is missing on disk |
+| **Deprecated skill mentions** | WARN     | Slash-form references like `/old-skill` to skills with `status: deprecated`                                      |
+| **Stale-by-git**              | INFO     | Site-published files untouched in git for > 180 days                                                             |
+| **Sidebar drift**             | INFO     | `astro.config.mjs` `autogenerate` directories that don't exist or are empty on disk                              |
+| **Captain-review candidates** | INFO     | Subset of stale-by-git: narrative content (no TBD/auto-gen markers) the audit can't verify                       |
 
-Six checks across site-published `docs/` directories:
+Self-diagnostic ERROR: if `astro.config.mjs` extraction returns zero `autogenerate` entries, the tool emits an `audit-tool-broken` ERROR rather than silently producing a clean report.
 
-- **Dead internal links** (ERROR) — `[x](path.md)` whose target is missing.
-- **Broken `crane_doc()` references** (ERROR) — calls whose target doc isn't on disk.
-- **Deprecated-skill mentions** (WARN) — slash-form references to retired skills.
-- **Stale-by-git** (INFO) — files untouched > 180 days.
-- **Sidebar drift** (INFO) — `astro.config.mjs` references vs. `docs/` reality.
-- **Captain-review candidates** (INFO) — narrative content the audit can't verify.
+## Workflow
 
-Self-diagnostic: if the sidebar parser returns zero entries, the tool emits an `audit-tool-broken` ERROR rather than silently producing a clean report.
+### Step 1: Run the audit
 
-## Cadence semantics
-
-Completion result is `success` whenever the audit runs cleanly, regardless of drift count. `failure` only on tool error or `audit-tool-broken`. Drift counts go in the summary field. This diverges from `/skill-audit` and `/memory-audit` semantics intentionally — conflating "audit ran" with "drift exists" degrades the cadence-engine signal.
-
-## Options
+Call the MCP tool:
 
 ```
-crane_docs_drift_audit(scope: "runbooks")              # one site-published subdir
-crane_docs_drift_audit(scope: "ventures/vc")           # one venture
-crane_docs_drift_audit(stale_threshold_days: 90)       # tighter staleness window
-crane_docs_drift_audit(severity_filter: "error")       # errors only
+crane_docs_drift_audit()
 ```
 
-## Full workflow
+Default parameters:
 
-See `.agents/skills/docs-audit/SKILL.md` for the complete step-by-step workflow including how to act on each finding category and the `success`/`failure` divergence rationale.
+- `stale_threshold_days`: 180
+- `severity_filter`: all
+- `scope`: undefined (walks every site-published subdir)
+
+Narrow the scope to a single directory if iterating on a specific area:
+
+```
+crane_docs_drift_audit(scope: "runbooks")
+crane_docs_drift_audit(scope: "ventures/vc")
+```
+
+### Step 2: Interpret the report
+
+**Errors** — block site truth. Each entry shows the file, line, and the broken reference. Fix in a PR; do not record completion until cleared (or accepted as known and tracked elsewhere).
+
+**Warnings** — deprecated-skill mentions. Either update the doc to reference the replacement skill, or — if the deprecated skill is being kept around — note the exception. Open a PR with the fixes.
+
+**Info findings** — read for signal, no immediate action required.
+
+- _Stale-by-git_: a file hasn't been touched in 180+ days. May still be accurate; the audit can't tell.
+- _Captain-review candidates_: a Captain-only check. The audit flags narrative content untouched > threshold for human verification of accuracy.
+- _Sidebar drift_: `astro.config.mjs` references a directory that's missing or empty. Either fix the config or restore the directory.
+
+If you see `audit-tool-broken`, treat the report as incomplete. Fix the self-diagnostic before trusting other findings.
+
+### Step 3: Record completion
+
+```
+crane_schedule(
+  action: "complete",
+  name: "docs-audit",
+  result: "<success | failure>",
+  summary: "<N docs audited, X errors / Y warns / Z infos>"
+)
+```
+
+**Result mapping** (diverges from `/skill-audit` and `/memory-audit`):
+
+- `success` — the audit ran cleanly and produced a valid report. **Drift count does not affect the result.**
+- `failure` — only on tool error or `audit-tool-broken` self-diagnostic.
+
+This is intentional: conflating "audit ran" with "drift exists" trains operators to either ignore failures or rush to clear them. Drift counts go in the `summary` field where they belong.
+
+## Cadence
+
+Monthly cadence (`schedule_items` name: `docs-audit`). Surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- **Scope**: `docs/` in this repo only. Venture-repo READMEs and `.design/` files are out of scope (they have different decay modes; cross-repo audit is a separate concern).
+- **No auto-fix in v1**. The tool is report-only. Auto-fixing dead links is brittle (rename vs. delete is non-obvious); deprecated-mention rewriting risks losing context.
+- **Markdown parsing** uses the `remark` AST. Code blocks, inline code spans, and reference-style links are handled correctly.
+- **`astro.config.mjs` parsing** evaluates the config in a Node subprocess (`import()` ESM), not regex. Robust against config refactors.
+- **Git mtime** is collected via a single `git log` pass for the whole `docs/` tree, not per-file subprocesses.
 """

--- a/.gemini/commands/docs-refresh.toml
+++ b/.gemini/commands/docs-refresh.toml
@@ -2,50 +2,123 @@ description = "Enterprise Docs Refresh"
 
 prompt = """
 
-Review and update enterprise documentation site content at `crane-console.vercel.app`. Identifies stale pages and enriches them with data from existing sources.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "docs-refresh")`. This is non-blocking — if the call fails, log the warning and continue.
 
-## Arguments
+Refresh managed-block content on the crane-command site (`docs/ventures/<code>/{product-overview,roadmap}.md`). Companion to `/docs-audit` (which detects drift) — this is the appliance that closes the loop.
+
+The skill is a thin wrapper around `npm run docs-refresh -w @venturecrane/crane-mcp`. The CLI is deterministic Node.js — no LLM in the loop. It's safe to wire to a cron, and a weekly cron is already in `.github/workflows/docs-refresh.yml`.
+
+## Usage
 
 ```
-/docs-refresh [scope]
+/docs-refresh                        # audit mode (no writes)
+/docs-refresh <code>                 # refresh a venture's marked pages
+/docs-refresh <code>/<page>          # refresh a single page
+/docs-refresh <page-type>            # refresh page type across configured ventures
+/docs-refresh --init-markers <code>  # seed markers (first-run, gate-bypassed)
+/docs-refresh --dry-run <code>       # render but don't write
 ```
 
-- No argument: Audit mode - lists stale pages, does NOT modify files
-- Venture code (`vc`, `dfg`, `sc`, `ke`, `dc`): Update all 3 pages for one venture
-- Page type (`metrics`, `roadmaps`, `overviews`): Update one page type across all ventures
-- Single page (`vc/metrics`, `dfg/roadmap`): Update one page
+Behind every form, the skill runs:
 
-## Execution
+```
+npm run docs-refresh -w @venturecrane/crane-mcp -- <args>
+```
 
-### Step 1: Audit
+## What it manages
 
-Read all files in `docs/ventures/*/`, `docs/company/`, `docs/operations/`. Report line count, TBD count, stale flag (>2 TBDs or <20 lines).
+Two page types carry markers in v1; metrics has no managed blocks (placeholder-preserving renderer is a no-op):
 
-**If no scope provided, STOP after audit. Ask Captain which scope to run.**
+| Page type          | Markers                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `product-overview` | `activity-shipped` (last 5 merged feat: PRs)                                                                                                      |
+| `roadmap`          | `activity-current-focus` (status:in-progress issues), `activity-near-term` (status:ready issues), `activity-completed` (last 10 merged feat: PRs) |
+| `metrics`          | (none in v1)                                                                                                                                      |
 
-### Step 2: Gather Data
+Per-venture query strategy lives in `config/docs-refresh.json`. Adding a venture means adding an entry there with `primaryRepo` and `labels`, then running `/docs-refresh --init-markers <code>` to seed the markers.
 
-For pages in scope, pull from:
+## What it does NOT touch
 
-- **Overviews**: `config/ventures.json` + `docs/design/ventures/{code}/design-spec.md` + VCMS exec summaries
-- **Metrics**: BVM stage from ventures.json + VCMS strategy/prd notes + stage-appropriate defaults
-- **Roadmaps**: `gh issue list --repo venturecrane/{code}-console` + `crane_handoffs` + SOD data
+- **Build-time tokens** (`{{venture:CODE:FIELD}}`, `{{portfolio:table}}`, etc.). Those resolve in `site/scripts/sync-docs.mjs` at site build time and don't need a refresh step.
+- **Captain-curated narrative** (sections that aren't managed blocks). Refresh has a structural diff gate that aborts if anything outside marker pairs changes.
+- **Pages without markers.** Refresh warns-and-skips. Run `--init-markers <code>` first.
+- **Sections whose content is a table or prose** (not a bullet list). The `--init-markers` step refuses to wrap incompatible structure and reports a warning. Captain can normalize the page (e.g., convert a table to a bullet list under `## Near-term`) and re-run init.
 
-### Step 3: Draft
+## Workflow
 
-Write updated markdown matching existing good pages (DFG/SC overviews as templates). Use real data. Preserve existing substantive content. Target: overviews 40-70 lines, metrics 25-35 lines, roadmaps 25-40 lines.
+### Audit a venture's pages
 
-### Step 4: Approve
+```
+/docs-refresh
+```
 
-Present drafts to Captain. Show before/after line counts and data sources. **Wait for approval.**
+Prints per-page report: line count, markers present vs. expected, missing markers. No writes. Use this to triage.
 
-### Step 5: PR
+### Seed markers on a new venture
 
-Branch `docs/refresh-{scope}-{date}`, write files, verify `cd site && npm run build`, commit, push, `gh pr create`.
+Add the venture to `config/docs-refresh.json`, then:
+
+```
+/docs-refresh --init-markers <code>
+```
+
+Inspect the diff before committing — `--init-markers` bypasses the structural gate (it has to, since markers don't exist yet). Warnings are emitted for any section that can't be safely wrapped (heading missing, content not a bullet list).
+
+### Refresh content from canonical sources
+
+```
+/docs-refresh <code>
+```
+
+Walks the venture's marked pages, fetches gh data per `config/docs-refresh.json`, replaces marker bodies, and runs the structural diff gate (asserts marker set is unchanged and outside-marker content is byte-equal). Aborts with a named violation if the gate fails.
+
+### Closed-loop weekly run
+
+`.github/workflows/docs-refresh.yml` runs the refresh weekly (Monday 13:17 UTC) for every venture in `config/docs-refresh.json` and opens a PR if the diff is non-empty. No manual invocation needed for ongoing maintenance — the loop is closed.
+
+## How the diff gate works
+
+After rendering, the CLI asserts:
+
+1. **Marker set equal across runs.** `parseMarkers(before).names === parseMarkers(after).names`. New marker insertion only happens via `--init-markers`.
+2. **Outside-marker content byte-equal.** The bytes outside any marker pair must be identical. This catches renderer overreach (e.g., accidentally rewriting prose adjacent to a marker).
+
+Gate failure exits 2 and names the violation. Init mode bypasses both checks.
+
+## Configuration
+
+`config/docs-refresh.json`:
+
+```json
+{
+  "ventures": {
+    "<code>": {
+      "primaryRepo": "venturecrane/<repo>",
+      "labels": { "in_progress": "status:in-progress", "ready": "status:ready" },
+      "shippedSearch": "feat: in:title"
+    }
+  },
+  "limits": { "shippedRecent": 5, "completedHistory": 10, "currentFocus": 10, "nearTerm": 10 }
+}
+```
+
+Both vc (in `crane-console`) and dfg (in `dfg-console`) use the same `status:` label vocabulary. If a venture uses different labels, override per-venture.
+
+## Failure modes
+
+| Condition                                    | Behavior                                   | Exit |
+| -------------------------------------------- | ------------------------------------------ | ---- |
+| `config/docs-refresh.json` missing           | Throw                                      | 1    |
+| Venture not in config                        | skip with reason                           | 0    |
+| Page missing all markers                     | skip with reason; suggest `--init-markers` | 0    |
+| Page missing some markers                    | refresh present markers; warn about absent | 0    |
+| Diff gate violation                          | Print named violation; exit 2              | 2    |
+| `gh` CLI failure                             | Throw with `gh` stderr                     | 1    |
+| Malformed marker (unclosed/nested/duplicate) | Throw with line number                     | 1    |
 
 ## Notes
 
-- Template variables (`{{portfolio:table}}`) are handled by the build script — don't duplicate that data
-- After merge, Vercel auto-rebuilds the site
-- Quality bar: 0 unjustified TBDs, 20+ lines, real data
+- **Token vocabulary is unchanged.** `site/scripts/sync-docs.mjs` already supports every fact-zone field — `{{venture:CODE:FIELD}}` resolves both top-level and `portfolio.*` fields. No resolver extension was needed for v1.
+- **Only bullet-list sections are wrapped.** This is intentional. Tables and prose require Captain decisions about structure that the renderer can't safely make.
+- **Source code:** `packages/crane-mcp/src/cli/docs-refresh.ts` (44 unit + integration tests in the sibling `.test.ts`).
 """

--- a/.gemini/commands/edit-article.toml
+++ b/.gemini/commands/edit-article.toml
@@ -2,6 +2,8 @@ description = "Editorial Review Agent"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-article")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command runs an article through two parallel editor agents, applies blocking fixes directly, and reports what changed. Advisory issues are reported but not auto-fixed.
 
 ## Arguments
@@ -105,6 +107,10 @@ Read the article line by line. Check every line against the rules below. Report 
 
 **Founder-voice fabrication** - any sentence that puts words in the founder's mouth or manufactures a personal anecdote
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (should fix)
 
 - Public venture names per the tag-dependent rules above (suggest genericizing for focus where no matching tag exists)
@@ -113,6 +119,7 @@ Read the article line by line. Check every line against the rules below. Report 
 - Throat-clearing openers ("In this article, we will...", "Today we're going to...")
 - Marketing language (superlatives, hype, "revolutionary", "game-changing", etc.)
 - Register mismatch (article should be analytical/explanatory, not terse build-log voice)
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the article's title or H1 describe a Claude Code capability, workflow, or session? (2) Does the article already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### Output Format
 

--- a/.gemini/commands/edit-log.toml
+++ b/.gemini/commands/edit-log.toml
@@ -2,6 +2,8 @@ description = "Build Log Editorial Review"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "edit-log")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Single-agent editorial review for build logs. Checks genericization and style, auto-fixes blocking issues, reports advisory issues for human judgment.
 
 ## Arguments
@@ -109,6 +111,10 @@ For each blocking issue, provide:
 - venturecrane org -> Omit or "example-org"
 - Specific counts -> "multiple ventures" or "several projects"
 
+**Claude-attribution overclaim** - per terminology.md Claude Attribution Section 1. Check each sentence that characterizes the VC-Anthropic partnership relationship. If the characterization matches a canonical form verbatim ("in the Claude Partner Network", "pursuing Partner Network status", "applied to the Claude Partner Network"), pass. If not, flag BLOCKING and propose a rewrite toward the closest canonical form. Do NOT auto-fix; rewrites are human-review only because surrounding context shapes which canonical form fits.
+
+**Tool attribution conflation** - per terminology.md Claude Attribution Section 2 (lexicon) and Section 3 (venture-to-integration mapping). Flag BLOCKING when a tool term does not match the integration point the sentence describes. Examples: "Claude Code" naming a direct HTTP API call (fix: "the Claude API"); "Claude" in a sentence specifically describing an SS or DFG pipeline call (fix: "the Claude API"); "MCP" used as if it were the agent itself (fix: "Claude Code" or "the agent"). Auto-fix only when the mapping yields an unambiguous target; otherwise flag for human review.
+
 ### ADVISORY checks (report but don't auto-fix)
 
 - Public venture names per the tag-dependent rules above (not auto-fixed; suggest genericizing for focus)
@@ -116,6 +122,7 @@ For each blocking issue, provide:
 - Article-register voice: flag analytical or explanatory tone that reads like an article rather than an operational log. Build logs should feel like a field report, not an essay.
 - Numbers that might go stale: specific counts, percentages, or metrics that will become wrong over time
 - Article overlap: search the article index for keyword overlap with the log's content. If found, surface: "This log discusses [topic]. An article on this topic exists at [slug]. Verify consistency."
+- **Generic AI-agent language** - per terminology.md Claude Attribution Section 4. Apply the two-question retrofit heuristic: (1) Does the log's title describe a Claude Code capability, workflow, or session? (2) Does the log already name Claude Code at least once? If YES to either, the retrofit exception does NOT apply: flag the generic reference as advisory with a specific Claude Code attribution suggestion. If NO to both, the retrofit exception applies: suppress silently.
 
 ### NOT checked (explicitly out of scope)
 

--- a/.gemini/commands/enterprise-review.toml
+++ b/.gemini/commands/enterprise-review.toml
@@ -2,6 +2,8 @@ description = "Cross-Venture Codebase Audit"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "enterprise-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Detects configuration drift, structural drift, and practice drift across all venture repos. Produces a consistency report stored in VCMS.
 
 **Must run from crane-console.** This command is not synced to venture repos.
@@ -80,6 +82,39 @@ for CODE in {TARGET_VENTURES}; do
   echo "-- commands --"
   ls "$REPO"/.claude/commands/*.md 2>/dev/null | xargs -I{} basename {} | sort
 
+  # Design-system adoption signals (Stream D1)
+  echo "-- design-system --"
+  TOKENS_DEP=N
+  CSS_IMPORT=N
+  CLAUDE_MD=N
+  AUDIT_YML=N
+
+  # 1. token-package consumed: package.json includes @venturecrane/tokens
+  if [ -n "$PKGJSON" ] && grep -q '"@venturecrane/tokens"' "$PKGJSON" 2>/dev/null; then
+    TOKENS_DEP=Y
+  fi
+
+  # 2. CSS imports the package: any *.css under common src roots imports @venturecrane/tokens/
+  for SRCDIR in "$REPO/src" "$REPO/app/src" "$REPO/web/src" "$REPO/app" "$REPO"; do
+    [ -d "$SRCDIR" ] || continue
+    if grep -rEl "@import\s+['\"]@venturecrane/tokens/" "$SRCDIR" --include='*.css' 2>/dev/null | head -1 | grep -q .; then
+      CSS_IMPORT=Y
+      break
+    fi
+  done
+
+  # 3. CLAUDE.md references design-system/patterns
+  if [ -f "$REPO/CLAUDE.md" ] && grep -q 'design-system/patterns' "$REPO/CLAUDE.md" 2>/dev/null; then
+    CLAUDE_MD=Y
+  fi
+
+  # 4. audit workflow wired
+  if [ -f "$REPO/.github/workflows/ui-drift-audit.yml" ]; then
+    AUDIT_YML=Y
+  fi
+
+  echo "[design-system] tokens-dep=$TOKENS_DEP import=$CSS_IMPORT claude-md=$CLAUDE_MD audit-yml=$AUDIT_YML"
+
   echo ""
 done
 ```
@@ -141,6 +176,36 @@ Cross-cutting issues that affect multiple ventures or represent enterprise-wide 
 - Missing enterprise standards (e.g., "3/5 repos missing security.yml workflow")
 - Practice drift (e.g., "only 2/5 repos have pre-commit hooks configured")
 
+**3e. Design System Compliance**
+
+Parse the `[design-system]` line emitted by Step 2 for each venture and build a 4-point compliance matrix. The four checks correspond to the [adoption runbook](../../../docs/design-system/adoption-runbook.md) "what 'compliant' means" definition:
+
+1. **Tokens-dep** — venture's `package.json` declares `@venturecrane/tokens` as a dependency (any version).
+2. **CSS-import** — at least one `*.css` file in the venture imports `@venturecrane/tokens/{code}.css` (or any path under that scope).
+3. **CLAUDE.md** — the venture's root `CLAUDE.md` references `design-system/patterns` (the canonical snippet block).
+4. **Audit-yml** — `.github/workflows/ui-drift-audit.yml` exists.
+
+Render a per-venture row with the four columns plus a total `N/4` and a tier-aware status:
+
+| Venture | Tokens-dep | CSS-import | CLAUDE.md | Audit-yml | Compliance  |
+| ------- | ---------- | ---------- | --------- | --------- | ----------- |
+| ss      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| dc      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| ke      | ✓          | ✓          | ✓         | ✓         | 4/4 ✓       |
+| vc      | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| sc      | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| dfg     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| dcm     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+| smd     | ✗          | ✗          | ✗         | ✗         | 0/4 PENDING |
+
+Status interpretation:
+
+- **4/4 ✓ COMPLIANT** — venture has fully adopted the enterprise design system.
+- **N/4 PARTIAL** — adoption is in progress; the missing column(s) name the next step (e.g., `3/4 PARTIAL — missing CLAUDE.md snippet`).
+- **0/4 PENDING_MIGRATION** — no signals present; venture has not started Stream C migration.
+
+A brownfield venture that has shipped its migration PR but only scores 3/4 is the highest-value drift signal — flag it loudly in 3d (Drift Hotspots) so the gap closes in the next session.
+
 ### Step 4: Store and Report
 
 **4a. VCMS Report**
@@ -152,7 +217,7 @@ Store concise report in VCMS using `crane_note`:
 - Venture: (omit - this is cross-venture)
 - Title: `Enterprise Review - {YYYY-MM-DD}`
 
-Content (under 500 words): date, ventures audited, version alignment summary, top 3-5 drift hotspots, overall consistency assessment.
+Content (under 500 words): date, ventures audited, version alignment summary, top 3-5 drift hotspots, **design-system compliance summary** (count of ventures at 4/4 vs partial vs 0/4, plus the names of any partial ventures and their missing columns), overall consistency assessment.
 
 **4b. Compare with Previous Review**
 
@@ -183,6 +248,9 @@ Present the full report inline (this is the primary output - no separate file si
 ### Commands Sync Status
 {table}
 
+### Design System Compliance
+{4-point matrix from 3e}
+
 ### Drift Hotspots
 {numbered list}
 
@@ -199,6 +267,7 @@ After displaying the report, suggest next steps:
 
 - If commands are out of sync: "Run `sync-commands.sh` to distribute missing commands."
 - If version drift detected: "Consider creating issues to align dependency versions."
+- If any venture is at a partial design-system compliance score (1/4, 2/4, or 3/4): name the venture and the missing column(s) (e.g., "ke is 3/4 — missing CLAUDE.md snippet; copy the canonical block from `docs/design-system/adoption/claude-md-snippet.md`"). For ventures at 0/4, point at the [adoption runbook](../../../docs/design-system/adoption-runbook.md) without flagging — those are pending migration, not drift.
 
 Do NOT automatically take any action. Wait for the Captain.
 
@@ -234,6 +303,17 @@ crane_schedule(action: "complete", name: "enterprise-review", result: "success",
 - Security workflow present
 - Secret scanning configured (.gitleaks.toml)
 - Test framework configured
+
+### Design System Compliance
+
+The 4-point compliance matrix (Step 3e) measures Stream C migration status per venture:
+
+- `@venturecrane/tokens` package consumed (`package.json` dependency)
+- CSS imports the package (`@import '@venturecrane/tokens/{code}.css'`)
+- `CLAUDE.md` references `design-system/patterns` (canonical snippet wired)
+- `.github/workflows/ui-drift-audit.yml` workflow exists
+
+Per [adoption-runbook.md](../../../docs/design-system/adoption-runbook.md), a venture is COMPLIANT at 4/4. Brownfield ventures with shipped migration PRs scoring less than 4/4 are the highest-value drift signal — they shipped a migration but missed a step.
 
 ---
 

--- a/.gemini/commands/go-live.toml
+++ b/.gemini/commands/go-live.toml
@@ -2,6 +2,8 @@ description = "Venture Go-Live Process"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "go-live")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Launch a venture to production with mandatory secret rotation and readiness checks.
 
 ```

--- a/.gemini/commands/heartbeat.toml
+++ b/.gemini/commands/heartbeat.toml
@@ -2,6 +2,8 @@ description = "Keep Session Alive"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "heartbeat")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Send a heartbeat to prevent your session from timing out.
 
 ## What It Does

--- a/.gemini/commands/nav-spec.toml
+++ b/.gemini/commands/nav-spec.toml
@@ -1,6 +1,8 @@
-description = "> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`."
+description = "Nav Spec Authority (v3)"
 
 prompt = """
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "nav-spec")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
 > **Design system context.** Before authoring or revising any IA / pattern / chrome layer of `NAVIGATION.md`, load the cross-venture pattern + component catalog so the spec snaps to the shared vocabulary:
 >
@@ -8,8 +10,6 @@ prompt = """
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then load the active venture's `design-spec.md` for venture-specific palette and tone. The catalog is the shared vocabulary across all eight ventures; the venture spec is the venture's identity. The pattern catalog (Patterns 1–8) is enterprise-canonical and supplements — does not replace — the navigation pattern catalog at [references/pattern-catalog.md](references/pattern-catalog.md).
-
-# /nav-spec - Nav Spec Authority (v3)
 
 You are an Information Architecture lead. Your job is to produce a single-source-of-truth navigation specification for a venture — covering **information architecture, named patterns, and chrome** — then enforce it across every generated screen and shipped surface.
 

--- a/.gemini/commands/new-client.toml
+++ b/.gemini/commands/new-client.toml
@@ -2,6 +2,8 @@ description = "Set Up a New SS Client"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-client")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Adds a client entity under the SS venture. A client is the billing entity; engagements (the unit of work) live underneath.
 
 This is **wiring**, not process — no SOW, kickoff, lifecycle states, or templates. Just the registry and Infisical entries needed for `/new-engagement` to work for that client.

--- a/.gemini/commands/new-engagement.toml
+++ b/.gemini/commands/new-engagement.toml
@@ -2,6 +2,8 @@ description = "Set Up a New SS Engagement"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-engagement")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Creates a new engagement repo under an existing client and wires it into the launcher. An engagement is the unit of billable work for a client.
 
 This is **wiring**, not process — no SOW scaffolding, kickoff documents, status reporting cadence, or lifecycle states. The agent inside the engagement repo writes whatever the engagement actually needs.

--- a/.gemini/commands/new-venture.toml
+++ b/.gemini/commands/new-venture.toml
@@ -2,6 +2,8 @@ description = "Set Up a New Venture"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "new-venture")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command walks through setting up a new venture with Crane infrastructure.
 
 ## Prerequisites (Manual)
@@ -74,6 +76,7 @@ After the script completes, walk through remaining manual steps from the checkli
 4. **Code quality** (Phase 4.5) - testing scaffold, CI/CD, pre-commit hooks
 5. **Monitoring** (Phase 4.6) - Sentry, uptime checks
 6. **PWA setup** (Phase 4.7) - manifest, service worker, icons, iOS meta tags. Framework-specific: Serwist for Next.js, @vite-pwa/astro for Astro. See `docs/standards/golden-path.md` PWA section and `docs/process/new-venture-setup-checklist.md` Phase 4.7 for step-by-step.
+7. **Claude Design onboarding** (Phase 3.8) - create a named design system in claude.ai/design, link the recommended subdirectory, seed with the venture's `design-spec.md`. Full steps in `docs/runbooks/claude-design-enterprise-setup.md`; context in `docs/instructions/claude-design.md`.
 
 ### Step 5: Update CLAUDE.md
 

--- a/.gemini/commands/operator-onboard.toml
+++ b/.gemini/commands/operator-onboard.toml
@@ -7,6 +7,8 @@ description: Authors a validated Operator customer.yaml + onboarding plan from a
 
 # /operator-onboard - Author an Operator config from a client interview
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "operator-onboard")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns an initial client-interview transcript or notes into two artifacts under the
 venture repo's `operator/customers/<slug>/`:
 

--- a/.gemini/commands/own-it.toml
+++ b/.gemini/commands/own-it.toml
@@ -2,6 +2,8 @@ description = "Own the decision, own the finish"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "own-it")`. Non-blocking - if it fails, log and continue.
+
 You are running this skill because you were about to punt - or because the Captain just called you on it.
 
 The Captain's language, distilled:
@@ -110,4 +112,16 @@ If after running this skill you still believe the question is legitimately Capta
 > **Default if no response:** _<what you will proceed with>_
 
 The "default if no response" line is mandatory. It is the forcing function: if you can name the default, you can just do it.
+
+## Related memory
+
+This skill consolidates recurring feedback captured in auto-memory. Existing entries reinforce specific facets:
+
+- `feedback_kill_dont_file.md` - rule 4 (no follow-up tickets for speculative work).
+- `feedback_critique_deferrals.md` - rule 4 (critique deferrals are not the answer).
+- `feedback_no_human_ergonomics_arguments.md` - rule 3 (agents write the code; valid reasons are determinism/cost/parallelism).
+- `feedback_agents_produce_content.md` - rule 1 (don't defer content to "Captain input").
+- `feedback_verify_root_cause_before_fixing.md` - rule 3 (fix root causes, not symptoms).
+
+When this skill fires, it takes precedence over isolated interpretations of those memories.
 """

--- a/.gemini/commands/platform-audit.toml
+++ b/.gemini/commands/platform-audit.toml
@@ -2,6 +2,8 @@ description = "Platform Audit"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "platform-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 End-to-end senior-engineer audit of the crane operating system. Catches sprawl, dead code, incomplete migrations, and accumulated cruft before they compound. Produces a kill / fix / invest list a Captain can act on.
 
 ## Scope

--- a/.gemini/commands/portfolio-review.toml
+++ b/.gemini/commands/portfolio-review.toml
@@ -2,6 +2,8 @@ description = "Portfolio Status Review"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "portfolio-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Review and update venture portfolio data. Collects live signals, compares against current records, and presents changes for Captain approval.
 
 ## Status Taxonomy

--- a/.gemini/commands/prd-review.toml
+++ b/.gemini/commands/prd-review.toml
@@ -2,6 +2,8 @@ description = "Multi-Agent PRD Review"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "prd-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 This command orchestrates a 6-agent PRD review process with configurable rounds. It reads existing source documents, runs structured critique rounds with parallel agents, and synthesizes the output into a production-ready PRD.
 
 Works in any venture console that has the required source documents.

--- a/.gemini/commands/product-design.toml
+++ b/.gemini/commands/product-design.toml
@@ -1,6 +1,8 @@
-description = "> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue."
+description = "— Product UI realization"
 
 prompt = """
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "product-design")`. Non-blocking — if the call fails, log and continue.
 
 > **Design system context.** Before any component generation — including pre-flight, prompt assembly, and the iteration loop — load the cross-venture pattern + component catalog. Generated components should reference the catalog's components map for analogous implementations and respect Patterns 1–8 (status display by context, button hierarchy, shared primitives, actions and menus, etc.):
 >
@@ -8,8 +10,6 @@ prompt = """
 > - `crane_doc('global', 'design-system/components/index.md')`
 >
 > Then continue with the existing pre-flight: venture identification, NAVIGATION.md / DESIGN.md / UX-brief checks, adapter resolution. The catalog is supplementary context — the venture's own DESIGN.md / @theme remains the source for tokens.
-
-# /product-design — Product UI realization
 
 You produce Astro/React components in a venture's own repo. You consume the harness inputs (nav-spec + DESIGN.md + UX brief + existing component source) and emit components that satisfy them — validated by the venture's build command and `validate.py`, reviewed by the Captain.
 
@@ -63,6 +63,9 @@ Five steps. Every generation follows this shape. Do not add steps without Captai
 
 1. **Assemble prompt.** See [references/prompt-assembly.md](references/prompt-assembly.md) for exactly what goes into the prompt and in what order. Inputs: nav-spec surface-class appendix, DESIGN.md or @theme tokens, UX brief section for this surface, five-tag classification (`surface=`, `archetype=`, `viewport=`, `task=`, `pattern=`), adapter template, **raw source of every file under the venture's `src/components/**`\*\*. No registry. No AST. Let Claude read the component source directly.
 2. **Generate code.** Use the Write tool to produce the component file at its target path in the venture repo.
+
+   **Greenfield branch.** If no file exists at the target component path AND `--revise` was not passed, the workflow first invokes `Skill(frontend-design:frontend-design)` to produce a per-surface composition reference within the venture's locked design language (no new fonts, colors, or spacing — just composition exploration). The reference is captured as HTML and appended to the prompt-assembly as block 7-bis ("Aesthetic reference"); the in-loop generator then produces the Astro component as usual. Existing files and `--revise` invocations skip this branch entirely. See [references/frontend-design-handoff.md](references/frontend-design-handoff.md) for the seed prompt and constraints.
+
 3. **Build check.** Run the venture's build command (detected from lockfile — see package-manager note above). If it fails: read the compile errors, append to the prompt, regenerate. Max one retry.
 4. **Structural validate.** If a preview route is wired for this surface, extract the rendered HTML and run `~/.agents/skills/nav-spec/validate.py --file <html> --surface <tag> --archetype <tag> --viewport <tag> --task <tag> --pattern <tag> --spec <path-to-NAVIGATION.md>`. If structural violations: append to prompt, regenerate. Max one retry. If no preview route exists for this surface yet, skip — validator runs after the Captain promotes.
 5. **Land.** The component file is in place. Report to the Captain: file path, how to preview (the venture's dev command → `/design-preview/<surface>`), and anything you iterated on. Done.
@@ -100,6 +103,7 @@ If a preview route for the requested surface doesn't exist yet, the skill create
 - `design-brief` — PRD → design charter (upstream)
 - `nav-spec` — IA + patterns + chrome authority (sibling; structural authority)
 - `ux-brief` — three-reviewer surface-level UX brief (upstream)
+- `frontend-design` (Anthropic plugin) — per-surface composition reference generator on greenfield runs (sibling; aesthetic exploration within locked design language)
 
 ## Known limits (v1)
 

--- a/.gemini/commands/save-lesson.toml
+++ b/.gemini/commands/save-lesson.toml
@@ -2,7 +2,11 @@ description = "Capture Session Lesson"
 
 prompt = """
 
-Capture a memoryable lesson or anti-pattern from the current session into the enterprise memory system. Agent drafts frontmatter and body from session context; Captain confirms before the note is written.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "save-lesson")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Capture a memoryable lesson or anti-pattern from this session into the enterprise memory system. Agent drafts the memory; Captain confirms before it is written.
+
+After filing runs `/eos`, the recommended capture path for routine session learning is the "Memoryable moments?" step at session close. Use `/save-lesson` when you want to capture something immediately, mid-session, without waiting for `/eos`.
 
 ## Usage
 
@@ -10,23 +14,116 @@ Capture a memoryable lesson or anti-pattern from the current session into the en
 /save-lesson [optional one-line summary]
 ```
 
-If a summary is omitted, the agent drafts one from recent session context.
+## Execution Steps
 
-## What it does
+### Step 1: Telemetry
 
-1. Infers `kind` (lesson vs anti-pattern), `scope`, and `applies_when` from session context.
-2. Drafts a 1-2 sentence body and shows it to you for confirmation.
-3. Applies the 3 memoryability tests (actionable, non-obvious, general enough to recur).
-4. Saves to VCMS with `status: draft, captain_approved: false`.
-5. Reports the saved note ID.
+Call `crane_skill_invoked(skill_name: "save-lesson")`.
 
-Draft memories become injection-eligible only after Captain approval via `/memory-audit` or `crane_memory(update)`. For immediate `captain_approved: true` capture, use the "Memoryable moments?" step in `/eos`.
+### Step 2: Parse arguments
 
-## Examples
+Parse `$ARGUMENTS` as an optional one-line summary.
+
+- If a summary is provided, use it as the seed for the draft body.
+- If empty, scan the last 10 messages of the session transcript for the most operationally significant event — a correction made, an unexpected failure, a gotcha discovered, an anti-pattern avoided. Draft a one-line summary from that context.
+
+### Step 3: Infer frontmatter from session context
+
+Infer the following fields from the session transcript and environment:
+
+**kind** — default `lesson`. Use `anti-pattern` if the summary contains "don't", "never", "avoid", "stop", or "do not".
+
+**scope** — default `enterprise`. Use `venture:<code>` for any rule that only applies inside one venture, including: marketing voice and positioning, business-model rules, page-level copy patterns, and venture-specific code (API contracts, data models). Use `global` if the learning applies outside the Venture Crane enterprise (e.g., a third-party tool gotcha).
+
+**Why scope matters:** the SOS injection path filters by `scope === 'enterprise' || scope === 'global' || scope === 'venture:<active_venture>'` (`packages/crane-mcp/src/tools/memory.ts` recall path). An enterprise-scoped memory surfaces in **every** venture's session. A SMD-positioning rule filed at `enterprise` scope will inject into KE/VC/SC/etc sessions where it does not apply. When in doubt about whether a rule generalizes across ventures, narrow to `venture:<code>` — Captain can promote it to `enterprise` later via `/memory-audit`.
+
+**severity** — required only for `anti-pattern`. Infer:
+
+- `P0` — data loss, security exposure, or production outage risk
+- `P1` — significant wasted time or correctness risk
+- `P2` — workflow friction
+
+**applies_when.skills** — list any skill names mentioned or invoked in the relevant session window (e.g., `["eos", "ship"]`). Omit if no specific skills are relevant.
+
+**applies_when.commands** — list any CLI commands prominent in the relevant context (e.g., `["git", "wrangler"]`). Omit if none.
+
+**applies_when.files** — list abbreviated stems of file paths touched in the relevant session window (e.g., `[".infisical*", "wrangler.toml"]`). Omit if none.
+
+**supersedes_source** — if the lesson was derived from a specific retrospective or incident file, include its path.
+
+### Step 4: Draft body
+
+Write 1-2 sentences:
+
+1. What to do (or not do) — concrete and actionable.
+2. Why — the failure mode or benefit this rule prevents or produces.
+
+Show the full proposed memory to the Captain for confirmation:
 
 ```
-/save-lesson
-/save-lesson "parallel agents writing to the same branch collide — always use worktrees"
-/save-lesson "never run infisical secrets -o json — it dumps plaintext values into the transcript"
+Proposed memory:
+  kind: {kind}
+  scope: {scope}
+  severity: {P0/P1/P2 or omitted}
+  applies_when: {json summary}
+  body: "{draft body}"
+
+Save this memory? (y/n)
 ```
+
+Wait for Captain response before proceeding.
+
+### Step 5: Apply the 3 memoryability tests
+
+Before calling save, verify all three tests hold:
+
+1. **Actionable** — tells a future agent what to do or avoid, not how someone felt.
+2. **Non-obvious** — not derivable from reading the codebase or default Claude reasoning.
+3. **General enough to recur** — applies to a class of situations, not a single accident.
+
+If any test fails, report which one failed and explain why, then suggest a refinement. Do not proceed to save until the draft passes all three or the Captain explicitly overrides.
+
+### Step 5b: Scope/name consistency check
+
+Before calling save, verify both:
+
+1. **If `scope: enterprise` or `global`:** the proposed `name` must NOT encode a single venture's code (current codes: `vc`, `sc`, `dfg`, `ke`, `smd`, `ss`, `dc`) as a prefix or suffix (e.g., `ke-`, `ss-`, `-for-ke`, `-for-ss`). The name should be venture-agnostic. If the rule truly applies cross-venture, the name must read as such.
+2. **If `scope: venture:<code>`:** the `venture` field (passed to `crane_memory(action: 'save')`) must equal `<code>`. Both fields populated, both consistent.
+
+If a venture marker appears in the name despite an enterprise scope, either rename (drop the marker) or rescope (narrow to `venture:<code>`). Mismatched name and scope is the failure mode that surfaces SMD-positioning rules in KE sessions.
+
+### Step 6: Save
+
+Call `crane_memory(action: 'save', ...)` with:
+
+```yaml
+name: { kebab-case from body; strip venture markers if scope is enterprise or global }
+description: { one-sentence purpose, same as body sentence 1 }
+kind: { inferred kind }
+scope: { inferred scope }
+venture: { the venture code, e.g. "ss" — REQUIRED when scope is venture:<code>; omit otherwise }
+owner: captain
+status: draft
+captain_approved: false
+version: 1.0.1
+severity: { if anti-pattern }
+applies_when: { inferred }
+supersedes_source: { if applicable }
+last_validated_on: { today ISO date }
+```
+
+Note: `/save-lesson` always saves `status: draft, captain_approved: false`. The `/eos` path is the only path that creates `captain_approved: true` memories at write time. Captain promotes drafts to injection-eligible via the weekly `/memory-audit` review flow.
+
+### Step 7: Report
+
+```
+Memory saved (draft).
+ID: {note_id}
+Kind: {kind} | Scope: {scope} | Status: draft
+To promote for always-on SOS injection: approve via /memory-audit or crane_memory(update, id, captain_approved: true)
+```
+
+## Key Principle
+
+Zero nagging. If the Captain declines the proposed memory (Step 4 response is "n"), stop immediately. Do not re-propose or suggest alternatives. The session learning was considered and the Captain chose not to file it — that is a valid answer.
 """

--- a/.gemini/commands/ship.toml
+++ b/.gemini/commands/ship.toml
@@ -2,6 +2,8 @@ description = "Ship to Production"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ship")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Commit, push, PR, CI, merge, and confirm deployment - all in one shot. Follows enterprise rules (branch, PR, CI) but executes the full pipeline without stopping.
 
 ```

--- a/.gemini/commands/skill-audit.toml
+++ b/.gemini/commands/skill-audit.toml
@@ -11,43 +11,83 @@ status: stable
 
 # /skill-audit - Monthly Skill Health Report
 
-Invoke the `crane_skill_audit` MCP tool and walk through the report.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-## How to run
+Run a repo-wide audit of every SKILL.md in the enterprise and global skill libraries. The report surfaces schema gaps, stale skills, and zero-usage candidates.
+
+## Usage
 
 ```
 /skill-audit
 ```
 
-This command:
+No arguments required. The audit runs across all scopes by default.
 
-1. Calls `crane_skill_audit()` with default parameters (`scope: all`, `stale_threshold_days: 180`, `include_deprecated: true`).
-2. Displays the structured report with sections for inventory, schema gaps, staleness, and the deprecation queue.
-3. Prompts you to review any flagged items.
-4. Records completion via `crane_schedule(action: "complete", name: "skill-audit", ...)`.
+## What it checks
 
-## What to expect
+| Section         | What it surfaces                                                                                                      |
+| --------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Inventory**   | Total skill count, broken down by scope, status, and owner                                                            |
+| **Schema gaps** | Skills missing one or more required frontmatter fields (`name`, `description`, `version`, `scope`, `owner`, `status`) |
+| **Staleness**   | Skills whose `SKILL.md` has not been touched in git for more than 180 days                                            |
+| **Zero-usage**  | Skills with zero invocations in the last 90 days — retirement candidates                                              |
 
-The report contains four sections:
+Reference drift (broken `depends_on.mcp_tools`, `depends_on.files`, `depends_on.commands`) is NOT included in this tool - it requires invoking the `skill-review` CLI which cross-checks against live manifests. Run `/skill-review --all` for reference-drift details.
 
-- **Inventory** - Total skills by scope, status, and owner.
-- **Schema gaps** - Skills missing required frontmatter fields. Each entry shows which fields are missing.
-- **Staleness** - Skills not touched in git for more than 180 days, sorted worst-first.
-- **Deprecation queue** - Skills with `status: deprecated`, sorted by days until sunset.
+## Workflow
 
-Reference drift checking (broken MCP tool / file / command references) is not included here. Run `/skill-review --all` separately for that.
+### Step 1: Run the audit
 
-## Options
-
-You can customize the audit:
+Call the MCP tool:
 
 ```
-crane_skill_audit(scope: "enterprise")          # enterprise skills only
-crane_skill_audit(stale_threshold_days: 90)     # tighter staleness window
-crane_skill_audit(include_deprecated: false)    # exclude deprecated from counts
+crane_skill_audit()
 ```
 
-## Full workflow
+Default parameters:
 
-See `.agents/skills/skill-audit/SKILL.md` for the complete step-by-step workflow including how to act on each report section and record completion.
+- `scope`: `all` (enterprise + global)
+- `stale_threshold_days`: 180
+
+You can narrow the scope:
+
+```
+crane_skill_audit(scope: "enterprise", stale_threshold_days: 90)
+```
+
+### Step 2: Interpret the report
+
+**Inventory** - Review the totals. A healthy library has no skills in `unknown` status. Skills in `draft` for more than 30 days should be reviewed.
+
+**Schema gaps** - Each entry names the skill and the missing fields. Schema gaps should be fixed before the skill is marked `stable`. Open a PR to fill them.
+
+**Staleness** - Skills not touched in 180+ days may be outdated. Review each:
+
+- If the skill is still accurate: touch the file (whitespace-only commit) to reset the clock.
+- If the skill is obsolete: get Captain directive, then open a PR that deletes the SKILL.md, dispatcher, `config/skill-owners.json` entry, and any code references.
+
+**Zero-usage candidates** - Skills with zero invocations in 90 days. Either the skill isn't calling `crane_skill_invoked` (fix the SKILL.md), or it's genuinely unused. For genuine orphans, get Captain directive and retire in a single PR.
+
+### Step 3: Record completion
+
+After reviewing the report and taking any required actions, record the audit as complete:
+
+```
+crane_schedule(
+  action: "complete",
+  name: "skill-audit",
+  result: "success",
+  summary: "<one-line summary, e.g. '18 skills audited, 2 stale flagged, 0 schema gaps'>"
+)
+```
+
+## Cadence
+
+This skill is on a monthly cadence (`schedule_items` name: `skill-audit`). It surfaces in the `/sos` briefing when due.
+
+## Notes
+
+- Staleness is derived from `git log -1 --format=%cI -- <path>`. Files never committed show as `last_touched: unknown` and are treated as maximally stale.
+- Skills with `backend_only: true` still appear in the audit - they just have no dispatcher parity requirement.
+- This tool does not modify any SKILL.md. It is read-only.
 """

--- a/.gemini/commands/skill-review.toml
+++ b/.gemini/commands/skill-review.toml
@@ -11,39 +11,156 @@ status: stable
 
 # /skill-review
 
-Lint a skill directory or all skills against the schema in `docs/skills/governance.md`.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skill-review")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-## Usage
+Lint a skill directory (or all skills) against the governance schema defined in `docs/skills/governance.md`. Surfaces violations as structured output and exits non-zero in strict mode if any errors are found.
 
-```
-/skill-review [skill-name] [--strict]
-```
+## Behavior
 
-- `/skill-review` - review all skills in advisory mode (always exits 0)
-- `/skill-review sos` - review the `sos` skill only
-- `/skill-review --strict` - review all skills, exit 1 on errors
-- `/skill-review sos --strict` - review `sos`, exit 1 on errors
+The skill delegates to the CLI at `packages/crane-mcp/src/cli/skill-review.ts`. It is the creation/change gate — run it before flipping `status: stable` and opening a PR. CI runs it in advisory mode on every PR that touches `.agents/skills/**`.
 
-## What the Agent Does
-
-When you invoke `/skill-review`, the agent runs:
+### Invocation
 
 ```bash
-# Single skill
+# Review a single skill
 npm run skill-review -w @venturecrane/crane-mcp -- --path .agents/skills/<name>
 
-# All skills
-npm run skill-review -w @venturecrane/crane-mcp -- --all [--strict] [--json]
+# Review all skills (advisory — exits 0 regardless of findings)
+npm run skill-review -w @venturecrane/crane-mcp -- --all
+
+# Review all skills, block on errors (CI strict mode)
+npm run skill-review -w @venturecrane/crane-mcp -- --all --strict
+
+# Machine-readable JSON output
+npm run skill-review -w @venturecrane/crane-mcp -- --all --json
+
+# Custom MCP tool manifest path
+npm run skill-review -w @venturecrane/crane-mcp -- --all --manifest config/mcp-tool-manifest.json
 ```
 
-The CLI builds from TypeScript, runs all five checks against each `SKILL.md`, then prints a human-readable report (or JSON with `--json`).
+### Flags
 
-## Output
+| Flag                | Default                         | Description                                                                |
+| ------------------- | ------------------------------- | -------------------------------------------------------------------------- |
+| `--path <dir>`      | -                               | Review a single skill directory. Mutually exclusive with `--all`.          |
+| `--all`             | -                               | Review every skill in `.agents/skills/`. Mutually exclusive with `--path`. |
+| `--strict`          | advisory (exit 0)               | Exit 1 if any `error` violations are found.                                |
+| `--json`            | human-readable                  | Emit machine-readable JSON report.                                         |
+| `--manifest <path>` | `config/mcp-tool-manifest.json` | Path to MCP tool manifest used for `mcp_tools` validation.                 |
 
-Human-readable (default):
+## Rule Categories
+
+Five rule categories are checked. Each violation has a `severity` of `error`, `warning`, or `info`.
+
+### 1. Frontmatter Conformance (`frontmatter.*`)
+
+Validates the YAML frontmatter block at the top of each `SKILL.md`.
+
+Required fields: `name`, `description`, `version`, `scope`, `owner`, `status`.
+
+Violation examples:
 
 ```
-Reviewed 12 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
+ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
+  Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
+
+ERROR [frontmatter.name-mismatch] .agents/skills/foo/SKILL.md: name "bar" does not match directory name "foo"
+  Fix: Set `name: foo` in frontmatter to match the skill directory.
+
+ERROR [frontmatter.invalid-semver] .agents/skills/foo/SKILL.md: version "1.0" is not valid semver (expected MAJOR.MINOR.PATCH)
+  Fix: Set version to a semver string, e.g. `version: 1.0.0`.
+
+ERROR [frontmatter.invalid-scope] .agents/skills/foo/SKILL.md: scope "vc" is invalid. Must be enterprise, global, or venture:<code>
+  Fix: Set scope to one of: `enterprise`, `global`, or `venture:<lowercase-code>` (e.g. `venture:ss`).
+
+ERROR [frontmatter.invalid-status] .agents/skills/foo/SKILL.md: status "beta" is invalid. Must be one of: draft, stable, deprecated
+  Fix: Set status to `draft`, `stable`, or `deprecated`.
+
+ERROR [frontmatter.unknown-owner] .agents/skills/foo/SKILL.md: owner "unknown-team" is not a known key in config/skill-owners.json
+  Fix: Add the skill under an existing owner key (captain, agent-team) in config/skill-owners.json, or add a new owner key.
+```
+
+### 2. Dispatcher Parity (`dispatcher.*`)
+
+Unless `backend_only: true` is set, every skill must have a matching `.claude/commands/<name>.md` command dispatcher.
+
+Violation example:
+
+```
+ERROR [dispatcher.missing-command-file] .agents/skills/foo/SKILL.md: No dispatcher found at .claude/commands/foo.md
+  Fix: Create .claude/commands/foo.md, or set `backend_only: true` in frontmatter if this skill has no slash command.
+```
+
+### 3. Reference Validity (`references.*`)
+
+Validates entries in `depends_on.mcp_tools`, `depends_on.files`, and `depends_on.commands`.
+
+- `mcp_tools`: each name must appear in `config/mcp-tool-manifest.json` (errors if manifest exists).
+- `files`: each entry must be scope-prefixed (`crane-console:`, `venture:`, or `global:`). Unprefixed paths are an error. `crane-console:` paths are resolved from repo root. `venture:` paths require `CRANE_VENTURE_SAMPLE_REPO` env var (warning if unset). `global:` paths expand `~/` and check local filesystem; in CI (`CI=true`) they emit a warning instead of an error.
+- `commands`: checked via `which <cmd>`. Missing commands are warnings, not errors.
+
+Violation examples:
+
+```
+ERROR [references.unknown-mcp-tool] .agents/skills/foo/SKILL.md: MCP tool "crane_missing" not found in config/mcp-tool-manifest.json
+  Fix: Remove the tool reference, add it to the manifest, or check for a typo in the tool name.
+
+ERROR [references.file-missing-scope-prefix] .agents/skills/foo/SKILL.md: File path missing scope prefix (expected `crane-console:`, `venture:`, or `global:`): "docs/foo.md"
+  Fix: Prefix the file path with `crane-console:`, `venture:`, or `global:` to indicate where the file lives.
+
+ERROR [references.broken-crane-console-file] .agents/skills/foo/SKILL.md: crane-console file not found: "docs/missing.md"
+  Fix: Create the file at docs/missing.md relative to the repo root, or remove the reference.
+
+WARNING [references.venture-file-unverified] .agents/skills/foo/SKILL.md: venture file reference ".design/DESIGN.md" not verified — CRANE_VENTURE_SAMPLE_REPO is not set
+  Fix: Set CRANE_VENTURE_SAMPLE_REPO to a local venture repo path to enable validation, or verify the path manually.
+
+WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "missing-cli" not found on PATH
+  Fix: Install "missing-cli" or remove it from depends_on.commands if it is optional.
+```
+
+### 4. Structural Lint (`structure.*`)
+
+The SKILL.md body (text after the closing `---`) must:
+
+1. Have a top-level `#` heading that starts with `/<name>` (e.g. `# /skill-review` or `# /skill-review - Title`).
+2. Contain at least one second-level section named `## Phases`, `## Workflow`, or `## Behavior`.
+
+Violation examples:
+
+```
+ERROR [structure.missing-h1-heading] .agents/skills/foo/SKILL.md: Body has no top-level # heading
+  Fix: Add a `# /foo` heading as the first heading in the SKILL.md body.
+
+ERROR [structure.heading-mismatch] .agents/skills/foo/SKILL.md: First # heading "Foo" does not start with "/foo"
+  Fix: Change the first heading to `# /foo` or `# /foo - Description`.
+
+ERROR [structure.missing-workflow-section] .agents/skills/foo/SKILL.md: Body is missing a workflow section (## Phases, ## Workflow, or ## Behavior)
+  Fix: Add a `## Phases`, `## Workflow`, or `## Behavior` section describing how the skill executes.
+```
+
+### 5. Deprecation Sanity (`deprecation.*`)
+
+If `status: deprecated`, both `deprecation_date` and `sunset_date` must be present, parseable as ISO dates, and `sunset_date` must be strictly after `deprecation_date`.
+
+Violation examples:
+
+```
+ERROR [deprecation.missing-deprecation-date] .agents/skills/foo/SKILL.md: status is deprecated but deprecation_date is missing
+  Fix: Add `deprecation_date: YYYY-MM-DD` to frontmatter.
+
+ERROR [deprecation.missing-sunset-date] .agents/skills/foo/SKILL.md: status is deprecated but sunset_date is missing
+  Fix: Add `sunset_date: YYYY-MM-DD` to frontmatter (typically deprecation_date + 90 days).
+
+ERROR [deprecation.sunset-before-deprecation] .agents/skills/foo/SKILL.md: sunset_date "2025-01-01" must be after deprecation_date "2025-03-01"
+  Fix: Set sunset_date to a date strictly after deprecation_date.
+```
+
+## Output Formats
+
+### Human-readable (default)
+
+```
+Reviewed 3 skill(s) — 2 violation(s) (1 error, 1 warning, 0 info)
 
 ERROR [frontmatter.missing-field] .agents/skills/foo/SKILL.md: Missing required field: owner
   Fix: Add `owner: <team>` to frontmatter. See docs/skills/governance.md.
@@ -51,25 +168,46 @@ WARNING [references.missing-command] .agents/skills/foo/SKILL.md: Command "jq" n
   Fix: Install "jq" or remove it from depends_on.commands if it is optional.
 ```
 
-JSON (with `--json`):
+### JSON (`--json`)
 
 ```json
 {
-  "skills_reviewed": 12,
+  "skills_reviewed": 3,
   "total_violations": 2,
   "by_severity": { "error": 1, "warning": 1, "info": 0 },
-  "violations": [...]
+  "violations": [
+    {
+      "rule": "frontmatter.missing-field",
+      "severity": "error",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Missing required field: owner",
+      "fix": "Add `owner: <team>` to frontmatter. See docs/skills/governance.md."
+    },
+    {
+      "rule": "references.missing-command",
+      "severity": "warning",
+      "path": ".agents/skills/foo/SKILL.md",
+      "message": "Command \"jq\" not found on PATH",
+      "fix": "Install \"jq\" or remove it from depends_on.commands if it is optional."
+    }
+  ]
 }
 ```
 
-## Exit Codes
+## Adding a New Skill
 
-- Default (advisory): always exits 0
-- `--strict`: exits 1 if any `error`-severity violations are found
+Follow the workflow in `docs/skills/governance.md`:
+
+1. Scaffold the skill directory at `.agents/skills/<name>/SKILL.md`.
+2. Fill in all required frontmatter fields (start with `status: draft`).
+3. Ensure `config/skill-owners.json` has the owning key.
+4. Create `.claude/commands/<name>.md` unless `backend_only: true`.
+5. Run `/skill-review --path .agents/skills/<name>` until zero errors.
+6. Flip to `status: stable` and open a PR.
 
 ## Reference
 
-Full governance spec and rule definitions: `docs/skills/governance.md`
+Full governance spec: `docs/skills/governance.md`
 
 CLI source: `packages/crane-mcp/src/cli/skill-review.ts`
 """

--- a/.gemini/commands/skunkworks.toml
+++ b/.gemini/commands/skunkworks.toml
@@ -2,6 +2,8 @@ description = "Operating stance for a live operation"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "skunkworks")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 The Captain has put you on a skunkworks operation: a small, trusted, fast-moving effort where the stakes are real and the full path isn't mapped. You are not a task-taker waiting for the next instruction - you own the outcome. Load this stance at the start of the operation and hold it as a filter on every move.
 
 ## Behavior

--- a/.gemini/commands/status.toml
+++ b/.gemini/commands/status.toml
@@ -2,6 +2,8 @@ description = "Show Session Status"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "status")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Display current session state, tasks, and git status for situational awareness.
 
 ## What to Show

--- a/.gemini/commands/ui-drift-audit.toml
+++ b/.gemini/commands/ui-drift-audit.toml
@@ -11,27 +11,132 @@ status: stable
 
 # /ui-drift-audit - Visual drift audit
 
-Run a source-level audit of the venture's UI code and produce a per-file violation matrix. Use to seed pattern-spec citations, size remediation PRs, or gate token-compliance in CI.
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "ui-drift-audit")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
 
-See `.agents/skills/ui-drift-audit/SKILL.md` for the full rule mapping, output schemas, and per-venture configuration via `.ui-drift.json`.
+Runs a source-level scan of a venture's UI code and emits a surfaces × rules matrix with violation counts. Use to seed pattern-spec citations, size remediation PRs, and gate token-compliance in CI.
 
-## Quick start
+This is a heuristic, not a verifier. Counts approximate drift scale; inspect hot-spots before writing rule citations. Rendered-DOM checks via Playwright are deliberately out of scope — they earn in only for rules that grep demonstrably can't catch.
+
+## When to run
+
+- **Before authoring or revising a venture's pattern spec** (e.g., `docs/style/UI-PATTERNS.md`) — the matrix tells you which rules bite hardest and on which surfaces.
+- **Before sizing a Rule-class remediation PR** — violation counts set the PR scope; >30 per tier splits by component family.
+- **Monthly as a drift watchdog** — new violations in surfaces previously clean indicate spec erosion or escape-hatch abuse.
+- **In CI on every PR** — token-compliance columns gate merges via `--format json` + threshold checks.
+
+## How to run
 
 ```bash
 # Markdown report (default)
 python3 .agents/skills/ui-drift-audit/audit.py
+# writes .design/audits/ui-drift-{YYYY-MM-DD}.md
 
-# JSON report for CI threshold gates
+# JSON report
 python3 .agents/skills/ui-drift-audit/audit.py --format json --out audit.json
 
-# Custom status words for redundancy detection
+# Override status words for redundancy detection
 python3 .agents/skills/ui-drift-audit/audit.py --status-words "Pending,Approved,Draft"
+
+# Use venture's .ui-drift.json config
+# (auto-loaded from <repo-root>/.ui-drift.json)
 ```
 
-## When to invoke
+Optional flags:
 
-- Before authoring or revising a venture's pattern spec.
-- Before sizing a Rule-class remediation PR (count > 30 → split by component family).
-- Monthly as a drift watchdog.
-- In CI on every PR — see `docs/design-system/adoption/audit-workflow.yml.template`.
+- `--out PATH` — override output path.
+- `--format {markdown,json}` — output format. Default `markdown`.
+- `--status-words "Word1,Word2,..."` — comma-separated list of pill status keywords for the redundancy check. Overrides `.ui-drift.json` and built-in defaults.
+- `--src DIR` — repeatable. Source directories to scan. Defaults to `src/pages` + `src/components`. Override for venture layouts that use different roots.
+- `--config PATH` — explicit `.ui-drift.json` config file. Default: auto-discover at repo root.
+
+No external dependencies — pure Python stdlib. Walks the configured source directories for files ending `.astro`, `.tsx`, `.jsx`.
+
+## Per-venture configuration: `.ui-drift.json`
+
+Each venture may drop a `.ui-drift.json` at repo root to set defaults:
+
+```json
+{
+  "status_words": ["Pending", "Approved", "Draft", "Rejected"],
+  "src_dirs": ["src/pages", "src/components", "app"],
+  "thresholds": {
+    "raw_hex_rgb_in_jsx_max": 0,
+    "raw_hex_rgb_in_inline_style_max": 0,
+    "raw_tailwind_color_classes_max": 5
+  }
+}
+```
+
+Precedence (highest to lowest): CLI flag > `.ui-drift.json` > built-in default.
+
+## What it counts (rule mapping)
+
+The detector covers **7 of 7 patterns** (Rules 1-7 in `docs/style/UI-PATTERNS.md`).
+
+| Column                          | Rule                                          | Signal                                                                                                                                                                  |
+| ------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pills**                       | Rule 1 (status display) + Rule 2 (redundancy) | `rounded-full` + tint bg pattern; avatars excluded (base bg).                                                                                                           |
+| **Typo (arb / token)**          | Rule 5 (typography scale)                     | Arbitrary: `text-[Npx]`. Token: `text-xs/sm/base/lg/xl/...`. Both flag post-Rule-5 tokens.                                                                              |
+| **Spacing (arb / token)**       | Rule 6 (spacing rhythm)                       | Arbitrary: `p-[N]`, `gap-[N]`. Token: raw `p-N`, `gap-N`.                                                                                                               |
+| **H-skips**                     | Rule 4 (heading skip ban)                     | Document-order `h{N}` → `h{N+2+}` jumps within a single file.                                                                                                           |
+| **Primary CTAs**                | Rule 3 (one primary per view)                 | Count of `bg-primary` or `bg-[color:var(--color-primary)]` per file. Violation = count > 1.                                                                             |
+| **Redundancy**                  | Rule 2                                        | Tinted pill whose status-keyword content is echoed in ±10 lines of prose.                                                                                               |
+| **Shared primitives**           | Rule 7 (shared primitives)                    | Hand-rolled `StatusPill`/`MoneyDisplay`/`PortalListItem` shape in files that don't import the primitive. Per-primitive breakdown in JSON `shared_primitives_breakdown`. |
+| **raw_hex_rgb_in_jsx**          | Token compliance                              | Raw `#abc` / `#aabbcc` / `rgba(...)` literals anywhere in `.tsx`/`.jsx` files.                                                                                          |
+| **raw_hex_rgb_in_inline_style** | Token compliance                              | Same regex but only inside `style={{...}}` JSX expressions.                                                                                                             |
+| **raw_tailwind_color_classes**  | Token compliance                              | Tailwind palette colors (`bg-blue-500`, `text-red-300`, ...) — semantic-token replacement candidates.                                                                   |
+
+### Pattern 7 (shared primitives) detection notes
+
+The Pattern 7 detector deliberately trades recall for precision so the
+column is trustworthy in CI:
+
+- **Status pill** matches inline `<span>`/`<div>` combining `rounded-full`
+  with `text-xs` (or arbitrary tiny size) AND `uppercase` or `tracking-`.
+  Avatars (`w-N h-N rounded-full`), progress bars (`h-N rounded-full`),
+  and unstyled `text-xs rounded-full` filter chips are intentionally
+  excluded — they're not the StatusPill shape.
+- **Money display** matches lines containing `tabular-nums` only when a
+  currency-formatter signal (`Intl.NumberFormat(... 'currency')`,
+  `style: 'currency'`, `formatCentsToCurrency`) appears within ±1 line.
+  `tabular-nums` used for dates, phones, or progress numbers is excluded.
+- **List row** is scoped to portal `index.astro` files that iterate via
+  `.map(` and emit `flex` + `justify-between` layout without importing
+  `PortalListItem`. Detail pages (`engagement/index.astro` and
+  `[id].astro`) are excluded.
+- Files that ARE the canonical primitive (`StatusPill.astro`,
+  `MoneyDisplay.astro`, `PortalListItem.astro`) are skipped entirely.
+
+If a violation is real but the file legitimately can't use the primitive,
+the escape hatch is the same as for other rules: see Rule 7 in
+`docs/style/UI-PATTERNS.md` for the `LIST_INDEX_ALLOWLIST` mechanism.
+
+## Known limits (shipped as v2)
+
+- **Source-level only.** Component-rendered headings (e.g., `<PortalHeader>` emits `<h1>` internally) are invisible to the file-local heading-skip scan.
+- **Redundancy uses a curated status-keyword list.** Override per venture via `.ui-drift.json` or `--status-words`. The built-in default covers common SaaS billing / contracting states.
+- **Primary CTA count > 1 is a suggestion, not a verdict.** A page with multi-state branches can legitimately declare multiple primaries as long as only one renders per state.
+- **Tier classification is heuristic.** Defaults to path-prefix mapping; ventures with different IA can customize via `--src` to scope the audit.
+
+## Output formats
+
+### Markdown (default)
+
+Markdown document at `.design/audits/ui-drift-{YYYY-MM-DD}.md`:
+
+1. **Tier totals** — aggregated counts per tier.
+2. **Per-file matrix** — every file's column counts, sorted within tier by total violations.
+3. **Redundancy detail** — pill-line + echoed-word per hit; seeds Rule 2 anti-pattern citations.
+4. **Heading-skip detail** — skip pairs per file; seeds Rule 4 citations.
+5. **Token compliance summary** — per-file counts of the 3 token-compliance columns.
+
+### JSON (`--format json`)
+
+Stable schema documented in `audit.py` module docstring. Designed for CI threshold gating and tooling integration.
+
+## Relationship to other skills
+
+- **Upstream of venture pattern specs.** The audit produces the anti-pattern roster; the venture's spec codifies the rules.
+- **Not overlapping `nav-spec`.** Nav spec governs IA + chrome + navigation patterns. This audit governs visual/component semantics.
+- **Not overlapping `design-brief` or `ux-brief`.** Those are upstream authoring pipelines (PRD → brief → `product-design`). This is a post-hoc audit of what shipped.
 """

--- a/.gemini/commands/update.toml
+++ b/.gemini/commands/update.toml
@@ -2,6 +2,8 @@ description = "Update Session Context"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "update")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Update your session with current branch, commit, and work metadata.
 
 ## What It Does

--- a/.gemini/commands/video-build.toml
+++ b/.gemini/commands/video-build.toml
@@ -2,6 +2,8 @@ description = "Scaffold, Align & Render an Explainer"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-build")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Takes an approved script + an approved voice take and produces a rendered
 explainer: scaffolds `videos/<slug>/`, locks beat timing with Whisper forced
 alignment, guides scene authoring against the house style, and renders. The

--- a/.gemini/commands/video-package.toml
+++ b/.gemini/commands/video-package.toml
@@ -2,6 +2,8 @@ description = "Caption, Chapter & Package an Explainer"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-package")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns a final render into the publish bundle: SRT captions, YouTube chapters, a
 filled-in `youtube.md` (title / description / tags), and thumbnail candidates.
 Deterministic — the exact bundle `/video-publish` consumes.

--- a/.gemini/commands/video-publish.toml
+++ b/.gemini/commands/video-publish.toml
@@ -2,6 +2,8 @@ description = "Upload to YouTube & Cross-Promote"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-publish")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Publishes a packaged explainer to the Venture Crane channel via Playwright and
 wires the bidirectional cross-promotion with venturecrane.com. The human performs
 the Google login/2FA; the agent drives Studio and opens the vc-web PR.

--- a/.gemini/commands/video-script.toml
+++ b/.gemini/commands/video-script.toml
@@ -2,6 +2,8 @@ description = "Explainer Script Drafting"
 
 prompt = """
 
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "video-script")`. This is non-blocking — if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
 Turns a topic or an existing vc-web article into a house-format **6-beat narration
 script** with per-beat visual notes and alignment anchors — the input to
 `/video-build`. Drafting only; it does not generate audio or render anything.

--- a/packages/crane-mcp/src/cli/skill-review.test.ts
+++ b/packages/crane-mcp/src/cli/skill-review.test.ts
@@ -253,6 +253,14 @@ describe('checkDispatcherParity', () => {
     expect(v!.message).toContain('first divergence')
   })
 
+  it('ignores a leading frontmatter block in the dispatcher when comparing', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    const dispatcherWithFm = `---\nname: foo\ndescription: Does something.\n---\n${BODY}`
+    vi.mocked(readFileSync).mockReturnValue(dispatcherWithFm)
+    const violations = checkDispatcherParity(SKILL_PATH, goodFrontmatter(), REPO_ROOT, BODY)
+    expect(violations).toHaveLength(0)
+  })
+
   it('warns when dispatcher is missing the invocation directive', () => {
     vi.mocked(existsSync).mockReturnValue(true)
     const noDirective = `# /foo - Does Something\n\n## Behavior\n\nStep one.\nStep two.\n`

--- a/packages/crane-mcp/src/cli/skill-review/checks.ts
+++ b/packages/crane-mcp/src/cli/skill-review/checks.ts
@@ -109,14 +109,28 @@ export function checkFrontmatterConformance(
 }
 
 /**
- * Normalize a markdown body for parity comparison: drop the telemetry
- * directive line (injected independently on each side), blank lines, and
- * trailing whitespace. The remaining lines must match exactly — the
- * dispatcher is what Claude Code executes, so silent body drift means the
- * SKILL.md and the running skill are different programs.
+ * Strip a leading YAML frontmatter block (between the first two `---` fence
+ * lines). Some dispatchers carry their own frontmatter for the Claude Code
+ * command palette; it is not part of the executable body.
+ */
+function stripLeadingFrontmatter(text: string): string {
+  const lines = text.split('\n')
+  if (lines[0] !== '---') return text
+  const end = lines.indexOf('---', 1)
+  if (end === -1) return text
+  return lines.slice(end + 1).join('\n')
+}
+
+/**
+ * Normalize a markdown body for parity comparison: drop any leading
+ * frontmatter block, the telemetry directive line (injected independently
+ * on each side), blank lines, and trailing whitespace. The remaining lines
+ * must match exactly — the dispatcher is what Claude Code executes, so
+ * silent body drift means the SKILL.md and the running skill are different
+ * programs.
  */
 function normalizeBody(text: string): string[] {
-  return text
+  return stripLeadingFrontmatter(text)
     .split('\n')
     .map((l) => l.replace(/\s+$/, ''))
     .filter((l) => l !== '' && !l.includes('crane_skill_invoked'))
@@ -167,7 +181,7 @@ export function checkDispatcherParity(
     })
   }
 
-  const dispatcherHead = dispatcherRaw
+  const dispatcherHead = stripLeadingFrontmatter(dispatcherRaw)
     .split('\n')
     .filter((l) => l.trim() !== '')
     .slice(0, 20)


### PR DESCRIPTION
## Summary

Executes #1110: brings every skill's Claude Code dispatcher to byte parity with its SKILL.md body and adds the `crane_skill_invoked` telemetry directive across the board. Follows the pattern from #1109 (which fixed sos/eos/critique).

## Changes

- **12 stale dispatchers** regenerated from their newer/richer SKILL.md bodies (drift direction determined per skill via git history + diff inspection)
- **code-review → 1.2.0**: drift direction was reversed — the SKILL.md body was an old pre-`--quick` snapshot; rebuilt from the canonical dispatcher (multi-model + `--quick` mode preserved)
- **new-venture → 1.1.0**: genuine two-way divergence; merged the dispatcher's AC-enforcement content with SKILL.md's Claude Design onboarding step
- **20 directive-only skills**: dispatchers regenerated to carry the telemetry directive
- **nav-spec / own-it / product-design**: preamble blockquotes moved below the H1 so the CC command palette shows the skill title instead of the invocation directive
- **Linter fix**: parity comparison now strips a leading frontmatter block from dispatchers — operator-onboard and verify-audit were false-positive drift (dispatcher frontmatter is a legitimate CC palette feature); new test covers it
- All 36 touched skills version-bumped (patch, minor where body content changed); Gemini TOML + Codex SKILL.md mirrors regenerated

## Verification

- `skill-review --all`: **0 errors, 0 dispatcher warnings** (down from 54 warnings; 4 remaining are pre-existing env-dependent venture-file checks, 5 info pre-existing)
- `./scripts/sync-commands.sh --check`: all generated files match
- `npm run verify`: green (one unit test in crane-context `sessions.test.ts` was flaky in the batch run, passes standalone; the 18 `integration-legacy` failures on direct vitest invocation are infra-dependent tests excluded from verify)

Closes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRtD3ArkPK913zuK6vJF2a