### PR TITLE
fix(crane-mcp): advertise the schemas we actually implement, and guard the gap

### DIFF
--- a/.agents/skills/wired/SKILL.md
+++ b/.agents/skills/wired/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: wired
+description: Convert an ask into a reachability contract before planning. Names the act the client performs, the terminal seam the change must land on, and every gate in between, so a feature cannot be reported done while a real client still cannot use it.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_skill_invoked
+    - crane_verify
+---
+
+# /wired - Reachability Contract
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "wired")`. This is non-blocking; if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Converts an ask into a contract that names what the client can do, where the change must land, and every gate in between.
+
+Run it on the **ask**, before writing a plan and before `/critique`. Order matters: a plan written against a component-shaped ask gets critiqued as a good component build, and the critique never notices the feature is unreachable.
+
+## Why this exists
+
+The 2026-07-28 entitlement-control incident in ss-console. Four PRs, each individually honest, each defining "done" as the artifact it added. One of them wrote "Next slices, unbuilt and not implied here." Nobody lied. The artifacts summed to less than the feature, and the work was reported built, wired, and tested while a real client could not perform the act.
+
+That is a definition problem, not a diligence problem. More care would not have caught it, because every PR met its own definition. This skill replaces the definition.
+
+Three terms, used precisely:
+
+- **Built** - the code exists and its own tests pass. The weakest of the three and the easiest to mistake for done, because it produces the most visible evidence.
+- **Wired** - every gate between a real client's finger and the effect is open **on the deployment that client uses**. Not "would work once configured." Configured. Secrets and config authoring are part of the deliverable, not prerequisites belonging to someone else.
+- **Tested** - someone performed the act **as the client, on the real deployment**, and observed the far end change. A green unit test against a fake token is not this.
+
+## When it applies
+
+Required when the effect is observable by someone outside the repo: a client, the Captain on a live surface, an Operator seat, a prospect on a marketing page.
+
+Skipped for internal refactors, test-only changes, and documentation. Do not grow a gate table on a typo fix. An obstacle course that fires on everything gets routed around, and then it protects nothing.
+
+## Workflow
+
+1. **The sentence** - the act a named person performs, and what they observe.
+2. **The terminal seam** - the last place the change must land for that sentence to be true.
+3. **The gate chain** - every gate between the finger and the effect, enumerated backwards from the seam.
+4. **The feasibility probe** - close-now yes or no per gate, before any code, escalating what cannot be closed.
+5. **Emit the contract** - the chain becomes the issue's layer-tagged acceptance criteria.
+6. **Hand off to planning** - plan against the contract, then `/critique` against the chain.
+7. **Close against the contract** - each runtime row needs a `crane_verify` observation, not an artifact.
+
+## Step 1: The sentence
+
+Rewrite the ask as **an act a named person performs** and **an outcome they observe**. One sentence.
+
+A component noun is not a deliverable. A component can be complete while the feature is dead, which is exactly how the incident happened.
+
+| Rejected                        | Accepted                                                                                                                                       |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Build the entitlement control" | "A Named Administrator at the client firm can raise a routine's level and lower it back, and the Operator's next action honors the new level." |
+| "Add the pause API"             | "A principal can pause a routine from the portal and the next scheduled run does not fire."                                                    |
+| "Wire up webhook ingestion"     | "A countersignature lands and the engagement's status changes on the client's portal without anyone touching the admin console."               |
+
+If you cannot write the sentence without naming a component, you do not yet know what the work is for. Ask.
+
+## Step 2: The terminal seam
+
+Name the **last place the change must land** for the sentence to be true.
+
+Not a merged PR. Not a green test. Not a row in a ledger. Whoever takes the work owns the entire distance to that seam.
+
+## Step 3: The gate chain
+
+Enumerate every gate between the finger and the effect, **working backwards from the seam**.
+
+Backwards is not a stylistic preference. Forward enumeration produces the artifacts you already planned to build. Backwards enumeration is what surfaces adoption, roles, secrets, and transport, which are the gates nobody plans because they are not code. Start at the effect and ask what must be true immediately before it, then repeat until you reach the client's finger.
+
+Ask the venture where its state can live, and gate every layer that applies. The ss-console list, which is the worked example (its inverse is that repo's "Gone means gone" removal discipline):
+
+| Layer                           | Runtime? | Typical gates                                |
+| ------------------------------- | -------- | -------------------------------------------- |
+| git (source, fixtures, docs)    | repo     | code exists, tests pass                      |
+| Database projections            | runtime  | row written, projection re-synced            |
+| Object storage (skills, config) | runtime  | object present at the key the runtime reads  |
+| Persistent volumes              | runtime  | profile home, cron store, token on disk      |
+| The running process             | runtime  | env loaded, config adopted, behavior changed |
+| Monitoring                      | runtime  | heartbeat field, alert sink, error tracker   |
+| External records                | runtime  | GitHub, mailbox, calendar, vendor dashboard  |
+
+A layer that survives a redeploy is exactly the layer a merge cannot reach. Those are the rows that kill features.
+
+Emit the chain as a table:
+
+| #   | Gate                                          | Layer            | Owner            | Closable now? | Proof |
+| --- | --------------------------------------------- | ---------------- | ---------------- | ------------- | ----- |
+| 1   | Control renders for that role                 | repo             | agent            | yes           |       |
+| 2   | Write persists                                | runtime (DB)     | agent            | yes           |       |
+| 3   | Role granted on the real deployment           | runtime          | ?                | probe         |       |
+| 4   | Authority authored for that customer          | runtime (config) | client / Captain | probe         |       |
+| 5   | Secret deployed                               | runtime          | agent            | probe         |       |
+| 6   | Transport reachable                           | runtime          | agent            | probe         |       |
+| 7   | Running process adopts the change             | runtime          | agent            | probe         |       |
+| 8   | Act performed as the client, far end observed | runtime          | agent            | probe         |       |
+
+**Owner** is resolved per the ownership law: agents own execution, the Captain owns strategy, spend, and external commitments, the client owns their own posture (entitlements, autonomy tiers, risk acceptance). A gate whose owner is not the executing agent is not thereby out of scope. It is a gate you must surface, not silently skip.
+
+## Step 4: The feasibility probe
+
+This is the load-bearing step, and the one an agent will want to skip because it feels like stalling before the real work.
+
+**Before writing any code**, probe every row marked `probe` and record closable-now yes or no. Probing costs minutes. It converts "would work once configured" into a known fact at plan time instead of at delivery time.
+
+Then apply the stop clause, pre-registered here so it does not have to be remembered mid-flight:
+
+> If any gate cannot be made true, stop and report which gate and why, **before building the gates that can**.
+
+Not "build my slice and note the rest as unbuilt." That sentence is what turns an honest agent into a producer of honest slices that never reach the client. An unclosable gate is an escalation, and it is due at the top of the work, not at the end.
+
+## Step 5: Emit the contract
+
+Write the gate chain into the tracking issue as acceptance criteria, one per gate, each tagged with its layer:
+
+```markdown
+## Acceptance criteria
+
+- [ ] (repo) Entitlement control renders for the Named Administrator role
+- [ ] (runtime) Level write persists and survives re-projection
+- [ ] (runtime) Authority authored on the customer's seat
+- [ ] (runtime) Running Operator adopts the new level without a reprovision
+- [ ] (runtime) Level raised and lowered as the client on the real seat, next action observed honoring it
+```
+
+The tags are load-bearing, not decoration. In ventures carrying the gate (ss-console today, via `.github/workflows/runtime-ac-proof.yml`), a PR that marks a `(runtime)` AC met without a `crane_verify` ID in the Evidence column is blocked. Elsewhere the tags still tell a reviewer which claims need an observation rather than a file:line.
+
+That gate exists because the acceptance-criteria machinery otherwise certifies the author's own definition of done: `tick-acs-on-merge` parses the merging PR's own status table to tick the linked issue, and `unmet-ac-on-close` skips PR-driven closes. A slice that declares itself met is what closes the epic.
+
+Record the contract's sentence and terminal seam in the issue body above the ACs, so the next agent to pick it up inherits the definition rather than re-deriving one.
+
+## Step 6: Hand off to planning
+
+State the contract, then write the plan against it, then run `/critique`. Critique carries one mandatory added dimension when a contract exists:
+
+> Does this plan close every row of the gate chain, or does it silently defer some? Name any row the plan does not reach.
+
+## Step 7: Close against the contract
+
+At completion, each runtime row needs an observation, not an artifact. Run the act, capture the output, record it with `crane_verify`, and put the returned ID in the row's Proof cell. A row without one is not closed, and reporting it as closed is the failure this skill exists to prevent.
+
+Handoffs and status reports lead with mission-level readiness: what the customer can now do, and what they still cannot. "End-to-end" is banned unless the end is customer-visible.
+
+## Output
+
+```
+Sentence:      <act + observed outcome>
+Terminal seam: <the last place the change must land>
+
+<gate chain table>
+
+Unclosable now: <rows, owners, and what would unblock them>  |  none
+```
+
+If any row is unclosable, that is the whole output. Stop there and escalate.

--- a/.claude/commands/wired.md
+++ b/.claude/commands/wired.md
@@ -1,0 +1,160 @@
+---
+name: wired
+description: Convert an ask into a reachability contract before planning. Names the act the client performs, the terminal seam the change must land on, and every gate in between, so a feature cannot be reported done while a real client still cannot use it.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_skill_invoked
+    - crane_verify
+---
+
+# /wired - Reachability Contract
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "wired")`. This is non-blocking; if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Converts an ask into a contract that names what the client can do, where the change must land, and every gate in between.
+
+Run it on the **ask**, before writing a plan and before `/critique`. Order matters: a plan written against a component-shaped ask gets critiqued as a good component build, and the critique never notices the feature is unreachable.
+
+## Why this exists
+
+The 2026-07-28 entitlement-control incident in ss-console. Four PRs, each individually honest, each defining "done" as the artifact it added. One of them wrote "Next slices, unbuilt and not implied here." Nobody lied. The artifacts summed to less than the feature, and the work was reported built, wired, and tested while a real client could not perform the act.
+
+That is a definition problem, not a diligence problem. More care would not have caught it, because every PR met its own definition. This skill replaces the definition.
+
+Three terms, used precisely:
+
+- **Built** - the code exists and its own tests pass. The weakest of the three and the easiest to mistake for done, because it produces the most visible evidence.
+- **Wired** - every gate between a real client's finger and the effect is open **on the deployment that client uses**. Not "would work once configured." Configured. Secrets and config authoring are part of the deliverable, not prerequisites belonging to someone else.
+- **Tested** - someone performed the act **as the client, on the real deployment**, and observed the far end change. A green unit test against a fake token is not this.
+
+## When it applies
+
+Required when the effect is observable by someone outside the repo: a client, the Captain on a live surface, an Operator seat, a prospect on a marketing page.
+
+Skipped for internal refactors, test-only changes, and documentation. Do not grow a gate table on a typo fix. An obstacle course that fires on everything gets routed around, and then it protects nothing.
+
+## Workflow
+
+1. **The sentence** - the act a named person performs, and what they observe.
+2. **The terminal seam** - the last place the change must land for that sentence to be true.
+3. **The gate chain** - every gate between the finger and the effect, enumerated backwards from the seam.
+4. **The feasibility probe** - close-now yes or no per gate, before any code, escalating what cannot be closed.
+5. **Emit the contract** - the chain becomes the issue's layer-tagged acceptance criteria.
+6. **Hand off to planning** - plan against the contract, then `/critique` against the chain.
+7. **Close against the contract** - each runtime row needs a `crane_verify` observation, not an artifact.
+
+## Step 1: The sentence
+
+Rewrite the ask as **an act a named person performs** and **an outcome they observe**. One sentence.
+
+A component noun is not a deliverable. A component can be complete while the feature is dead, which is exactly how the incident happened.
+
+| Rejected                        | Accepted                                                                                                                                       |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Build the entitlement control" | "A Named Administrator at the client firm can raise a routine's level and lower it back, and the Operator's next action honors the new level." |
+| "Add the pause API"             | "A principal can pause a routine from the portal and the next scheduled run does not fire."                                                    |
+| "Wire up webhook ingestion"     | "A countersignature lands and the engagement's status changes on the client's portal without anyone touching the admin console."               |
+
+If you cannot write the sentence without naming a component, you do not yet know what the work is for. Ask.
+
+## Step 2: The terminal seam
+
+Name the **last place the change must land** for the sentence to be true.
+
+Not a merged PR. Not a green test. Not a row in a ledger. Whoever takes the work owns the entire distance to that seam.
+
+## Step 3: The gate chain
+
+Enumerate every gate between the finger and the effect, **working backwards from the seam**.
+
+Backwards is not a stylistic preference. Forward enumeration produces the artifacts you already planned to build. Backwards enumeration is what surfaces adoption, roles, secrets, and transport, which are the gates nobody plans because they are not code. Start at the effect and ask what must be true immediately before it, then repeat until you reach the client's finger.
+
+Ask the venture where its state can live, and gate every layer that applies. The ss-console list, which is the worked example (its inverse is that repo's "Gone means gone" removal discipline):
+
+| Layer                           | Runtime? | Typical gates                                |
+| ------------------------------- | -------- | -------------------------------------------- |
+| git (source, fixtures, docs)    | repo     | code exists, tests pass                      |
+| Database projections            | runtime  | row written, projection re-synced            |
+| Object storage (skills, config) | runtime  | object present at the key the runtime reads  |
+| Persistent volumes              | runtime  | profile home, cron store, token on disk      |
+| The running process             | runtime  | env loaded, config adopted, behavior changed |
+| Monitoring                      | runtime  | heartbeat field, alert sink, error tracker   |
+| External records                | runtime  | GitHub, mailbox, calendar, vendor dashboard  |
+
+A layer that survives a redeploy is exactly the layer a merge cannot reach. Those are the rows that kill features.
+
+Emit the chain as a table:
+
+| #   | Gate                                          | Layer            | Owner            | Closable now? | Proof |
+| --- | --------------------------------------------- | ---------------- | ---------------- | ------------- | ----- |
+| 1   | Control renders for that role                 | repo             | agent            | yes           |       |
+| 2   | Write persists                                | runtime (DB)     | agent            | yes           |       |
+| 3   | Role granted on the real deployment           | runtime          | ?                | probe         |       |
+| 4   | Authority authored for that customer          | runtime (config) | client / Captain | probe         |       |
+| 5   | Secret deployed                               | runtime          | agent            | probe         |       |
+| 6   | Transport reachable                           | runtime          | agent            | probe         |       |
+| 7   | Running process adopts the change             | runtime          | agent            | probe         |       |
+| 8   | Act performed as the client, far end observed | runtime          | agent            | probe         |       |
+
+**Owner** is resolved per the ownership law: agents own execution, the Captain owns strategy, spend, and external commitments, the client owns their own posture (entitlements, autonomy tiers, risk acceptance). A gate whose owner is not the executing agent is not thereby out of scope. It is a gate you must surface, not silently skip.
+
+## Step 4: The feasibility probe
+
+This is the load-bearing step, and the one an agent will want to skip because it feels like stalling before the real work.
+
+**Before writing any code**, probe every row marked `probe` and record closable-now yes or no. Probing costs minutes. It converts "would work once configured" into a known fact at plan time instead of at delivery time.
+
+Then apply the stop clause, pre-registered here so it does not have to be remembered mid-flight:
+
+> If any gate cannot be made true, stop and report which gate and why, **before building the gates that can**.
+
+Not "build my slice and note the rest as unbuilt." That sentence is what turns an honest agent into a producer of honest slices that never reach the client. An unclosable gate is an escalation, and it is due at the top of the work, not at the end.
+
+## Step 5: Emit the contract
+
+Write the gate chain into the tracking issue as acceptance criteria, one per gate, each tagged with its layer:
+
+```markdown
+## Acceptance criteria
+
+- [ ] (repo) Entitlement control renders for the Named Administrator role
+- [ ] (runtime) Level write persists and survives re-projection
+- [ ] (runtime) Authority authored on the customer's seat
+- [ ] (runtime) Running Operator adopts the new level without a reprovision
+- [ ] (runtime) Level raised and lowered as the client on the real seat, next action observed honoring it
+```
+
+The tags are load-bearing, not decoration. In ventures carrying the gate (ss-console today, via `.github/workflows/runtime-ac-proof.yml`), a PR that marks a `(runtime)` AC met without a `crane_verify` ID in the Evidence column is blocked. Elsewhere the tags still tell a reviewer which claims need an observation rather than a file:line.
+
+That gate exists because the acceptance-criteria machinery otherwise certifies the author's own definition of done: `tick-acs-on-merge` parses the merging PR's own status table to tick the linked issue, and `unmet-ac-on-close` skips PR-driven closes. A slice that declares itself met is what closes the epic.
+
+Record the contract's sentence and terminal seam in the issue body above the ACs, so the next agent to pick it up inherits the definition rather than re-deriving one.
+
+## Step 6: Hand off to planning
+
+State the contract, then write the plan against it, then run `/critique`. Critique carries one mandatory added dimension when a contract exists:
+
+> Does this plan close every row of the gate chain, or does it silently defer some? Name any row the plan does not reach.
+
+## Step 7: Close against the contract
+
+At completion, each runtime row needs an observation, not an artifact. Run the act, capture the output, record it with `crane_verify`, and put the returned ID in the row's Proof cell. A row without one is not closed, and reporting it as closed is the failure this skill exists to prevent.
+
+Handoffs and status reports lead with mission-level readiness: what the customer can now do, and what they still cannot. "End-to-end" is banned unless the end is customer-visible.
+
+## Output
+
+```
+Sentence:      <act + observed outcome>
+Terminal seam: <the last place the change must land>
+
+<gate chain table>
+
+Unclosable now: <rows, owners, and what would unblock them>  |  none
+```
+
+If any row is unclosable, that is the whole output. Stop there and escalate.

--- a/.gemini/commands/wired.toml
+++ b/.gemini/commands/wired.toml
@@ -1,0 +1,163 @@
+description = "---"
+
+prompt = """
+name: wired
+description: Convert an ask into a reachability contract before planning. Names the act the client performs, the terminal seam the change must land on, and every gate in between, so a feature cannot be reported done while a real client still cannot use it.
+version: 1.0.0
+scope: enterprise
+owner: captain
+status: stable
+depends_on:
+  mcp_tools:
+    - crane_skill_invoked
+    - crane_verify
+---
+
+# /wired - Reachability Contract
+
+> **Invocation:** As your first action, call `crane_skill_invoked(skill_name: "wired")`. This is non-blocking; if the call fails, log the warning and continue. Usage data drives `/skill-audit`.
+
+Converts an ask into a contract that names what the client can do, where the change must land, and every gate in between.
+
+Run it on the **ask**, before writing a plan and before `/critique`. Order matters: a plan written against a component-shaped ask gets critiqued as a good component build, and the critique never notices the feature is unreachable.
+
+## Why this exists
+
+The 2026-07-28 entitlement-control incident in ss-console. Four PRs, each individually honest, each defining "done" as the artifact it added. One of them wrote "Next slices, unbuilt and not implied here." Nobody lied. The artifacts summed to less than the feature, and the work was reported built, wired, and tested while a real client could not perform the act.
+
+That is a definition problem, not a diligence problem. More care would not have caught it, because every PR met its own definition. This skill replaces the definition.
+
+Three terms, used precisely:
+
+- **Built** - the code exists and its own tests pass. The weakest of the three and the easiest to mistake for done, because it produces the most visible evidence.
+- **Wired** - every gate between a real client's finger and the effect is open **on the deployment that client uses**. Not "would work once configured." Configured. Secrets and config authoring are part of the deliverable, not prerequisites belonging to someone else.
+- **Tested** - someone performed the act **as the client, on the real deployment**, and observed the far end change. A green unit test against a fake token is not this.
+
+## When it applies
+
+Required when the effect is observable by someone outside the repo: a client, the Captain on a live surface, an Operator seat, a prospect on a marketing page.
+
+Skipped for internal refactors, test-only changes, and documentation. Do not grow a gate table on a typo fix. An obstacle course that fires on everything gets routed around, and then it protects nothing.
+
+## Workflow
+
+1. **The sentence** - the act a named person performs, and what they observe.
+2. **The terminal seam** - the last place the change must land for that sentence to be true.
+3. **The gate chain** - every gate between the finger and the effect, enumerated backwards from the seam.
+4. **The feasibility probe** - close-now yes or no per gate, before any code, escalating what cannot be closed.
+5. **Emit the contract** - the chain becomes the issue's layer-tagged acceptance criteria.
+6. **Hand off to planning** - plan against the contract, then `/critique` against the chain.
+7. **Close against the contract** - each runtime row needs a `crane_verify` observation, not an artifact.
+
+## Step 1: The sentence
+
+Rewrite the ask as **an act a named person performs** and **an outcome they observe**. One sentence.
+
+A component noun is not a deliverable. A component can be complete while the feature is dead, which is exactly how the incident happened.
+
+| Rejected                        | Accepted                                                                                                                                       |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Build the entitlement control" | "A Named Administrator at the client firm can raise a routine's level and lower it back, and the Operator's next action honors the new level." |
+| "Add the pause API"             | "A principal can pause a routine from the portal and the next scheduled run does not fire."                                                    |
+| "Wire up webhook ingestion"     | "A countersignature lands and the engagement's status changes on the client's portal without anyone touching the admin console."               |
+
+If you cannot write the sentence without naming a component, you do not yet know what the work is for. Ask.
+
+## Step 2: The terminal seam
+
+Name the **last place the change must land** for the sentence to be true.
+
+Not a merged PR. Not a green test. Not a row in a ledger. Whoever takes the work owns the entire distance to that seam.
+
+## Step 3: The gate chain
+
+Enumerate every gate between the finger and the effect, **working backwards from the seam**.
+
+Backwards is not a stylistic preference. Forward enumeration produces the artifacts you already planned to build. Backwards enumeration is what surfaces adoption, roles, secrets, and transport, which are the gates nobody plans because they are not code. Start at the effect and ask what must be true immediately before it, then repeat until you reach the client's finger.
+
+Ask the venture where its state can live, and gate every layer that applies. The ss-console list, which is the worked example (its inverse is that repo's "Gone means gone" removal discipline):
+
+| Layer                           | Runtime? | Typical gates                                |
+| ------------------------------- | -------- | -------------------------------------------- |
+| git (source, fixtures, docs)    | repo     | code exists, tests pass                      |
+| Database projections            | runtime  | row written, projection re-synced            |
+| Object storage (skills, config) | runtime  | object present at the key the runtime reads  |
+| Persistent volumes              | runtime  | profile home, cron store, token on disk      |
+| The running process             | runtime  | env loaded, config adopted, behavior changed |
+| Monitoring                      | runtime  | heartbeat field, alert sink, error tracker   |
+| External records                | runtime  | GitHub, mailbox, calendar, vendor dashboard  |
+
+A layer that survives a redeploy is exactly the layer a merge cannot reach. Those are the rows that kill features.
+
+Emit the chain as a table:
+
+| #   | Gate                                          | Layer            | Owner            | Closable now? | Proof |
+| --- | --------------------------------------------- | ---------------- | ---------------- | ------------- | ----- |
+| 1   | Control renders for that role                 | repo             | agent            | yes           |       |
+| 2   | Write persists                                | runtime (DB)     | agent            | yes           |       |
+| 3   | Role granted on the real deployment           | runtime          | ?                | probe         |       |
+| 4   | Authority authored for that customer          | runtime (config) | client / Captain | probe         |       |
+| 5   | Secret deployed                               | runtime          | agent            | probe         |       |
+| 6   | Transport reachable                           | runtime          | agent            | probe         |       |
+| 7   | Running process adopts the change             | runtime          | agent            | probe         |       |
+| 8   | Act performed as the client, far end observed | runtime          | agent            | probe         |       |
+
+**Owner** is resolved per the ownership law: agents own execution, the Captain owns strategy, spend, and external commitments, the client owns their own posture (entitlements, autonomy tiers, risk acceptance). A gate whose owner is not the executing agent is not thereby out of scope. It is a gate you must surface, not silently skip.
+
+## Step 4: The feasibility probe
+
+This is the load-bearing step, and the one an agent will want to skip because it feels like stalling before the real work.
+
+**Before writing any code**, probe every row marked `probe` and record closable-now yes or no. Probing costs minutes. It converts "would work once configured" into a known fact at plan time instead of at delivery time.
+
+Then apply the stop clause, pre-registered here so it does not have to be remembered mid-flight:
+
+> If any gate cannot be made true, stop and report which gate and why, **before building the gates that can**.
+
+Not "build my slice and note the rest as unbuilt." That sentence is what turns an honest agent into a producer of honest slices that never reach the client. An unclosable gate is an escalation, and it is due at the top of the work, not at the end.
+
+## Step 5: Emit the contract
+
+Write the gate chain into the tracking issue as acceptance criteria, one per gate, each tagged with its layer:
+
+```markdown
+## Acceptance criteria
+
+- [ ] (repo) Entitlement control renders for the Named Administrator role
+- [ ] (runtime) Level write persists and survives re-projection
+- [ ] (runtime) Authority authored on the customer's seat
+- [ ] (runtime) Running Operator adopts the new level without a reprovision
+- [ ] (runtime) Level raised and lowered as the client on the real seat, next action observed honoring it
+```
+
+The tags are load-bearing, not decoration. In ventures carrying the gate (ss-console today, via `.github/workflows/runtime-ac-proof.yml`), a PR that marks a `(runtime)` AC met without a `crane_verify` ID in the Evidence column is blocked. Elsewhere the tags still tell a reviewer which claims need an observation rather than a file:line.
+
+That gate exists because the acceptance-criteria machinery otherwise certifies the author's own definition of done: `tick-acs-on-merge` parses the merging PR's own status table to tick the linked issue, and `unmet-ac-on-close` skips PR-driven closes. A slice that declares itself met is what closes the epic.
+
+Record the contract's sentence and terminal seam in the issue body above the ACs, so the next agent to pick it up inherits the definition rather than re-deriving one.
+
+## Step 6: Hand off to planning
+
+State the contract, then write the plan against it, then run `/critique`. Critique carries one mandatory added dimension when a contract exists:
+
+> Does this plan close every row of the gate chain, or does it silently defer some? Name any row the plan does not reach.
+
+## Step 7: Close against the contract
+
+At completion, each runtime row needs an observation, not an artifact. Run the act, capture the output, record it with `crane_verify`, and put the returned ID in the row's Proof cell. A row without one is not closed, and reporting it as closed is the failure this skill exists to prevent.
+
+Handoffs and status reports lead with mission-level readiness: what the customer can now do, and what they still cannot. "End-to-end" is banned unless the end is customer-visible.
+
+## Output
+
+```
+Sentence:      <act + observed outcome>
+Terminal seam: <the last place the change must land>
+
+<gate chain table>
+
+Unclosable now: <rows, owners, and what would unblock them>  |  none
+```
+
+If any row is unclosable, that is the whole output. Stop there and escalate.
+"""

--- a/config/skill-owners.json
+++ b/config/skill-owners.json
@@ -23,7 +23,8 @@
     "status",
     "update",
     "heartbeat",
-    "operator-onboard"
+    "operator-onboard",
+    "wired"
   ],
   "agent-team": [
     "build-log",

--- a/packages/crane-mcp/src/registry/schema-parity.test.ts
+++ b/packages/crane-mcp/src/registry/schema-parity.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Advertised-vs-implemented schema parity for the local crane-mcp tool surface.
+ *
+ * Why this exists (2026-07-28). `crane_handoff` implemented `final`,
+ * `override_pr_merge_gate`, and `override_verify_coverage_gate` in its zod
+ * schema, and TOOL_SCHEMAS advertised none of them. `final` shipped in #752 to
+ * make multi-venture /eos work; the advertised schema was never updated, so no
+ * agent could see the parameter and every cross-venture /eos failed with a 409
+ * on its second handoff. Worse, the PR-merge and verify-coverage gates print
+ * "Pass override_..._gate=true if the gate is producing a false positive" —
+ * instructions an agent cannot follow for a parameter absent from the schema it
+ * was served.
+ *
+ * The defect class is built-not-wired: the code works, and the contract that
+ * tells callers it exists does not mention it. Nothing anywhere compared the
+ * two. check-hosted-mcp-parity.ts compares the HOSTED surface's three sources
+ * by tool NAME and is a different check with a different job; it never looks at
+ * the local surface and never looks at properties.
+ *
+ * What this pins:
+ *   1. SCHEMA_BY_TOOL covers exactly the advertised tools (no tool escapes the
+ *      check by being added to TOOL_SCHEMAS and forgotten here)
+ *   2. per tool, advertised property names == zod shape keys
+ *   3. per tool, advertised `required` == zod's non-optional keys
+ *
+ * Adding a tool parameter now means touching the zod schema and TOOL_SCHEMAS in
+ * the same change, which is the whole point.
+ */
+import { describe, it, expect } from 'vitest'
+import type { ZodTypeAny } from 'zod'
+
+import { TOOL_SCHEMAS } from './tool-schemas.js'
+
+import { claimOriginInputSchema, verifyInputSchema } from '../tools/verify.js'
+import { contextInputSchema } from '../tools/context.js'
+import { deployHeartbeatInputSchema } from '../tools/deploy-heartbeat.js'
+import { docAuditInputSchema } from '../tools/doc-audit.js'
+import { docInputSchema } from '../tools/doc.js'
+import { docsDriftAuditInputSchema } from '../tools/docs-drift-audit.js'
+import { fleetDispatchInputSchema } from '../tools/fleet-dispatch.js'
+import { fleetStatusInputSchema } from '../tools/fleet-status.js'
+import { handoffInputSchema } from '../tools/handoff.js'
+import { memoryAuditInputSchema } from '../tools/memory-audit.js'
+import { memoryInputSchema } from '../tools/memory.js'
+import { memoryInvokeInputSchema, memoryUsageInputSchema } from '../tools/memory-invoke.js'
+import { noteInputSchema, notesInputSchema } from '../tools/notes.js'
+import { notificationsInputSchema, notificationUpdateInputSchema } from '../tools/notifications.js'
+import { preflightInputSchema } from '../tools/preflight.js'
+import { scheduleInputSchema } from '../tools/schedule.js'
+import { secretCheckInputSchema } from '../tools/secret-check.js'
+import { secretSetInputSchema } from '../tools/secret-set.js'
+import { skillAuditInputSchema } from '../tools/skill-audit.js'
+import { skillInvokeInputSchema, skillUsageInputSchema } from '../tools/skill-invoke.js'
+import { sosInputSchema } from '../tools/sos.js'
+import { statusInputSchema } from '../tools/status.js'
+import { venturesInputSchema } from '../tools/ventures.js'
+import { verifyAuditInputSchema } from '../tools/verify-audit.js'
+import { worktreeDoctorInputSchema } from '../tools/worktree-doctor.js'
+
+/**
+ * Tool name to the zod schema `dispatch.ts` actually parses its args with.
+ *
+ * Authored by hand because HANDLERS uses inline arrow functions and exposes no
+ * name-to-schema map to iterate. The first assertion below pins this map's key
+ * set to TOOL_SCHEMAS, so a new tool cannot quietly skip the parity check: it
+ * fails here until it is registered.
+ */
+const SCHEMA_BY_TOOL: Record<string, ZodTypeAny> = {
+  crane_claim_origin: claimOriginInputSchema,
+  crane_context: contextInputSchema,
+  crane_deploy_heartbeat: deployHeartbeatInputSchema,
+  crane_doc: docInputSchema,
+  crane_doc_audit: docAuditInputSchema,
+  crane_docs_drift_audit: docsDriftAuditInputSchema,
+  crane_fleet_dispatch: fleetDispatchInputSchema,
+  crane_fleet_status: fleetStatusInputSchema,
+  crane_handoff: handoffInputSchema,
+  crane_memory: memoryInputSchema,
+  crane_memory_audit: memoryAuditInputSchema,
+  crane_memory_invoked: memoryInvokeInputSchema,
+  crane_memory_usage: memoryUsageInputSchema,
+  crane_note: noteInputSchema,
+  crane_notes: notesInputSchema,
+  crane_notification_update: notificationUpdateInputSchema,
+  crane_notifications: notificationsInputSchema,
+  crane_preflight: preflightInputSchema,
+  crane_schedule: scheduleInputSchema,
+  crane_secret_check: secretCheckInputSchema,
+  crane_secret_set: secretSetInputSchema,
+  crane_skill_audit: skillAuditInputSchema,
+  crane_skill_invoked: skillInvokeInputSchema,
+  crane_skill_usage: skillUsageInputSchema,
+  crane_sos: sosInputSchema,
+  crane_status: statusInputSchema,
+  crane_ventures: venturesInputSchema,
+  crane_verify: verifyInputSchema,
+  crane_verify_audit: verifyAuditInputSchema,
+  crane_worktree_doctor: worktreeDoctorInputSchema,
+}
+
+interface AdvertisedSchema {
+  name: string
+  inputSchema: {
+    properties?: Record<string, unknown>
+    required?: readonly string[]
+  }
+}
+
+const advertised = TOOL_SCHEMAS as unknown as readonly AdvertisedSchema[]
+
+/**
+ * Resolve a zod schema to the list of object shapes a caller could satisfy.
+ *
+ * One entry for a plain `z.object()`. N entries for a discriminated union
+ * (crane_memory), one per branch. `.shape` sits one level down on schemas
+ * wrapped by `.superRefine()` / `.refine()` (crane_verify), under a key that has
+ * moved across zod versions, so walk the known wrapper keys rather than pinning
+ * to one. Returns null when nothing can be resolved, which the assertions
+ * surface as an explicit failure rather than an empty pass.
+ */
+function resolveShapes(schema: unknown): Record<string, unknown>[] | null {
+  const s = schema as Record<string, unknown> | null
+  if (!s || typeof s !== 'object') return null
+
+  if ('shape' in s && s.shape && typeof s.shape === 'object') {
+    return [s.shape as Record<string, unknown>]
+  }
+
+  const def = (s.def ?? s._def) as Record<string, unknown> | undefined
+  if (!def) return null
+
+  const options = (s.options ?? def.options) as unknown[] | undefined
+  if (Array.isArray(options) && options.length > 0) {
+    const shapes = options.flatMap((o) => resolveShapes(o) ?? [])
+    return shapes.length === options.length ? shapes : null
+  }
+
+  for (const key of ['innerType', 'schema', 'in']) {
+    if (def[key]) {
+      const inner = resolveShapes(def[key])
+      if (inner) return inner
+    }
+  }
+  return null
+}
+
+/** Every field name a caller could legitimately send, across all branches. */
+function allKeys(shapes: Record<string, unknown>[]): string[] {
+  return [...new Set(shapes.flatMap((s) => Object.keys(s)))]
+}
+
+/** Field names one zod object treats as required (i.e. not `.optional()`). */
+function requiredIn(shape: Record<string, unknown>): string[] {
+  return Object.entries(shape)
+    .filter(([, field]) => {
+      const f = field as { safeParse?: (v: unknown) => { success: boolean } }
+      // A field is optional iff it accepts `undefined`. Cheaper and far more
+      // version-stable than reading zod's internal type tags.
+      return typeof f?.safeParse === 'function' ? !f.safeParse(undefined).success : true
+    })
+    .map(([name]) => name)
+}
+
+/**
+ * Fields the advertised schema may honestly mark required.
+ *
+ * For a union that is the INTERSECTION across branches, not the union: a field
+ * required only by `action: "save"` is not required of every caller, and
+ * advertising it as such would reject valid `action: "list"` calls at the
+ * client before they were ever sent. Per-branch requirements belong in the
+ * field descriptions, which is where the generated `(actions: ...)` notes go.
+ */
+function requiredEverywhere(shapes: Record<string, unknown>[]): string[] {
+  const perShape = shapes.map((s) => new Set(requiredIn(s)))
+  return [...perShape[0]].filter((k) => perShape.every((set) => set.has(k)))
+}
+
+describe('tool surface: the parity map is complete', () => {
+  it('covers exactly the advertised tools', () => {
+    const advertisedNames = advertised.map((t) => t.name).sort()
+    const mapped = Object.keys(SCHEMA_BY_TOOL).sort()
+    expect(
+      mapped,
+      'SCHEMA_BY_TOOL must list every tool in TOOL_SCHEMAS and nothing else. ' +
+        'A new tool added to TOOL_SCHEMAS must be registered here so it is parity-checked.'
+    ).toEqual(advertisedNames)
+  })
+
+  it('finds tools at all (sanity: an emptied registry must not pass green)', () => {
+    expect(advertised.length).toBeGreaterThanOrEqual(30)
+  })
+
+  it('resolves a shape for every mapped schema', () => {
+    const unresolved = Object.entries(SCHEMA_BY_TOOL)
+      .filter(([, schema]) => resolveShapes(schema) === null)
+      .map(([name]) => name)
+    expect(
+      unresolved,
+      'resolveShapes() could not reach these schemas; the parity assertions below ' +
+        'would silently pass on them. Teach resolveShapes the new wrapper shape.'
+    ).toEqual([])
+  })
+})
+
+describe('tool surface: advertised schema matches implemented schema', () => {
+  for (const tool of advertised) {
+    const schema = SCHEMA_BY_TOOL[tool.name]
+    if (!schema) continue // covered by the completeness test above
+
+    it(`${tool.name}: advertised properties match the zod shape`, () => {
+      const shapes = resolveShapes(schema)
+      expect(shapes).not.toBeNull()
+
+      const implemented = allKeys(shapes!).sort()
+      const declared = Object.keys(tool.inputSchema.properties ?? {}).sort()
+
+      const unadvertised = implemented.filter((k) => !declared.includes(k))
+      const phantom = declared.filter((k) => !implemented.includes(k))
+
+      expect(
+        { unadvertised, phantom },
+        `${tool.name} schema drift.\n` +
+          `  unadvertised (implemented, invisible to callers): ${unadvertised.join(', ') || '(none)'}\n` +
+          `  phantom (advertised, not implemented): ${phantom.join(', ') || '(none)'}\n` +
+          `Fix both sides in the same change.`
+      ).toEqual({ unadvertised: [], phantom: [] })
+    })
+
+    it(`${tool.name}: advertised required list matches the zod shape`, () => {
+      const shapes = resolveShapes(schema)
+      const implementedRequired = requiredEverywhere(shapes!).sort()
+      const declaredRequired = [...(tool.inputSchema.required ?? [])].sort()
+
+      expect(
+        declaredRequired,
+        `${tool.name} required-field drift. Advertising a field as optional when zod ` +
+          `requires it produces a runtime parse error the caller could not have predicted; ` +
+          `the reverse makes callers send fields they need not.`
+      ).toEqual(implementedRequired)
+    })
+  }
+})

--- a/packages/crane-mcp/src/registry/tool-schemas-core.ts
+++ b/packages/crane-mcp/src/registry/tool-schemas-core.ts
@@ -126,6 +126,21 @@ export const CORE_TOOL_SCHEMAS = [
           description:
             'Venture code override for cross-venture sessions. When set, writes the handoff for this venture instead of auto-detecting from the current repo.',
         },
+        final: {
+          type: 'boolean',
+          description:
+            'When false, create the handoff but keep the session active so additional per-venture handoffs can be saved. Pass false for ventures 1..N-1 in a multi-venture /eos flow, then true (or omit) on the final call. Defaults to true (ends the session).',
+        },
+        override_pr_merge_gate: {
+          type: 'boolean',
+          description:
+            'Bypass the EOS PR merge gate (Layer 4b). Used in rare flows where the gate produces a false positive. Each override is logged in the handoff record for audit.',
+        },
+        override_verify_coverage_gate: {
+          type: 'boolean',
+          description:
+            'Bypass the EOS verify-coverage gate (Layer 4c). The gate refuses status=done when a session touched a cross-boundary surface (mcp-tool, boot-config, fleet-artifact, config-canon) without recording any crane_verify rows. Pass true only when the gate is producing a false positive; each override is logged in the handoff record for audit.',
+        },
       },
       required: ['summary', 'status'],
     },

