### PR TITLE
feat(memory): 'either' injection gate — captain approval is sovereign (#1164)

### DIFF
--- a/docs/memory/governance.md
+++ b/docs/memory/governance.md
@@ -115,14 +115,14 @@ Enforcement: `crane_memory(save)` validates at save time. A draft that fails any
 
 ## Injection gates — what goes into every session
 
-The `captain_approved` boolean is the single gate that separates "injected into every session" from "available via explicit query."
+Injection is gated by `MEMORY_INJECTION_GATE` (crane-context `wrangler.toml`; read live by SOS via `/config/memory-gate`). The deployed value is **`either`** (union, crane-console#1164): a `stable` record injects when the nightly curator set `notes.injectable = 1` **or** the record carries `captain_approved: true`. Curator promotion is the automated path; Captain approval is the sovereign override — an approved record never waits on the curator, and a cleanly-curated record never waits on a manual approval sweep. Other gate values: `injectable`, `captain_approved`, `both` (strictest; also the fallback for unknown values on both the client and the filter).
 
-- **SOS Critical Anti-Patterns** (always-on, top 5): filter `kind: anti-pattern AND status: stable AND captain_approved: true AND scope ∈ {enterprise, global, venture:current}`.
+- **SOS Critical Anti-Patterns** (always-on, top 5): filter `kind: anti-pattern AND status: stable AND <gate> AND scope ∈ {enterprise, global, venture:current}`.
 - **SOS Relevant Lessons** (context-matched, top 3): same filter with `kind: lesson`.
 - **On-demand pulls** from skills (`/code-review`, `/ship`): may pass `captain_approved_only: false` to access the broader stable corpus.
-- **Auto-promoted drafts**: reach `status: stable` but NOT `captain_approved: true`. They are on-demand-only until Captain approves.
+- **Drafts never inject** under any gate value: `status: stable` is a precondition before the gate is even consulted.
 
-This prevents the "noise bomb" failure mode where batch-migrated or auto-authored drafts flood every session with varying-quality content before a human has vetted them.
+This preserves the "noise bomb" defense — batch-migrated or auto-authored drafts cannot flood sessions before a human or the curator has vetted them — without making Captain approval decorative (the pre-#1164 state: gate `injectable` alone meant explicitly-approved records waited up to 24h on a cron while unapproved curator picks surfaced).
 
 ## Authorship paths
 

--- a/packages/crane-mcp/src/lib/crane-api-base.ts
+++ b/packages/crane-mcp/src/lib/crane-api-base.ts
@@ -434,7 +434,7 @@ export class CraneApiBase {
    * Fetch the SOS memory injection gate from the worker.
    * Defaults to 'both' on any failure (most conservative).
    */
-  async getMemoryInjectionGate(): Promise<'captain_approved' | 'injectable' | 'both'> {
+  async getMemoryInjectionGate(): Promise<'captain_approved' | 'injectable' | 'either' | 'both'> {
     try {
       const response = await fetch(`${this.apiBase}/config/memory-gate`, {
         headers: { 'X-Relay-Key': this.apiKey },
@@ -442,7 +442,16 @@ export class CraneApiBase {
       if (!response.ok) return 'both'
       const data = (await response.json()) as { gate?: string }
       const gate = data.gate
-      if (gate === 'captain_approved' || gate === 'injectable' || gate === 'both') {
+      // 'either' (crane-console#1164): union gate — curator-set injectable
+      // OR captain_approved admits a record. Clients older than this change
+      // coerce 'either' to 'both' here, which degrades strict (fewer records
+      // surface), never open.
+      if (
+        gate === 'captain_approved' ||
+        gate === 'injectable' ||
+        gate === 'either' ||
+        gate === 'both'
+      ) {
         return gate
       }
       return 'both'

--- a/packages/crane-mcp/src/tools/sos/memory-gate.test.ts
+++ b/packages/crane-mcp/src/tools/sos/memory-gate.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Gate-semantics tests for filterEligibleRecords (crane-console#1164).
+ *
+ * The 'either' union gate: curator-set injectable OR captain_approved admits
+ * a stable record — approval is sovereign, curation is the automated path.
+ * Also pins two safety properties that predate #1164 but were untested:
+ * an UNKNOWN gate value must degrade to the strictest mode ('both'), never
+ * to gate-off (the old fall-through admitted everything stable), and drafts
+ * never inject under any gate value.
+ */
+import { describe, it, expect } from 'vitest'
+import { filterEligibleRecords } from './memory-inject.js'
+import type { MemoryRecord } from '../memory-frontmatter.js'
+
+function record(over: {
+  name: string
+  approved?: boolean
+  injectable?: boolean
+  status?: string
+  scope?: string
+}): MemoryRecord {
+  return {
+    note_id: `note_${over.name}`,
+    injectable: over.injectable ?? false,
+    parse_error: false,
+    body: 'body',
+    frontmatter: {
+      name: over.name,
+      description: 'test record',
+      kind: 'anti-pattern',
+      scope: over.scope ?? 'enterprise',
+      owner: 'captain',
+      status: (over.status ?? 'stable') as never,
+      captain_approved: over.approved ?? false,
+      version: '1.0.0',
+    },
+  } as unknown as MemoryRecord
+}
+
+const approvedOnly = record({ name: 'approved-only', approved: true })
+const injectableOnly = record({ name: 'injectable-only', injectable: true })
+const bothFlags = record({ name: 'both-flags', approved: true, injectable: true })
+const neitherFlag = record({ name: 'neither-flag' })
+const draftApproved = record({ name: 'draft-approved', approved: true, status: 'draft' })
+const otherVenture = record({
+  name: 'other-venture',
+  approved: true,
+  injectable: true,
+  scope: 'venture:ke',
+})
+const all = [approvedOnly, injectableOnly, bothFlags, neitherFlag, draftApproved, otherVenture]
+
+const names = (rs: MemoryRecord[]) => rs.map((r) => r.frontmatter.name).sort()
+
+describe("gate 'either' — the union gate (#1164)", () => {
+  it('admits captain-approved records without curator promotion (approval is sovereign)', () => {
+    expect(names(filterEligibleRecords(all, 'either', 'ss'))).toEqual([
+      'approved-only',
+      'both-flags',
+      'injectable-only',
+    ])
+  })
+})
+
+describe('existing gate modes are unchanged', () => {
+  it("'injectable' admits curator picks only", () => {
+    expect(names(filterEligibleRecords(all, 'injectable', 'ss'))).toEqual([
+      'both-flags',
+      'injectable-only',
+    ])
+  })
+
+  it("'captain_approved' admits approved records only", () => {
+    expect(names(filterEligibleRecords(all, 'captain_approved', 'ss'))).toEqual([
+      'approved-only',
+      'both-flags',
+    ])
+  })
+
+  it("'both' requires both flags", () => {
+    expect(names(filterEligibleRecords(all, 'both', 'ss'))).toEqual(['both-flags'])
+  })
+})
+
+describe('safety properties', () => {
+  it('an unknown gate value degrades to the strictest mode, never to gate-off', () => {
+    expect(names(filterEligibleRecords(all, 'someday-a-typo', 'ss'))).toEqual(['both-flags'])
+  })
+
+  it('drafts never inject, even captain-approved, under every gate value', () => {
+    for (const gate of ['either', 'injectable', 'captain_approved', 'both', 'unknown']) {
+      expect(names(filterEligibleRecords([draftApproved], gate, 'ss'))).toEqual([])
+    }
+  })
+
+  it('scope filtering still applies after the gate', () => {
+    expect(names(filterEligibleRecords([otherVenture], 'either', 'ss'))).toEqual([])
+    expect(names(filterEligibleRecords([otherVenture], 'either', 'ke'))).toEqual(['other-venture'])
+  })
+})

--- a/packages/crane-mcp/src/tools/sos/memory-inject.ts
+++ b/packages/crane-mcp/src/tools/sos/memory-inject.ts
@@ -42,7 +42,27 @@ interface MemoryInjectionResult {
   memoryAuditDaysSince: number | null
 }
 
-function filterEligibleRecords(
+/**
+ * Gate semantics (crane-console#1164): 'either' is the union gate — curator
+ * promotion admits the automated path, captain_approved is the sovereign
+ * override. An unknown gate value resolves to the strictest mode ('both')
+ * rather than admitting everything: before this default-deny, an
+ * unrecognized string skipped every check and turned the gate off entirely.
+ */
+function passesGate(gate: string, captainOk: boolean, injectableOk: boolean): boolean {
+  switch (gate) {
+    case 'captain_approved':
+      return captainOk
+    case 'injectable':
+      return injectableOk
+    case 'either':
+      return captainOk || injectableOk
+    default: // 'both' and unknown values
+      return captainOk && injectableOk
+  }
+}
+
+export function filterEligibleRecords(
   allRecords: MemoryRecord[],
   gate: string,
   ventureCode: string
@@ -50,11 +70,7 @@ function filterEligibleRecords(
   return allRecords.filter((r) => {
     if (r.parse_error || r.frontmatter.status === 'parse_error') return false
     if (r.frontmatter.status !== 'stable') return false
-    const captainOk = !!r.frontmatter.captain_approved
-    const injectableOk = !!r.injectable
-    if (gate === 'captain_approved' && !captainOk) return false
-    if (gate === 'injectable' && !injectableOk) return false
-    if (gate === 'both' && !(captainOk && injectableOk)) return false
+    if (!passesGate(gate, !!r.frontmatter.captain_approved, !!r.injectable)) return false
     const scope = r.frontmatter.scope
     return scope === 'enterprise' || scope === 'global' || scope === `venture:${ventureCode}`
   })

--- a/workers/crane-context/src/types/env.ts
+++ b/workers/crane-context/src/types/env.ts
@@ -23,7 +23,9 @@ export interface Env {
   // surfaces as Critical Anti-Patterns. Values:
   //   'captain_approved' - legacy: require frontmatter.captain_approved
   //   'injectable'       - require notes.injectable=1 (curator-set)
-  //   'both'             - require BOTH (PR 2 default; bake-in mode)
+  //   'either'           - union (crane-console#1164): injectable OR
+  //                        captain_approved; approval is sovereign
+  //   'both'             - require BOTH (bake-in mode; unknown-value fallback)
   // Bake-in default is 'both' so an unflagged-but-cleanly-curated memory
   // does NOT inject until the Captain has spot-checked. Flip to
   // 'injectable' after the 48h observation window. Rollback path is the

--- a/workers/crane-context/wrangler.toml
+++ b/workers/crane-context/wrangler.toml
@@ -43,11 +43,13 @@ ENVIRONMENT = "staging"
 # until PR A2 is verified end-to-end via the staging integration test.
 # Flipped to "true" in PR A4 after the production backfill completes.
 NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "true"
-# Memory recall (PR 2). 'both' is the bake-in default: requires BOTH
-# the curator-set notes.injectable=1 AND captain_approved=true to inject
-# into SOS. After 48h spot-check window, flip to 'injectable' to drop the
-# captain gate. Rollback path: flip back to 'captain_approved' and redeploy.
-MEMORY_INJECTION_GATE = "injectable"
+# Memory injection gate. 'either' (union, crane-console#1164): a record
+# injects into SOS when the curator set notes.injectable=1 OR the record
+# carries captain_approved=true — curator promotion is the automated path,
+# Captain approval is the sovereign override. Other values: 'injectable',
+# 'captain_approved', 'both' (strictest; also the fallback for unknown
+# values on both client and filter). Rollback: flip the value, redeploy.
+MEMORY_INJECTION_GATE = "either"
 
 # Secrets (set via: wrangler secret put <NAME>)
 # CONTEXT_RELAY_KEY = "<same-as-relay-key>"
@@ -75,5 +77,5 @@ HEARTBEAT_JITTER_SECONDS = "120"
 # Plan v3.1 §D.1: explicit environment marker for /version endpoint.
 ENVIRONMENT = "production"
 NOTIFICATIONS_AUTO_RESOLVE_ENABLED = "true"
-# Memory recall (PR 2). See [vars] above for semantics.
-MEMORY_INJECTION_GATE = "injectable"
+# Memory injection gate. See [vars] above for semantics.
+MEMORY_INJECTION_GATE = "either"


### PR DESCRIPTION
## What

Fixes the gate inversion found live during the 2026-07-26 corpus migration: with `MEMORY_INJECTION_GATE=injectable`, 10 records saved `stable + captain_approved` under explicit Captain batch approval could not surface at SOS until the nightly curator cron concurred, while an unapproved curator-promoted record did surface. Captain approval was functionally decorative.

## The fix — union semantics

- **`filterEligibleRecords`**: gate decision extracted to `passesGate()`; new `'either'` mode admits a stable record when the curator set `injectable=1` **or** the record carries `captain_approved: true`. Curator promotion stays the automated path; approval is the sovereign override.
- **Default-deny hardening** (latent hazard, previously untested): an unknown gate value used to fall through every check and admit **everything stable** — gate-off. It now resolves to the strictest mode (`both`).
- **`getMemoryInjectionGate`** accepts `'either'`. Clients older than this change coerce it to `'both'` — degrades strict, never open, so rollout order doesn't matter.
- **`crane-context/wrangler.toml`**: `MEMORY_INJECTION_GATE=either` in both environment blocks (deploys via deploy.yml on merge). Types comment and `docs/memory/governance.md` updated to describe the deployed reality.
- **`memory-gate.test.ts`**: union semantics, all legacy modes pinned unchanged, unknown-gate default-deny, drafts-never-inject under every gate value, scope-after-gate.

## Verification

- crane-mcp typecheck + gate suite green locally; full verify runs on pre-push + CI.
- Post-merge: `/config/memory-gate` returns `either`; next session's SOS surfaces the 2026-07-26 approved batch without waiting on the 04:17 UTC curator run. The noise-bomb defense holds: drafts never inject under any gate value.

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gPBdsp4M9oD34teW3NWec