### PR TITLE
feat(memory): restore /eos capture step + Directives-block parity test

### DIFF
--- a/.agents/skills/eos/SKILL.md
+++ b/.agents/skills/eos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: eos
 description: End of Session Handoff
-version: 2.2.0
+version: 2.3.0
 scope: enterprise
 owner: captain
 status: stable
@@ -267,6 +267,22 @@ Using conversation history and gathered context, the agent generates a summary c
 
 **Anti-Fabrication rule (also applies to this section).** The same gate from Step 2 governs what goes into "In Progress," "Blocked," and "Next Session." If an item does not pass the Step 2 gate, it does not belong in the synthesized handoff. Write "(none)" for empty sections. Do not pad.
 
+### 3b. Memoryable Moments (inline capture)
+
+This is the governed write path from a session's corrections to the injected memory corpus (`docs/memory/governance.md`, "Authorship path 1"). It is the ONLY path that creates `captain_approved: true` records at creation time. Skipping it is how corrections pool in ungoverned local files that fleet agents never see (restored 2026-07-26 after being found missing while the governance doc cited it as load-bearing).
+
+After synthesizing the handoff and BEFORE saving, propose **0-2 memoryable moments** observed this session:
+
+- A moment qualifies only if it passes all three memoryability tests (same tests as `/save-lesson` Step 5): **actionable** (tells a future agent what to do or avoid, not how someone felt), **non-obvious** (not derivable from the codebase or default reasoning), and **general enough to recur** (a class of situations, not a single accident).
+- Err on fewer. **0 is a valid answer** — cheap misses beat noisy hits. Routine work is not a lesson.
+- Captain redirects and corrections given this session are the primary candidates. A correction the Captain had to repeat is ALWAYS a candidate.
+
+For each proposal, show the draft inline: `kind` (lesson | anti-pattern), `scope` (enterprise | global | venture:<code> — apply the `/save-lesson` Step 5b scope/name consistency checks), `severity` (required for anti-patterns), `applies_when` (skills / commands / file globs), and a 2-4 sentence body. If the session's venture maintains an operating-doctrine registry (e.g. ss-console `docs/doctrine/agent-operating-doctrine.md`), name the law the moment evidences in the body (`law: <id>`) — the venture's closure loop diffs captured incidents against that registry.
+
+Present all proposals in ONE consolidated question (fold into the Step 2 close-out question when both fire; the one-interaction principle holds). Captain accepts or rejects each inline.
+
+For each ACCEPTED item, call `crane_memory(action: 'save')` with `status: stable, captain_approved: true` — no draft queue. Rejected items are dropped without ceremony. If the Captain is unavailable (headless close), save nothing here; note candidate moments in the handoff's "Next Session" block instead.
+
 ### 4. Display and Save (Auto-Save)
 
 Display the generated handoff, then **immediately save it to D1 without asking for confirmation.** Do not prompt the user with "Save to D1?" or any yes/no question. Just show the summary and save.
@@ -316,9 +332,9 @@ Handoff saved to D1. Next session will see this via crane_sos.
 
 ## Key Principle
 
-**The agent summarizes. The agent saves. No confirmation needed — with one targeted exception: if Step 2's audit surfaces genuine unshipped work, the skill asks ONE consolidated close-out question before proceeding. Otherwise, auto-save proceeds silently.**
+**The agent summarizes. The agent saves. No confirmation needed — with one targeted exception: if Step 2's audit surfaces genuine unshipped work or Step 3b proposes memoryable moments, the skill asks ONE consolidated close-out question (both concerns folded together) before proceeding. Otherwise, auto-save proceeds silently.**
 
-The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything. The Session Close-Out Audit is the only place `/eos` produces a prompt, and only when objective detection checks find loose ends that pass the anti-fabrication gate.
+The agent has full session context - every command run, every file edited, every conversation turn. It should synthesize this into a coherent handoff without asking the user to remember or summarize anything. The Step 2 audit and the Step 3b memoryable proposals are the only places `/eos` produces a prompt, and only when objective detection finds loose ends or a moment passes all three memoryability tests.
 
 ## Related
 

--- a/docs/instructions/guardrails.md
+++ b/docs/instructions/guardrails.md
@@ -7,10 +7,10 @@
 - Never remove, deprecate, or disable existing features without explicit Captain directive
 - Never drop database columns/tables or run destructive migrations without Captain directive
 - Never modify authentication flows or remove access controls without Captain directive
-- Never invent client-facing content — no fallback sentences, borrowed copy, or fabricated defaults (Pattern A / Pattern B below)
+- Never invent client-facing content — no fallback sentences, borrowed copy, or fabricated defaults (Pattern A / Pattern B in `guardrails.md`)
 - "Unused" is not sufficient justification - external consumers, bookmarks, and integrations may depend on it
 - Infrastructure changes that affect agent-facing tools must update the corresponding instruction modules in the same PR