--- a/packages/crane-mcp/src/registry/tool-schemas-telemetry.ts
+++ b/packages/crane-mcp/src/registry/tool-schemas-telemetry.ts
@@ -20,10 +20,10 @@ export const TELEMETRY_TOOL_SCHEMAS = [
           type: 'number',
           description: 'Days without a git touch before a skill is considered stale. Default: 180.',
         },
-        include_deprecated: {
+        include_usage: {
           type: 'boolean',
           description:
-            'Include deprecated skills in staleness and inventory counts. Default: true.',
+            'Fetch skill invocation counts from the last 90 days and surface zero-usage candidates. Default: true.',
         },
       },
     },
@@ -89,6 +89,114 @@ export const TELEMETRY_TOOL_SCHEMAS = [
         action: {
           type: 'string',
           enum: ['save', 'list', 'get', 'update', 'deprecate', 'recall'],
+        },
+        name: {
+          type: 'string',
+          description: 'kebab-case unique name for this memory (actions: save, update)',
+        },
+        description: {
+          type: 'string',
+          description: '1-2 sentence purpose statement (actions: save, update)',
+        },
+        kind: {
+          type: 'string',
+          enum: ['lesson', 'anti-pattern', 'runbook', 'incident'],
+          description: '(actions: save, list, update, recall)',
+        },
+        scope: {
+          default: 'enterprise',
+          description: 'enterprise | global | venture:<code> (actions: save, list, update)',
+          type: 'string',
+        },
+        owner: {
+          default: 'captain',
+          description: 'captain or agent-team (actions: save, update)',
+          type: 'string',
+        },
+        status: {
+          default: 'draft',
+          type: 'string',
+          enum: ['draft', 'stable'],
+          description: '(actions: save, list, update)',
+        },
+        captain_approved: {
+          default: false,
+          type: 'boolean',
+          description: '(actions: save, list, update)',
+        },
+        version: { default: '1.0.0', type: 'string', description: '(actions: save, update)' },
+        severity: {
+          description: 'Anti-patterns only (actions: save, update)',
+          type: 'string',
+          enum: ['P0', 'P1', 'P2'],
+        },
+        applies_when: {
+          type: 'object',
+          properties: {
+            commands: { type: 'array', items: { type: 'string' } },
+            files: { type: 'array', items: { type: 'string' } },
+            skills: { type: 'array', items: { type: 'string' } },
+          },
+          description: '(actions: save, update)',
+        },
+        supersedes: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '(actions: save, update)',
+        },
+        supersedes_source: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '(actions: save, update)',
+        },
+        evidence_verify_ids: {
+          description:
+            'Verify-ledger row IDs that are evidence for this memory (populated by crane_verify_audit --apply). Each must match /^vfy_[26 Crockford]$/ (actions: save, update)',
+          type: 'array',
+          items: { type: 'string', pattern: '^vfy_[0-9A-HJKMNP-TV-Z]{26}$' },
+        },
+        last_validated_on: { type: 'string', description: '(actions: save, update)' },
+        body: {
+          type: 'string',
+          description: 'Memory body content (the lesson/rule/procedure) (actions: save, update)',
+        },
+        venture: {
+          description:
+            'Venture code for venture-scoped memories (actions: save, list, update, recall)',
+          type: 'string',
+        },
+        limit: { default: 20, type: 'number', description: '(actions: list, recall)' },
+        id: {
+          type: 'string',
+          description: 'Note ID of the memory (actions: get, update, deprecate)',
+        },
+        reason: { description: 'Optional deprecation reason (actions: deprecate)', type: 'string' },
+        repo: { type: 'string', description: '(actions: recall)' },
+        files: {
+          description: 'Currently active file paths (actions: recall)',
+          type: 'array',
+          items: { type: 'string' },
+        },
+        commands: {
+          description: 'Recently used commands (actions: recall)',
+          type: 'array',
+          items: { type: 'string' },
+        },
+        skills: {
+          description: 'Recently invoked skill names (actions: recall)',
+          type: 'array',
+          items: { type: 'string' },
+        },
+        query: {
+          description:
+            'Free-form text query. When set, uses FTS5 against memory bodies and titles, ranked by hybrid score (bm25 + applies_when + severity). Drops captain_approved_only default to false. (actions: recall)',
+          type: 'string',
+        },
+        captain_approved_only: {
+          default: false,
+          description:
+            'Defaults false. SOS injection path applies its own gate via MEMORY_INJECTION_GATE; pull recall returns drafts and stable so agents can ask broadly. (actions: recall)',
+          type: 'boolean',
         },
       },
       required: ['action'],


