### PR TITLE
fix(worktree-doctor): match the lock format git actually writes (#1179)

### DIFF
--- a/packages/crane-mcp/src/tools/worktree-doctor.test.ts
+++ b/packages/crane-mcp/src/tools/worktree-doctor.test.ts
@@ -131,7 +131,7 @@ describe('crane_worktree_doctor', () => {
             path: wtPath,
             head: 'b'.repeat(40),
             branch,
-            locked: `claude agent ${id} (pid 99998)`,
+            locked: `claude session ${id} (pid 99998 start Fri Jul 31 15:33:23 2026)`,
           }),
       },
       { match: 'gh pr list', respond: () => '[]' },
@@ -184,7 +184,7 @@ describe('crane_worktree_doctor', () => {
           porcelainBlock({
             path: wtPath,
             branch,
-            locked: `claude agent ${id} (pid 99998)`,
+            locked: `claude session ${id} (pid 99998 start Fri Jul 31 15:33:23 2026)`,
           }),
       },
       { match: 'gh pr list', respond: () => '[]' },
@@ -228,7 +228,7 @@ describe('crane_worktree_doctor', () => {
           porcelainBlock({
             path: wtPath,
             branch: `worktree-${id}`,
-            locked: `claude agent ${id} (pid 12345)`,
+            locked: `claude session ${id} (pid 12345 start Fri Jul 31 15:33:23 2026)`,
           }),
       },
       { match: 'gh pr list', respond: () => '[]' },
@@ -579,7 +579,7 @@ describe('crane_worktree_doctor', () => {
         porcelainBlock({
           path: `${WORKTREES_DIR}/agent-${String(i).padStart(3, '0')}`,
           branch: `wt-${i}`,
-          locked: `claude agent agent-${String(i).padStart(3, '0')} (pid 99999)`,
+          locked: `claude session agent-${String(i).padStart(3, '0')} (pid 99999 start Fri Jul 31 15:33:23 2026)`,
         }) + '\n'
     }
 
@@ -705,7 +705,7 @@ describe('crane_worktree_doctor', () => {
           porcelainBlock({
             path: wtPath,
             branch: `worktree-${id}`,
-            locked: `claude agent ${id} (pid 12345)`,
+            locked: `claude session ${id} (pid 12345 start Fri Jul 31 15:33:23 2026)`,
           }),
       },
       { match: 'gh pr list', respond: () => '[]' },
@@ -749,13 +749,15 @@ branch refs/heads/main
 worktree /repo/.claude/worktrees/agent-x
 HEAD bbb
 branch refs/heads/wt-x
-locked claude agent agent-x (pid 1234)
+locked claude session agent-x (pid 1234 start Fri Jul 31 15:33:23 2026)
 `
     const records = parseWorktreeList(input)
     expect(records).toHaveLength(2)
     expect(records[0].path).toBe('/repo')
     expect(records[0].branch).toBe('main')
-    expect(records[1].locked?.reason).toBe('claude agent agent-x (pid 1234)')
+    expect(records[1].locked?.reason).toBe(
+      'claude session agent-x (pid 1234 start Fri Jul 31 15:33:23 2026)'
+    )
   })
 
   it('parser: handles bare locked line', async () => {
@@ -770,12 +772,49 @@ locked
     expect(cls.kind).toBe('foreign')
   })
 
-  it('parser: classifies claude-agent-pid pattern', async () => {
+  it('parser: classifies the legacy "claude agent" spelling', async () => {
     const { classifyLock } = await getModule()
     const cls = classifyLock('claude agent agent-abc (pid 27557)')
     expect(cls.kind).toBe('claude-agent')
     if (cls.kind === 'claude-agent') {
       expect(cls.pid).toBe(27557)
     }
+  })
+
+  /**
+   * The spelling actually found on disk. Copied verbatim from
+   * ss-console/.git/worktrees/sos-2026-07-31/locked on 2026-07-31.
+   *
+   * The classifier previously required `claude agent <name> (pid N)`, so this
+   * string fell through to `foreign`, landed in needs_review, and never
+   * reached the alive/dead-pid triage. Every fixture in this file used the
+   * synthetic legacy form, which is how CI stayed green while the backstop
+   * caught nothing in production.
+   */
+  it('parser: classifies the real "claude session ... start <date>" spelling', async () => {
+    const { classifyLock } = await getModule()
+    const cls = classifyLock(
+      'claude session sos-2026-07-31 (pid 50065 start Fri Jul 31 15:33:23 2026)'
+    )
+    expect(cls.kind).toBe('claude-agent')
+    if (cls.kind === 'claude-agent') {
+      expect(cls.pid).toBe(50065)
+    }
+  })
+
+  it('parser: a session lock with no trailing segment still classifies', async () => {
+    const { classifyLock } = await getModule()
+    const cls = classifyLock('claude session wt-name (pid 4242)')
+    expect(cls.kind).toBe('claude-agent')
+    if (cls.kind === 'claude-agent') {
+      expect(cls.pid).toBe(4242)
+    }
+  })
+
+  /** A genuinely foreign lock must still be left alone. */
+  it('parser: a non-Claude lock stays foreign', async () => {
+    const { classifyLock } = await getModule()
+    const cls = classifyLock('git rebase in progress')
+    expect(cls.kind).toBe('foreign')
   })
 })

--- a/packages/crane-mcp/src/tools/worktree-doctor/parse.ts
+++ b/packages/crane-mcp/src/tools/worktree-doctor/parse.ts
@@ -100,7 +100,29 @@ export function parseWorktreeList(porcelain: string): WorktreeRecord[] {
 // Lock classifier
 // ----------------------------------------------------------------------------
 
-const CLAUDE_AGENT_LOCK_RE = /^claude agent\s+\S+\s+\(pid\s+(\d+)\)$/
+/**
+ * Locks written by Claude Code when a session enters a worktree.
+ *
+ * TWO SPELLINGS, BOTH LIVE. The original was `claude agent <name> (pid N)`.
+ * Current harnesses write `claude session <name> (pid N start <ctime>)`:
+ *
+ *   claude session sos-2026-07-31 (pid 50065 start Fri Jul 31 15:33:23 2026)
+ *
+ * Matching only the first spelling is not a cosmetic miss. Every real lock
+ * fell through to `foreign`, which routes to `needs_review` and SKIPS the
+ * alive/dead-pid triage entirely — so the orphan backstop silently stopped
+ * backstopping. Observed 2026-07-31 in ss-console: `/sos` reported four
+ * locked worktrees and cleaned none, and one of them (pid 1712) died during
+ * the session and stayed locked and unattended, which is exactly the case
+ * the triage exists to catch. Every fixture in worktree-doctor.test.ts used
+ * the synthetic first spelling, so CI was green against a format that no
+ * longer occurs on disk.
+ *
+ * The trailing group is deliberately `[^)]*` rather than `start .*`: only the
+ * pid is load-bearing, and a third spelling should degrade to a correct pid
+ * rather than back to `foreign`.
+ */
+const CLAUDE_SESSION_LOCK_RE = /^claude (?:agent|session)\s+\S+\s+\(pid\s+(\d+)(?:\s+[^)]*)?\)$/
 
 /**
  * Parse the lock reason. Returns:
@@ -111,7 +133,7 @@ export function classifyLock(
   reason: string
 ): { kind: 'claude-agent'; pid: number } | { kind: 'foreign'; reason: string } {
   const trimmed = reason.trim()
-  const m = trimmed.match(CLAUDE_AGENT_LOCK_RE)
+  const m = trimmed.match(CLAUDE_SESSION_LOCK_RE)
   if (m) return { kind: 'claude-agent', pid: parseInt(m[1], 10) }
   return { kind: 'foreign', reason: trimmed || 'no reason' }
 }


### PR DESCRIPTION
Closes half of #1179. Found while fixing venturecrane/ss-console#2110.

## The bug

`worktree-doctor/parse.ts:103` required:

```ts
const CLAUDE_AGENT_LOCK_RE = /^claude agent\s+\S+\s+\(pid\s+(\d+)\)$/
```

Claude Code writes something else. Verbatim from `ss-console/.git/worktrees/sos-2026-07-31/locked`:

```
claude session sos-2026-07-31 (pid 50065 start Fri Jul 31 15:33:23 2026)
```

Two mismatches: `agent` vs `session`, and the trailing ` start <ctime>` before the paren.

## Why it is not cosmetic

`classifyLock` returning `foreign` routes the worktree to `needs_review` and **skips the alive/dead-pid triage entirely**. So every real lock was exempt from triage, and the orphan backstop silently stopped backstopping.

Observed in ss-console on 2026-07-31: `/sos` reported four locked worktrees and cleaned none. During that same session pid 1712 died, and its worktree stayed locked and unattended holding uncommitted work — exactly the orphan the triage exists to catch.

## Why it survived

Every fixture in `worktree-doctor.test.ts` used the synthetic legacy spelling (lines 134, 187, 231, 582, 708, 752, 775). The tests described the classifier's own assumption back to it, so CI stayed green against a format that does not occur on disk.

Fixtures now carry the real spelling, so the three behavioural arms — dead-pid cleanup, alive-pid skip, EPERM-treated-as-alive — actually exercise it.

## Kill test

Restoring the old regex against the new fixtures:

```
× 1. dead-PID lock + clean tree + squash-merged → cleaned (apply=true unlocks and removes)
× 2. dead-PID lock + clean tree + squash-merged → would-clean (apply=false)
× 3. alive-PID lock → skipped, no unlock attempted
× 17. PidChecker EPERM treated as alive → skipped same as alive PID
× parser: classifies the real "claude session ... start <date>" spelling
× parser: a session lock with no trailing segment still classifies
Tests  6 failed | 18 passed (24)
```

Restored: 24 passed. Full package suite: **904 passed (50 files)**.

## The change

```ts
const CLAUDE_SESSION_LOCK_RE = /^claude (?:agent|session)\s+\S+\s+\(pid\s+(\d+)(?:\s+[^)]*)?\)$/
```

Both spellings accepted. The trailing group is `[^)]*` rather than `start .*` deliberately: only the pid is load-bearing, so a third spelling should degrade to a correct pid rather than back to `foreign`. A genuinely foreign lock (`git rebase in progress`) still classifies as foreign, and that now has a test.

## Not in this PR

The other half of #1179 — SOS "Other Active Sessions" filtering out same-host peers — is not fixable in crane-mcp. `startSession` sends `client_session_id` and `host` (`crane-api-base.ts:116-117`), but `ActiveSession` (`crane-api-types.ts:34`) returns neither, so there is nothing to filter on. That needs a crane-context worker and contracts change. Filed rather than absorbed.

## Acceptance criteria

- [x] The real lock format classifies as `claude-agent` with the correct pid
- [x] Legacy spelling still classifies
- [x] Foreign locks still classify as foreign
- [x] Behavioural arms exercise the real format
- [x] Kill-tested: old regex fails 6 tests
- [ ] **(runtime)** `crane_worktree_doctor` triaging a real lock on a live repo

Runtime AC needs the local build (`crane-mcp` is npm-linked, so build equals deploy) and a real locked worktree to observe. `ss-console` currently has one with a dead pid, which is the case to verify against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