-- When in doubt, STOP and escalate using the format below
+- When in doubt, STOP and escalate (format in `guardrails.md`)
 <!-- SOD_SUMMARY_END -->
 
 ---
@@ -212,5 +212,5 @@ action in a category not covered above):
 1. Add the new category to the Protected Actions section
 2. Add concrete heuristic examples
 3. Update the SOD summary between the markers
-4. Upload the updated doc: `./scripts/upload-doc-to-context-worker.sh docs/instructions/guardrails.md`
-5. The SOD section updates automatically - no TypeScript changes needed
+4. Mirror the change into `SOD_SUMMARY_BULLETS` in `packages/crane-mcp/src/tools/sos/message-sections.ts` in the same PR. The SOS Directives block is an inlined copy, not a live read; `directives-parity.test.ts` fails the build if the two drift. (An earlier version of this list claimed the SOD section updates automatically with no TypeScript changes. That was never true and let two bullets go missing from every session briefing until 2026-07-26.)
+5. Upload the updated doc: `./scripts/upload-doc-to-context-worker.sh docs/instructions/guardrails.md`

--- a/packages/crane-mcp/src/tools/sos/directives-parity.test.ts
+++ b/packages/crane-mcp/src/tools/sos/directives-parity.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Directives-block parity gate (2026-07-26).
+ *
+ * The SOS Directives block inlines the guardrails.md SOD_SUMMARY bullets as a
+ * TypeScript constant "to avoid an HTTP fetch per session." A hand-maintained
+ * copy of always-on rules is a drift machine: before this test existed, two SOD
+ * bullets (client-content fabrication; instruction-module coupling) were absent
+ * from every session briefing, while the doc's own editing instructions claimed
+ * the SOD section "updates automatically - no TypeScript changes needed."
+ *
+ * The contract: every bullet between SOD_SUMMARY_START/END in
+ * docs/instructions/guardrails.md appears VERBATIM in renderDirectivesBlock's
+ * output. Edit the doc first, mirror into SOD_SUMMARY_BULLETS in
+ * message-sections.ts in the same PR; this test blocks the drift.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderDirectivesBlock } from './message-sections.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(here, '..', '..', '..', '..', '..')
+const guardrailsPath = path.join(repoRoot, 'docs', 'instructions', 'guardrails.md')
+
+function sodBullets(): string[] {
+  const raw = readFileSync(guardrailsPath, 'utf8')
+  const match = raw.match(/<!-- SOD_SUMMARY_START -->([\s\S]*?)<!-- SOD_SUMMARY_END -->/)
+  if (!match) return []
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+}
+
+describe('SOS Directives block stays in parity with guardrails.md SOD markers', () => {
+  const bullets = sodBullets()
+  const rendered = renderDirectivesBlock('venturecrane/example-repo')
+
+  it('finds the SOD_SUMMARY block (sanity: a moved marker must not pass green)', () => {
+    expect(bullets.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('every SOD bullet appears verbatim in the rendered Directives block', () => {
+    const missing = bullets.filter((b) => !rendered.includes(b))
+    expect(missing).toEqual([])
+  })
+
+  it('the rendered block still points at the full guardrails doc', () => {
+    expect(rendered).toContain("crane_doc('global', 'guardrails.md')")
+  })
+})

--- a/packages/crane-mcp/src/tools/sos/message-sections.ts
+++ b/packages/crane-mcp/src/tools/sos/message-sections.ts
@@ -50,22 +50,35 @@ export function renderSessionBlock(params: {
   return out + '\n'
 }
 
+/**
+ * The guardrails.md SOD_SUMMARY block, mirrored verbatim (one bullet per line,
+ * exactly as between the markers). directives-parity.test.ts fails the build if
+ * this drifts from docs/instructions/guardrails.md. Edit the doc first.
+ */
+const SOD_SUMMARY_BULLETS = [
+  `- Never remove, deprecate, or disable existing features without explicit Captain directive`,
+  `- Never drop database columns/tables or run destructive migrations without Captain directive`,
+  `- Never modify authentication flows or remove access controls without Captain directive`,
+  `- Never invent client-facing content — no fallback sentences, borrowed copy, or fabricated defaults (Pattern A / Pattern B in \`guardrails.md\`)`,
+  `- "Unused" is not sufficient justification - external consumers, bookmarks, and integrations may depend on it`,
+  `- Infrastructure changes that affect agent-facing tools must update the corresponding instruction modules in the same PR`,
+  `- When in doubt, STOP and escalate (format in \`guardrails.md\`)`,
+].join('\n')
+
 export function renderDirectivesBlock(fullRepo: string): string {
   let out = `## Directives\n\n`
   out += `**Operating ethos:** You are one of a wild band of AI agents with an ape commander - not a corporate employee. You run a state-of-the-art model with a massive context window, the full toolkit (file/shell ops, MCP integrations, parallel sub-agents, fleet dispatch, browser automation), and teammates. Powerful individually, unstoppable together. Parallelize, hold whole systems in context, verify end-to-end. Confidence, not anxiety - no timidity, no cow-towing. Mission first. Execute. If unclear, ask plainly. Otherwise, move out. No phases, no safeguards, no corporate theater for work that fits in one session. The rules below protect the mission, not slow it down. Full ethos: \`crane_doc('global', 'operating-ethos.md')\`. Toolkit: \`crane_doc('global', 'tooling.md')\`.\n\n`
   out += `- All changes through PRs. Never push directly to main.\n`
   out += `- All GitHub issues this session target **${fullRepo}**. Targeting a different repo? STOP.\n`
-  out += `- Never remove, deprecate, or disable features without Captain directive.\n`
   out += `- Run \`npm run verify\` before pushing. Fix root causes, not symptoms.\n`
   out += `- **Done means wired**, not merged or deployed: every seam your change introduces or relies on must be observed working on the real runtime, with a \`crane_verify\` record naming the seam and output showing it carried data. Unverifiable seams → \`status:blocked\`, never a silent stub. Definition of Done: \`crane_doc('global', 'team-workflow.md')\`.\n`
   out += `- Scope discipline: finish current task, file new issues for discovered work.\n`
   out += `- Never switch repos or ventures without explicit Captain approval. Announce all context switches.\n`
   out += `- Before editing against any third-party API/SDK/CLI (GitHub, Vercel, Cloudflare, npm, etc.), consult Context7 (\`mcp__plugin_context7_context7__*\`) — training data is frozen; don't guess at vendor syntax. Full tooling catalog: \`crane_doc('global', 'tooling.md')\`.\n`
-  // Inlined from guardrails.md SOD markers (avoids HTTP fetch per session)
-  out += `- Never drop database columns/tables or run destructive migrations without Captain directive.\n`
-  out += `- Never modify authentication flows or remove access controls without Captain directive.\n`
-  out += `- "Unused" is not sufficient justification - external consumers may depend on it.\n`
-  out += `- When in doubt, STOP and escalate.\n`
+  // Inlined VERBATIM from guardrails.md SOD_SUMMARY markers (avoids HTTP fetch per
+  // session). Parity is enforced by directives-parity.test.ts: every bullet between
+  // the markers must appear verbatim below. Edit guardrails.md first, then mirror here.
+  out += `${SOD_SUMMARY_BULLETS}\n`
   out += `\nFull guardrails: \`crane_doc('global', 'guardrails.md')\`\n\n`
   return out
 }


### PR DESCRIPTION
## What

Two write-path repairs to the enterprise lesson pipeline, from the 2026-07-26 ss-console failure-pattern audit (companion to venturecrane/ss-console#2011).

### 1. The /eos capture step existed only in the governance doc

`docs/memory/governance.md:129` names /eos inline capture **the only path to `captain_approved: true` at creation** — and the skill never had the step (`crane_memory` declared in `depends_on`, zero calls). Consequence: /save-lesson drafts are excluded by the injection filter, so **no correction could ever reach a future session's SOS briefing**, and fleet workers ran on the hardcoded Directives paragraph alone.

Restored as Step 3b per the governance spec: 0-2 proposals max, the three memoryability tests, one consolidated close-out question (folded with Step 2's, preserving the one-interaction principle), accepted items saved `stable + captain_approved`, headless closes save nothing. Ventures with an operating-doctrine registry (ss-console `docs/doctrine/agent-operating-doctrine.md`) get law-id tagging so their closure loop can diff captured incidents against the ledger. eos 2.2.0 → 2.3.0.

### 2. The always-on Directives block had drifted from its source

`renderDirectivesBlock` hand-inlines the guardrails.md SOD_SUMMARY bullets; the doc's own editing instructions claimed the SOD section "updates automatically - no TypeScript changes needed." It does not, and two bullets — **client-content fabrication** and **instruction-module coupling** — were missing from every session briefing in the fleet.

Fixed: bullets synced verbatim as `SOD_SUMMARY_BULLETS`; `directives-parity.test.ts` fails the build if any SOD bullet is absent from the rendered block; guardrails.md editing instructions corrected (mirror in the same PR, the test enforces); the two context-bound bullets made context-free so verbatim inlining reads correctly.

## Verification

- `npm run typecheck` + `format:check` + `lint` + crane-mcp workspace tests: green, 831 passed incl. the new parity suite.
- Post-merge: next `crane_sos` briefing carries all 7 SOD bullets; next `/eos` close proposes memoryable moments.

## Follow-on (filed separately)

D1 batch migration of the ss-console correction corpus (presented to the Captain for approval per VCMS rule); `applies_when` scoring dead at SOS injection; `docs/global/` upload-whitelist indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gPBdsp4M9oD34teW3NWec