### PR DESCRIPTION
## Summary

Three tools advertised a different input schema than they implement, and nothing compared the two. Fixes all three and adds the guard that makes the class impossible to reintroduce silently.

Found while investigating why this session's cross-venture `/eos` failed: I reported to the Captain that `crane_handoff` had no `final` parameter. It has one, and has since #752. The advertised schema never learned about it, so that is what every agent sees.

## Linked issue

Closes #1169

## Acceptance criteria status

| AC (verbatim from issue) | Status | Evidence |
| --- | --- | --- |
| (repo) All three advertised schemas match their zod schemas | met | tool-schemas-core.ts (crane_handoff), tool-schemas-telemetry.ts (crane_skill_audit, crane_memory) |
| (repo) A guard pins advertised properties and required-lists to the zod schemas for every tool, and cannot be skipped by adding a new tool | met | src/registry/schema-parity.test.ts, 63 tests over 30 tools; SCHEMA_BY_TOOL pinned to TOOL_SCHEMAS by set equality |
| (runtime) A freshly spawned `crane-mcp` advertises `final` on `crane_handoff` over `tools/list` | met | MCP initialize + tools/list against the real binary: vfy_01KYP3EVNF6Q1EBH98A5BVZSBK |
| (runtime) A live agent session writes two per-venture handoffs in one /eos, the first with `final: false`, and both land | deferred | see below |

## Deferred ACs

- **AC:** _(runtime) A live agent session writes two per-venture handoffs in one /eos, the first with `final: false`, and both land_
  - **Why deferred:** ordering, not scope. An MCP server's tool list is fixed at session start, so the session that made this change cannot observe its own fix; it needs a `crane <venture>` relaunch. Claiming it now would be a runtime claim backed by an artifact, which is the failure this repo's `/wired` skill exists to prevent.
  - **Tracked in:** #1169 (stays open until observed; the row gets a `crane_verify` ID then)

## Notes for the reviewer

**crane_memory's 25 added properties were generated, not transcribed.** `z.toJSONSchema()` over each union branch, with `(actions: ...)` appended per field, so the advertised types are faithful by construction. `required` stays `["action"]` because that is the only field required in every branch.

**Unions are handled deliberately in the guard.** Properties compare as union-of-keys across branches; `required` compares as intersection. Advertising `name` as required because `action: "save"` needs it would reject valid `action: "list"` calls at the client.

**`scripts/check-hosted-mcp-parity.ts` is untouched and still passes.** It compares the HOSTED surface's three sources by tool name, which is a different check with a different job. Worth knowing: the hosted `crane_handoff` is a different tool sharing the name (`summary`/`to_agent`/`status_label`, "without ending the session"), so it has no `final` to expose.

## Test plan

- [x] `npm run verify` passes (1622 tests across 7 workspaces, 0 errors, hosted-mcp-parity OK)
- [x] Guard fails on the pre-fix schemas and passes after (it is how all three drifts were found)
- [x] Live `tools/list` against a spawned `crane-mcp` confirms all three fixed schemas
- [ ] Two-handoff `/eos` in a relaunched session

## Security Checklist

- No secrets, credentials, or tokens added or read.
- No auth flow, access control, or permission logic touched.
- Schema declarations and one test file; no change to any executor or handler.